### PR TITLE
Add examples and processes for generating them

### DIFF
--- a/examples/Datasheet-001.yaml
+++ b/examples/Datasheet-001.yaml
@@ -1,3 +1,0 @@
-# Example data object
----
-id: data_sheets_schema:Datasheet001

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,0 @@
-# Examples of use of data_sheets_schema
-
-This folder contains example data conforming to data_sheets_schema
-
-The source for these is in [src/data](../src/data/examples)

--- a/examples/output/AddressingGap-minimal.json
+++ b/examples/output/AddressingGap-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:AddressingGap",
+  "@type": "AddressingGap"
+}

--- a/examples/output/AddressingGap-minimal.yaml
+++ b/examples/output/AddressingGap-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:AddressingGap

--- a/examples/output/AddressingGap-valid.json
+++ b/examples/output/AddressingGap-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:AddressingGap",
+  "@type": "AddressingGap"
+}

--- a/examples/output/AddressingGap-valid.yaml
+++ b/examples/output/AddressingGap-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:AddressingGap

--- a/examples/output/CleaningStrategy-minimal.json
+++ b/examples/output/CleaningStrategy-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CleaningStrategy",
+  "description": "[]",
+  "@type": "CleaningStrategy"
+}

--- a/examples/output/CleaningStrategy-minimal.yaml
+++ b/examples/output/CleaningStrategy-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CleaningStrategy
+description: '[]'

--- a/examples/output/CleaningStrategy-valid.json
+++ b/examples/output/CleaningStrategy-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CleaningStrategy",
+  "description": "[]",
+  "@type": "CleaningStrategy"
+}

--- a/examples/output/CleaningStrategy-valid.yaml
+++ b/examples/output/CleaningStrategy-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CleaningStrategy
+description: '[]'

--- a/examples/output/CollectionConsent-minimal.json
+++ b/examples/output/CollectionConsent-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CollectionConsent",
+  "description": "[]",
+  "@type": "CollectionConsent"
+}

--- a/examples/output/CollectionConsent-minimal.yaml
+++ b/examples/output/CollectionConsent-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CollectionConsent
+description: '[]'

--- a/examples/output/CollectionConsent-valid.json
+++ b/examples/output/CollectionConsent-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CollectionConsent",
+  "description": "[]",
+  "@type": "CollectionConsent"
+}

--- a/examples/output/CollectionConsent-valid.yaml
+++ b/examples/output/CollectionConsent-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CollectionConsent
+description: '[]'

--- a/examples/output/CollectionMechanism-minimal.json
+++ b/examples/output/CollectionMechanism-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CollectionMechanism",
+  "description": "[]",
+  "@type": "CollectionMechanism"
+}

--- a/examples/output/CollectionMechanism-minimal.yaml
+++ b/examples/output/CollectionMechanism-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CollectionMechanism
+description: '[]'

--- a/examples/output/CollectionMechanism-valid.json
+++ b/examples/output/CollectionMechanism-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CollectionMechanism",
+  "description": "[]",
+  "@type": "CollectionMechanism"
+}

--- a/examples/output/CollectionMechanism-valid.yaml
+++ b/examples/output/CollectionMechanism-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CollectionMechanism
+description: '[]'

--- a/examples/output/CollectionNotification-minimal.json
+++ b/examples/output/CollectionNotification-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CollectionNotification",
+  "description": "[]",
+  "@type": "CollectionNotification"
+}

--- a/examples/output/CollectionNotification-minimal.yaml
+++ b/examples/output/CollectionNotification-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CollectionNotification
+description: '[]'

--- a/examples/output/CollectionNotification-valid.json
+++ b/examples/output/CollectionNotification-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CollectionNotification",
+  "description": "[]",
+  "@type": "CollectionNotification"
+}

--- a/examples/output/CollectionNotification-valid.yaml
+++ b/examples/output/CollectionNotification-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CollectionNotification
+description: '[]'

--- a/examples/output/CollectionTimeframe-minimal.json
+++ b/examples/output/CollectionTimeframe-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CollectionTimeframe",
+  "description": "[]",
+  "@type": "CollectionTimeframe"
+}

--- a/examples/output/CollectionTimeframe-minimal.yaml
+++ b/examples/output/CollectionTimeframe-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CollectionTimeframe
+description: '[]'

--- a/examples/output/CollectionTimeframe-valid.json
+++ b/examples/output/CollectionTimeframe-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:CollectionTimeframe",
+  "description": "[]",
+  "@type": "CollectionTimeframe"
+}

--- a/examples/output/CollectionTimeframe-valid.yaml
+++ b/examples/output/CollectionTimeframe-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:CollectionTimeframe
+description: '[]'

--- a/examples/output/Confidentiality-minimal.json
+++ b/examples/output/Confidentiality-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Confidentiality",
+  "description": "[]",
+  "@type": "Confidentiality"
+}

--- a/examples/output/Confidentiality-minimal.yaml
+++ b/examples/output/Confidentiality-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Confidentiality
+description: '[]'

--- a/examples/output/Confidentiality-valid.json
+++ b/examples/output/Confidentiality-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Confidentiality",
+  "description": "[]",
+  "@type": "Confidentiality"
+}

--- a/examples/output/Confidentiality-valid.yaml
+++ b/examples/output/Confidentiality-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Confidentiality
+description: '[]'

--- a/examples/output/ConsentRevocation-minimal.json
+++ b/examples/output/ConsentRevocation-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ConsentRevocation",
+  "description": "[]",
+  "@type": "ConsentRevocation"
+}

--- a/examples/output/ConsentRevocation-minimal.yaml
+++ b/examples/output/ConsentRevocation-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ConsentRevocation
+description: '[]'

--- a/examples/output/ConsentRevocation-valid.json
+++ b/examples/output/ConsentRevocation-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ConsentRevocation",
+  "description": "[]",
+  "@type": "ConsentRevocation"
+}

--- a/examples/output/ConsentRevocation-valid.yaml
+++ b/examples/output/ConsentRevocation-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ConsentRevocation
+description: '[]'

--- a/examples/output/ContentWarning-minimal.json
+++ b/examples/output/ContentWarning-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ContentWarning",
+  "@type": "ContentWarning"
+}

--- a/examples/output/ContentWarning-minimal.yaml
+++ b/examples/output/ContentWarning-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ContentWarning

--- a/examples/output/ContentWarning-valid.json
+++ b/examples/output/ContentWarning-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ContentWarning",
+  "@type": "ContentWarning"
+}

--- a/examples/output/ContentWarning-valid.yaml
+++ b/examples/output/ContentWarning-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ContentWarning

--- a/examples/output/Creator-minimal.json
+++ b/examples/output/Creator-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Creator",
+  "@type": "Creator"
+}

--- a/examples/output/Creator-minimal.yaml
+++ b/examples/output/Creator-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Creator

--- a/examples/output/Creator-valid.json
+++ b/examples/output/Creator-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Creator",
+  "@type": "Creator"
+}

--- a/examples/output/Creator-valid.yaml
+++ b/examples/output/Creator-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Creator

--- a/examples/output/DataAnomaly-minimal.json
+++ b/examples/output/DataAnomaly-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DataAnomaly",
+  "description": "[]",
+  "@type": "DataAnomaly"
+}

--- a/examples/output/DataAnomaly-minimal.yaml
+++ b/examples/output/DataAnomaly-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DataAnomaly
+description: '[]'

--- a/examples/output/DataAnomaly-valid.json
+++ b/examples/output/DataAnomaly-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DataAnomaly",
+  "description": "[]",
+  "@type": "DataAnomaly"
+}

--- a/examples/output/DataAnomaly-valid.yaml
+++ b/examples/output/DataAnomaly-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DataAnomaly
+description: '[]'

--- a/examples/output/DataCollector-minimal.json
+++ b/examples/output/DataCollector-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DataCollector",
+  "description": "[]",
+  "@type": "DataCollector"
+}

--- a/examples/output/DataCollector-minimal.yaml
+++ b/examples/output/DataCollector-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DataCollector
+description: '[]'

