### PR TITLE
Add budget monitoring to D4D Assistant

### DIFF
--- a/.github/workflows/d4d-agent.yml
+++ b/.github/workflows/d4d-agent.yml
@@ -182,6 +182,8 @@ jobs:
 
       - name: Respond with AI Agent
         uses: dragon-ai-agent/run-claude-obo@v1.0.2
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           github-token: ${{ secrets.PAT_FOR_PR }}

--- a/.github/workflows/d4d_assistant_create.md
+++ b/.github/workflows/d4d_assistant_create.md
@@ -336,7 +336,24 @@ EOF
 )"
 ```
 
-### 8. Notify User in GitHub Issue
+### 8. Check Budget and Prepare Warning (If Needed)
+
+Before posting your final comment to the GitHub issue, check the CBORG API budget:
+
+```bash
+# Check budget spending and capture warning if over threshold
+BUDGET_WARNING=$(python3 scripts/check_budget.py)
+```
+
+**What this does:**
+- Queries the CBORG API to get current spending
+- If spending is > 75% of the $500 budget, outputs a warning message
+- The warning will be appended to your GitHub issue comment
+- If spending is under 75%, `BUDGET_WARNING` will be empty (no warning needed)
+
+**Note**: The script handles missing API keys gracefully - if `ANTHROPIC_API_KEY` is not set, it will skip the check and exit cleanly.
+
+### 9. Notify User in GitHub Issue
 
 ```bash
 # Comment on the original issue with PR link and instructions
@@ -373,9 +390,12 @@ I've created a new D4D datasheet for **${DATASET_NAME}** and opened a pull reque
 
 The datasheet has been validated against the D4D schema and is ready for review.
 
+${BUDGET_WARNING}
 ---
 🤖 D4D Assistant"
 ```
+
+**Important**: The `${BUDGET_WARNING}` variable will be empty if spending is under 75%, or will contain the budget alert message if over threshold. This ensures the warning only appears when needed.
 
 ## Modifying an Existing PR
 

--- a/.github/workflows/d4d_assistant_edit.md
+++ b/.github/workflows/d4d_assistant_edit.md
@@ -391,7 +391,24 @@ EOF
 )"
 ```
 
-### 8. Notify User in GitHub Issue
+### 8. Check Budget and Prepare Warning (If Needed)
+
+Before posting your final comment to the GitHub issue, check the CBORG API budget:
+
+```bash
+# Check budget spending and capture warning if over threshold
+BUDGET_WARNING=$(python3 scripts/check_budget.py)
+```
+
+**What this does:**
+- Queries the CBORG API to get current spending
+- If spending is > 75% of the $500 budget, outputs a warning message
+- The warning will be appended to your GitHub issue comment
+- If spending is under 75%, `BUDGET_WARNING` will be empty (no warning needed)
+
+**Note**: The script handles missing API keys gracefully - if `ANTHROPIC_API_KEY` is not set, it will skip the check and exit cleanly.
+
+### 9. Notify User in GitHub Issue
 
 ```bash
 # Comment on the original issue with PR link
@@ -429,9 +446,12 @@ I've updated the D4D datasheet for **${DATASET_NAME}** and opened a pull request
 
 The updated datasheet has been validated and is ready for review.
 
+${BUDGET_WARNING}
 ---
 🤖 D4D Assistant"
 ```
+
+**Important**: The `${BUDGET_WARNING}` variable will be empty if spending is under 75%, or will contain the budget alert message if over threshold. This ensures the warning only appears when needed.
 
 ## Modifying an Existing PR
 

