### PR TITLE
Add D4D datasheet: T2D Longitudinal Study

### DIFF
--- a/data/sheets_d4dassistant/t2d_longitudinal_study_d4d.html
+++ b/data/sheets_d4dassistant/t2d_longitudinal_study_d4d.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>T2D Longitudinal Study</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        h1 { color: #333; }
+        .field { margin-bottom: 20px; }
+        .field-label { font-weight: bold; color: #555; }
+        .field-value { margin-left: 20px; }
+    </style>
+</head>
+<body>
+    <h1>D4D Datasheet: T2D Longitudinal Study</h1>
+    
+    <div class="field">
+        <div class="field-label">Dataset ID:</div>
+        <div class="field-value">t2d_longitudinal_study</div>
+    </div>
+    
+    <div class="field">
+        <div class="field-label">Dataset Name:</div>
+        <div class="field-value">T2D Longitudinal Study</div>
+    </div>
+    
+    <div class="field">
+        <div class="field-label">Description:</div>
+        <div class="field-value">5-year longitudinal study of 1000 Type 2 diabetes patients to track clinical measurements and lab results over time. Dataset contains CSV files with clinical measurements and laboratory test results.</div>
+    </div>
+    
+    <div class="field">
+        <div class="field-label">License:</div>
+        <div class="field-value">CC-BY-4.0</div>
+    </div>
+</body>
+</html>

--- a/data/sheets_d4dassistant/t2d_longitudinal_study_d4d.yaml
+++ b/data/sheets_d4dassistant/t2d_longitudinal_study_d4d.yaml
@@ -1,0 +1,4 @@
+id: t2d_longitudinal_study
+name: T2D Longitudinal Study
+description: 5-year longitudinal study of 1000 Type 2 diabetes patients to track clinical measurements and lab results over time. Dataset contains CSV files with clinical measurements and laboratory test results.
+license: CC-BY-4.0


### PR DESCRIPTION
## Summary
Created new D4D datasheet for **T2D Longitudinal Study** based on information provided in issue #76:

### Source Information
- Dataset name: T2D Longitudinal Study
- Description: 5-year longitudinal study of 1000 Type 2 diabetes patients
- Format: CSV files with clinical measurements and lab results
- License: CC-BY-4.0

## Files Added
- `data/sheets_d4dassistant/t2d_longitudinal_study_d4d.yaml` - D4D YAML datasheet
- `data/sheets_d4dassistant/t2d_longitudinal_study_d4d.html` - HTML preview

## Validation
- ✅ Schema validation passed
- ✅ Required fields populated (id, name)
- ✅ YAML syntax valid

## Key Metadata Extracted
- **Dataset ID**: `t2d_longitudinal_study`
- **Dataset Name**: T2D Longitudinal Study
- **Description**: 5-year longitudinal study of 1000 Type 2 diabetes patients to track clinical measurements and lab results over time
- **License**: CC-BY-4.0

## How to Review
1. **View HTML preview**: Open `data/sheets_d4dassistant/t2d_longitudinal_study_d4d.html` in a browser for human-readable format
2. **Check YAML**: Review `data/sheets_d4dassistant/t2d_longitudinal_study_d4d.yaml` for completeness and accuracy
3. **Verify required fields**: Ensure `id` and `name` are present and accurate

## Notes
- This is a minimal datasheet created from limited information provided in the issue
- Additional metadata can be added if more detailed documentation sources are available
- The datasheet follows the D4D schema structure with only required fields populated

Related to: #76

---
🤖 Generated with D4D Assistant