--- a/examples/output/DataCollector-valid.json
+++ b/examples/output/DataCollector-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DataCollector",
+  "description": "[]",
+  "@type": "DataCollector"
+}

--- a/examples/output/DataCollector-valid.yaml
+++ b/examples/output/DataCollector-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DataCollector
+description: '[]'

--- a/examples/output/DataProtectionImpact-minimal.json
+++ b/examples/output/DataProtectionImpact-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DataProtectionImpact",
+  "description": "[]",
+  "@type": "DataProtectionImpact"
+}

--- a/examples/output/DataProtectionImpact-minimal.yaml
+++ b/examples/output/DataProtectionImpact-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DataProtectionImpact
+description: '[]'

--- a/examples/output/DataProtectionImpact-valid.json
+++ b/examples/output/DataProtectionImpact-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DataProtectionImpact",
+  "description": "[]",
+  "@type": "DataProtectionImpact"
+}

--- a/examples/output/DataProtectionImpact-valid.yaml
+++ b/examples/output/DataProtectionImpact-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DataProtectionImpact
+description: '[]'

--- a/examples/output/DataSubset-minimal.json
+++ b/examples/output/DataSubset-minimal.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "DataSubset"
+}

--- a/examples/output/DataSubset-minimal.yaml
+++ b/examples/output/DataSubset-minimal.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/DataSubset-valid.json
+++ b/examples/output/DataSubset-valid.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "DataSubset"
+}

--- a/examples/output/DataSubset-valid.yaml
+++ b/examples/output/DataSubset-valid.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/Dataset-minimal.json
+++ b/examples/output/Dataset-minimal.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "Dataset"
+}

--- a/examples/output/Dataset-minimal.yaml
+++ b/examples/output/Dataset-minimal.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/Dataset-valid.json
+++ b/examples/output/Dataset-valid.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "Dataset"
+}

--- a/examples/output/Dataset-valid.yaml
+++ b/examples/output/Dataset-valid.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/DatasetCollection-minimal.json
+++ b/examples/output/DatasetCollection-minimal.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "DatasetCollection"
+}

--- a/examples/output/DatasetCollection-minimal.yaml
+++ b/examples/output/DatasetCollection-minimal.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/DatasetCollection-valid.json
+++ b/examples/output/DatasetCollection-valid.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "DatasetCollection"
+}

--- a/examples/output/DatasetCollection-valid.yaml
+++ b/examples/output/DatasetCollection-valid.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/DatasetProperty-minimal.json
+++ b/examples/output/DatasetProperty-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DatasetProperty",
+  "@type": "DatasetProperty"
+}

--- a/examples/output/DatasetProperty-minimal.yaml
+++ b/examples/output/DatasetProperty-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DatasetProperty

--- a/examples/output/DatasetProperty-valid.json
+++ b/examples/output/DatasetProperty-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DatasetProperty",
+  "@type": "DatasetProperty"
+}

--- a/examples/output/DatasetProperty-valid.yaml
+++ b/examples/output/DatasetProperty-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DatasetProperty

--- a/examples/output/Deidentification-minimal.json
+++ b/examples/output/Deidentification-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Deidentification",
+  "description": "[]",
+  "@type": "Deidentification"
+}

--- a/examples/output/Deidentification-minimal.yaml
+++ b/examples/output/Deidentification-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Deidentification
+description: '[]'

--- a/examples/output/Deidentification-valid.json
+++ b/examples/output/Deidentification-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Deidentification",
+  "description": "[]",
+  "@type": "Deidentification"
+}

--- a/examples/output/Deidentification-valid.yaml
+++ b/examples/output/Deidentification-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Deidentification
+description: '[]'

--- a/examples/output/DirectCollection-minimal.json
+++ b/examples/output/DirectCollection-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DirectCollection",
+  "description": "[]",
+  "@type": "DirectCollection"
+}

--- a/examples/output/DirectCollection-minimal.yaml
+++ b/examples/output/DirectCollection-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DirectCollection
+description: '[]'

--- a/examples/output/DirectCollection-valid.json
+++ b/examples/output/DirectCollection-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DirectCollection",
+  "description": "[]",
+  "@type": "DirectCollection"
+}

--- a/examples/output/DirectCollection-valid.yaml
+++ b/examples/output/DirectCollection-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DirectCollection
+description: '[]'

--- a/examples/output/DiscouragedUse-minimal.json
+++ b/examples/output/DiscouragedUse-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DiscouragedUse",
+  "description": "[]",
+  "@type": "DiscouragedUse"
+}

--- a/examples/output/DiscouragedUse-minimal.yaml
+++ b/examples/output/DiscouragedUse-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DiscouragedUse
+description: '[]'

--- a/examples/output/DiscouragedUse-valid.json
+++ b/examples/output/DiscouragedUse-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DiscouragedUse",
+  "description": "[]",
+  "@type": "DiscouragedUse"
+}

--- a/examples/output/DiscouragedUse-valid.yaml
+++ b/examples/output/DiscouragedUse-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DiscouragedUse
+description: '[]'

--- a/examples/output/DistributionDate-minimal.json
+++ b/examples/output/DistributionDate-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DistributionDate",
+  "description": "[]",
+  "@type": "DistributionDate"
+}

--- a/examples/output/DistributionDate-minimal.yaml
+++ b/examples/output/DistributionDate-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DistributionDate
+description: '[]'

--- a/examples/output/DistributionDate-valid.json
+++ b/examples/output/DistributionDate-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DistributionDate",
+  "description": "[]",
+  "@type": "DistributionDate"
+}

--- a/examples/output/DistributionDate-valid.yaml
+++ b/examples/output/DistributionDate-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DistributionDate
+description: '[]'

--- a/examples/output/DistributionFormat-minimal.json
+++ b/examples/output/DistributionFormat-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DistributionFormat",
+  "description": "[]",
+  "@type": "DistributionFormat"
+}

--- a/examples/output/DistributionFormat-minimal.yaml
+++ b/examples/output/DistributionFormat-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DistributionFormat
+description: '[]'

--- a/examples/output/DistributionFormat-valid.json
+++ b/examples/output/DistributionFormat-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:DistributionFormat",
+  "description": "[]",
+  "@type": "DistributionFormat"
+}

--- a/examples/output/DistributionFormat-valid.yaml
+++ b/examples/output/DistributionFormat-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:DistributionFormat
+description: '[]'

--- a/examples/output/Erratum-minimal.json
+++ b/examples/output/Erratum-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Erratum",
+  "description": "[]",
+  "@type": "Erratum"
+}

--- a/examples/output/Erratum-minimal.yaml
+++ b/examples/output/Erratum-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Erratum
+description: '[]'

--- a/examples/output/Erratum-valid.json
+++ b/examples/output/Erratum-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Erratum",
+  "description": "[]",
+  "@type": "Erratum"
+}

--- a/examples/output/Erratum-valid.yaml
+++ b/examples/output/Erratum-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Erratum
+description: '[]'

--- a/examples/output/EthicalReview-minimal.json
+++ b/examples/output/EthicalReview-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:EthicalReview",
+  "description": "[]",
+  "@type": "EthicalReview"
+}

--- a/examples/output/EthicalReview-minimal.yaml
+++ b/examples/output/EthicalReview-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:EthicalReview
+description: '[]'

--- a/examples/output/EthicalReview-valid.json
+++ b/examples/output/EthicalReview-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:EthicalReview",
+  "description": "[]",
+  "@type": "EthicalReview"
+}

--- a/examples/output/EthicalReview-valid.yaml
+++ b/examples/output/EthicalReview-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:EthicalReview
+description: '[]'

--- a/examples/output/ExistingUse-minimal.json
+++ b/examples/output/ExistingUse-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ExistingUse",
+  "description": "[]",
+  "@type": "ExistingUse"
+}

--- a/examples/output/ExistingUse-minimal.yaml
+++ b/examples/output/ExistingUse-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ExistingUse
+description: '[]'

