### PR TITLE
Add Read, Glob, and Grep tool permissions to D4D Assistant

### DIFF
--- a/.github/workflows/d4d-agent.yml
+++ b/.github/workflows/d4d-agent.yml
@@ -197,4 +197,4 @@ jobs:
           enable-obo-scripts: 'true'
           enable-python-tools: 'true'
           python-packages: 'aurelian jinja2-cli "wrapt>=1.17.2"'
-          claude-allowed-tools: '["FileEdit", "Edit", "Edit(*)", "Write", "Bash", "Bash(git:*)", "Bash(gh:*)", "Bash(poetry:*)", "Bash(make:*)", "Bash(python:*)", "Bash(uv:*)", "Bash(echo:*)", "Bash(cat:*)", "Bash(mkdir:*)", "Bash(grep:*)", "Bash(head:*)", "Bash(tail:*)", "Bash(sort:*)", "Bash(curl:*)", "mcp__github__*", "mcp__artl__*", "WebSearch", "WebFetch"]'
+          claude-allowed-tools: '["Read", "Glob", "Grep", "FileEdit", "Edit", "Edit(*)", "Write", "Bash", "Bash(git:*)", "Bash(gh:*)", "Bash(poetry:*)", "Bash(make:*)", "Bash(python:*)", "Bash(uv:*)", "Bash(echo:*)", "Bash(cat:*)", "Bash(mkdir:*)", "Bash(grep:*)", "Bash(head:*)", "Bash(tail:*)", "Bash(sort:*)", "Bash(curl:*)", "mcp__github__*", "mcp__artl__*", "WebSearch", "WebFetch"]'


### PR DESCRIPTION
## Summary

Adds essential file operation tools to the D4D Assistant's allowed tools list.

## Problem

The D4D Assistant was getting permission errors in GitHub Actions:
```
Claude requested permissions to read from /tmp/ai-input/user-prompt.txt, 
but you haven't granted it
```

This happened because the `Read` tool wasn't in the allowed tools list.

## Solution

Added three fundamental tools to `claude-allowed-tools`:
- **`Read`** - Read files from the repository and system (including `/tmp/ai-input/user-prompt.txt`)
- **`Glob`** - Find files by pattern when exploring the codebase
- **`Grep`** - Search file contents during metadata extraction

## Why These Are Needed

- **Read**: Required to read the user's prompt and any files in the repository
- **Glob**: Helps find schema files, examples, and other resources by pattern
- **Grep**: Searches for specific content when extracting metadata

Without these tools, the assistant cannot perform basic file operations needed for D4D datasheet creation.

## Related

- Follows up on #67 (MCP permissions)
- Fixes permission error from: https://github.com/bridge2ai/data-sheets-schema/actions/runs/19179976699/job/54834131167

🤖 Generated with [Claude Code](https://claude.com/claude-code)