--- a/scripts/check_budget.py
+++ b/scripts/check_budget.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Check CBORG API budget spending and warn if over threshold.
+
+This script queries the CBORG API to get current spending information
+and outputs a warning if spending exceeds 75% of the budget.
+
+Environment variables:
+    ANTHROPIC_API_KEY: Anthropic API key managed by CBORG (required)
+
+Exit codes:
+    0: Success (budget checked, under threshold or warning printed)
+    1: Error (could not check budget)
+
+Output format (if > 75%):
+    WARNING: XX.X%
+    $XXX.XX / $XXX.XX
+"""
+
+import os
+import sys
+import json
+
+def check_budget():
+    """
+    Check the CBORG API budget and return spending information.
+
+    Returns:
+        dict or None: Dictionary with 'spend', 'max_budget', and 'percent' keys,
+                     or None if budget check failed or API key not available.
+    """
+    # Check for API key - prefer ANTHROPIC_API_KEY (GitHub Actions), fall back to CBORG_API_KEY (local dev)
+    api_key = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CBORG_API_KEY")
+    if not api_key:
+        print("Warning: Neither ANTHROPIC_API_KEY nor CBORG_API_KEY set, skipping budget check", file=sys.stderr)
+        return None
+
+    try:
+        # Use requests if available, otherwise fall back to urllib
+        try:
+            import requests
+            response = requests.get(
+                "https://api.cborg.lbl.gov/key/info",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=10
+            )
+            response.raise_for_status()
+            data = response.json()
+        except ImportError:
+            # Fallback to urllib if requests not available
+            import urllib.request
+            import urllib.error
+
+            req = urllib.request.Request(
+                "https://api.cborg.lbl.gov/key/info",
+                headers={"Authorization": f"Bearer {api_key}"}
+            )
+            with urllib.request.urlopen(req, timeout=10) as response:
+                data = json.loads(response.read().decode())
+
+        spend = data["info"]["spend"]
+        max_budget = data["info"]["max_budget"]
+        percent = (spend / max_budget) * 100
+
+        return {
+            "spend": spend,
+            "max_budget": max_budget,
+            "percent": percent
+        }
+    except Exception as e:
+        print(f"Warning: Could not check budget: {e}", file=sys.stderr)
+        return None
+
+
+def format_budget_warning(budget_info):
+    """
+    Format budget information as a warning message.
+
+    Args:
+        budget_info (dict): Budget information with spend, max_budget, and percent
+
+    Returns:
+        str: Formatted warning message for GitHub comments
+    """
+    return f"""---
+⚠️ **Budget Alert**: D4D Assistant CBORG API spending is at {budget_info['percent']:.1f}% of budget (${budget_info['spend']:.2f} / ${budget_info['max_budget']:.2f})
+
+Please notify the maintainers to review CBORG API budget.
+"""
+
+
+def main():
+    """Main entry point for budget checking script."""
+    result = check_budget()
+
+    if result is None:
+        # Could not check budget, exit silently (already warned to stderr)
+        sys.exit(0)
+
+    # Print budget info to stderr for logging
+    print(f"Budget check: ${result['spend']:.2f} / ${result['max_budget']:.2f} ({result['percent']:.1f}%)",
+          file=sys.stderr)
+
+    # If over threshold, print warning to stdout for capture
+    if result["percent"] > 75:
+        print(format_budget_warning(result))
+        sys.exit(0)
+
+    # Under threshold, no output needed
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add automatic budget monitoring to the D4D Assistant that checks CBORG API spending after each run and displays a warning in GitHub issue comments when spending exceeds 75% of the configured budget.

## Changes

### New Files
- `scripts/check_budget.py` - Python script to query CBORG API and check spending
  - Queries `https://api.cborg.lbl.gov/key/info` for current spending
  - Outputs formatted warning message if spending > 75% of $500 budget
  - Handles missing API keys gracefully
  - Works with both `ANTHROPIC_API_KEY` (GitHub Actions) and `CBORG_API_KEY` (local dev)

### Modified Files
- `.github/workflows/d4d-agent.yml` - Pass `ANTHROPIC_API_KEY` to assistant environment
- `.github/workflows/d4d_assistant_create.md` - Add budget check step before final issue comment
- `.github/workflows/d4d_assistant_edit.md` - Add budget check step before final issue comment

## How It Works

1. **After completing its work**, the D4D Assistant runs `python3 scripts/check_budget.py`
2. **Script queries CBORG API** using the `ANTHROPIC_API_KEY` to get current spending
3. **If spending > 75%**, the script outputs a warning message:
   ```
   ⚠️ Budget Alert: D4D Assistant CBORG API spending is at XX.X% of budget ($XXX / $500)
   Please notify the maintainers to review CBORG API budget.
   ```
4. **Warning is appended** to the GitHub issue comment automatically
5. **If under 75%**, no warning is shown

## Benefits
- **Proactive monitoring** - Maintainers are notified before budget is exhausted
- **Automatic tracking** - No manual budget checks needed
- **Unobtrusive** - Only appears when action is needed (>75% threshold)
- **Informative** - Shows exact spending and percentage

## Testing

Tested locally:
- ✅ Script handles missing API keys gracefully
- ✅ Warning format is correct and readable
- ✅ Threshold logic (75%) works correctly
- ✅ Falls back to `CBORG_API_KEY` for local development

## Next Steps

After merging, ensure that:
1. `ANTHROPIC_API_KEY` secret is set in GitHub repository settings (already exists)
2. The key has access to the CBORG API endpoint
3. Monitor the first few assistant runs to verify budget checks work as expected

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)