--- a/examples/output/ExistingUse-valid.json
+++ b/examples/output/ExistingUse-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ExistingUse",
+  "description": "[]",
+  "@type": "ExistingUse"
+}

--- a/examples/output/ExistingUse-valid.yaml
+++ b/examples/output/ExistingUse-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ExistingUse
+description: '[]'

--- a/examples/output/ExportControlRegulatoryRestrictions-minimal.json
+++ b/examples/output/ExportControlRegulatoryRestrictions-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ExportControlRegulatoryRestrictions",
+  "description": "[]",
+  "@type": "ExportControlRegulatoryRestrictions"
+}

--- a/examples/output/ExportControlRegulatoryRestrictions-minimal.yaml
+++ b/examples/output/ExportControlRegulatoryRestrictions-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ExportControlRegulatoryRestrictions
+description: '[]'

--- a/examples/output/ExportControlRegulatoryRestrictions-valid.json
+++ b/examples/output/ExportControlRegulatoryRestrictions-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ExportControlRegulatoryRestrictions",
+  "description": "[]",
+  "@type": "ExportControlRegulatoryRestrictions"
+}

--- a/examples/output/ExportControlRegulatoryRestrictions-valid.yaml
+++ b/examples/output/ExportControlRegulatoryRestrictions-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ExportControlRegulatoryRestrictions
+description: '[]'

--- a/examples/output/ExtensionMechanism-minimal.json
+++ b/examples/output/ExtensionMechanism-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ExtensionMechanism",
+  "description": "[]",
+  "@type": "ExtensionMechanism"
+}

--- a/examples/output/ExtensionMechanism-minimal.yaml
+++ b/examples/output/ExtensionMechanism-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ExtensionMechanism
+description: '[]'

--- a/examples/output/ExtensionMechanism-valid.json
+++ b/examples/output/ExtensionMechanism-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ExtensionMechanism",
+  "description": "[]",
+  "@type": "ExtensionMechanism"
+}

--- a/examples/output/ExtensionMechanism-valid.yaml
+++ b/examples/output/ExtensionMechanism-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ExtensionMechanism
+description: '[]'

--- a/examples/output/ExternalResource-minimal.json
+++ b/examples/output/ExternalResource-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ExternalResource",
+  "@type": "ExternalResource"
+}

--- a/examples/output/ExternalResource-minimal.yaml
+++ b/examples/output/ExternalResource-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ExternalResource

--- a/examples/output/ExternalResource-valid.json
+++ b/examples/output/ExternalResource-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ExternalResource",
+  "@type": "ExternalResource"
+}

--- a/examples/output/ExternalResource-valid.yaml
+++ b/examples/output/ExternalResource-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ExternalResource

--- a/examples/output/FormatDialect-minimal.json
+++ b/examples/output/FormatDialect-minimal.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "FormatDialect"
+}

--- a/examples/output/FormatDialect-minimal.yaml
+++ b/examples/output/FormatDialect-minimal.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/FormatDialect-valid.json
+++ b/examples/output/FormatDialect-valid.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "FormatDialect"
+}

--- a/examples/output/FormatDialect-valid.yaml
+++ b/examples/output/FormatDialect-valid.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/FundingMechanism-minimal.json
+++ b/examples/output/FundingMechanism-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:FundingMechanism",
+  "@type": "FundingMechanism"
+}

--- a/examples/output/FundingMechanism-minimal.yaml
+++ b/examples/output/FundingMechanism-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:FundingMechanism

--- a/examples/output/FundingMechanism-valid.json
+++ b/examples/output/FundingMechanism-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:FundingMechanism",
+  "@type": "FundingMechanism"
+}

--- a/examples/output/FundingMechanism-valid.yaml
+++ b/examples/output/FundingMechanism-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:FundingMechanism

--- a/examples/output/FutureUseImpact-minimal.json
+++ b/examples/output/FutureUseImpact-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:FutureUseImpact",
+  "description": "[]",
+  "@type": "FutureUseImpact"
+}

--- a/examples/output/FutureUseImpact-minimal.yaml
+++ b/examples/output/FutureUseImpact-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:FutureUseImpact
+description: '[]'

--- a/examples/output/FutureUseImpact-valid.json
+++ b/examples/output/FutureUseImpact-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:FutureUseImpact",
+  "description": "[]",
+  "@type": "FutureUseImpact"
+}

--- a/examples/output/FutureUseImpact-valid.yaml
+++ b/examples/output/FutureUseImpact-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:FutureUseImpact
+description: '[]'

--- a/examples/output/Grant-minimal.json
+++ b/examples/output/Grant-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Grant",
+  "@type": "Grant"
+}

--- a/examples/output/Grant-minimal.yaml
+++ b/examples/output/Grant-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Grant

--- a/examples/output/Grant-valid.json
+++ b/examples/output/Grant-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Grant",
+  "@type": "Grant"
+}

--- a/examples/output/Grant-valid.yaml
+++ b/examples/output/Grant-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Grant

--- a/examples/output/Grantor-minimal.json
+++ b/examples/output/Grantor-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Grantor",
+  "@type": "Grantor"
+}

--- a/examples/output/Grantor-minimal.yaml
+++ b/examples/output/Grantor-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Grantor

--- a/examples/output/Grantor-valid.json
+++ b/examples/output/Grantor-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Grantor",
+  "@type": "Grantor"
+}

--- a/examples/output/Grantor-valid.yaml
+++ b/examples/output/Grantor-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Grantor

--- a/examples/output/IPRestrictions-minimal.json
+++ b/examples/output/IPRestrictions-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:IPRestrictions",
+  "description": "[]",
+  "@type": "IPRestrictions"
+}

--- a/examples/output/IPRestrictions-minimal.yaml
+++ b/examples/output/IPRestrictions-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:IPRestrictions
+description: '[]'

--- a/examples/output/IPRestrictions-valid.json
+++ b/examples/output/IPRestrictions-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:IPRestrictions",
+  "description": "[]",
+  "@type": "IPRestrictions"
+}

--- a/examples/output/IPRestrictions-valid.yaml
+++ b/examples/output/IPRestrictions-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:IPRestrictions
+description: '[]'

--- a/examples/output/Information-minimal.json
+++ b/examples/output/Information-minimal.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "Information"
+}

--- a/examples/output/Information-minimal.yaml
+++ b/examples/output/Information-minimal.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/Information-valid.json
+++ b/examples/output/Information-valid.json
@@ -1,0 +1,4 @@
+{
+  "id": "data_sheets_schema:123",
+  "@type": "Information"
+}

--- a/examples/output/Information-valid.yaml
+++ b/examples/output/Information-valid.yaml
@@ -1,0 +1,1 @@
+id: data_sheets_schema:123

--- a/examples/output/Instance-minimal.json
+++ b/examples/output/Instance-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Instance",
+  "@type": "Instance"
+}

--- a/examples/output/Instance-minimal.yaml
+++ b/examples/output/Instance-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Instance

--- a/examples/output/Instance-valid.json
+++ b/examples/output/Instance-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Instance",
+  "@type": "Instance"
+}

--- a/examples/output/Instance-valid.yaml
+++ b/examples/output/Instance-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Instance

--- a/examples/output/InstanceAcquisition-minimal.json
+++ b/examples/output/InstanceAcquisition-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:InstanceAcquisition",
+  "description": "[]",
+  "@type": "InstanceAcquisition"
+}

--- a/examples/output/InstanceAcquisition-minimal.yaml
+++ b/examples/output/InstanceAcquisition-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:InstanceAcquisition
+description: '[]'

--- a/examples/output/InstanceAcquisition-valid.json
+++ b/examples/output/InstanceAcquisition-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:InstanceAcquisition",
+  "description": "[]",
+  "@type": "InstanceAcquisition"
+}

--- a/examples/output/InstanceAcquisition-valid.yaml
+++ b/examples/output/InstanceAcquisition-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:InstanceAcquisition
+description: '[]'

--- a/examples/output/LabelingStrategy-minimal.json
+++ b/examples/output/LabelingStrategy-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:LabelingStrategy",
+  "description": "[]",
+  "@type": "LabelingStrategy"
+}

