### PR TITLE
Fix D4D Assistant MCP tool permissions in GitHub Actions

### DIFF
--- a/.github/workflows/d4d-agent.yml
+++ b/.github/workflows/d4d-agent.yml
@@ -197,4 +197,4 @@ jobs:
           enable-obo-scripts: 'true'
           enable-python-tools: 'true'
           python-packages: 'aurelian jinja2-cli "wrapt>=1.17.2"'
-          claude-allowed-tools: '["FileEdit", "Edit", "Edit(*)", "Write", "Bash", "Bash(git:*)", "Bash(gh:*)", "Bash(echo:*)", "Bash(cat:*)", "Bash(mkdir:*)"]'
+          claude-allowed-tools: '["FileEdit", "Edit", "Edit(*)", "Write", "Bash", "Bash(git:*)", "Bash(gh:*)", "Bash(poetry:*)", "Bash(make:*)", "Bash(python:*)", "Bash(uv:*)", "Bash(echo:*)", "Bash(cat:*)", "Bash(mkdir:*)", "Bash(grep:*)", "Bash(head:*)", "Bash(tail:*)", "Bash(sort:*)", "Bash(curl:*)", "mcp__github__*", "mcp__artl__*", "WebSearch", "WebFetch"]'


### PR DESCRIPTION
## Summary

Fixes the permission error when the D4D Assistant tries to use MCP tools in GitHub Actions (issue #66).

## Problem

The D4D Assistant workflow had a restrictive claude-allowed-tools list that didn't include MCP server permissions, causing permission errors when trying to use mcp__artl__get_europepmc_full_text and other MCP tools.

## Solution

Updated .github/workflows/d4d-agent.yml to include:
- mcp__github__* - GitHub operations via MCP
- mcp__artl__* - Academic literature retrieval via MCP
- WebSearch - Web search capabilities  
- WebFetch - Web content fetching
- Additional Bash commands for tooling (poetry, make, python, uv, grep, etc.)

This matches the local .claude/settings.json permissions and allows the assistant to retrieve scientific papers when creating datasheets.

## Test Plan

- [x] Verified changes match local settings.json permissions
- [ ] Test on issue #66 after merge to verify MCP tools work in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)