### PR TITLE
Add Direct File Access link to D4D Assistant instructions

### DIFF
--- a/.github/workflows/d4d_assistant_create.md
+++ b/.github/workflows/d4d_assistant_create.md
@@ -350,6 +350,9 @@ I've created a new D4D datasheet for **${DATASET_NAME}** and opened a pull reque
 ## Pull Request
 🔗 #${PR_NUMBER}
 
+## Direct File Access
+📄 **D4D YAML Link**: https://raw.githubusercontent.com/bridge2ai/data-sheets-schema/${BRANCH_NAME}/${OUTPUT_FILE}
+
 ## What I Created
 - **YAML Datasheet**: \`${OUTPUT_FILE}\`
 - **HTML Preview**: \`${OUTPUT_FILE%.yaml}.html\`

--- a/.github/workflows/d4d_assistant_edit.md
+++ b/.github/workflows/d4d_assistant_edit.md
@@ -405,6 +405,9 @@ I've updated the D4D datasheet for **${DATASET_NAME}** and opened a pull request
 ## Pull Request
 🔗 #${PR_NUMBER}
 
+## Direct File Access
+📄 **D4D YAML Link**: https://raw.githubusercontent.com/bridge2ai/data-sheets-schema/${BRANCH_NAME}/<path-to-file>.yaml
+
 ## Changes Summary
 <!-- Briefly describe what was changed -->
 - ✏️ **Modified**: <list modified fields>


### PR DESCRIPTION
## Summary
Added a **Direct File Access** section to both D4D Assistant instruction files that includes a raw GitHub URL for directly accessing the YAML files created by the assistant.

## Changes Made
- **Added**: Direct File Access section to `d4d_assistant_create.md`
- **Added**: Direct File Access section to `d4d_assistant_edit.md`

## Files Modified
- `.github/workflows/d4d_assistant_create.md`
- `.github/workflows/d4d_assistant_edit.md`

## What This Enables
When the D4D Assistant creates or updates datasheets and posts comments to GitHub issues, it will now include a direct raw GitHub URL to the YAML file in the format:

```
## Direct File Access
📄 **D4D YAML Link**: https://raw.githubusercontent.com/bridge2ai/data-sheets-schema/{BRANCH_NAME}/{OUTPUT_FILE}
```

This allows external APIs and agents to:
- Directly download the YAML file without parsing through the PR
- Access the file via HTTP requests (`curl`, `wget`, etc.)
- Retrieve the content programmatically without GitHub authentication (for public repos)

## Example URL
For a file created at `data/sheets_d4dassistant/cm4ai_d4d.yaml` on branch `d4d/add-cm4ai-datasheet`:

📄 **D4D YAML Link**: https://raw.githubusercontent.com/bridge2ai/data-sheets-schema/d4d/add-cm4ai-datasheet/data/sheets_d4dassistant/cm4ai_d4d.yaml

## Validation
✅ No code changes - documentation only
✅ Follows existing formatting patterns
✅ Uses template variables consistent with the rest of the instructions

Related to: #74

---
🤖 Generated with D4D Assistant