--- a/examples/output/LabelingStrategy-minimal.yaml
+++ b/examples/output/LabelingStrategy-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:LabelingStrategy
+description: '[]'

--- a/examples/output/LabelingStrategy-valid.json
+++ b/examples/output/LabelingStrategy-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:LabelingStrategy",
+  "description": "[]",
+  "@type": "LabelingStrategy"
+}

--- a/examples/output/LabelingStrategy-valid.yaml
+++ b/examples/output/LabelingStrategy-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:LabelingStrategy
+description: '[]'

--- a/examples/output/LicenseAndUseTerms-minimal.json
+++ b/examples/output/LicenseAndUseTerms-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:LicenseAndUseTerms",
+  "description": "[]",
+  "@type": "LicenseAndUseTerms"
+}

--- a/examples/output/LicenseAndUseTerms-minimal.yaml
+++ b/examples/output/LicenseAndUseTerms-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:LicenseAndUseTerms
+description: '[]'

--- a/examples/output/LicenseAndUseTerms-valid.json
+++ b/examples/output/LicenseAndUseTerms-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:LicenseAndUseTerms",
+  "description": "[]",
+  "@type": "LicenseAndUseTerms"
+}

--- a/examples/output/LicenseAndUseTerms-valid.yaml
+++ b/examples/output/LicenseAndUseTerms-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:LicenseAndUseTerms
+description: '[]'

--- a/examples/output/Maintainer-minimal.json
+++ b/examples/output/Maintainer-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Maintainer",
+  "description": "[]",
+  "@type": "Maintainer"
+}

--- a/examples/output/Maintainer-minimal.yaml
+++ b/examples/output/Maintainer-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Maintainer
+description: '[]'

--- a/examples/output/Maintainer-valid.json
+++ b/examples/output/Maintainer-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Maintainer",
+  "description": "[]",
+  "@type": "Maintainer"
+}

--- a/examples/output/Maintainer-valid.yaml
+++ b/examples/output/Maintainer-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Maintainer
+description: '[]'

--- a/examples/output/MissingInfo-minimal.json
+++ b/examples/output/MissingInfo-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:MissingInfo",
+  "@type": "MissingInfo"
+}

--- a/examples/output/MissingInfo-minimal.yaml
+++ b/examples/output/MissingInfo-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:MissingInfo

--- a/examples/output/MissingInfo-valid.json
+++ b/examples/output/MissingInfo-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:MissingInfo",
+  "@type": "MissingInfo"
+}

--- a/examples/output/MissingInfo-valid.yaml
+++ b/examples/output/MissingInfo-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:MissingInfo

--- a/examples/output/OtherTask-minimal.json
+++ b/examples/output/OtherTask-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:OtherTask",
+  "description": "[]",
+  "@type": "OtherTask"
+}

--- a/examples/output/OtherTask-minimal.yaml
+++ b/examples/output/OtherTask-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:OtherTask
+description: '[]'

--- a/examples/output/OtherTask-valid.json
+++ b/examples/output/OtherTask-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:OtherTask",
+  "description": "[]",
+  "@type": "OtherTask"
+}

--- a/examples/output/OtherTask-valid.yaml
+++ b/examples/output/OtherTask-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:OtherTask
+description: '[]'

--- a/examples/output/Person-minimal.json
+++ b/examples/output/Person-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Person",
+  "@type": "Person"
+}

--- a/examples/output/Person-minimal.yaml
+++ b/examples/output/Person-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Person

--- a/examples/output/Person-valid.json
+++ b/examples/output/Person-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Person",
+  "@type": "Person"
+}

--- a/examples/output/Person-valid.yaml
+++ b/examples/output/Person-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Person

--- a/examples/output/PreprocessingStrategy-minimal.json
+++ b/examples/output/PreprocessingStrategy-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:PreprocessingStrategy",
+  "description": "[]",
+  "@type": "PreprocessingStrategy"
+}

--- a/examples/output/PreprocessingStrategy-minimal.yaml
+++ b/examples/output/PreprocessingStrategy-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:PreprocessingStrategy
+description: '[]'

--- a/examples/output/PreprocessingStrategy-valid.json
+++ b/examples/output/PreprocessingStrategy-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:PreprocessingStrategy",
+  "description": "[]",
+  "@type": "PreprocessingStrategy"
+}

--- a/examples/output/PreprocessingStrategy-valid.yaml
+++ b/examples/output/PreprocessingStrategy-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:PreprocessingStrategy
+description: '[]'

--- a/examples/output/Purpose-minimal.json
+++ b/examples/output/Purpose-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Purpose",
+  "@type": "Purpose"
+}

--- a/examples/output/Purpose-minimal.yaml
+++ b/examples/output/Purpose-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Purpose

--- a/examples/output/Purpose-valid.json
+++ b/examples/output/Purpose-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Purpose",
+  "@type": "Purpose"
+}

--- a/examples/output/Purpose-valid.yaml
+++ b/examples/output/Purpose-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Purpose

--- a/examples/output/README.md
+++ b/examples/output/README.md
@@ -1,0 +1,1044 @@
+## Grantor-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Dataset-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Information-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## VersionAccess-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExistingUse-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExportControlRegulatoryRestrictions-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Information-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## FutureUseImpact-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DatasetProperty-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ContentWarning-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionTimeframe-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Deidentification-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Maintainer-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExistingUse-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Task-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Purpose-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## FundingMechanism-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Splits-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## VersionAccess-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## AddressingGap-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Instance-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DistributionFormat-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Instance-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionNotification-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## FormatDialect-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExtensionMechanism-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Person-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DatasetCollection-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## MissingInfo-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DatasetCollection-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## LabelingStrategy-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Grant-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## InstanceAcquisition-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Splits-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExternalResource-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Erratum-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## IPRestrictions-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DistributionDate-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExtensionMechanism-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Task-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## RetentionLimits-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## EthicalReview-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExportControlRegulatoryRestrictions-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionMechanism-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataCollector-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionConsent-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionConsent-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Purpose-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionTimeframe-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataAnomaly-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataProtectionImpact-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## LicenseAndUseTerms-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## PreprocessingStrategy-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Grant-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Creator-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## SamplingStrategy-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## UpdatePlan-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## FormatDialect-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataSubset-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Confidentiality-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## InstanceAcquisition-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## IPRestrictions-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DirectCollection-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Person-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Subpopulation-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## RawData-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CleaningStrategy-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Relationships-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## LicenseAndUseTerms-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Maintainer-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Erratum-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ThirdPartySharing-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Software-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## FundingMechanism-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Relationships-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DirectCollection-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## UseRepository-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## LabelingStrategy-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## RawData-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExternalResource-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Creator-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ThirdPartySharing-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataSubset-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Grantor-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DistributionDate-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## AddressingGap-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## SensitiveElement-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DatasetProperty-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionMechanism-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataAnomaly-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## PreprocessingStrategy-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## MissingInfo-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## UpdatePlan-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Subpopulation-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Deidentification-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Confidentiality-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataCollector-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Dataset-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ConsentRevocation-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## SensitiveElement-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Software-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataProtectionImpact-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DiscouragedUse-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DistributionFormat-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## RetentionLimits-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CleaningStrategy-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## OtherTask-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionNotification-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ConsentRevocation-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## SamplingStrategy-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## OtherTask-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ContentWarning-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## UseRepository-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DiscouragedUse-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## FutureUseImpact-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## EthicalReview-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExistingUse-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Software-invalid
+### Input
+```yaml
+id: 123
+
+```
+## CollectionConsent-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Subpopulation-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Creator-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Relationships-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Maintainer-invalid
+### Input
+```yaml
+id: 123
+
+```
+## LicenseAndUseTerms-invalid
+### Input
+```yaml
+id: 123
+
+```
+## LabelingStrategy-invalid
+### Input
+```yaml
+id: 123
+
+```
+## AddressingGap-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DistributionFormat-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Grant-invalid
+### Input
+```yaml
+id: 123
+
+```
+## InstanceAcquisition-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Dataset-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Confidentiality-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ThirdPartySharing-invalid
+### Input
+```yaml
+id: 123
+
+```
+## OtherTask-invalid
+### Input
+```yaml
+id: 123
+
+```
+## VersionAccess-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DataSubset-invalid
+### Input
+```yaml
+id: 123
+
+```
+## FundingMechanism-invalid
+### Input
+```yaml
+id: 123
+
+```
+## PreprocessingStrategy-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DirectCollection-invalid
+### Input
+```yaml
+id: 123
+
+```
+## MissingInfo-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ExportControlRegulatoryRestrictions-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Task-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Splits-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Grantor-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Instance-invalid
+### Input
+```yaml
+id: 123
+
+```
+## IPRestrictions-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Information-invalid
+### Input
+```yaml
+id: 123
+
+```
+## EthicalReview-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Purpose-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Erratum-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Person-invalid
+### Input
+```yaml
+id: 123
+
+```
+## UpdatePlan-invalid
+### Input
+```yaml
+id: 123
+
+```
+## CollectionTimeframe-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Deidentification-invalid
+### Input
+```yaml
+id: 123
+
+```
+## SamplingStrategy-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DataProtectionImpact-invalid
+### Input
+```yaml
+id: 123
+
+```
+## FutureUseImpact-invalid
+### Input
+```yaml
+id: 123
+
+```
+## CleaningStrategy-invalid
+### Input
+```yaml
+id: 123
+
+```
+## CollectionNotification-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DatasetProperty-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ContentWarning-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DataCollector-invalid
+### Input
+```yaml
+id: 123
+
+```
+## FormatDialect-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DistributionDate-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DiscouragedUse-invalid
+### Input
+```yaml
+id: 123
+
+```
+## RetentionLimits-invalid
+### Input
+```yaml
+id: 123
+
+```
+## CollectionMechanism-invalid
+### Input
+```yaml
+id: 123
+
+```
+## RawData-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ExternalResource-invalid
+### Input
+```yaml
+id: 123
+
+```
+## UseRepository-invalid
+### Input
+```yaml
+id: 123
+
+```
+## SensitiveElement-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DatasetCollection-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ConsentRevocation-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ExtensionMechanism-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DataAnomaly-invalid
+### Input
+```yaml
+id: 123
+
+```

