### PR TITLE
fix(workflow): add token permissions

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -7,6 +7,13 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+
+    # Grant GITHUB_TOKEN permissions to make a Pages deployment
+    permissions:
+      contents: write  # to let mkdocs write the new docs
+      pages: write     # to deploy to Pages
+      id-token: write  # to verify deployment is from appropriate source
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR may fix failing deploy-docs workflow.