### PR TITLE
Add explicit save location for D4D Assistant datasheets

### DIFF
--- a/.github/workflows/d4d_assistant_create.md
+++ b/.github/workflows/d4d_assistant_create.md
@@ -167,15 +167,21 @@ collection_process:
 
 ### 5. Save and Validate
 
-**Determine Save Location:**
-```bash
-# Suggested locations:
-# - src/data/examples/valid/<dataset_name>_d4d.yaml (for example datasets)
-# - data/extracted_by_column/<project>/<dataset_name>_d4d.yaml (for project datasets)
+**Save Location:**
 
-# Use project-specific directory if dataset belongs to a known project (AI_READI, CHORUS, CM4AI, VOICE)
-OUTPUT_FILE="data/extracted_by_column/<project>/<dataset_name>_d4d.yaml"
+All D4D datasheets created by the assistant MUST be saved to:
+```bash
+# Extract dataset name from YAML (use lowercase, replace spaces with underscores)
+DATASET_NAME="<dataset_name>"  # e.g., "cm4ai", "ai_readi_voice"
+
+# Save location (REQUIRED - all assistant-created D4Ds go here)
+OUTPUT_FILE="data/sheets_d4dassistant/${DATASET_NAME}_d4d.yaml"
 ```
+
+**Why this location:**
+- Separates assistant-created datasheets from manually curated examples
+- All assistant outputs in one place for easy review and management
+- Distinct from project-specific extraction outputs in `data/extracted_by_column/`
 
 **Validate Against Schema:**
 

--- a/data/sheets_d4dassistant/README.md
+++ b/data/sheets_d4dassistant/README.md
@@ -1,0 +1,41 @@
+# D4D Assistant Generated Datasheets
+
+This directory contains D4D (Datasheets for Datasets) YAML files created by the D4D Assistant via GitHub Actions.
+
+## Purpose
+
+- **Automated Extraction**: Datasheets generated from documentation URLs by the D4D Assistant
+- **Review Staging**: All assistant-created datasheets saved here for human review before promotion
+- **Separation of Concerns**: Keeps automated outputs separate from:
+  - Manually curated examples (`src/data/examples/valid/`)
+  - Project-specific extractions (`data/extracted_by_column/`)
+
+## File Naming Convention
+
+Files follow the pattern: `<dataset_name>_d4d.yaml`
+
+Where `<dataset_name>` is:
+- Lowercase
+- Spaces replaced with underscores
+- Derived from the dataset's official name or identifier
+
+Examples:
+- `cm4ai_d4d.yaml`
+- `ai_readi_voice_d4d.yaml`
+- `chorus_dataset_d4d.yaml`
+
+## Workflow
+
+1. **Creation**: D4D Assistant extracts metadata from documentation URLs
+2. **Validation**: YAML validated against D4D schema before PR creation
+3. **Review**: Human reviewers check accuracy and completeness
+4. **Promotion**: After approval, files may be:
+   - Moved to `src/data/examples/valid/` (if suitable as example)
+   - Kept here as project documentation
+   - Integrated into project-specific directories
+
+## Related Documentation
+
+- `.github/workflows/d4d_assistant_create.md` - Instructions for D4D Assistant
+- `CLAUDE.md` - Project instructions and D4D guidance
+- `src/data_sheets_schema/schema/data_sheets_schema_all.yaml` - Full D4D schema


### PR DESCRIPTION
## Summary

Adds a designated directory for D4D Assistant to save all created datasheets.

## Changes

- **Create** `data/sheets_d4dassistant/` directory with README
- **Update** `.github/workflows/d4d_assistant_create.md` with explicit save location
- **Replace** ambiguous 'suggested locations' with required `OUTPUT_FILE` path
- **Clarify** separation between assistant outputs, examples, and extractions

## Save Location

All D4D datasheets created by the assistant will now be saved to:
```
data/sheets_d4dassistant/${DATASET_NAME}_d4d.yaml
```

## Why This Change

Previously the instructions suggested multiple locations which could cause confusion. Now the assistant has one clear designated location for outputs, making it easier to:
- Find all assistant-created datasheets
- Review and manage automated outputs
- Separate from manually curated examples and project-specific extractions

## Test Plan

- [x] Created directory with README
- [x] Updated instructions to use explicit path
- [ ] Test with next D4D Assistant run to verify it uses this location

🤖 Generated with [Claude Code](https://claude.com/claude-code)