--- a/examples/output/RawData-minimal.json
+++ b/examples/output/RawData-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:RawData",
+  "description": "[]",
+  "@type": "RawData"
+}

--- a/examples/output/RawData-minimal.yaml
+++ b/examples/output/RawData-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:RawData
+description: '[]'

--- a/examples/output/RawData-valid.json
+++ b/examples/output/RawData-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:RawData",
+  "description": "[]",
+  "@type": "RawData"
+}

--- a/examples/output/RawData-valid.yaml
+++ b/examples/output/RawData-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:RawData
+description: '[]'

--- a/examples/output/Relationships-minimal.json
+++ b/examples/output/Relationships-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Relationships",
+  "description": "[]",
+  "@type": "Relationships"
+}

--- a/examples/output/Relationships-minimal.yaml
+++ b/examples/output/Relationships-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Relationships
+description: '[]'

--- a/examples/output/Relationships-valid.json
+++ b/examples/output/Relationships-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Relationships",
+  "description": "[]",
+  "@type": "Relationships"
+}

--- a/examples/output/Relationships-valid.yaml
+++ b/examples/output/Relationships-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Relationships
+description: '[]'

--- a/examples/output/RetentionLimits-minimal.json
+++ b/examples/output/RetentionLimits-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:RetentionLimits",
+  "description": "[]",
+  "@type": "RetentionLimits"
+}

--- a/examples/output/RetentionLimits-minimal.yaml
+++ b/examples/output/RetentionLimits-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:RetentionLimits
+description: '[]'

--- a/examples/output/RetentionLimits-valid.json
+++ b/examples/output/RetentionLimits-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:RetentionLimits",
+  "description": "[]",
+  "@type": "RetentionLimits"
+}

--- a/examples/output/RetentionLimits-valid.yaml
+++ b/examples/output/RetentionLimits-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:RetentionLimits
+description: '[]'

--- a/examples/output/SamplingStrategy-minimal.json
+++ b/examples/output/SamplingStrategy-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:SamplingStrategy",
+  "@type": "SamplingStrategy"
+}

--- a/examples/output/SamplingStrategy-minimal.yaml
+++ b/examples/output/SamplingStrategy-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:SamplingStrategy

--- a/examples/output/SamplingStrategy-valid.json
+++ b/examples/output/SamplingStrategy-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:SamplingStrategy",
+  "@type": "SamplingStrategy"
+}

--- a/examples/output/SamplingStrategy-valid.yaml
+++ b/examples/output/SamplingStrategy-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:SamplingStrategy

--- a/examples/output/SensitiveElement-minimal.json
+++ b/examples/output/SensitiveElement-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:SensitiveElement",
+  "description": "[]",
+  "@type": "SensitiveElement"
+}

--- a/examples/output/SensitiveElement-minimal.yaml
+++ b/examples/output/SensitiveElement-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:SensitiveElement
+description: '[]'

--- a/examples/output/SensitiveElement-valid.json
+++ b/examples/output/SensitiveElement-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:SensitiveElement",
+  "description": "[]",
+  "@type": "SensitiveElement"
+}

--- a/examples/output/SensitiveElement-valid.yaml
+++ b/examples/output/SensitiveElement-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:SensitiveElement
+description: '[]'

--- a/examples/output/Software-minimal.json
+++ b/examples/output/Software-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Software",
+  "@type": "Software"
+}

--- a/examples/output/Software-minimal.yaml
+++ b/examples/output/Software-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Software

--- a/examples/output/Software-valid.json
+++ b/examples/output/Software-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Software",
+  "@type": "Software"
+}

--- a/examples/output/Software-valid.yaml
+++ b/examples/output/Software-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Software

--- a/examples/output/Splits-minimal.json
+++ b/examples/output/Splits-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Splits",
+  "description": "[]",
+  "@type": "Splits"
+}

--- a/examples/output/Splits-minimal.yaml
+++ b/examples/output/Splits-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Splits
+description: '[]'

--- a/examples/output/Splits-valid.json
+++ b/examples/output/Splits-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Splits",
+  "description": "[]",
+  "@type": "Splits"
+}

--- a/examples/output/Splits-valid.yaml
+++ b/examples/output/Splits-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Splits
+description: '[]'

--- a/examples/output/Subpopulation-minimal.json
+++ b/examples/output/Subpopulation-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Subpopulation",
+  "@type": "Subpopulation"
+}

--- a/examples/output/Subpopulation-minimal.yaml
+++ b/examples/output/Subpopulation-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Subpopulation

--- a/examples/output/Subpopulation-valid.json
+++ b/examples/output/Subpopulation-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Subpopulation",
+  "@type": "Subpopulation"
+}

--- a/examples/output/Subpopulation-valid.yaml
+++ b/examples/output/Subpopulation-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Subpopulation

--- a/examples/output/Task-minimal.json
+++ b/examples/output/Task-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Task",
+  "@type": "Task"
+}

--- a/examples/output/Task-minimal.yaml
+++ b/examples/output/Task-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Task

--- a/examples/output/Task-valid.json
+++ b/examples/output/Task-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:Task",
+  "@type": "Task"
+}

--- a/examples/output/Task-valid.yaml
+++ b/examples/output/Task-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:Task

--- a/examples/output/ThirdPartySharing-minimal.json
+++ b/examples/output/ThirdPartySharing-minimal.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ThirdPartySharing",
+  "@type": "ThirdPartySharing"
+}

--- a/examples/output/ThirdPartySharing-minimal.yaml
+++ b/examples/output/ThirdPartySharing-minimal.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ThirdPartySharing

--- a/examples/output/ThirdPartySharing-valid.json
+++ b/examples/output/ThirdPartySharing-valid.json
@@ -1,0 +1,5 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:ThirdPartySharing",
+  "@type": "ThirdPartySharing"
+}

--- a/examples/output/ThirdPartySharing-valid.yaml
+++ b/examples/output/ThirdPartySharing-valid.yaml
@@ -1,0 +1,2 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:ThirdPartySharing

--- a/examples/output/UpdatePlan-minimal.json
+++ b/examples/output/UpdatePlan-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:UpdatePlan",
+  "description": "[]",
+  "@type": "UpdatePlan"
+}

--- a/examples/output/UpdatePlan-minimal.yaml
+++ b/examples/output/UpdatePlan-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:UpdatePlan
+description: '[]'

--- a/examples/output/UpdatePlan-valid.json
+++ b/examples/output/UpdatePlan-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:UpdatePlan",
+  "description": "[]",
+  "@type": "UpdatePlan"
+}

--- a/examples/output/UpdatePlan-valid.yaml
+++ b/examples/output/UpdatePlan-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:UpdatePlan
+description: '[]'

--- a/examples/output/UseRepository-minimal.json
+++ b/examples/output/UseRepository-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:UseRepository",
+  "description": "[]",
+  "@type": "UseRepository"
+}

--- a/examples/output/UseRepository-minimal.yaml
+++ b/examples/output/UseRepository-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:UseRepository
+description: '[]'

--- a/examples/output/UseRepository-valid.json
+++ b/examples/output/UseRepository-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:UseRepository",
+  "description": "[]",
+  "@type": "UseRepository"
+}

--- a/examples/output/UseRepository-valid.yaml
+++ b/examples/output/UseRepository-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:UseRepository
+description: '[]'

--- a/examples/output/VersionAccess-minimal.json
+++ b/examples/output/VersionAccess-minimal.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:VersionAccess",
+  "description": "[]",
+  "@type": "VersionAccess"
+}

--- a/examples/output/VersionAccess-minimal.yaml
+++ b/examples/output/VersionAccess-minimal.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:VersionAccess
+description: '[]'

--- a/examples/output/VersionAccess-valid.json
+++ b/examples/output/VersionAccess-valid.json
@@ -1,0 +1,6 @@
+{
+  "id": "data_sheets_schema:123",
+  "category": "data_sheets_schema:VersionAccess",
+  "description": "[]",
+  "@type": "VersionAccess"
+}

--- a/examples/output/VersionAccess-valid.yaml
+++ b/examples/output/VersionAccess-valid.yaml
@@ -1,0 +1,3 @@
+id: data_sheets_schema:123
+category: data_sheets_schema:VersionAccess
+description: '[]'

--- a/project.Makefile
+++ b/project.Makefile
@@ -1,5 +1,10 @@
 ## Add your own custom Makefile targets here
 
+SCHEMA_EXAMPLEDIR = src/data/examples
+VALID_EXAMPLEDIR = $(SCHEMA_EXAMPLEDIR)/valid
+INVALID_EXAMPLEDIR = $(SCHEMA_EXAMPLEDIR)/invalid
+SCHEMA_CLASSES = $(shell $(RUN) yq -cr '.classes | keys | join(" ")' $(SOURCE_SCHEMA_PATH))
+
 IMPORTS = standards-schema standards-organization-schema
 
 all: update-imports site
@@ -13,3 +18,10 @@ standards-schema:
 standards-organization-schema:
 	curl -s https://raw.githubusercontent.com/bridge2ai/standards-schemas/main/src/standards_schemas/schema/standards_organization_schema.yaml \
 		-o $(SOURCE_SCHEMA_DIR)standards_organization_schema.yaml -z $(SOURCE_SCHEMA_DIR)standards_organization_schema.yaml
+
+# Generate minimal example files for all classes
+# For each file in the list, populate it with an id field
+gen-minimal-examples:
+	printf "# Example data file\n---\nid: \"data_sheets_schema:123\"\n" | tee -a $(patsubst %, $(VALID_EXAMPLEDIR)/%-minimal.yaml, $(SCHEMA_CLASSES))
+	printf "# Example data file - needs more contents\n---\nid: \"data_sheets_schema:123\"\n" | tee -a $(patsubst %, $(VALID_EXAMPLEDIR)/%-valid.yaml, $(SCHEMA_CLASSES))
+	printf "# Example invalid data file\n---\nid: 123\n" | tee -a $(patsubst %, $(INVALID_EXAMPLEDIR)/%-invalid.yaml, $(SCHEMA_CLASSES))

--- a/src/data/examples/Datasheet-001.yaml
+++ b/src/data/examples/Datasheet-001.yaml
@@ -1,3 +1,0 @@
-# Example data object
----
-id: data_sheets_schema:Datasheet001

--- a/src/data/examples/invalid/AddressingGap-invalid.yaml
+++ b/src/data/examples/invalid/AddressingGap-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/CleaningStrategy-invalid.yaml
+++ b/src/data/examples/invalid/CleaningStrategy-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/CollectionConsent-invalid.yaml
+++ b/src/data/examples/invalid/CollectionConsent-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/CollectionMechanism-invalid.yaml
+++ b/src/data/examples/invalid/CollectionMechanism-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/CollectionNotification-invalid.yaml
+++ b/src/data/examples/invalid/CollectionNotification-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/CollectionTimeframe-invalid.yaml
+++ b/src/data/examples/invalid/CollectionTimeframe-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Confidentiality-invalid.yaml
+++ b/src/data/examples/invalid/Confidentiality-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/ConsentRevocation-invalid.yaml
+++ b/src/data/examples/invalid/ConsentRevocation-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/ContentWarning-invalid.yaml
+++ b/src/data/examples/invalid/ContentWarning-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Creator-invalid.yaml
+++ b/src/data/examples/invalid/Creator-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DataAnomaly-invalid.yaml
+++ b/src/data/examples/invalid/DataAnomaly-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DataCollector-invalid.yaml
+++ b/src/data/examples/invalid/DataCollector-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DataProtectionImpact-invalid.yaml
+++ b/src/data/examples/invalid/DataProtectionImpact-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DataSubset-invalid.yaml
+++ b/src/data/examples/invalid/DataSubset-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Dataset-invalid.yaml
+++ b/src/data/examples/invalid/Dataset-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DatasetCollection-invalid.yaml
+++ b/src/data/examples/invalid/DatasetCollection-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DatasetProperty-invalid.yaml
+++ b/src/data/examples/invalid/DatasetProperty-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Deidentification-invalid.yaml
+++ b/src/data/examples/invalid/Deidentification-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DirectCollection-invalid.yaml
+++ b/src/data/examples/invalid/DirectCollection-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DiscouragedUse-invalid.yaml
+++ b/src/data/examples/invalid/DiscouragedUse-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DistributionDate-invalid.yaml
+++ b/src/data/examples/invalid/DistributionDate-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/DistributionFormat-invalid.yaml
+++ b/src/data/examples/invalid/DistributionFormat-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Erratum-invalid.yaml
+++ b/src/data/examples/invalid/Erratum-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/EthicalReview-invalid.yaml
+++ b/src/data/examples/invalid/EthicalReview-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/ExistingUse-invalid.yaml
+++ b/src/data/examples/invalid/ExistingUse-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/ExportControlRegulatoryRestrictions-invalid.yaml
+++ b/src/data/examples/invalid/ExportControlRegulatoryRestrictions-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/ExtensionMechanism-invalid.yaml
+++ b/src/data/examples/invalid/ExtensionMechanism-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/ExternalResource-invalid.yaml
+++ b/src/data/examples/invalid/ExternalResource-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/FormatDialect-invalid.yaml
+++ b/src/data/examples/invalid/FormatDialect-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/FundingMechanism-invalid.yaml
+++ b/src/data/examples/invalid/FundingMechanism-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/FutureUseImpact-invalid.yaml
+++ b/src/data/examples/invalid/FutureUseImpact-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Grant-invalid.yaml
+++ b/src/data/examples/invalid/Grant-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Grantor-invalid.yaml
+++ b/src/data/examples/invalid/Grantor-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/IPRestrictions-invalid.yaml
+++ b/src/data/examples/invalid/IPRestrictions-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Information-invalid.yaml
+++ b/src/data/examples/invalid/Information-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Instance-invalid.yaml
+++ b/src/data/examples/invalid/Instance-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/InstanceAcquisition-invalid.yaml
+++ b/src/data/examples/invalid/InstanceAcquisition-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/LabelingStrategy-invalid.yaml
+++ b/src/data/examples/invalid/LabelingStrategy-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/LicenseAndUseTerms-invalid.yaml
+++ b/src/data/examples/invalid/LicenseAndUseTerms-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Maintainer-invalid.yaml
+++ b/src/data/examples/invalid/Maintainer-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/MissingInfo-invalid.yaml
+++ b/src/data/examples/invalid/MissingInfo-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/OtherTask-invalid.yaml
+++ b/src/data/examples/invalid/OtherTask-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Person-invalid.yaml
+++ b/src/data/examples/invalid/Person-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/PreprocessingStrategy-invalid.yaml
+++ b/src/data/examples/invalid/PreprocessingStrategy-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Purpose-invalid.yaml
+++ b/src/data/examples/invalid/Purpose-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/RawData-invalid.yaml
+++ b/src/data/examples/invalid/RawData-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Relationships-invalid.yaml
+++ b/src/data/examples/invalid/Relationships-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/RetentionLimits-invalid.yaml
+++ b/src/data/examples/invalid/RetentionLimits-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/SamplingStrategy-invalid.yaml
+++ b/src/data/examples/invalid/SamplingStrategy-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/SensitiveElement-invalid.yaml
+++ b/src/data/examples/invalid/SensitiveElement-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Software-invalid.yaml
+++ b/src/data/examples/invalid/Software-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Splits-invalid.yaml
+++ b/src/data/examples/invalid/Splits-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Subpopulation-invalid.yaml
+++ b/src/data/examples/invalid/Subpopulation-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/Task-invalid.yaml
+++ b/src/data/examples/invalid/Task-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/ThirdPartySharing-invalid.yaml
+++ b/src/data/examples/invalid/ThirdPartySharing-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/UpdatePlan-invalid.yaml
+++ b/src/data/examples/invalid/UpdatePlan-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/UseRepository-invalid.yaml
+++ b/src/data/examples/invalid/UseRepository-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/invalid/VersionAccess-invalid.yaml
+++ b/src/data/examples/invalid/VersionAccess-invalid.yaml
@@ -1,0 +1,3 @@
+# Example invalid data file
+---
+id: 123

--- a/src/data/examples/valid/AddressingGap-minimal.yaml
+++ b/src/data/examples/valid/AddressingGap-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/AddressingGap-valid.yaml
+++ b/src/data/examples/valid/AddressingGap-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CleaningStrategy-minimal.yaml
+++ b/src/data/examples/valid/CleaningStrategy-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CleaningStrategy-valid.yaml
+++ b/src/data/examples/valid/CleaningStrategy-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CollectionConsent-minimal.yaml
+++ b/src/data/examples/valid/CollectionConsent-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CollectionConsent-valid.yaml
+++ b/src/data/examples/valid/CollectionConsent-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CollectionMechanism-minimal.yaml
+++ b/src/data/examples/valid/CollectionMechanism-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CollectionMechanism-valid.yaml
+++ b/src/data/examples/valid/CollectionMechanism-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CollectionNotification-minimal.yaml
+++ b/src/data/examples/valid/CollectionNotification-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CollectionNotification-valid.yaml
+++ b/src/data/examples/valid/CollectionNotification-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CollectionTimeframe-minimal.yaml
+++ b/src/data/examples/valid/CollectionTimeframe-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/CollectionTimeframe-valid.yaml
+++ b/src/data/examples/valid/CollectionTimeframe-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Confidentiality-minimal.yaml
+++ b/src/data/examples/valid/Confidentiality-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Confidentiality-valid.yaml
+++ b/src/data/examples/valid/Confidentiality-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ConsentRevocation-minimal.yaml
+++ b/src/data/examples/valid/ConsentRevocation-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ConsentRevocation-valid.yaml
+++ b/src/data/examples/valid/ConsentRevocation-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ContentWarning-minimal.yaml
+++ b/src/data/examples/valid/ContentWarning-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ContentWarning-valid.yaml
+++ b/src/data/examples/valid/ContentWarning-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Creator-minimal.yaml
+++ b/src/data/examples/valid/Creator-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Creator-valid.yaml
+++ b/src/data/examples/valid/Creator-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DataAnomaly-minimal.yaml
+++ b/src/data/examples/valid/DataAnomaly-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DataAnomaly-valid.yaml
+++ b/src/data/examples/valid/DataAnomaly-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DataCollector-minimal.yaml
+++ b/src/data/examples/valid/DataCollector-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DataCollector-valid.yaml
+++ b/src/data/examples/valid/DataCollector-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DataProtectionImpact-minimal.yaml
+++ b/src/data/examples/valid/DataProtectionImpact-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DataProtectionImpact-valid.yaml
+++ b/src/data/examples/valid/DataProtectionImpact-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DataSubset-minimal.yaml
+++ b/src/data/examples/valid/DataSubset-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DataSubset-valid.yaml
+++ b/src/data/examples/valid/DataSubset-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Dataset-minimal.yaml
+++ b/src/data/examples/valid/Dataset-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Dataset-valid.yaml
+++ b/src/data/examples/valid/Dataset-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DatasetCollection-minimal.yaml
+++ b/src/data/examples/valid/DatasetCollection-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DatasetCollection-valid.yaml
+++ b/src/data/examples/valid/DatasetCollection-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DatasetProperty-minimal.yaml
+++ b/src/data/examples/valid/DatasetProperty-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DatasetProperty-valid.yaml
+++ b/src/data/examples/valid/DatasetProperty-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Deidentification-minimal.yaml
+++ b/src/data/examples/valid/Deidentification-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Deidentification-valid.yaml
+++ b/src/data/examples/valid/Deidentification-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DirectCollection-minimal.yaml
+++ b/src/data/examples/valid/DirectCollection-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DirectCollection-valid.yaml
+++ b/src/data/examples/valid/DirectCollection-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DiscouragedUse-minimal.yaml
+++ b/src/data/examples/valid/DiscouragedUse-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DiscouragedUse-valid.yaml
+++ b/src/data/examples/valid/DiscouragedUse-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DistributionDate-minimal.yaml
+++ b/src/data/examples/valid/DistributionDate-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DistributionDate-valid.yaml
+++ b/src/data/examples/valid/DistributionDate-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DistributionFormat-minimal.yaml
+++ b/src/data/examples/valid/DistributionFormat-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/DistributionFormat-valid.yaml
+++ b/src/data/examples/valid/DistributionFormat-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Erratum-minimal.yaml
+++ b/src/data/examples/valid/Erratum-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Erratum-valid.yaml
+++ b/src/data/examples/valid/Erratum-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/EthicalReview-minimal.yaml
+++ b/src/data/examples/valid/EthicalReview-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/EthicalReview-valid.yaml
+++ b/src/data/examples/valid/EthicalReview-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ExistingUse-minimal.yaml
+++ b/src/data/examples/valid/ExistingUse-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ExistingUse-valid.yaml
+++ b/src/data/examples/valid/ExistingUse-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ExportControlRegulatoryRestrictions-minimal.yaml
+++ b/src/data/examples/valid/ExportControlRegulatoryRestrictions-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ExportControlRegulatoryRestrictions-valid.yaml
+++ b/src/data/examples/valid/ExportControlRegulatoryRestrictions-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ExtensionMechanism-minimal.yaml
+++ b/src/data/examples/valid/ExtensionMechanism-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ExtensionMechanism-valid.yaml
+++ b/src/data/examples/valid/ExtensionMechanism-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ExternalResource-minimal.yaml
+++ b/src/data/examples/valid/ExternalResource-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ExternalResource-valid.yaml
+++ b/src/data/examples/valid/ExternalResource-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/FormatDialect-minimal.yaml
+++ b/src/data/examples/valid/FormatDialect-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/FormatDialect-valid.yaml
+++ b/src/data/examples/valid/FormatDialect-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/FundingMechanism-minimal.yaml
+++ b/src/data/examples/valid/FundingMechanism-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/FundingMechanism-valid.yaml
+++ b/src/data/examples/valid/FundingMechanism-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/FutureUseImpact-minimal.yaml
+++ b/src/data/examples/valid/FutureUseImpact-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/FutureUseImpact-valid.yaml
+++ b/src/data/examples/valid/FutureUseImpact-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Grant-minimal.yaml
+++ b/src/data/examples/valid/Grant-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Grant-valid.yaml
+++ b/src/data/examples/valid/Grant-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Grantor-minimal.yaml
+++ b/src/data/examples/valid/Grantor-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Grantor-valid.yaml
+++ b/src/data/examples/valid/Grantor-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/IPRestrictions-minimal.yaml
+++ b/src/data/examples/valid/IPRestrictions-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/IPRestrictions-valid.yaml
+++ b/src/data/examples/valid/IPRestrictions-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Information-minimal.yaml
+++ b/src/data/examples/valid/Information-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Information-valid.yaml
+++ b/src/data/examples/valid/Information-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Instance-minimal.yaml
+++ b/src/data/examples/valid/Instance-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Instance-valid.yaml
+++ b/src/data/examples/valid/Instance-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/InstanceAcquisition-minimal.yaml
+++ b/src/data/examples/valid/InstanceAcquisition-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/InstanceAcquisition-valid.yaml
+++ b/src/data/examples/valid/InstanceAcquisition-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/LabelingStrategy-minimal.yaml
+++ b/src/data/examples/valid/LabelingStrategy-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/LabelingStrategy-valid.yaml
+++ b/src/data/examples/valid/LabelingStrategy-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/LicenseAndUseTerms-minimal.yaml
+++ b/src/data/examples/valid/LicenseAndUseTerms-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/LicenseAndUseTerms-valid.yaml
+++ b/src/data/examples/valid/LicenseAndUseTerms-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Maintainer-minimal.yaml
+++ b/src/data/examples/valid/Maintainer-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Maintainer-valid.yaml
+++ b/src/data/examples/valid/Maintainer-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/MissingInfo-minimal.yaml
+++ b/src/data/examples/valid/MissingInfo-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/MissingInfo-valid.yaml
+++ b/src/data/examples/valid/MissingInfo-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/OtherTask-minimal.yaml
+++ b/src/data/examples/valid/OtherTask-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/OtherTask-valid.yaml
+++ b/src/data/examples/valid/OtherTask-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Person-minimal.yaml
+++ b/src/data/examples/valid/Person-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Person-valid.yaml
+++ b/src/data/examples/valid/Person-valid.yaml
@@ -1,3 +1,13 @@
-# Example data file - needs more contents
+# Example data file
 ---
-id: "data_sheets_schema:123"
+id: alice_smith
+name: "Alice Smith"
+description: "A person with a background in computer science and a passion for open source."
+affiliation:
+  - B2AI_ORG:8
+  - B2AI_ORG:31
+email: "alice.smith@example.com"
+contributor_name: "John Doe"
+contributor_github_name: "johndoe"
+contributor_orcid: "0000-0000-0000-0000"
+contribution_date: "2023-03-22"

--- a/src/data/examples/valid/Person-valid.yaml
+++ b/src/data/examples/valid/Person-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/PreprocessingStrategy-minimal.yaml
+++ b/src/data/examples/valid/PreprocessingStrategy-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/PreprocessingStrategy-valid.yaml
+++ b/src/data/examples/valid/PreprocessingStrategy-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Purpose-minimal.yaml
+++ b/src/data/examples/valid/Purpose-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Purpose-valid.yaml
+++ b/src/data/examples/valid/Purpose-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/RawData-minimal.yaml
+++ b/src/data/examples/valid/RawData-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/RawData-valid.yaml
+++ b/src/data/examples/valid/RawData-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Relationships-minimal.yaml
+++ b/src/data/examples/valid/Relationships-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Relationships-valid.yaml
+++ b/src/data/examples/valid/Relationships-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/RetentionLimits-minimal.yaml
+++ b/src/data/examples/valid/RetentionLimits-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/RetentionLimits-valid.yaml
+++ b/src/data/examples/valid/RetentionLimits-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/SamplingStrategy-minimal.yaml
+++ b/src/data/examples/valid/SamplingStrategy-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/SamplingStrategy-valid.yaml
+++ b/src/data/examples/valid/SamplingStrategy-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/SensitiveElement-minimal.yaml
+++ b/src/data/examples/valid/SensitiveElement-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/SensitiveElement-valid.yaml
+++ b/src/data/examples/valid/SensitiveElement-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Software-minimal.yaml
+++ b/src/data/examples/valid/Software-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Software-valid.yaml
+++ b/src/data/examples/valid/Software-valid.yaml
@@ -1,3 +1,8 @@
 # Example data file - needs more contents
 ---
-id: "data_sheets_schema:123"
+id: my_software
+name: "My Software"
+description: "This is an example of a software program."
+version: "1.0.0"
+license: "MIT License"
+url: "https://www.example.com/my_software"

--- a/src/data/examples/valid/Software-valid.yaml
+++ b/src/data/examples/valid/Software-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Splits-minimal.yaml
+++ b/src/data/examples/valid/Splits-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Splits-valid.yaml
+++ b/src/data/examples/valid/Splits-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Subpopulation-minimal.yaml
+++ b/src/data/examples/valid/Subpopulation-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Subpopulation-valid.yaml
+++ b/src/data/examples/valid/Subpopulation-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Task-minimal.yaml
+++ b/src/data/examples/valid/Task-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/Task-valid.yaml
+++ b/src/data/examples/valid/Task-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ThirdPartySharing-minimal.yaml
+++ b/src/data/examples/valid/ThirdPartySharing-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/ThirdPartySharing-valid.yaml
+++ b/src/data/examples/valid/ThirdPartySharing-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/UpdatePlan-minimal.yaml
+++ b/src/data/examples/valid/UpdatePlan-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/UpdatePlan-valid.yaml
+++ b/src/data/examples/valid/UpdatePlan-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/UseRepository-minimal.yaml
+++ b/src/data/examples/valid/UseRepository-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/UseRepository-valid.yaml
+++ b/src/data/examples/valid/UseRepository-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/VersionAccess-minimal.yaml
+++ b/src/data/examples/valid/VersionAccess-minimal.yaml
@@ -1,0 +1,3 @@
+# Example data file
+---
+id: "data_sheets_schema:123"

--- a/src/data/examples/valid/VersionAccess-valid.yaml
+++ b/src/data/examples/valid/VersionAccess-valid.yaml
@@ -1,0 +1,3 @@
+# Example data file - needs more contents
+---
+id: "data_sheets_schema:123"

--- a/src/data_sheets_schema/schema/data_sheets_schema.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema.yaml
@@ -122,6 +122,8 @@ classes:
       double_quote:
       header:
       quote_char:
+    slots:
+      - id
 
   Person:
     description: An individual human being.

--- a/src/data_sheets_schema/schema/data_sheets_schema.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema.yaml
@@ -85,7 +85,6 @@ classes:
   # Adapted from linkml Datasets schema - see
   # https://github.com/linkml/linkml-model/blob/main/linkml_model/model/schema/datasets.yaml
   Information:
-    abstract: true
     description: Grouping for datasets and data files
     close_mappings:
       - schema:CreativeWork


### PR DESCRIPTION
There is definitely a way to automate the process of generating data examples for a schema, but for now I am directly asking Mistral through its chat interface to do this:

Given the following LinkML schema in YAML format, please provide a data object conforming to the schema.
{schema class}

This really isn't that far off from what SPIRES already does or the approach [detailed here](https://linkml.io/linkml/howtos/generate-ai-prompts.html) in the LinkML docs, but it would be helpful to formalize it.