### PR TITLE
Add AIO ontology mappings to BiasTypeEnum

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - name: Install Poetry.
         uses: snok/install-poetry@v1.3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
 

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - name: Install Poetry.
         uses: snok/install-poetry@v1.3

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - name: Install Poetry
         run: |

--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,9 @@ examples/%.json: src/data/examples/%.yaml
 examples/%.ttl: src/data/examples/%.yaml
 	$(RUN) linkml-convert -P EXAMPLE=http://example.org/ -s $(SOURCE_SCHEMA_PATH) -C Person $< -o $@
 
-test-examples: examples/output
+test-examples: full-schema examples/output
 
-examples/output: src/data_sheets_schema/schema/data_sheets_schema.yaml
+examples/output: src/data_sheets_schema/schema/data_sheets_schema_all.yaml
 	mkdir -p $@
 	$(RUN) linkml-run-examples \
 		--output-formats json \

--- a/docs/enum_ontology_grounding_report.md
+++ b/docs/enum_ontology_grounding_report.md
@@ -1,0 +1,396 @@
+# Enumeration Ontology Grounding Report
+
+**Date**: 2025-12-01
+**Issue**: Identify and ground enumerations in ontology terms where appropriate
+**Related PR**: #96 (RO-Crate integration)
+
+## Executive Summary
+
+Analyzed all enumerations in the D4D schema to identify which lack ontology term groundings. Successfully added **Artificial Intelligence Ontology (AIO)** mappings to BiasTypeEnum (9 bias types), complementing existing DUO mappings for data use permissions and ISO/NIST/TLP mappings for confidentiality levels.
+
+**Status Overview:**
+- **Fully Grounded**: 3 enums (DataUsePermissionEnum, ConfidentialityLevelEnum, BiasTypeEnum)
+- **Taxonomy-Based**: 2 enums (CRediTRoleEnum, VersionTypeEnum)
+- **Technical Standards**: 4 enums (FormatEnum, MediaTypeEnum, CompressionEnum, EncodingEnum)
+- **Ungrounded**: 5 enums (VariableTypeEnum, DatasetRelationshipTypeEnum, ComplianceStatusEnum, AIActRiskEnum, CreatorOrMaintainerEnum)
+
+## Changes Made
+
+### BiasTypeEnum - Added AIO Mappings
+
+**File**: `src/data_sheets_schema/schema/D4D_Base_import.yaml`
+
+**Changes**:
+1. Added AIO prefix: `AIO: https://w3id.org/aio/`
+2. Updated BiasTypeEnum description to reference AIO taxonomy
+3. Added ontology mappings for all 9 bias types
+
+| Enum Value | Mapping Type | AIO Term | IRI |
+|------------|--------------|----------|-----|
+| confirmation_bias | `meaning:` (exact) | ConfirmationBias | AIO:ConfirmationBias |
+| historical_bias | `meaning:` (exact) | HistoricalBias | AIO:HistoricalBias |
+| representation_bias | `meaning:` (exact) | RepresentationBias | AIO:RepresentationBias |
+| measurement_bias | `meaning:` (exact) | MeasurementBias | AIO:MeasurementBias |
+| selection_bias | `broad_mappings:` | SelectionAndSamplingBias | AIO:SelectionAndSamplingBias |
+| sampling_bias | `broad_mappings:` | SelectionAndSamplingBias | AIO:SelectionAndSamplingBias |
+| aggregation_bias | `broad_mappings:` | EcologicalFallacyBias | AIO:EcologicalFallacyBias |
+| algorithmic_bias | `broad_mappings:` | ProcessingBias, ComputationalBias | AIO:ProcessingBias, AIO:ComputationalBias |
+| annotation_bias | `broad_mappings:` | AnnotatorReportingBias | AIO:AnnotatorReportingBias |
+
+**Mapping Strategy**:
+- **Exact matches** (`meaning:`): Used when D4D bias type semantically equals AIO term
+- **Broader mappings** (`broad_mappings:`): Used when AIO provides parent class or related concept
+
+## Complete Enumeration Inventory
+
+### 1. GROUNDED ENUMERATIONS (using ontology terms)
+
+#### DataUsePermissionEnum ✓
+- **Location**: `D4D_Data_Governance.yaml`
+- **Values**: 22 permission types
+- **Ontology**: Data Use Ontology (DUO) from GA4GH
+- **Grounding**: All values have `meaning:` mappings to DUO terms
+- **Examples**:
+  - `no_restriction` → DUO:0000004
+  - `general_research_use` → DUO:0000042
+  - `health_medical_biomedical_research` → DUO:0000006
+  - `no_commercial_use` → DUO:0000046
+  - `ethics_approval_required` → DUO:0000021
+
+#### ConfidentialityLevelEnum ✓
+- **Location**: `D4D_Data_Governance.yaml`
+- **Values**: 3 confidentiality levels
+- **Standards**: Traffic Light Protocol (TLP), NIST SP 800-60, ISO 27001
+- **Grounding**: All values have `broad_mappings:` to established classification frameworks
+- **Mappings**:
+  - `unrestricted` → TLP:CLEAR, NIST_Low_Impact, ISO27001_Public
+  - `restricted` → TLP:GREEN, NIST_Moderate_Impact, ISO27001_Internal
+  - `confidential` → TLP:AMBER, NIST_High_Impact, ISO27001_Highly_Confidential
+
+#### BiasTypeEnum ✓ (NEW)
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 9 bias types
+- **Ontology**: Artificial Intelligence Ontology (AIO) from BioPortal
+- **Grounding**: 4 exact matches (`meaning:`), 5 broader mappings (`broad_mappings:`)
+- **Reference**: https://bioportal.bioontology.org/ontologies/AIO
+- **See**: Detailed mapping table above
+
+### 2. TAXONOMY-BASED ENUMERATIONS (self-referential standards)
+
+#### CRediTRoleEnum
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 14 contributor roles
+- **Taxonomy**: CRediT (Contributor Roles Taxonomy)
+- **Status**: CRediT is itself a standardized taxonomy
+- **Grounding**: Could add official CRediT URIs (e.g., from CASRAI)
+- **Priority**: Low (CRediT roles are widely recognized standard)
+- **Examples**: conceptualization, data_curation, formal_analysis, funding_acquisition
+
+#### VersionTypeEnum
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 3 version types (MAJOR, MINOR, PATCH)
+- **Standard**: Semantic Versioning (semver.org)
+- **Status**: Description references semver.org specification
+- **Grounding**: Could add semver URIs if formalized ontology exists
+- **Priority**: Low (semver is universally recognized standard)
+
+### 3. TECHNICAL/REGISTRY ENUMERATIONS (standard registries)
+
+#### FormatEnum
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 5 format types (CSV, JSON, XML, Parquet, HDF5)
+- **Registry**: Format names follow common conventions
+- **Grounding**: Could map to PRONOM/IANA format registries
+- **Priority**: Medium
+- **Note**: These are technical file formats with established registries
+
+#### MediaTypeEnum
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 13 MIME types
+- **Registry**: IANA Media Types Registry
+- **Grounding**: Values ARE the standard (IANA MIME types)
+- **Priority**: N/A (already using standard format)
+- **Examples**: text/csv, application/json, application/pdf
+
+#### CompressionEnum
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 6 compression types (gzip, bzip2, zip, tar, xz, lzma)
+- **Standard**: File compression standards
+- **Grounding**: Could map to format registries
+- **Priority**: Low (well-established compression formats)
+
+#### EncodingEnum
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 43 character encodings
+- **Registry**: IANA Character Sets Registry
+- **Grounding**: Values follow IANA encoding names
+- **Priority**: N/A (already using standard format)
+- **Examples**: UTF-8, UTF-16, ISO-8859-1, Windows-1252
+
+### 4. UNGROUNDED ENUMERATIONS (candidates for ontology mapping)
+
+#### VariableTypeEnum - HIGH PRIORITY
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 13 variable types
+- **Current Status**: No ontology mappings
+- **Recommendation**: Map to schema.org or statistical ontologies (STATO)
+- **Examples**:
+  - categorical, continuous, ordinal, binary, nominal
+  - temporal, spatial, identifier, text, image
+- **Potential Ontologies**:
+  - schema.org (PropertyValue types)
+  - Statistics Ontology (STATO)
+  - Dublin Core types
+- **Impact**: Medium - affects variable metadata documentation
+
+#### DatasetRelationshipTypeEnum - MEDIUM PRIORITY
+- **Location**: `D4D_Composition.yaml`
+- **Values**: 14 relationship types
+- **Current Status**: No ontology mappings
+- **Recommendation**: Map to DataCite/Dublin Core relationship vocabularies
+- **Examples**:
+  - derives_from, supplements, is_version_of, replaces
+  - is_part_of, has_part, references, is_identical_to
+- **Potential Standards**:
+  - DataCite Relation Type vocabulary
+  - Dublin Core Terms (dcterms relations)
+  - PROV-O (provenance relationships)
+- **Impact**: Medium - affects dataset composition and provenance
+
+#### ComplianceStatusEnum - LOW PRIORITY
+- **Location**: `D4D_Data_Governance.yaml`
+- **Values**: 5 compliance status values
+- **Current Status**: No ontology mappings
+- **Status Values**: compliant, partially_compliant, not_compliant, not_applicable, under_review
+- **Recommendation**: Generic workflow states; ontology mapping may not add value
+- **Priority**: Low (domain-agnostic status values)
+- **Impact**: Low - clear semantic meaning without ontology
+
+#### AIActRiskEnum - LOW PRIORITY
+- **Location**: `D4D_Data_Governance.yaml`
+- **Values**: 4 risk categories
+- **Current Status**: References EU AI Act in description
+- **Status Values**: minimal_risk, limited_risk, high_risk, unacceptable_risk
+- **Recommendation**: Add official EU AI Act regulation URIs if available
+- **Reference**: https://artificialintelligenceact.eu/
+- **Priority**: Low (EU AI Act categories are legally defined)
+- **Impact**: Low - EU AI Act provides authoritative definitions
+
+#### CreatorOrMaintainerEnum - LOW PRIORITY
+- **Location**: `D4D_Base_import.yaml`
+- **Values**: 2 role values (creator, maintainer)
+- **Current Status**: No ontology mappings
+- **Recommendation**: Could map to PROV-O or Dublin Core roles
+- **Priority**: Low (simple role distinction)
+- **Impact**: Low - clear semantic meaning
+
+## Recommendations
+
+### Immediate Actions (Completed)
+- [x] Map BiasTypeEnum to AIO terms
+- [x] Add AIO prefix to schema
+- [x] Regenerate schema artifacts
+- [x] Update documentation
+
+### Future Enhancements (Priority Order)
+
+1. **HIGH PRIORITY**: VariableTypeEnum
+   - Map to STATO (Statistics Ontology) or schema.org
+   - Improves statistical metadata interoperability
+   - Benefits: Better tooling integration, clearer semantics
+
+2. **MEDIUM PRIORITY**: DatasetRelationshipTypeEnum
+   - Map to DataCite Relation Types and/or Dublin Core
+   - Improves dataset provenance interoperability
+   - Benefits: Standards compliance, better discovery
+
+3. **LOW PRIORITY**: Technical enumerations
+   - FormatEnum: Map to PRONOM format registry
+   - CRediTRoleEnum: Add official CRediT URIs
+   - AIActRiskEnum: Add EU AI Act regulation URIs
+   - Benefits: Marginal improvement to interoperability
+
+4. **OPTIONAL**: Status/Role enumerations
+   - ComplianceStatusEnum: Consider generic workflow ontology
+   - CreatorOrMaintainerEnum: Map to PROV-O or Dublin Core
+   - Benefits: Minimal - clear without ontology grounding
+
+### Considerations
+
+**When to Ground in Ontology Terms:**
+- ✅ Domain-specific concepts with established ontologies (bias types, data use permissions)
+- ✅ Concepts with semantic ambiguity across communities
+- ✅ Interoperability with other systems/schemas is important
+
+**When NOT to Ground:**
+- ❌ Self-evident technical standards (MIME types, character encodings)
+- ❌ Legally defined categories (EU AI Act risk levels)
+- ❌ Simple binary/ternary distinctions (creator vs maintainer)
+- ❌ When values ARE the standard (IANA registry entries)
+
+## References
+
+### Ontologies & Standards Used
+
+1. **Data Use Ontology (DUO)**
+   - URL: https://github.com/EBISPOT/DUO
+   - Used for: DataUsePermissionEnum
+   - Coverage: Comprehensive data use permissions
+
+2. **Artificial Intelligence Ontology (AIO)**
+   - URL: https://bioportal.bioontology.org/ontologies/AIO
+   - Used for: BiasTypeEnum
+   - Coverage: 59 bias classes covering AI/ML contexts
+
+3. **Information Classification Frameworks**
+   - Traffic Light Protocol (TLP)
+   - NIST SP 800-60 (Security Categorization)
+   - ISO 27001 (Information Security)
+   - Used for: ConfidentialityLevelEnum
+
+### Potential Future Ontologies
+
+4. **Statistics Ontology (STATO)**
+   - URL: http://stato-ontology.org/
+   - Candidate for: VariableTypeEnum
+   - Coverage: Statistical concepts and data types
+
+5. **DataCite Metadata Schema**
+   - URL: https://schema.datacite.org/
+   - Candidate for: DatasetRelationshipTypeEnum
+   - Coverage: Dataset relationships and provenance
+
+6. **Dublin Core Terms**
+   - URL: http://purl.org/dc/terms/
+   - Candidate for: DatasetRelationshipTypeEnum, CreatorOrMaintainerEnum
+   - Coverage: General metadata relationships
+
+7. **PROV Ontology (PROV-O)**
+   - URL: https://www.w3.org/TR/prov-o/
+   - Candidate for: DatasetRelationshipTypeEnum, CreatorOrMaintainerEnum
+   - Coverage: Provenance and attribution
+
+8. **CRediT Taxonomy**
+   - URL: https://credit.niso.org/
+   - Candidate for: CRediTRoleEnum (add formal URIs)
+   - Coverage: Contributor roles in scholarly publishing
+
+## Implementation Notes
+
+### Mapping Types in LinkML
+
+LinkML supports several mapping relationship types:
+
+- **`meaning:`** - Exact semantic equivalence to ontology term
+- **`exact_mappings:`** - Exactly equivalent terms
+- **`broad_mappings:`** - Current term is narrower than mapped term
+- **`narrow_mappings:`** - Current term is broader than mapped term
+- **`close_mappings:`** - Closely related but not exact
+- **`related_mappings:`** - Related concepts
+
+### BiasTypeEnum Mapping Decisions
+
+**Exact Matches (meaning:)**
+- Used when D4D definition precisely matches AIO definition
+- Examples: confirmation_bias, historical_bias, measurement_bias, representation_bias
+
+**Broader Mappings (broad_mappings:)**
+- Used when AIO provides parent class or related concept
+- Examples: selection_bias → SelectionAndSamplingBias (parent class)
+- Examples: algorithmic_bias → ProcessingBias + ComputationalBias (related concepts)
+
+**Rationale**: Preserves semantic precision while enabling ontology-based reasoning and interoperability.
+
+## Impact Assessment
+
+### Benefits of Ontology Grounding
+
+1. **Improved Interoperability**
+   - Schema consumers can map to same ontology terms
+   - Enables automated reasoning and inference
+   - Facilitates data integration across systems
+
+2. **Semantic Clarity**
+   - Ontology definitions provide authoritative semantics
+   - Reduces ambiguity in interpretation
+   - Links to broader knowledge graphs
+
+3. **Tooling Support**
+   - Ontology-aware tools can provide better validation
+   - Enables semantic search and discovery
+   - Supports automated metadata enrichment
+
+4. **Standards Alignment**
+   - Demonstrates commitment to community standards
+   - Facilitates regulatory compliance (e.g., GDPR, HIPAA)
+   - Improves citation and attribution
+
+### Risks and Trade-offs
+
+1. **Ontology Stability**
+   - External ontologies may change or deprecate terms
+   - Requires monitoring and maintenance
+   - Mitigation: Use stable, well-maintained ontologies (DUO, AIO)
+
+2. **Complexity**
+   - Additional learning curve for schema users
+   - More complex validation requirements
+   - Mitigation: Clear documentation and examples
+
+3. **Flexibility**
+   - Ontology constraints may limit expressiveness
+   - May not cover all edge cases
+   - Mitigation: Use `broad_mappings:` for approximate matches
+
+## Appendix: AIO Bias Taxonomy
+
+### AIO Ontology Structure
+
+The Artificial Intelligence Ontology (AIO) provides a comprehensive taxonomy of 59 bias types organized hierarchically:
+
+**Top-Level Bias Classes:**
+- **Bias** (root class)
+  - **ComputationalBias** - Bias in data analysis and methods
+    - ProcessingBias
+    - SelectionAndSamplingBias
+  - **IndividualBias** - Cognitive and behavioral biases
+    - CognitiveBias
+    - BehavioralBias
+  - **SystemicBias** - Structural and societal biases
+    - GroupBias
+    - InstitutionalBias
+  - **HistoricalBias** - Long-standing societal biases
+  - **HumanBias** - Human-introduced biases
+
+**Selection and Sampling Bias Subclasses (relevant to D4D):**
+- MeasurementBias
+- RepresentationBias
+- DetectionBias
+- EvaluationBias
+- ExclusionBias
+- EcologicalFallacyBias
+- DataGenerationBias
+- PopulationBias
+
+**Processing Bias Subclasses:**
+- AmplificationBias
+- ErrorPropagationBias
+- ModelSelectionBias
+- InheritedBias
+
+**Individual Bias Subclasses:**
+- ConfirmationBias
+- AnnotatorReportingBias
+- AnchoringBias
+- AvailabilityHeuristicBias
+- AutomationComplacencyBias
+
+This hierarchical structure enables fine-grained bias classification while maintaining compatibility with broader bias categories.
+
+## Changelog
+
+**2025-12-01**:
+- Initial enumeration inventory completed
+- Added AIO mappings to BiasTypeEnum (9 bias types)
+- Documented grounding strategy and recommendations
+- Created comprehensive enumeration report

--- a/examples/output/FormatDialect-minimal.json
+++ b/examples/output/FormatDialect-minimal.json
@@ -1,4 +1,0 @@
-{
-  "id": "data_sheets_schema:123",
-  "@type": "FormatDialect"
-}

--- a/examples/output/FormatDialect-minimal.yaml
+++ b/examples/output/FormatDialect-minimal.yaml
@@ -1,1 +1,0 @@
-id: data_sheets_schema:123

--- a/examples/output/FormatDialect-valid.json
+++ b/examples/output/FormatDialect-valid.json
@@ -1,4 +1,0 @@
-{
-  "id": "data_sheets_schema:123",
-  "@type": "FormatDialect"
-}

--- a/examples/output/FormatDialect-valid.yaml
+++ b/examples/output/FormatDialect-valid.yaml
@@ -1,1 +1,0 @@
-id: data_sheets_schema:123

--- a/examples/output/Person-minimal.json
+++ b/examples/output/Person-minimal.json
@@ -1,4 +1,0 @@
-{
-  "id": "data_sheets_schema:123",
-  "@type": "Person"
-}

--- a/examples/output/Person-minimal.yaml
+++ b/examples/output/Person-minimal.yaml
@@ -1,1 +1,0 @@
-id: data_sheets_schema:123

--- a/examples/output/Person-valid.json
+++ b/examples/output/Person-valid.json
@@ -1,5 +1,0 @@
-{
-  "id": "data_sheets_schema:123",
-  "category": "data_sheets_schema:Person",
-  "@type": "Person"
-}

--- a/examples/output/Person-valid.yaml
+++ b/examples/output/Person-valid.yaml
@@ -1,2 +1,0 @@
-id: data_sheets_schema:123
-category: data_sheets_schema:Person

--- a/examples/output/README.md
+++ b/examples/output/README.md
@@ -1,136 +1,4 @@
-## DatasetProperty-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Splits-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## FundingMechanism-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Dataset-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Subpopulation-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## LicenseAndUseTerms-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## CleaningStrategy-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DataAnomaly-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ExportControlRegulatoryRestrictions-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## AddressingGap-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Splits-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DataProtectionImpact-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## LicenseAndUseTerms-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ConsentRevocation-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ExternalResource-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DirectCollection-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## CollectionNotification-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## SensitiveElement-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## CollectionMechanism-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DirectCollection-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## LabelingStrategy-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Grant-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DataAnomaly-valid
+## EthicalReview-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -142,31 +10,25 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
-## CollectionTimeframe-valid
+## InstanceAcquisition-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## FutureUseImpact-valid
+## Software-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## DataCollector-minimal
+## Task-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## LabelingStrategy-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## UpdatePlan-valid
+## Instance-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -178,37 +40,156 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
-## DistributionFormat-valid
+## LabelingStrategy-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## InstanceAcquisition-minimal
+## CollectionNotification-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## DatasetProperty-valid
+## Task-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## DistributionDate-valid
+## PreprocessingStrategy-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## OtherTask-minimal
+## SamplingStrategy-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## OtherTask-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Creator-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Grantor-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## UseRepository-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Software-valid
+### Input
+```yaml
+description: This is an example of a software program.
+id: my_software
+license: MIT License
+name: My Software
+url: https://www.example.com/my_software
+version: 1.0.0
+
+```
+## DataProtectionImpact-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Splits-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
 ## Relationships-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Splits-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExistingUse-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Purpose-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ThirdPartySharing-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## RetentionLimits-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## LicenseAndUseTerms-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## UpdatePlan-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Confidentiality-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionTimeframe-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataProtectionImpact-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## SensitiveElement-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DatasetProperty-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -226,31 +207,7 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
-## CollectionNotification-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Creator-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## EthicalReview-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DatasetCollection-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DistributionDate-minimal
+## CollectionTimeframe-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -262,13 +219,133 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
-## PreprocessingStrategy-valid
+## Maintainer-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## Information-valid
+## FutureUseImpact-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Maintainer-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CleaningStrategy-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Purpose-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## UpdatePlan-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExternalResource-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionMechanism-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Subpopulation-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExtensionMechanism-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataAnomaly-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExtensionMechanism-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataSubset-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DistributionFormat-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## RetentionLimits-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DataCollector-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## InstanceAcquisition-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## LabelingStrategy-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExistingUse-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## UseRepository-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Erratum-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Deidentification-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -286,91 +363,13 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
-## RetentionLimits-valid
+## IPRestrictions-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## Deidentification-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Subpopulation-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Grantor-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DataSubset-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## AddressingGap-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## RawData-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Maintainer-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ExtensionMechanism-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DiscouragedUse-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DistributionFormat-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Instance-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DataProtectionImpact-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## SamplingStrategy-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## FutureUseImpact-minimal
+## DatasetProperty-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -382,103 +381,13 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
-## Task-valid
+## DataAnomaly-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## RawData-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Grant-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Erratum-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Confidentiality-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ContentWarning-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Deidentification-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Purpose-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DataCollector-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ConsentRevocation-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Dataset-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ExistingUse-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## DatasetCollection-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Software-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## CollectionTimeframe-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## PreprocessingStrategy-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## CleaningStrategy-minimal
+## LicenseAndUseTerms-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -490,127 +399,13 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
-## ThirdPartySharing-valid
+## Deidentification-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## CollectionMechanism-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ThirdPartySharing-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Confidentiality-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ContentWarning-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Purpose-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ExtensionMechanism-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## ExternalResource-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Task-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## IPRestrictions-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Maintainer-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## UpdatePlan-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Relationships-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## UseRepository-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## SamplingStrategy-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## IPRestrictions-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## SensitiveElement-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## MissingInfo-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Instance-minimal
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Creator-valid
-### Input
-```yaml
-id: data_sheets_schema:123
-
-```
-## Grantor-valid
+## PreprocessingStrategy-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -622,13 +417,91 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
+## Dataset-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CleaningStrategy-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionNotification-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Creator-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## FutureUseImpact-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
 ## Erratum-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## ExistingUse-minimal
+## RawData-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Instance-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ConsentRevocation-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## AddressingGap-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DistributionDate-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## IPRestrictions-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## FundingMechanism-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Confidentiality-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DatasetCollection-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
@@ -640,114 +513,169 @@ id: data_sheets_schema:123
 id: data_sheets_schema:123
 
 ```
-## OtherTask-valid
+## Grantor-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## Software-valid
-### Input
-```yaml
-description: This is an example of a software program.
-id: my_software
-license: MIT License
-name: My Software
-url: https://www.example.com/my_software
-version: 1.0.0
-
-```
-## InstanceAcquisition-valid
+## DatasetCollection-valid
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## RetentionLimits-minimal
+## ContentWarning-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## UseRepository-valid
+## Dataset-minimal
 ### Input
 ```yaml
 id: data_sheets_schema:123
 
 ```
-## ThirdPartySharing-invalid
+## DirectCollection-valid
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## UpdatePlan-invalid
+## ExportControlRegulatoryRestrictions-valid
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## MissingInfo-invalid
+## Relationships-minimal
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## DistributionFormat-invalid
+## RawData-valid
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## CollectionMechanism-invalid
+## DataCollector-minimal
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## ContentWarning-invalid
+## ContentWarning-valid
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## Splits-invalid
+## ConsentRevocation-minimal
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## ExtensionMechanism-invalid
+## DirectCollection-minimal
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## Grantor-invalid
+## OtherTask-minimal
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## DataAnomaly-invalid
+## Grant-valid
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## Subpopulation-invalid
+## SensitiveElement-valid
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## DataProtectionImpact-invalid
+## DistributionFormat-minimal
 ### Input
 ```yaml
-id: 123
+id: data_sheets_schema:123
 
 ```
-## RawData-invalid
+## DistributionDate-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Subpopulation-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## MissingInfo-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Grant-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ThirdPartySharing-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## DiscouragedUse-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionMechanism-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## SamplingStrategy-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## AddressingGap-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## Information-valid
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## ExternalResource-minimal
+### Input
+```yaml
+id: data_sheets_schema:123
+
+```
+## CollectionConsent-invalid
 ### Input
 ```yaml
 id: 123
@@ -759,235 +687,7 @@ id: 123
 id: 123
 
 ```
-## Purpose-invalid
-### Input
-```yaml
-id: 123
-
-```
-## SamplingStrategy-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Relationships-invalid
-### Input
-```yaml
-id: 123
-
-```
-## FormatDialect-invalid
-### Input
-```yaml
-id: 123
-
-```
-## CollectionConsent-invalid
-### Input
-```yaml
-id: 123
-
-```
-## DistributionDate-invalid
-### Input
-```yaml
-id: 123
-
-```
-## DataSubset-invalid
-### Input
-```yaml
-id: 123
-
-```
-## DatasetProperty-invalid
-### Input
-```yaml
-id: 123
-
-```
 ## CollectionTimeframe-invalid
-### Input
-```yaml
-id: 123
-
-```
-## PreprocessingStrategy-invalid
-### Input
-```yaml
-id: 123
-
-```
-## DiscouragedUse-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Dataset-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Erratum-invalid
-### Input
-```yaml
-id: 123
-
-```
-## CollectionNotification-invalid
-### Input
-```yaml
-id: 123
-
-```
-## LicenseAndUseTerms-invalid
-### Input
-```yaml
-id: 123
-
-```
-## IPRestrictions-invalid
-### Input
-```yaml
-id: 123
-
-```
-## DataCollector-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Deidentification-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Maintainer-invalid
-### Input
-```yaml
-id: 123
-
-```
-## RetentionLimits-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Creator-invalid
-### Input
-```yaml
-id: 123
-
-```
-## OtherTask-invalid
-### Input
-```yaml
-id: 123
-
-```
-## DirectCollection-invalid
-### Input
-```yaml
-id: 123
-
-```
-## SensitiveElement-invalid
-### Input
-```yaml
-id: 123
-
-```
-## ExportControlRegulatoryRestrictions-invalid
-### Input
-```yaml
-id: 123
-
-```
-## FutureUseImpact-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Task-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Grant-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Instance-invalid
-### Input
-```yaml
-id: 123
-
-```
-## CleaningStrategy-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Confidentiality-invalid
-### Input
-```yaml
-id: 123
-
-```
-## ConsentRevocation-invalid
-### Input
-```yaml
-id: 123
-
-```
-## VersionAccess-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Software-invalid
-### Input
-```yaml
-id: 123
-
-```
-## InstanceAcquisition-invalid
-### Input
-```yaml
-id: 123
-
-```
-## DatasetCollection-invalid
-### Input
-```yaml
-id: 123
-
-```
-## AddressingGap-invalid
-### Input
-```yaml
-id: 123
-
-```
-## ExternalResource-invalid
-### Input
-```yaml
-id: 123
-
-```
-## Person-invalid
 ### Input
 ```yaml
 id: 123
@@ -999,7 +699,79 @@ id: 123
 id: 123
 
 ```
+## LicenseAndUseTerms-invalid
+### Input
+```yaml
+id: 123
+
+```
+## UpdatePlan-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Confidentiality-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DataProtectionImpact-invalid
+### Input
+```yaml
+id: 123
+
+```
+## SensitiveElement-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ExtensionMechanism-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DataSubset-invalid
+### Input
+```yaml
+id: 123
+
+```
+## RetentionLimits-invalid
+### Input
+```yaml
+id: 123
+
+```
 ## ExistingUse-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Maintainer-invalid
+### Input
+```yaml
+id: 123
+
+```
+## FutureUseImpact-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Subpopulation-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ExportControlRegulatoryRestrictions-invalid
 ### Input
 ```yaml
 id: 123
@@ -1011,13 +783,241 @@ id: 123
 id: 123
 
 ```
+## FormatDialect-invalid
+### Input
+```yaml
+id: 123
+
+```
+## CollectionNotification-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Task-invalid
+### Input
+```yaml
+id: 123
+
+```
+## InstanceAcquisition-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Software-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Grantor-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Splits-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Purpose-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Dataset-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Person-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Relationships-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DataCollector-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DistributionDate-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DatasetCollection-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ContentWarning-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ThirdPartySharing-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DiscouragedUse-invalid
+### Input
+```yaml
+id: 123
+
+```
+## CollectionMechanism-invalid
+### Input
+```yaml
+id: 123
+
+```
+## SamplingStrategy-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ExternalResource-invalid
+### Input
+```yaml
+id: 123
+
+```
+## ConsentRevocation-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DirectCollection-invalid
+### Input
+```yaml
+id: 123
+
+```
+## OtherTask-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DistributionFormat-invalid
+### Input
+```yaml
+id: 123
+
+```
+## MissingInfo-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Grant-invalid
+### Input
+```yaml
+id: 123
+
+```
+## IPRestrictions-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DatasetProperty-invalid
+### Input
+```yaml
+id: 123
+
+```
+## VersionAccess-invalid
+### Input
+```yaml
+id: 123
+
+```
 ## UseRepository-invalid
 ### Input
 ```yaml
 id: 123
 
 ```
+## Erratum-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Deidentification-invalid
+### Input
+```yaml
+id: 123
+
+```
 ## FundingMechanism-invalid
+### Input
+```yaml
+id: 123
+
+```
+## CleaningStrategy-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Creator-invalid
+### Input
+```yaml
+id: 123
+
+```
+## Instance-invalid
+### Input
+```yaml
+id: 123
+
+```
+## RawData-invalid
+### Input
+```yaml
+id: 123
+
+```
+## AddressingGap-invalid
+### Input
+```yaml
+id: 123
+
+```
+## DataAnomaly-invalid
+### Input
+```yaml
+id: 123
+
+```
+## PreprocessingStrategy-invalid
 ### Input
 ```yaml
 id: 123

--- a/project/jsonld/data_sheets_schema.jsonld
+++ b/project/jsonld/data_sheets_schema.jsonld
@@ -8013,9 +8013,9 @@
   ],
   "metamodel_version": "1.7.0",
   "source_file": "data_sheets_schema.yaml",
-  "source_file_date": "2025-12-01T20:19:46",
+  "source_file_date": "2025-12-02T20:12:10",
   "source_file_size": 12266,
-  "generation_date": "2025-12-01T21:10:33",
+  "generation_date": "2025-12-02T20:14:02",
   "@type": "SchemaDefinition",
   "@context": [
     "project/jsonld/data_sheets_schema.context.jsonld",

--- a/project/jsonld/data_sheets_schema.jsonld
+++ b/project/jsonld/data_sheets_schema.jsonld
@@ -827,44 +827,64 @@
     {
       "name": "BiasTypeEnum",
       "definition_uri": "https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum",
-      "description": "Types of bias that may be present in datasets",
+      "description": "Types of bias that may be present in datasets. Values are mapped to the Artificial Intelligence Ontology (AIO) bias taxonomy from BioPortal. See https://bioportal.bioontology.org/ontologies/AIO",
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
       "permissible_values": [
         {
           "text": "selection_bias",
-          "description": "Bias arising from non-random selection of data or participants"
+          "description": "Bias arising from non-random selection of data or participants.",
+          "broad_mappings": [
+            "AIO:SelectionAndSamplingBias"
+          ]
         },
         {
           "text": "measurement_bias",
-          "description": "Bias in how data is measured or recorded"
+          "description": "Bias in how data is measured or recorded. Occurs when features and labels are proxies for desired quantities, potentially leading to differential performance.",
+          "meaning": "AIO:MeasurementBias"
         },
         {
           "text": "historical_bias",
-          "description": "Bias reflecting historical inequities or societal biases"
+          "description": "Bias reflecting historical inequities or societal biases. Long-standing biases encoded in society over time.",
+          "meaning": "AIO:HistoricalBias"
         },
         {
           "text": "representation_bias",
-          "description": "Certain groups are over- or under-represented in the data"
+          "description": "Certain groups are over- or under-represented in the data. Results from non-random sampling of subgroups making trends non-generalizable to new populations.",
+          "meaning": "AIO:RepresentationBias"
         },
         {
           "text": "aggregation_bias",
-          "description": "Bias from inappropriately combining distinct groups"
+          "description": "Bias from inappropriately combining distinct groups. Related to making inferences about individuals based on their group membership.",
+          "broad_mappings": [
+            "AIO:EcologicalFallacyBias"
+          ]
         },
         {
           "text": "algorithmic_bias",
-          "description": "Bias introduced or amplified by algorithmic processing"
+          "description": "Bias introduced or amplified by algorithmic processing. Computational bias from data analysis processes and methods.",
+          "broad_mappings": [
+            "AIO:ProcessingBias",
+            "AIO:ComputationalBias"
+          ]
         },
         {
           "text": "sampling_bias",
-          "description": "Bias from sampling methodology not representative of the population"
+          "description": "Bias from sampling methodology not representative of the population.",
+          "broad_mappings": [
+            "AIO:SelectionAndSamplingBias"
+          ]
         },
         {
           "text": "annotation_bias",
-          "description": "Bias introduced during data labeling or annotation"
+          "description": "Bias introduced during data labeling or annotation. Occurs when annotators rely on heuristics or exhibit systematic patterns in labeling.",
+          "broad_mappings": [
+            "AIO:AnnotatorReportingBias"
+          ]
         },
         {
           "text": "confirmation_bias",
-          "description": "Bias from seeking data that confirms pre-existing beliefs"
+          "description": "Bias from seeking data that confirms pre-existing beliefs. Tendency to prefer information that confirms existing beliefs, influencing the search for, interpretation of, and recall of information.",
+          "meaning": "AIO:ConfirmationBias"
         }
       ]
     },
@@ -7993,9 +8013,9 @@
   ],
   "metamodel_version": "1.7.0",
   "source_file": "data_sheets_schema.yaml",
-  "source_file_date": "2025-11-24T22:16:32",
+  "source_file_date": "2025-12-01T20:19:46",
   "source_file_size": 12266,
-  "generation_date": "2025-11-25T12:07:55",
+  "generation_date": "2025-12-01T21:10:33",
   "@type": "SchemaDefinition",
   "@context": [
     "project/jsonld/data_sheets_schema.context.jsonld",

--- a/project/jsonschema/data_sheets_schema.schema.json
+++ b/project/jsonschema/data_sheets_schema.schema.json
@@ -58,7 +58,7 @@
             "type": "object"
         },
         "BiasTypeEnum": {
-            "description": "Types of bias that may be present in datasets",
+            "description": "Types of bias that may be present in datasets. Values are mapped to the Artificial Intelligence Ontology (AIO) bias taxonomy from BioPortal. See https://bioportal.bioontology.org/ontologies/AIO",
             "enum": [
                 "selection_bias",
                 "measurement_bias",

--- a/project/owl/data_sheets_schema.owl.ttl
+++ b/project/owl/data_sheets_schema.owl.ttl
@@ -36,49 +36,49 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FormatDialect" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:header ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:quote_char ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:double_quote ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:header ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:double_quote ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:header ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:header ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:comment_prefix ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:delimiter ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:double_quote ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:quote_char ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:double_quote ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:header ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:header ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:delimiter ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:double_quote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:quote_char ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:delimiter ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:quote_char ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:comment_prefix ] ;
     skos:definition "Additional format information for a file" ;
     skos:inScheme data_sheets_schema:base .
@@ -87,10 +87,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DirectCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Indicates whether the data was collected directly from the individuals in question or obtained via third parties/other sources.
@@ -101,10 +101,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Relationships" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are relationships between individual instances made explicit (e.g., users' movie ratings, social network links)?
@@ -129,10 +129,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ThirdPartySharing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#description> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
@@ -146,10 +146,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Did the individuals in question consent to the collection and use of their data? If so, how was consent requested and provided, and what language did individuals consent to?
@@ -160,10 +160,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionNotification" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were the individuals in question notified about the data collection? If so, please describe (or show with screenshots, etc.) how notice was provided, and reproduce the language of the notification itself if possible.
@@ -174,10 +174,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ConsentRevocation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If consent was obtained, were the consenting individuals provided with a mechanism to revoke their consent in the future or for certain uses? If so, please describe.
@@ -211,14 +211,14 @@ data_sheets_schema:DataSubset a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataSubset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_subpopulation ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_subpopulation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty data_sheets_schema:is_data_split ],
@@ -227,7 +227,7 @@ data_sheets_schema:DataSubset a owl:Class,
             owl:onProperty data_sheets_schema:is_subpopulation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_data_split ],
+            owl:onProperty data_sheets_schema:is_subpopulation ],
         data_sheets_schema:Dataset ;
     skos:definition "A subset of a dataset, likely containing multiple files of multiple potential purposes and properties." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
@@ -236,8 +236,17 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Software" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:url ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:url ],
@@ -246,21 +255,12 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
+            owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:version ],
         data_sheets_schema:NamedThing ;
     skos:definition "A software program or library." ;
@@ -285,10 +285,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionTimeframe" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Over what timeframe was the data collected, and does this timeframe match the creation timeframe of the underlying data?
@@ -299,10 +299,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataCollector" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who was involved in the data collection (e.g., students, crowdworkers, contractors), and how they were compensated.
@@ -313,12 +313,15 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "InstanceAcquisition" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
         [ a owl:Restriction ;
@@ -326,33 +329,30 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Describes how data associated with each instance was acquired (e.g., directly observed, reported by subjects, inferred).
@@ -363,8 +363,11 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Confidentiality" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
@@ -372,11 +375,8 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be confidential (e.g., protected by legal privilege, patient data, non-public communications)?
 """ ;
@@ -387,18 +387,18 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ContentWarning" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain any data that might be offensive, insulting, threatening, or otherwise anxiety-provoking if viewed directly?
@@ -409,10 +409,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataAnomaly" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are there any errors, sources of noise, or redundancies in the dataset?
@@ -423,32 +423,32 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DatasetRelationshipTypeEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:DatasetRelationshipTypeEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Typed relationship to another dataset, enabling precise specification of how datasets relate to each other (e.g., supplements, derives from, is version of). Supports RO-Crate-style dataset interlinking.
 """ ;
@@ -458,20 +458,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Deidentification" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is it possible to identify individuals in the dataset, either directly or indirectly (in combination with other data)?
 """ ;
@@ -482,16 +482,13 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ExternalResource" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#external_resources> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#external_resources> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#external_resources> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
@@ -500,10 +497,13 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#external_resources> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is the dataset self-contained or does it rely on external resources (e.g., websites, other datasets)? If external, are there guarantees that those resources will remain available and unchanged?
 """ ;
@@ -513,11 +513,38 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Instance" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
@@ -525,59 +552,32 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What do the instances that comprise the dataset represent (e.g., documents, photos, people, countries)?
 """ ;
@@ -587,14 +587,14 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MissingInfo" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
@@ -607,11 +607,11 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SensitiveElement" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
@@ -619,7 +619,7 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be considered sensitive (e.g., race, sexual orientation, religion, biometrics)?
@@ -630,23 +630,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Subpopulation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
@@ -659,62 +659,62 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExportControlRegulatoryRestrictions" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:AIActRiskEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Do any export controls or other regulatory restrictions apply to the dataset or to individual instances? Includes compliance tracking for regulations like GDPR, HIPAA, and EU AI Act. If so, please describe these restrictions and provide a link or copy of any supporting documentation. Maps to DUO terms related to ethics approval, geographic restrictions, and institutional requirements.
 """ ;
@@ -738,26 +738,26 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "LicenseAndUseTerms" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DataUsePermissionEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:DataUsePermissionEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed under a copyright or other IP license, and/or under applicable terms of use? Provide a link or copy of relevant licensing terms and any fees.
 """ ;
@@ -795,10 +795,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataProtectionImpact" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has an analysis of the potential impact of the dataset and its use on data subjects (e.g., a data protection impact analysis) been conducted? If so, please provide a description of this analysis, including the outcomes, and any supporting documentation.
@@ -809,28 +809,28 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "EthicalReview" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were any ethical or compliance review processes conducted (e.g., by an institutional review board)? If so, please provide a description of these review processes, including the frequency of review and documentation of outcomes, as well as a link or other access point to any supporting documentation.
@@ -841,11 +841,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "HumanSubjectCompensation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
@@ -854,18 +863,9 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about compensation or incentives provided to human research participants.
@@ -877,34 +877,34 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "HumanSubjectResearch" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
@@ -917,24 +917,18 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "InformedConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
         [ a owl:Restriction ;
@@ -942,12 +936,18 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Details about informed consent procedures used in human subjects research.
@@ -958,11 +958,8 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ParticipantPrivacy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
@@ -971,16 +968,19 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about privacy protections and anonymization procedures for human research participants.
 """ ;
@@ -990,32 +990,32 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VulnerablePopulations" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#vulnerable_groups_included> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#vulnerable_groups_included> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#vulnerable_groups_included> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#vulnerable_groups_included> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about protections for vulnerable populations in human subjects research.
 """ ;
@@ -1025,10 +1025,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Erratum" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there an erratum? If so, please provide a link or other access point.
@@ -1053,10 +1053,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Maintainer" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who will be supporting/hosting/maintaining the dataset?
@@ -1081,10 +1081,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UpdatePlan" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be updated (e.g., to correct labeling errors, add new instances, delete instances)? If so, how often, by whom, and how will these updates be communicated?
@@ -1095,10 +1095,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VersionAccess" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will older versions of the dataset continue to be supported/hosted/maintained? If so, how? If not, how will obsolescence be communicated to dataset consumers?
@@ -1125,29 +1125,29 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Creator" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CRediTRoleEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Organization ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Organization ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who created the dataset (e.g., which team, research group) and on behalf of which entity (e.g., company, institution, organization)? This may also be considered a team.
 """ ;
@@ -1157,23 +1157,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FundingMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grantor> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who funded the creation of the dataset? If there is an associated grant, please provide the name of the grantor and the grant name and number.
 """ ;
@@ -1183,13 +1183,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Grant" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         data_sheets_schema:NamedThing ;
     skos:definition """The name and/or identifier of the specific mechanism providing monetary support or other resources supporting creation of the dataset.
@@ -1208,13 +1208,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Purpose" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "For what purpose was the dataset created?" ;
@@ -1240,10 +1240,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CleaningStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any cleaning of the data done (e.g., removal of instances, processing of missing values)?
@@ -1254,27 +1254,30 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "LabelingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_platform> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_platform> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_platform> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         [ a owl:Restriction ;
@@ -1282,16 +1285,13 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_platform> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_platform> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any labeling of the data done (e.g., part-of-speech tagging)? This class documents the annotation process and quality metrics.
 """ ;
@@ -1301,10 +1301,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "PreprocessingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any preprocessing of the data done (e.g., discretization or bucketing, tokenization, SIFT feature extraction)?
@@ -1343,10 +1343,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExistingUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has the dataset been used for any tasks already?
@@ -1357,10 +1357,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FutureUseImpact" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there anything about the dataset's composition or collection that might impact future uses or create risks/harm (e.g., unfair treatment, legal or financial risks)? If so, describe these impacts and any mitigation strategies.
@@ -1372,16 +1372,16 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "IntendedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of intended uses for this dataset. Complements FutureUseImpact by focusing on positive, recommended applications rather than risks. Aligns with RO-Crate "Intended Use" field.
 """ ;
@@ -1391,10 +1391,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "OtherTask" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What other tasks could the dataset be used for?
@@ -1406,15 +1406,15 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ProhibitedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of prohibited or forbidden uses for this dataset. Stronger than DiscouragedUse - these are uses that are explicitly not permitted by license, ethics, or policy. Aligns with RO-Crate "Prohibited Uses" field.
@@ -1439,119 +1439,119 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VariableMetadata" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Metadata describing an individual variable, field, or column in a dataset. Variables may represent measurements, observations, derived values, or categorical attributes." ;
     skos:exactMatch schema1:PropertyValue,
@@ -2257,184 +2257,184 @@ data_sheets_schema:Information a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Information" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
+            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:modified_by ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:last_updated_on ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
-            owl:onProperty data_sheets_schema:compression ],
+            owl:onProperty data_sheets_schema:conforms_to ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty data_sheets_schema:download_url ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_on ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:title ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:download_url ],
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:publisher ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:download_url ],
+            owl:onProperty data_sheets_schema:title ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:created_by ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:keywords ],
+            owl:onProperty data_sheets_schema:was_derived_from ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
+            owl:onProperty data_sheets_schema:last_updated_on ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:status ],
+            owl:onProperty data_sheets_schema:modified_by ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:page ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:conforms_to_schema ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:page ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license ],
+            owl:onProperty data_sheets_schema:modified_by ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:modified_by ],
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Datetime ;
             owl:onProperty data_sheets_schema:last_updated_on ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:keywords ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_on ],
+            owl:onProperty data_sheets_schema:page ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "10\\.\\d{4,}\\/.+" ] ) ] ;
             owl:onProperty data_sheets_schema:doi ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:was_derived_from ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:issued ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:issued ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version ],
         data_sheets_schema:NamedThing ;
     skos:closeMatch schema1:CreativeWork ;
     skos:definition "Grouping for datasets and data files" ;
@@ -2701,46 +2701,46 @@ data_sheets_schema:collection_timeframes a owl:ObjectProperty,
     rdfs:label "SamplingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain all possible instances, or is it a sample (not necessarily random) of instances from a larger set? If so, how representative is it?
 """ ;
@@ -3270,442 +3270,442 @@ data_sheets_schema:Dataset a owl:Class,
     rdfs:seeAlso frictionless:data-resource ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:cleaning_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:anomalies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
-            owl:onProperty data_sheets_schema:cleaning_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:hash ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DataSubset ;
-            owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
-            owl:onProperty data_sheets_schema:purposes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
-            owl:onProperty data_sheets_schema:content_warnings ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
-            owl:onProperty data_sheets_schema:tasks ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:content_warnings ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
-            owl:onProperty data_sheets_schema:funders ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
             owl:onProperty data_sheets_schema:subpopulations ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:vulnerable_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:hash ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:md5 ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
             owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:maintainers ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#VulnerablePopulations> ;
-            owl:onProperty data_sheets_schema:vulnerable_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:funders ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
-            owl:onProperty data_sheets_schema:anomalies ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
-            owl:onProperty data_sheets_schema:creators ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
-            owl:onProperty data_sheets_schema:errata ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FormatEnum ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:vulnerable_populations ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version_access ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
+            owl:onProperty data_sheets_schema:intended_uses ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
             owl:onProperty data_sheets_schema:discouraged_uses ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:hash ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:md5 ],
+            owl:onProperty data_sheets_schema:path ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
+            owl:onProperty data_sheets_schema:vulnerable_populations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:variables ],
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
+            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:intended_uses ],
+            owl:onProperty data_sheets_schema:dialect ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
             owl:onProperty data_sheets_schema:other_tasks ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+            owl:onProperty data_sheets_schema:other_tasks ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
+            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
+            owl:onProperty data_sheets_schema:encoding ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:sha256 ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:distribution_formats ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
             owl:onProperty data_sheets_schema:distribution_dates ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:discouraged_uses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:errata ],
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:purposes ],
+            owl:onProperty data_sheets_schema:creators ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
+            owl:onProperty data_sheets_schema:content_warnings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FormatEnum ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:updates ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:collection_mechanisms ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:raw_sources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:DataSubset ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:cleaning_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:vulnerable_populations ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
             owl:onProperty data_sheets_schema:creators ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#VulnerablePopulations> ;
+            owl:onProperty data_sheets_schema:vulnerable_populations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:content_warnings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
+            owl:onProperty data_sheets_schema:distribution_formats ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
             owl:onProperty data_sheets_schema:maintainers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:distribution_dates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
+            owl:onProperty data_sheets_schema:raw_sources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
             owl:onProperty data_sheets_schema:ethical_reviews ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
+            owl:onProperty data_sheets_schema:parent_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
+            owl:onProperty data_sheets_schema:cleaning_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "data package",
@@ -4338,10 +4338,19 @@ data_sheets_schema:Person a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:affiliation ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:email ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:email ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:orcid ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
@@ -4350,17 +4359,8 @@ data_sheets_schema:Person a owl:Class,
                                 owl:withRestrictions ( [ xsd:pattern "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$" ] ) ] ) ] ;
             owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:email ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty data_sheets_schema:affiliation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:email ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:orcid ],
         data_sheets_schema:NamedThing ;
     skos:definition "An individual human being. This class represents a person in the context of a specific dataset. Attributes like affiliation and email represent the person's current or most relevant contact information for this dataset. For stable cross-dataset identification, use the ORCID field. Note that contributor roles (CRediT) are specified in the usage context (e.g., Creator class) rather than on the Person directly, since roles vary by dataset." ;
     skos:exactMatch schema1:Person,
@@ -4378,25 +4378,25 @@ data_sheets_schema:NamedThing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "NamedThing" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:name ],
+            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;

--- a/project/owl/data_sheets_schema.owl.ttl
+++ b/project/owl/data_sheets_schema.owl.ttl
@@ -36,11 +36,29 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FormatDialect" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:quote_char ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:header ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:quote_char ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:double_quote ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:delimiter ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:double_quote ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:header ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:double_quote ],
+            owl:onProperty data_sheets_schema:header ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:comment_prefix ],
@@ -48,38 +66,20 @@ data_sheets_schema:FormatDialect a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:double_quote ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:header ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:header ],
+            owl:onProperty data_sheets_schema:delimiter ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:delimiter ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:delimiter ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:double_quote ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:quote_char ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:quote_char ] ;
+            owl:onProperty data_sheets_schema:comment_prefix ] ;
     skos:definition "Additional format information for a file" ;
     skos:inScheme data_sheets_schema:base .
 
@@ -101,10 +101,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Relationships" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are relationships between individual instances made explicit (e.g., users' movie ratings, social network links)?
@@ -132,10 +132,10 @@ data_sheets_schema:FormatDialect a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#description> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed to third parties outside of the entity (e.g., company, institution, organization) on behalf of which the dataset was created?
@@ -146,10 +146,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Did the individuals in question consent to the collection and use of their data? If so, how was consent requested and provided, and what language did individuals consent to?
@@ -160,10 +160,10 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionNotification" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were the individuals in question notified about the data collection? If so, please describe (or show with screenshots, etc.) how notice was provided, and reproduce the language of the notification itself if possible.
@@ -211,23 +211,23 @@ data_sheets_schema:DataSubset a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataSubset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:is_subpopulation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_subpopulation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_data_split ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty data_sheets_schema:is_subpopulation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:is_data_split ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_subpopulation ],
         data_sheets_schema:Dataset ;
     skos:definition "A subset of a dataset, likely containing multiple files of multiple potential purposes and properties." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
@@ -236,20 +236,14 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Software" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version ],
+            owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
+            owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:version ],
@@ -257,11 +251,17 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:url ],
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version ],
         data_sheets_schema:NamedThing ;
     skos:definition "A software program or library." ;
     skos:exactMatch schema1:SoftwareApplication ;
@@ -313,47 +313,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "InstanceAcquisition" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Describes how data associated with each instance was acquired (e.g., directly observed, reported by subjects, inferred).
 """ ;
@@ -363,20 +363,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Confidentiality" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be confidential (e.g., protected by legal privilege, patient data, non-public communications)?
 """ ;
@@ -387,9 +387,9 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ContentWarning" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -398,8 +398,8 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain any data that might be offensive, insulting, threatening, or otherwise anxiety-provoking if viewed directly?
 """ ;
@@ -423,32 +423,32 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:DatasetRelationshipTypeEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DatasetRelationshipTypeEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Typed relationship to another dataset, enabling precise specification of how datasets relate to each other (e.g., supplements, derives from, is version of). Supports RO-Crate-style dataset interlinking.
 """ ;
@@ -459,18 +459,18 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "Deidentification" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is it possible to identify individuals in the dataset, either directly or indirectly (in combination with other data)?
@@ -481,26 +481,26 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExternalResource" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#external_resources> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#external_resources> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#external_resources> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#external_resources> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
@@ -513,71 +513,71 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Instance" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What do the instances that comprise the dataset represent (e.g., documents, photos, people, countries)?
 """ ;
@@ -590,14 +590,14 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is any information missing from individual instances? (e.g., unavailable data)
 """ ;
@@ -607,20 +607,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SensitiveElement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be considered sensitive (e.g., race, sexual orientation, religion, biometrics)?
 """ ;
@@ -631,25 +631,25 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "Subpopulation" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset identify any subpopulations (e.g., by age, gender)? If so, how are they identified and what are their distributions?
 """ ;
@@ -663,58 +663,58 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:AIActRiskEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:AIActRiskEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#eu_ai_act_risk_category> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#gdpr_compliant> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Do any export controls or other regulatory restrictions apply to the dataset or to individual instances? Includes compliance tracking for regulations like GDPR, HIPAA, and EU AI Act. If so, please describe these restrictions and provide a link or copy of any supporting documentation. Maps to DUO terms related to ethics approval, geographic restrictions, and institutional requirements.
 """ ;
@@ -738,16 +738,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "LicenseAndUseTerms" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:DataUsePermissionEnum ;
@@ -756,7 +750,13 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed under a copyright or other IP license, and/or under applicable terms of use? Provide a link or copy of relevant licensing terms and any fees.
@@ -781,10 +781,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DistributionFormat" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """How will the dataset be distributed (e.g., tarball on a website, API, GitHub)?
@@ -795,10 +795,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataProtectionImpact" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has an analysis of the potential impact of the dataset and its use on data subjects (e.g., a data protection impact analysis) been conducted? If so, please provide a description of this analysis, including the outcomes, and any supporting documentation.
@@ -809,29 +809,29 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "EthicalReview" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were any ethical or compliance review processes conducted (e.g., by an institutional review board)? If so, please provide a description of these review processes, including the frequency of review and documentation of outcomes, as well as a link or other access point to any supporting documentation.
 """ ;
@@ -844,28 +844,28 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about compensation or incentives provided to human research participants.
@@ -876,38 +876,38 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "HumanSubjectResearch" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about whether the dataset involves human subjects research and what regulatory or ethical review processes were followed.
 """ ;
@@ -917,38 +917,38 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "InformedConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Details about informed consent procedures used in human subjects research.
 """ ;
@@ -958,29 +958,29 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ParticipantPrivacy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about privacy protections and anonymization procedures for human research participants.
 """ ;
@@ -999,23 +999,23 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#vulnerable_groups_included> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#vulnerable_groups_included> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#vulnerable_groups_included> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about protections for vulnerable populations in human subjects research.
 """ ;
@@ -1053,10 +1053,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Maintainer" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who will be supporting/hosting/maintaining the dataset?
@@ -1081,10 +1081,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UpdatePlan" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be updated (e.g., to correct labeling errors, add new instances, delete instances)? If so, how often, by whom, and how will these updates be communicated?
@@ -1095,10 +1095,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VersionAccess" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will older versions of the dataset continue to be supported/hosted/maintained? If so, how? If not, how will obsolescence be communicated to dataset consumers?
@@ -1112,10 +1112,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Was there a specific gap that needed to be filled by creation of the dataset?" ;
@@ -1125,20 +1125,11 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Creator" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Organization ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CRediTRoleEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
@@ -1148,6 +1139,15 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Organization ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliation> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who created the dataset (e.g., which team, research group) and on behalf of which entity (e.g., company, institution, organization)? This may also be considered a team.
 """ ;
@@ -1157,20 +1157,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FundingMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grantor> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant> ],
@@ -1183,13 +1183,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Grant" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         data_sheets_schema:NamedThing ;
     skos:definition """The name and/or identifier of the specific mechanism providing monetary support or other resources supporting creation of the dataset.
@@ -1208,13 +1208,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Purpose" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "For what purpose was the dataset created?" ;
@@ -1224,10 +1224,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Task" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -1240,10 +1240,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CleaningStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any cleaning of the data done (e.g., removal of instances, processing of missing values)?
@@ -1254,41 +1254,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "LabelingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_platform> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_platform> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_platform> ],
@@ -1301,10 +1301,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "PreprocessingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any preprocessing of the data done (e.g., discretization or bucketing, tokenization, SIFT feature extraction)?
@@ -1374,11 +1374,11 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
@@ -1405,17 +1405,17 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ProhibitedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of prohibited or forbidden uses for this dataset. Stronger than DiscouragedUse - these are uses that are explicitly not permitted by license, ethics, or policy. Aligns with RO-Crate "Prohibited Uses" field.
 """ ;
@@ -1439,119 +1439,119 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VariableMetadata" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Float ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Metadata describing an individual variable, field, or column in a dataset. Variables may represent measurements, observations, derived values, or categorical attributes." ;
     skos:exactMatch schema1:PropertyValue,
@@ -1643,6 +1643,26 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "no_population_ancestry_research" ;
     rdfs:subClassOf data_sheets_schema:DataUsePermissionEnum .
 
+<https://w3id.org/aio/ConfirmationBias> a owl:Class,
+        data_sheets_schema:BiasTypeEnum ;
+    rdfs:label "confirmation_bias" ;
+    rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
+
+<https://w3id.org/aio/HistoricalBias> a owl:Class,
+        data_sheets_schema:BiasTypeEnum ;
+    rdfs:label "historical_bias" ;
+    rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
+
+<https://w3id.org/aio/MeasurementBias> a owl:Class,
+        data_sheets_schema:BiasTypeEnum ;
+    rdfs:label "measurement_bias" ;
+    rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
+
+<https://w3id.org/aio/RepresentationBias> a owl:Class,
+        data_sheets_schema:BiasTypeEnum ;
+    rdfs:label "representation_bias" ;
+    rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/AIActRiskEnum#high_risk> a owl:Class,
         data_sheets_schema:AIActRiskEnum ;
     rdfs:label "high_risk" ;
@@ -1676,26 +1696,6 @@ data_sheets_schema:Software a owl:Class,
 <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#annotation_bias> a owl:Class,
         data_sheets_schema:BiasTypeEnum ;
     rdfs:label "annotation_bias" ;
-    rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#confirmation_bias> a owl:Class,
-        data_sheets_schema:BiasTypeEnum ;
-    rdfs:label "confirmation_bias" ;
-    rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#historical_bias> a owl:Class,
-        data_sheets_schema:BiasTypeEnum ;
-    rdfs:label "historical_bias" ;
-    rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#measurement_bias> a owl:Class,
-        data_sheets_schema:BiasTypeEnum ;
-    rdfs:label "measurement_bias" ;
-    rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#representation_bias> a owl:Class,
-        data_sheets_schema:BiasTypeEnum ;
-    rdfs:label "representation_bias" ;
     rdfs:subClassOf data_sheets_schema:BiasTypeEnum .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#sampling_bias> a owl:Class,
@@ -2258,108 +2258,19 @@ data_sheets_schema:Information a owl:Class,
     rdfs:label "Information" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:conforms_to ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "10\\.\\d{4,}\\/.+" ] ) ] ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:modified_by ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:last_updated_on ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:keywords ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:keywords ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:modified_by ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CompressionEnum ;
             owl:onProperty data_sheets_schema:compression ],
@@ -2368,73 +2279,162 @@ data_sheets_schema:Information a owl:Class,
             owl:onProperty data_sheets_schema:download_url ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:doi ],
+            owl:onProperty data_sheets_schema:created_on ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:title ],
+            owl:onProperty data_sheets_schema:download_url ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version ],
+            owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:download_url ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:conforms_to_schema ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_on ],
+            owl:onProperty data_sheets_schema:page ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:download_url ],
+            owl:onProperty data_sheets_schema:modified_by ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Datetime ;
             owl:onProperty data_sheets_schema:last_updated_on ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:status ],
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:doi ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:title ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:conforms_to_class ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:language ],
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:created_by ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:publisher ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:status ],
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:onDatatype xsd:string ;
+                    owl:withRestrictions ( [ xsd:pattern "10\\.\\d{4,}\\/.+" ] ) ] ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
         data_sheets_schema:NamedThing ;
     skos:closeMatch schema1:CreativeWork ;
     skos:definition "Grouping for datasets and data files" ;
@@ -2701,46 +2701,46 @@ data_sheets_schema:collection_timeframes a owl:ObjectProperty,
     rdfs:label "SamplingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain all possible instances, or is it a sample (not necessarily random) of instances from a larger set? If so, how representative is it?
 """ ;
@@ -3270,340 +3270,193 @@ data_sheets_schema:Dataset a owl:Class,
     rdfs:seeAlso frictionless:data-resource ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:vulnerable_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:funders ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:content_warnings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:cleaning_strategies ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DataSubset ;
-            owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FormatEnum ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
             owl:onProperty data_sheets_schema:related_datasets ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
             owl:onProperty data_sheets_schema:anomalies ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
-            owl:onProperty data_sheets_schema:maintainers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
-            owl:onProperty data_sheets_schema:purposes ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
             owl:onProperty data_sheets_schema:cleaning_strategies ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:vulnerable_populations ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version_access ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:raw_sources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
+            owl:onProperty data_sheets_schema:participant_privacy ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
+            owl:onProperty data_sheets_schema:use_repository ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:sha256 ],
+            owl:onProperty data_sheets_schema:citation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
-            owl:onProperty data_sheets_schema:funders ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:DataSubset ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
+            owl:onProperty data_sheets_schema:content_warnings ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:citation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:labeling_strategies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:anomalies ],
+            owl:onProperty data_sheets_schema:dialect ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
+            owl:onProperty data_sheets_schema:other_tasks ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:errata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:maintainers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:hash ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
-            owl:onProperty data_sheets_schema:creators ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:hash ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:sha256 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:tasks ],
+            owl:onProperty data_sheets_schema:existing_uses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:content_warnings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
             owl:onProperty data_sheets_schema:extension_mechanism ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:media_type ],
+            owl:onProperty data_sheets_schema:vulnerable_populations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:hash ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:path ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
+            owl:onProperty data_sheets_schema:distribution_formats ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:purposes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
-            owl:onProperty data_sheets_schema:tasks ],
+            owl:onProperty data_sheets_schema:md5 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
+            owl:onProperty data_sheets_schema:updates ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
-            owl:onProperty data_sheets_schema:intended_uses ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
             owl:onProperty data_sheets_schema:version_access ],
@@ -3611,101 +3464,248 @@ data_sheets_schema:Dataset a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:sha256 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
-            owl:onProperty data_sheets_schema:content_warnings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:hash ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#VulnerablePopulations> ;
-            owl:onProperty data_sheets_schema:vulnerable_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:bytes ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
+            owl:onProperty data_sheets_schema:retention_limit ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
+            owl:onProperty data_sheets_schema:participant_compensation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:bytes ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
-            owl:onProperty data_sheets_schema:use_repository ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:creators ],
+            owl:onProperty data_sheets_schema:subsets ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
-            owl:onProperty data_sheets_schema:errata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
+            owl:onProperty data_sheets_schema:variables ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
+            owl:onProperty data_sheets_schema:is_deidentified ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:updates ],
+            owl:onProperty data_sheets_schema:maintainers ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#VulnerablePopulations> ;
+            owl:onProperty data_sheets_schema:vulnerable_populations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:funders ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
             owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:distribution_formats ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
+            owl:onProperty data_sheets_schema:creators ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FormatEnum ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:distribution_dates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:vulnerable_populations ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
+            owl:onProperty data_sheets_schema:raw_sources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
+            owl:onProperty data_sheets_schema:other_tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
+            owl:onProperty data_sheets_schema:distribution_dates ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:creators ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
+            owl:onProperty data_sheets_schema:maintainers ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "data package",
@@ -4335,6 +4335,15 @@ data_sheets_schema:Person a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:affiliation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:orcid ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:email ],
+        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( linkml:String [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:string ;
@@ -4344,23 +4353,14 @@ data_sheets_schema:Person a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:email ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:orcid ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:orcid ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:affiliation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:email ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty data_sheets_schema:affiliation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:email ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:orcid ],
         data_sheets_schema:NamedThing ;
     skos:definition "An individual human being. This class represents a person in the context of a specific dataset. Attributes like affiliation and email represent the person's current or most relevant contact information for this dataset. For stable cross-dataset identification, use the ORCID field. Note that contributor roles (CRediT) are specified in the usage context (e.g., Creator class) rather than on the Person directly, since roles vary by dataset." ;
     skos:exactMatch schema1:Person,
@@ -4381,29 +4381,29 @@ data_sheets_schema:NamedThing a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
+            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ] ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:id ] ;
     skos:definition "A generic grouping for any identifiable entity." ;
     skos:exactMatch schema1:Thing ;
     skos:inScheme data_sheets_schema:base .
@@ -4559,14 +4559,14 @@ data_sheets_schema:variables a owl:ObjectProperty,
 
 data_sheets_schema:BiasTypeEnum a owl:Class,
         linkml:EnumDefinition ;
-    owl:unionOf ( <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#selection_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#measurement_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#historical_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#representation_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#aggregation_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#algorithmic_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#sampling_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#annotation_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#confirmation_bias> ) ;
-    linkml:permissible_values <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#aggregation_bias>,
+    owl:unionOf ( <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#selection_bias> <https://w3id.org/aio/MeasurementBias> <https://w3id.org/aio/HistoricalBias> <https://w3id.org/aio/RepresentationBias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#aggregation_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#algorithmic_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#sampling_bias> <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#annotation_bias> <https://w3id.org/aio/ConfirmationBias> ) ;
+    linkml:permissible_values <https://w3id.org/aio/ConfirmationBias>,
+        <https://w3id.org/aio/HistoricalBias>,
+        <https://w3id.org/aio/MeasurementBias>,
+        <https://w3id.org/aio/RepresentationBias>,
+        <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#aggregation_bias>,
         <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#algorithmic_bias>,
         <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#annotation_bias>,
-        <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#confirmation_bias>,
-        <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#historical_bias>,
-        <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#measurement_bias>,
-        <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#representation_bias>,
         <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#sampling_bias>,
         <https://w3id.org/bridge2ai/data-sheets-schema/BiasTypeEnum#selection_bias> .
 
@@ -4729,10 +4729,10 @@ data_sheets_schema:DatasetProperty a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetProperty" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:Software ;
             owl:onProperty data_sheets_schema:used_software ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Software ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:used_software ],
         data_sheets_schema:NamedThing ;
     skos:definition "Represents a single property of a dataset, or a set of related properties." ;

--- a/src/data_sheets_schema/datamodel/data_sheets_schema.py
+++ b/src/data_sheets_schema/datamodel/data_sheets_schema.py
@@ -1,5 +1,5 @@
-# Auto generated from data_sheets_schema.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-12-01T21:10:34
+# Auto generated from data_sheets_schema_all.yaml by pythongen.py version: 0.0.1
+# Generation date: 2025-12-02T20:18:36
 # Schema: data-sheets-schema
 #
 # id: https://w3id.org/bridge2ai/data-sheets-schema
@@ -56,13 +56,13 @@ from rdflib import (
     URIRef
 )
 
-from linkml_runtime.linkml_model.types import Boolean, Datetime, Float, Integer, String, Uri, Uriorcurie
-from linkml_runtime.utils.metamodelcore import Bool, URI, URIorCURIE, XSDDateTime
+from linkml_runtime.utils.metamodelcore import Bool, Curie, Decimal, ElementIdentifier, NCName, NodeIdentifier, URI, URIorCURIE, XSDDate, XSDDateTime, XSDTime
 
 metamodel_version = "1.7.0"
 version = None
 
 # Namespaces
+AIO = CurieNamespace('AIO', 'https://w3id.org/aio/')
 B2AI_STANDARD = CurieNamespace('B2AI_STANDARD', 'https://w3id.org/bridge2ai/b2ai-standards-registry/')
 B2AI_SUBSTRATE = CurieNamespace('B2AI_SUBSTRATE', 'https://w3id.org/bridge2ai/b2ai-standards-registry/')
 B2AI_TOPIC = CurieNamespace('B2AI_TOPIC', 'https://w3id.org/bridge2ai/b2ai-standards-registry/')
@@ -96,12 +96,165 @@ PROV = CurieNamespace('prov', 'http://www.w3.org/ns/prov#')
 QUDT = CurieNamespace('qudt', 'http://qudt.org/schema/qudt/')
 SCHEMA = CurieNamespace('schema', 'http://schema.org/')
 SH = CurieNamespace('sh', 'https://w3id.org/shacl/')
+SHEX = CurieNamespace('shex', 'http://www.w3.org/ns/shex#')
 SKOS = CurieNamespace('skos', 'http://www.w3.org/2004/02/skos/core#')
 VOID = CurieNamespace('void', 'http://rdfs.org/ns/void#')
+XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
 DEFAULT_ = DATA_SHEETS_SCHEMA
 
 
 # Types
+class String(str):
+    """ A character string """
+    type_class_uri = XSD["string"]
+    type_class_curie = "xsd:string"
+    type_name = "string"
+    type_model_uri = DATA_SHEETS_SCHEMA.String
+
+
+class Integer(int):
+    """ An integer """
+    type_class_uri = XSD["integer"]
+    type_class_curie = "xsd:integer"
+    type_name = "integer"
+    type_model_uri = DATA_SHEETS_SCHEMA.Integer
+
+
+class Boolean(Bool):
+    """ A binary (true or false) value """
+    type_class_uri = XSD["boolean"]
+    type_class_curie = "xsd:boolean"
+    type_name = "boolean"
+    type_model_uri = DATA_SHEETS_SCHEMA.Boolean
+
+
+class Float(float):
+    """ A real number that conforms to the xsd:float specification """
+    type_class_uri = XSD["float"]
+    type_class_curie = "xsd:float"
+    type_name = "float"
+    type_model_uri = DATA_SHEETS_SCHEMA.Float
+
+
+class Double(float):
+    """ A real number that conforms to the xsd:double specification """
+    type_class_uri = XSD["double"]
+    type_class_curie = "xsd:double"
+    type_name = "double"
+    type_model_uri = DATA_SHEETS_SCHEMA.Double
+
+
+class Decimal(Decimal):
+    """ A real number with arbitrary precision that conforms to the xsd:decimal specification """
+    type_class_uri = XSD["decimal"]
+    type_class_curie = "xsd:decimal"
+    type_name = "decimal"
+    type_model_uri = DATA_SHEETS_SCHEMA.Decimal
+
+
+class Time(XSDTime):
+    """ A time object represents a (local) time of day, independent of any particular day """
+    type_class_uri = XSD["time"]
+    type_class_curie = "xsd:time"
+    type_name = "time"
+    type_model_uri = DATA_SHEETS_SCHEMA.Time
+
+
+class Date(XSDDate):
+    """ a date (year, month and day) in an idealized calendar """
+    type_class_uri = XSD["date"]
+    type_class_curie = "xsd:date"
+    type_name = "date"
+    type_model_uri = DATA_SHEETS_SCHEMA.Date
+
+
+class Datetime(XSDDateTime):
+    """ The combination of a date and time """
+    type_class_uri = XSD["dateTime"]
+    type_class_curie = "xsd:dateTime"
+    type_name = "datetime"
+    type_model_uri = DATA_SHEETS_SCHEMA.Datetime
+
+
+class DateOrDatetime(str):
+    """ Either a date or a datetime """
+    type_class_uri = LINKML["DateOrDatetime"]
+    type_class_curie = "linkml:DateOrDatetime"
+    type_name = "date_or_datetime"
+    type_model_uri = DATA_SHEETS_SCHEMA.DateOrDatetime
+
+
+class Uriorcurie(URIorCURIE):
+    """ a URI or a CURIE """
+    type_class_uri = XSD["anyURI"]
+    type_class_curie = "xsd:anyURI"
+    type_name = "uriorcurie"
+    type_model_uri = DATA_SHEETS_SCHEMA.Uriorcurie
+
+
+class Curie(Curie):
+    """ a compact URI """
+    type_class_uri = XSD["string"]
+    type_class_curie = "xsd:string"
+    type_name = "curie"
+    type_model_uri = DATA_SHEETS_SCHEMA.Curie
+
+
+class Uri(URI):
+    """ a complete URI """
+    type_class_uri = XSD["anyURI"]
+    type_class_curie = "xsd:anyURI"
+    type_name = "uri"
+    type_model_uri = DATA_SHEETS_SCHEMA.Uri
+
+
+class Ncname(NCName):
+    """ Prefix part of CURIE """
+    type_class_uri = XSD["string"]
+    type_class_curie = "xsd:string"
+    type_name = "ncname"
+    type_model_uri = DATA_SHEETS_SCHEMA.Ncname
+
+
+class Objectidentifier(ElementIdentifier):
+    """ A URI or CURIE that represents an object in the model. """
+    type_class_uri = SHEX["iri"]
+    type_class_curie = "shex:iri"
+    type_name = "objectidentifier"
+    type_model_uri = DATA_SHEETS_SCHEMA.Objectidentifier
+
+
+class Nodeidentifier(NodeIdentifier):
+    """ A URI, CURIE or BNODE that represents a node in a model. """
+    type_class_uri = SHEX["nonLiteral"]
+    type_class_curie = "shex:nonLiteral"
+    type_name = "nodeidentifier"
+    type_model_uri = DATA_SHEETS_SCHEMA.Nodeidentifier
+
+
+class Jsonpointer(str):
+    """ A string encoding a JSON Pointer. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to a valid object within the current instance document when encoded in tree form. """
+    type_class_uri = XSD["string"]
+    type_class_curie = "xsd:string"
+    type_name = "jsonpointer"
+    type_model_uri = DATA_SHEETS_SCHEMA.Jsonpointer
+
+
+class Jsonpath(str):
+    """ A string encoding a JSON Path. The value of the string MUST conform to JSON Point syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded in tree form. """
+    type_class_uri = XSD["string"]
+    type_class_curie = "xsd:string"
+    type_name = "jsonpath"
+    type_model_uri = DATA_SHEETS_SCHEMA.Jsonpath
+
+
+class Sparqlpath(str):
+    """ A string encoding a SPARQL Property Path. The value of the string MUST conform to SPARQL syntax and SHOULD dereference to zero or more valid objects within the current instance document when encoded as RDF. """
+    type_class_uri = XSD["string"]
+    type_class_curie = "xsd:string"
+    type_name = "sparqlpath"
+    type_model_uri = DATA_SHEETS_SCHEMA.Sparqlpath
+
 
 # Class references
 class NamedThingId(URIorCURIE):
@@ -420,12 +573,20 @@ class Organization(NamedThing):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Organization
 
     id: Union[str, OrganizationId] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
             self.MissingRequiredField("id")
         if not isinstance(self.id, OrganizationId):
             self.id = OrganizationId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -444,6 +605,8 @@ class DatasetProperty(NamedThing):
 
     id: Union[str, DatasetPropertyId] = None
     used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -454,6 +617,12 @@ class DatasetProperty(NamedThing):
         if not isinstance(self.used_software, list):
             self.used_software = [self.used_software] if self.used_software is not None else []
         self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -474,6 +643,8 @@ class Software(NamedThing):
     version: Optional[str] = None
     license: Optional[str] = None
     url: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -489,6 +660,12 @@ class Software(NamedThing):
 
         if self.url is not None and not isinstance(self.url, str):
             self.url = str(self.url)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -512,6 +689,8 @@ class Person(NamedThing):
     affiliation: Optional[Union[Union[str, OrganizationId], list[Union[str, OrganizationId]]]] = empty_list()
     email: Optional[str] = None
     orcid: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -528,6 +707,12 @@ class Person(NamedThing):
 
         if self.orcid is not None and not isinstance(self.orcid, str):
             self.orcid = str(self.orcid)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -565,6 +750,8 @@ class Information(NamedThing):
     title: Optional[str] = None
     version: Optional[str] = None
     was_derived_from: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -633,6 +820,73 @@ class Information(NamedThing):
         if self.was_derived_from is not None and not isinstance(self.was_derived_from, str):
             self.was_derived_from = str(self.was_derived_from)
 
+        if self.compression is not None and not isinstance(self.compression, CompressionEnum):
+            self.compression = CompressionEnum(self.compression)
+
+        if self.conforms_to is not None and not isinstance(self.conforms_to, str):
+            self.conforms_to = str(self.conforms_to)
+
+        if self.conforms_to_class is not None and not isinstance(self.conforms_to_class, str):
+            self.conforms_to_class = str(self.conforms_to_class)
+
+        if self.conforms_to_schema is not None and not isinstance(self.conforms_to_schema, str):
+            self.conforms_to_schema = str(self.conforms_to_schema)
+
+        if self.created_by is not None and not isinstance(self.created_by, str):
+            self.created_by = str(self.created_by)
+
+        if self.created_on is not None and not isinstance(self.created_on, XSDDateTime):
+            self.created_on = XSDDateTime(self.created_on)
+
+        if self.doi is not None and not isinstance(self.doi, str):
+            self.doi = str(self.doi)
+
+        if self.download_url is not None and not isinstance(self.download_url, URI):
+            self.download_url = URI(self.download_url)
+
+        if self.issued is not None and not isinstance(self.issued, XSDDateTime):
+            self.issued = XSDDateTime(self.issued)
+
+        if not isinstance(self.keywords, list):
+            self.keywords = [self.keywords] if self.keywords is not None else []
+        self.keywords = [v if isinstance(v, str) else str(v) for v in self.keywords]
+
+        if self.language is not None and not isinstance(self.language, str):
+            self.language = str(self.language)
+
+        if self.last_updated_on is not None and not isinstance(self.last_updated_on, XSDDateTime):
+            self.last_updated_on = XSDDateTime(self.last_updated_on)
+
+        if self.license is not None and not isinstance(self.license, str):
+            self.license = str(self.license)
+
+        if self.modified_by is not None and not isinstance(self.modified_by, str):
+            self.modified_by = str(self.modified_by)
+
+        if self.page is not None and not isinstance(self.page, str):
+            self.page = str(self.page)
+
+        if self.publisher is not None and not isinstance(self.publisher, URIorCURIE):
+            self.publisher = URIorCURIE(self.publisher)
+
+        if self.status is not None and not isinstance(self.status, str):
+            self.status = str(self.status)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.version is not None and not isinstance(self.version, str):
+            self.version = str(self.version)
+
+        if self.was_derived_from is not None and not isinstance(self.was_derived_from, str):
+            self.was_derived_from = str(self.was_derived_from)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -650,6 +904,28 @@ class DatasetCollection(Information):
 
     id: Union[str, DatasetCollectionId] = None
     resources: Optional[Union[Union[str, DatasetId], list[Union[str, DatasetId]]]] = empty_list()
+    compression: Optional[Union[str, "CompressionEnum"]] = None
+    conforms_to: Optional[str] = None
+    conforms_to_class: Optional[str] = None
+    conforms_to_schema: Optional[str] = None
+    created_by: Optional[str] = None
+    created_on: Optional[Union[str, XSDDateTime]] = None
+    doi: Optional[str] = None
+    download_url: Optional[Union[str, URI]] = None
+    issued: Optional[Union[str, XSDDateTime]] = None
+    keywords: Optional[Union[str, list[str]]] = empty_list()
+    language: Optional[str] = None
+    last_updated_on: Optional[Union[str, XSDDateTime]] = None
+    license: Optional[str] = None
+    modified_by: Optional[str] = None
+    page: Optional[str] = None
+    publisher: Optional[Union[str, URIorCURIE]] = None
+    status: Optional[str] = None
+    title: Optional[str] = None
+    version: Optional[str] = None
+    was_derived_from: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -660,6 +936,73 @@ class DatasetCollection(Information):
         if not isinstance(self.resources, list):
             self.resources = [self.resources] if self.resources is not None else []
         self.resources = [v if isinstance(v, DatasetId) else DatasetId(v) for v in self.resources]
+
+        if self.compression is not None and not isinstance(self.compression, CompressionEnum):
+            self.compression = CompressionEnum(self.compression)
+
+        if self.conforms_to is not None and not isinstance(self.conforms_to, str):
+            self.conforms_to = str(self.conforms_to)
+
+        if self.conforms_to_class is not None and not isinstance(self.conforms_to_class, str):
+            self.conforms_to_class = str(self.conforms_to_class)
+
+        if self.conforms_to_schema is not None and not isinstance(self.conforms_to_schema, str):
+            self.conforms_to_schema = str(self.conforms_to_schema)
+
+        if self.created_by is not None and not isinstance(self.created_by, str):
+            self.created_by = str(self.created_by)
+
+        if self.created_on is not None and not isinstance(self.created_on, XSDDateTime):
+            self.created_on = XSDDateTime(self.created_on)
+
+        if self.doi is not None and not isinstance(self.doi, str):
+            self.doi = str(self.doi)
+
+        if self.download_url is not None and not isinstance(self.download_url, URI):
+            self.download_url = URI(self.download_url)
+
+        if self.issued is not None and not isinstance(self.issued, XSDDateTime):
+            self.issued = XSDDateTime(self.issued)
+
+        if not isinstance(self.keywords, list):
+            self.keywords = [self.keywords] if self.keywords is not None else []
+        self.keywords = [v if isinstance(v, str) else str(v) for v in self.keywords]
+
+        if self.language is not None and not isinstance(self.language, str):
+            self.language = str(self.language)
+
+        if self.last_updated_on is not None and not isinstance(self.last_updated_on, XSDDateTime):
+            self.last_updated_on = XSDDateTime(self.last_updated_on)
+
+        if self.license is not None and not isinstance(self.license, str):
+            self.license = str(self.license)
+
+        if self.modified_by is not None and not isinstance(self.modified_by, str):
+            self.modified_by = str(self.modified_by)
+
+        if self.page is not None and not isinstance(self.page, str):
+            self.page = str(self.page)
+
+        if self.publisher is not None and not isinstance(self.publisher, URIorCURIE):
+            self.publisher = URIorCURIE(self.publisher)
+
+        if self.status is not None and not isinstance(self.status, str):
+            self.status = str(self.status)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.version is not None and not isinstance(self.version, str):
+            self.version = str(self.version)
+
+        if self.was_derived_from is not None and not isinstance(self.was_derived_from, str):
+            self.was_derived_from = str(self.was_derived_from)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -740,6 +1083,28 @@ class Dataset(Information):
     citation: Optional[str] = None
     parent_datasets: Optional[Union[Union[str, DatasetId], list[Union[str, DatasetId]]]] = empty_list()
     related_datasets: Optional[Union[Union[str, DatasetRelationshipId], list[Union[str, DatasetRelationshipId]]]] = empty_list()
+    compression: Optional[Union[str, "CompressionEnum"]] = None
+    conforms_to: Optional[str] = None
+    conforms_to_class: Optional[str] = None
+    conforms_to_schema: Optional[str] = None
+    created_by: Optional[str] = None
+    created_on: Optional[Union[str, XSDDateTime]] = None
+    doi: Optional[str] = None
+    download_url: Optional[Union[str, URI]] = None
+    issued: Optional[Union[str, XSDDateTime]] = None
+    keywords: Optional[Union[str, list[str]]] = empty_list()
+    language: Optional[str] = None
+    last_updated_on: Optional[Union[str, XSDDateTime]] = None
+    license: Optional[str] = None
+    modified_by: Optional[str] = None
+    page: Optional[str] = None
+    publisher: Optional[Union[str, URIorCURIE]] = None
+    status: Optional[str] = None
+    title: Optional[str] = None
+    version: Optional[str] = None
+    was_derived_from: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -973,6 +1338,100 @@ class Dataset(Information):
             self.related_datasets = [self.related_datasets] if self.related_datasets is not None else []
         self.related_datasets = [v if isinstance(v, DatasetRelationshipId) else DatasetRelationshipId(v) for v in self.related_datasets]
 
+        if self.bytes is not None and not isinstance(self.bytes, int):
+            self.bytes = int(self.bytes)
+
+        if self.dialect is not None and not isinstance(self.dialect, str):
+            self.dialect = str(self.dialect)
+
+        if self.encoding is not None and not isinstance(self.encoding, EncodingEnum):
+            self.encoding = EncodingEnum(self.encoding)
+
+        if self.format is not None and not isinstance(self.format, FormatEnum):
+            self.format = FormatEnum(self.format)
+
+        if self.hash is not None and not isinstance(self.hash, str):
+            self.hash = str(self.hash)
+
+        if self.md5 is not None and not isinstance(self.md5, str):
+            self.md5 = str(self.md5)
+
+        if self.media_type is not None and not isinstance(self.media_type, MediaTypeEnum):
+            self.media_type = MediaTypeEnum(self.media_type)
+
+        if self.path is not None and not isinstance(self.path, str):
+            self.path = str(self.path)
+
+        if self.sha256 is not None and not isinstance(self.sha256, str):
+            self.sha256 = str(self.sha256)
+
+        if self.compression is not None and not isinstance(self.compression, CompressionEnum):
+            self.compression = CompressionEnum(self.compression)
+
+        if self.conforms_to is not None and not isinstance(self.conforms_to, str):
+            self.conforms_to = str(self.conforms_to)
+
+        if self.conforms_to_class is not None and not isinstance(self.conforms_to_class, str):
+            self.conforms_to_class = str(self.conforms_to_class)
+
+        if self.conforms_to_schema is not None and not isinstance(self.conforms_to_schema, str):
+            self.conforms_to_schema = str(self.conforms_to_schema)
+
+        if self.created_by is not None and not isinstance(self.created_by, str):
+            self.created_by = str(self.created_by)
+
+        if self.created_on is not None and not isinstance(self.created_on, XSDDateTime):
+            self.created_on = XSDDateTime(self.created_on)
+
+        if self.doi is not None and not isinstance(self.doi, str):
+            self.doi = str(self.doi)
+
+        if self.download_url is not None and not isinstance(self.download_url, URI):
+            self.download_url = URI(self.download_url)
+
+        if self.issued is not None and not isinstance(self.issued, XSDDateTime):
+            self.issued = XSDDateTime(self.issued)
+
+        if not isinstance(self.keywords, list):
+            self.keywords = [self.keywords] if self.keywords is not None else []
+        self.keywords = [v if isinstance(v, str) else str(v) for v in self.keywords]
+
+        if self.language is not None and not isinstance(self.language, str):
+            self.language = str(self.language)
+
+        if self.last_updated_on is not None and not isinstance(self.last_updated_on, XSDDateTime):
+            self.last_updated_on = XSDDateTime(self.last_updated_on)
+
+        if self.license is not None and not isinstance(self.license, str):
+            self.license = str(self.license)
+
+        if self.modified_by is not None and not isinstance(self.modified_by, str):
+            self.modified_by = str(self.modified_by)
+
+        if self.page is not None and not isinstance(self.page, str):
+            self.page = str(self.page)
+
+        if self.publisher is not None and not isinstance(self.publisher, URIorCURIE):
+            self.publisher = URIorCURIE(self.publisher)
+
+        if self.status is not None and not isinstance(self.status, str):
+            self.status = str(self.status)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.version is not None and not isinstance(self.version, str):
+            self.version = str(self.version)
+
+        if self.was_derived_from is not None and not isinstance(self.was_derived_from, str):
+            self.was_derived_from = str(self.was_derived_from)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -991,6 +1450,90 @@ class DataSubset(Dataset):
     id: Union[str, DataSubsetId] = None
     is_data_split: Optional[Union[bool, Bool]] = None
     is_subpopulation: Optional[Union[bool, Bool]] = None
+    bytes: Optional[int] = None
+    dialect: Optional[str] = None
+    encoding: Optional[Union[str, "EncodingEnum"]] = None
+    format: Optional[Union[str, "FormatEnum"]] = None
+    hash: Optional[str] = None
+    md5: Optional[str] = None
+    media_type: Optional[Union[str, "MediaTypeEnum"]] = None
+    path: Optional[str] = None
+    sha256: Optional[str] = None
+    purposes: Optional[Union[Union[str, PurposeId], list[Union[str, PurposeId]]]] = empty_list()
+    tasks: Optional[Union[Union[str, TaskId], list[Union[str, TaskId]]]] = empty_list()
+    addressing_gaps: Optional[Union[Union[str, AddressingGapId], list[Union[str, AddressingGapId]]]] = empty_list()
+    creators: Optional[Union[Union[str, CreatorId], list[Union[str, CreatorId]]]] = empty_list()
+    funders: Optional[Union[Union[str, FundingMechanismId], list[Union[str, FundingMechanismId]]]] = empty_list()
+    subsets: Optional[Union[Union[str, DataSubsetId], list[Union[str, DataSubsetId]]]] = empty_list()
+    instances: Optional[Union[Union[str, InstanceId], list[Union[str, InstanceId]]]] = empty_list()
+    anomalies: Optional[Union[Union[str, DataAnomalyId], list[Union[str, DataAnomalyId]]]] = empty_list()
+    external_resources: Optional[Union[Union[str, ExternalResourceId], list[Union[str, ExternalResourceId]]]] = empty_list()
+    confidential_elements: Optional[Union[Union[str, ConfidentialityId], list[Union[str, ConfidentialityId]]]] = empty_list()
+    content_warnings: Optional[Union[Union[str, ContentWarningId], list[Union[str, ContentWarningId]]]] = empty_list()
+    subpopulations: Optional[Union[Union[str, SubpopulationId], list[Union[str, SubpopulationId]]]] = empty_list()
+    sensitive_elements: Optional[Union[Union[str, SensitiveElementId], list[Union[str, SensitiveElementId]]]] = empty_list()
+    acquisition_methods: Optional[Union[Union[str, InstanceAcquisitionId], list[Union[str, InstanceAcquisitionId]]]] = empty_list()
+    collection_mechanisms: Optional[Union[Union[str, CollectionMechanismId], list[Union[str, CollectionMechanismId]]]] = empty_list()
+    sampling_strategies: Optional[Union[Union[str, SamplingStrategyId], list[Union[str, SamplingStrategyId]]]] = empty_list()
+    data_collectors: Optional[Union[Union[str, DataCollectorId], list[Union[str, DataCollectorId]]]] = empty_list()
+    collection_timeframes: Optional[Union[Union[str, CollectionTimeframeId], list[Union[str, CollectionTimeframeId]]]] = empty_list()
+    ethical_reviews: Optional[Union[Union[str, EthicalReviewId], list[Union[str, EthicalReviewId]]]] = empty_list()
+    data_protection_impacts: Optional[Union[Union[str, DataProtectionImpactId], list[Union[str, DataProtectionImpactId]]]] = empty_list()
+    human_subject_research: Optional[Union[str, HumanSubjectResearchId]] = None
+    informed_consent: Optional[Union[Union[str, InformedConsentId], list[Union[str, InformedConsentId]]]] = empty_list()
+    participant_privacy: Optional[Union[Union[str, ParticipantPrivacyId], list[Union[str, ParticipantPrivacyId]]]] = empty_list()
+    participant_compensation: Optional[Union[str, HumanSubjectCompensationId]] = None
+    vulnerable_populations: Optional[Union[str, VulnerablePopulationsId]] = None
+    preprocessing_strategies: Optional[Union[Union[str, PreprocessingStrategyId], list[Union[str, PreprocessingStrategyId]]]] = empty_list()
+    cleaning_strategies: Optional[Union[Union[str, CleaningStrategyId], list[Union[str, CleaningStrategyId]]]] = empty_list()
+    labeling_strategies: Optional[Union[Union[str, LabelingStrategyId], list[Union[str, LabelingStrategyId]]]] = empty_list()
+    raw_sources: Optional[Union[Union[str, RawDataId], list[Union[str, RawDataId]]]] = empty_list()
+    existing_uses: Optional[Union[Union[str, ExistingUseId], list[Union[str, ExistingUseId]]]] = empty_list()
+    use_repository: Optional[Union[Union[str, UseRepositoryId], list[Union[str, UseRepositoryId]]]] = empty_list()
+    other_tasks: Optional[Union[Union[str, OtherTaskId], list[Union[str, OtherTaskId]]]] = empty_list()
+    future_use_impacts: Optional[Union[Union[str, FutureUseImpactId], list[Union[str, FutureUseImpactId]]]] = empty_list()
+    discouraged_uses: Optional[Union[Union[str, DiscouragedUseId], list[Union[str, DiscouragedUseId]]]] = empty_list()
+    intended_uses: Optional[Union[Union[str, IntendedUseId], list[Union[str, IntendedUseId]]]] = empty_list()
+    prohibited_uses: Optional[Union[Union[str, ProhibitedUseId], list[Union[str, ProhibitedUseId]]]] = empty_list()
+    distribution_formats: Optional[Union[Union[str, DistributionFormatId], list[Union[str, DistributionFormatId]]]] = empty_list()
+    distribution_dates: Optional[Union[Union[str, DistributionDateId], list[Union[str, DistributionDateId]]]] = empty_list()
+    license_and_use_terms: Optional[Union[str, LicenseAndUseTermsId]] = None
+    ip_restrictions: Optional[Union[str, IPRestrictionsId]] = None
+    regulatory_restrictions: Optional[Union[str, ExportControlRegulatoryRestrictionsId]] = None
+    maintainers: Optional[Union[Union[str, MaintainerId], list[Union[str, MaintainerId]]]] = empty_list()
+    errata: Optional[Union[Union[str, ErratumId], list[Union[str, ErratumId]]]] = empty_list()
+    updates: Optional[Union[str, UpdatePlanId]] = None
+    retention_limit: Optional[Union[str, RetentionLimitsId]] = None
+    version_access: Optional[Union[str, VersionAccessId]] = None
+    extension_mechanism: Optional[Union[str, ExtensionMechanismId]] = None
+    variables: Optional[Union[Union[str, VariableMetadataId], list[Union[str, VariableMetadataId]]]] = empty_list()
+    is_deidentified: Optional[Union[str, DeidentificationId]] = None
+    is_tabular: Optional[Union[bool, Bool]] = None
+    citation: Optional[str] = None
+    parent_datasets: Optional[Union[Union[str, DatasetId], list[Union[str, DatasetId]]]] = empty_list()
+    related_datasets: Optional[Union[Union[str, DatasetRelationshipId], list[Union[str, DatasetRelationshipId]]]] = empty_list()
+    compression: Optional[Union[str, "CompressionEnum"]] = None
+    conforms_to: Optional[str] = None
+    conforms_to_class: Optional[str] = None
+    conforms_to_schema: Optional[str] = None
+    created_by: Optional[str] = None
+    created_on: Optional[Union[str, XSDDateTime]] = None
+    doi: Optional[str] = None
+    download_url: Optional[Union[str, URI]] = None
+    issued: Optional[Union[str, XSDDateTime]] = None
+    keywords: Optional[Union[str, list[str]]] = empty_list()
+    language: Optional[str] = None
+    last_updated_on: Optional[Union[str, XSDDateTime]] = None
+    license: Optional[str] = None
+    modified_by: Optional[str] = None
+    page: Optional[str] = None
+    publisher: Optional[Union[str, URIorCURIE]] = None
+    status: Optional[str] = None
+    title: Optional[str] = None
+    version: Optional[str] = None
+    was_derived_from: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1003,6 +1546,299 @@ class DataSubset(Dataset):
 
         if self.is_subpopulation is not None and not isinstance(self.is_subpopulation, Bool):
             self.is_subpopulation = Bool(self.is_subpopulation)
+
+        if self.bytes is not None and not isinstance(self.bytes, int):
+            self.bytes = int(self.bytes)
+
+        if self.dialect is not None and not isinstance(self.dialect, str):
+            self.dialect = str(self.dialect)
+
+        if self.encoding is not None and not isinstance(self.encoding, EncodingEnum):
+            self.encoding = EncodingEnum(self.encoding)
+
+        if self.format is not None and not isinstance(self.format, FormatEnum):
+            self.format = FormatEnum(self.format)
+
+        if self.hash is not None and not isinstance(self.hash, str):
+            self.hash = str(self.hash)
+
+        if self.md5 is not None and not isinstance(self.md5, str):
+            self.md5 = str(self.md5)
+
+        if self.media_type is not None and not isinstance(self.media_type, MediaTypeEnum):
+            self.media_type = MediaTypeEnum(self.media_type)
+
+        if self.path is not None and not isinstance(self.path, str):
+            self.path = str(self.path)
+
+        if self.sha256 is not None and not isinstance(self.sha256, str):
+            self.sha256 = str(self.sha256)
+
+        if not isinstance(self.purposes, list):
+            self.purposes = [self.purposes] if self.purposes is not None else []
+        self.purposes = [v if isinstance(v, PurposeId) else PurposeId(v) for v in self.purposes]
+
+        if not isinstance(self.tasks, list):
+            self.tasks = [self.tasks] if self.tasks is not None else []
+        self.tasks = [v if isinstance(v, TaskId) else TaskId(v) for v in self.tasks]
+
+        if not isinstance(self.addressing_gaps, list):
+            self.addressing_gaps = [self.addressing_gaps] if self.addressing_gaps is not None else []
+        self.addressing_gaps = [v if isinstance(v, AddressingGapId) else AddressingGapId(v) for v in self.addressing_gaps]
+
+        if not isinstance(self.creators, list):
+            self.creators = [self.creators] if self.creators is not None else []
+        self.creators = [v if isinstance(v, CreatorId) else CreatorId(v) for v in self.creators]
+
+        if not isinstance(self.funders, list):
+            self.funders = [self.funders] if self.funders is not None else []
+        self.funders = [v if isinstance(v, FundingMechanismId) else FundingMechanismId(v) for v in self.funders]
+
+        if not isinstance(self.subsets, list):
+            self.subsets = [self.subsets] if self.subsets is not None else []
+        self.subsets = [v if isinstance(v, DataSubsetId) else DataSubsetId(v) for v in self.subsets]
+
+        if not isinstance(self.instances, list):
+            self.instances = [self.instances] if self.instances is not None else []
+        self.instances = [v if isinstance(v, InstanceId) else InstanceId(v) for v in self.instances]
+
+        if not isinstance(self.anomalies, list):
+            self.anomalies = [self.anomalies] if self.anomalies is not None else []
+        self.anomalies = [v if isinstance(v, DataAnomalyId) else DataAnomalyId(v) for v in self.anomalies]
+
+        if not isinstance(self.external_resources, list):
+            self.external_resources = [self.external_resources] if self.external_resources is not None else []
+        self.external_resources = [v if isinstance(v, ExternalResourceId) else ExternalResourceId(v) for v in self.external_resources]
+
+        if not isinstance(self.confidential_elements, list):
+            self.confidential_elements = [self.confidential_elements] if self.confidential_elements is not None else []
+        self.confidential_elements = [v if isinstance(v, ConfidentialityId) else ConfidentialityId(v) for v in self.confidential_elements]
+
+        if not isinstance(self.content_warnings, list):
+            self.content_warnings = [self.content_warnings] if self.content_warnings is not None else []
+        self.content_warnings = [v if isinstance(v, ContentWarningId) else ContentWarningId(v) for v in self.content_warnings]
+
+        if not isinstance(self.subpopulations, list):
+            self.subpopulations = [self.subpopulations] if self.subpopulations is not None else []
+        self.subpopulations = [v if isinstance(v, SubpopulationId) else SubpopulationId(v) for v in self.subpopulations]
+
+        if not isinstance(self.sensitive_elements, list):
+            self.sensitive_elements = [self.sensitive_elements] if self.sensitive_elements is not None else []
+        self.sensitive_elements = [v if isinstance(v, SensitiveElementId) else SensitiveElementId(v) for v in self.sensitive_elements]
+
+        if not isinstance(self.acquisition_methods, list):
+            self.acquisition_methods = [self.acquisition_methods] if self.acquisition_methods is not None else []
+        self.acquisition_methods = [v if isinstance(v, InstanceAcquisitionId) else InstanceAcquisitionId(v) for v in self.acquisition_methods]
+
+        if not isinstance(self.collection_mechanisms, list):
+            self.collection_mechanisms = [self.collection_mechanisms] if self.collection_mechanisms is not None else []
+        self.collection_mechanisms = [v if isinstance(v, CollectionMechanismId) else CollectionMechanismId(v) for v in self.collection_mechanisms]
+
+        if not isinstance(self.sampling_strategies, list):
+            self.sampling_strategies = [self.sampling_strategies] if self.sampling_strategies is not None else []
+        self.sampling_strategies = [v if isinstance(v, SamplingStrategyId) else SamplingStrategyId(v) for v in self.sampling_strategies]
+
+        if not isinstance(self.data_collectors, list):
+            self.data_collectors = [self.data_collectors] if self.data_collectors is not None else []
+        self.data_collectors = [v if isinstance(v, DataCollectorId) else DataCollectorId(v) for v in self.data_collectors]
+
+        if not isinstance(self.collection_timeframes, list):
+            self.collection_timeframes = [self.collection_timeframes] if self.collection_timeframes is not None else []
+        self.collection_timeframes = [v if isinstance(v, CollectionTimeframeId) else CollectionTimeframeId(v) for v in self.collection_timeframes]
+
+        if not isinstance(self.ethical_reviews, list):
+            self.ethical_reviews = [self.ethical_reviews] if self.ethical_reviews is not None else []
+        self.ethical_reviews = [v if isinstance(v, EthicalReviewId) else EthicalReviewId(v) for v in self.ethical_reviews]
+
+        if not isinstance(self.data_protection_impacts, list):
+            self.data_protection_impacts = [self.data_protection_impacts] if self.data_protection_impacts is not None else []
+        self.data_protection_impacts = [v if isinstance(v, DataProtectionImpactId) else DataProtectionImpactId(v) for v in self.data_protection_impacts]
+
+        if self.human_subject_research is not None and not isinstance(self.human_subject_research, HumanSubjectResearchId):
+            self.human_subject_research = HumanSubjectResearchId(self.human_subject_research)
+
+        if not isinstance(self.informed_consent, list):
+            self.informed_consent = [self.informed_consent] if self.informed_consent is not None else []
+        self.informed_consent = [v if isinstance(v, InformedConsentId) else InformedConsentId(v) for v in self.informed_consent]
+
+        if not isinstance(self.participant_privacy, list):
+            self.participant_privacy = [self.participant_privacy] if self.participant_privacy is not None else []
+        self.participant_privacy = [v if isinstance(v, ParticipantPrivacyId) else ParticipantPrivacyId(v) for v in self.participant_privacy]
+
+        if self.participant_compensation is not None and not isinstance(self.participant_compensation, HumanSubjectCompensationId):
+            self.participant_compensation = HumanSubjectCompensationId(self.participant_compensation)
+
+        if self.vulnerable_populations is not None and not isinstance(self.vulnerable_populations, VulnerablePopulationsId):
+            self.vulnerable_populations = VulnerablePopulationsId(self.vulnerable_populations)
+
+        if not isinstance(self.preprocessing_strategies, list):
+            self.preprocessing_strategies = [self.preprocessing_strategies] if self.preprocessing_strategies is not None else []
+        self.preprocessing_strategies = [v if isinstance(v, PreprocessingStrategyId) else PreprocessingStrategyId(v) for v in self.preprocessing_strategies]
+
+        if not isinstance(self.cleaning_strategies, list):
+            self.cleaning_strategies = [self.cleaning_strategies] if self.cleaning_strategies is not None else []
+        self.cleaning_strategies = [v if isinstance(v, CleaningStrategyId) else CleaningStrategyId(v) for v in self.cleaning_strategies]
+
+        if not isinstance(self.labeling_strategies, list):
+            self.labeling_strategies = [self.labeling_strategies] if self.labeling_strategies is not None else []
+        self.labeling_strategies = [v if isinstance(v, LabelingStrategyId) else LabelingStrategyId(v) for v in self.labeling_strategies]
+
+        if not isinstance(self.raw_sources, list):
+            self.raw_sources = [self.raw_sources] if self.raw_sources is not None else []
+        self.raw_sources = [v if isinstance(v, RawDataId) else RawDataId(v) for v in self.raw_sources]
+
+        if not isinstance(self.existing_uses, list):
+            self.existing_uses = [self.existing_uses] if self.existing_uses is not None else []
+        self.existing_uses = [v if isinstance(v, ExistingUseId) else ExistingUseId(v) for v in self.existing_uses]
+
+        if not isinstance(self.use_repository, list):
+            self.use_repository = [self.use_repository] if self.use_repository is not None else []
+        self.use_repository = [v if isinstance(v, UseRepositoryId) else UseRepositoryId(v) for v in self.use_repository]
+
+        if not isinstance(self.other_tasks, list):
+            self.other_tasks = [self.other_tasks] if self.other_tasks is not None else []
+        self.other_tasks = [v if isinstance(v, OtherTaskId) else OtherTaskId(v) for v in self.other_tasks]
+
+        if not isinstance(self.future_use_impacts, list):
+            self.future_use_impacts = [self.future_use_impacts] if self.future_use_impacts is not None else []
+        self.future_use_impacts = [v if isinstance(v, FutureUseImpactId) else FutureUseImpactId(v) for v in self.future_use_impacts]
+
+        if not isinstance(self.discouraged_uses, list):
+            self.discouraged_uses = [self.discouraged_uses] if self.discouraged_uses is not None else []
+        self.discouraged_uses = [v if isinstance(v, DiscouragedUseId) else DiscouragedUseId(v) for v in self.discouraged_uses]
+
+        if not isinstance(self.intended_uses, list):
+            self.intended_uses = [self.intended_uses] if self.intended_uses is not None else []
+        self.intended_uses = [v if isinstance(v, IntendedUseId) else IntendedUseId(v) for v in self.intended_uses]
+
+        if not isinstance(self.prohibited_uses, list):
+            self.prohibited_uses = [self.prohibited_uses] if self.prohibited_uses is not None else []
+        self.prohibited_uses = [v if isinstance(v, ProhibitedUseId) else ProhibitedUseId(v) for v in self.prohibited_uses]
+
+        if not isinstance(self.distribution_formats, list):
+            self.distribution_formats = [self.distribution_formats] if self.distribution_formats is not None else []
+        self.distribution_formats = [v if isinstance(v, DistributionFormatId) else DistributionFormatId(v) for v in self.distribution_formats]
+
+        if not isinstance(self.distribution_dates, list):
+            self.distribution_dates = [self.distribution_dates] if self.distribution_dates is not None else []
+        self.distribution_dates = [v if isinstance(v, DistributionDateId) else DistributionDateId(v) for v in self.distribution_dates]
+
+        if self.license_and_use_terms is not None and not isinstance(self.license_and_use_terms, LicenseAndUseTermsId):
+            self.license_and_use_terms = LicenseAndUseTermsId(self.license_and_use_terms)
+
+        if self.ip_restrictions is not None and not isinstance(self.ip_restrictions, IPRestrictionsId):
+            self.ip_restrictions = IPRestrictionsId(self.ip_restrictions)
+
+        if self.regulatory_restrictions is not None and not isinstance(self.regulatory_restrictions, ExportControlRegulatoryRestrictionsId):
+            self.regulatory_restrictions = ExportControlRegulatoryRestrictionsId(self.regulatory_restrictions)
+
+        if not isinstance(self.maintainers, list):
+            self.maintainers = [self.maintainers] if self.maintainers is not None else []
+        self.maintainers = [v if isinstance(v, MaintainerId) else MaintainerId(v) for v in self.maintainers]
+
+        if not isinstance(self.errata, list):
+            self.errata = [self.errata] if self.errata is not None else []
+        self.errata = [v if isinstance(v, ErratumId) else ErratumId(v) for v in self.errata]
+
+        if self.updates is not None and not isinstance(self.updates, UpdatePlanId):
+            self.updates = UpdatePlanId(self.updates)
+
+        if self.retention_limit is not None and not isinstance(self.retention_limit, RetentionLimitsId):
+            self.retention_limit = RetentionLimitsId(self.retention_limit)
+
+        if self.version_access is not None and not isinstance(self.version_access, VersionAccessId):
+            self.version_access = VersionAccessId(self.version_access)
+
+        if self.extension_mechanism is not None and not isinstance(self.extension_mechanism, ExtensionMechanismId):
+            self.extension_mechanism = ExtensionMechanismId(self.extension_mechanism)
+
+        if not isinstance(self.variables, list):
+            self.variables = [self.variables] if self.variables is not None else []
+        self.variables = [v if isinstance(v, VariableMetadataId) else VariableMetadataId(v) for v in self.variables]
+
+        if self.is_deidentified is not None and not isinstance(self.is_deidentified, DeidentificationId):
+            self.is_deidentified = DeidentificationId(self.is_deidentified)
+
+        if self.is_tabular is not None and not isinstance(self.is_tabular, Bool):
+            self.is_tabular = Bool(self.is_tabular)
+
+        if self.citation is not None and not isinstance(self.citation, str):
+            self.citation = str(self.citation)
+
+        if not isinstance(self.parent_datasets, list):
+            self.parent_datasets = [self.parent_datasets] if self.parent_datasets is not None else []
+        self.parent_datasets = [v if isinstance(v, DatasetId) else DatasetId(v) for v in self.parent_datasets]
+
+        if not isinstance(self.related_datasets, list):
+            self.related_datasets = [self.related_datasets] if self.related_datasets is not None else []
+        self.related_datasets = [v if isinstance(v, DatasetRelationshipId) else DatasetRelationshipId(v) for v in self.related_datasets]
+
+        if self.compression is not None and not isinstance(self.compression, CompressionEnum):
+            self.compression = CompressionEnum(self.compression)
+
+        if self.conforms_to is not None and not isinstance(self.conforms_to, str):
+            self.conforms_to = str(self.conforms_to)
+
+        if self.conforms_to_class is not None and not isinstance(self.conforms_to_class, str):
+            self.conforms_to_class = str(self.conforms_to_class)
+
+        if self.conforms_to_schema is not None and not isinstance(self.conforms_to_schema, str):
+            self.conforms_to_schema = str(self.conforms_to_schema)
+
+        if self.created_by is not None and not isinstance(self.created_by, str):
+            self.created_by = str(self.created_by)
+
+        if self.created_on is not None and not isinstance(self.created_on, XSDDateTime):
+            self.created_on = XSDDateTime(self.created_on)
+
+        if self.doi is not None and not isinstance(self.doi, str):
+            self.doi = str(self.doi)
+
+        if self.download_url is not None and not isinstance(self.download_url, URI):
+            self.download_url = URI(self.download_url)
+
+        if self.issued is not None and not isinstance(self.issued, XSDDateTime):
+            self.issued = XSDDateTime(self.issued)
+
+        if not isinstance(self.keywords, list):
+            self.keywords = [self.keywords] if self.keywords is not None else []
+        self.keywords = [v if isinstance(v, str) else str(v) for v in self.keywords]
+
+        if self.language is not None and not isinstance(self.language, str):
+            self.language = str(self.language)
+
+        if self.last_updated_on is not None and not isinstance(self.last_updated_on, XSDDateTime):
+            self.last_updated_on = XSDDateTime(self.last_updated_on)
+
+        if self.license is not None and not isinstance(self.license, str):
+            self.license = str(self.license)
+
+        if self.modified_by is not None and not isinstance(self.modified_by, str):
+            self.modified_by = str(self.modified_by)
+
+        if self.page is not None and not isinstance(self.page, str):
+            self.page = str(self.page)
+
+        if self.publisher is not None and not isinstance(self.publisher, URIorCURIE):
+            self.publisher = URIorCURIE(self.publisher)
+
+        if self.status is not None and not isinstance(self.status, str):
+            self.status = str(self.status)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.version is not None and not isinstance(self.version, str):
+            self.version = str(self.version)
+
+        if self.was_derived_from is not None and not isinstance(self.was_derived_from, str):
+            self.was_derived_from = str(self.was_derived_from)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -1051,13 +1887,16 @@ class Purpose(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMOTIVATION["Purpose"]
-    class_class_curie: ClassVar[str] = "d4dmotivation:Purpose"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Purpose"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Purpose"
     class_name: ClassVar[str] = "Purpose"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Purpose
 
     id: Union[str, PurposeId] = None
     response: Optional[str] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1067,6 +1906,16 @@ class Purpose(DatasetProperty):
 
         if self.response is not None and not isinstance(self.response, str):
             self.response = str(self.response)
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -1078,13 +1927,16 @@ class Task(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMOTIVATION["Task"]
-    class_class_curie: ClassVar[str] = "d4dmotivation:Task"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Task"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Task"
     class_name: ClassVar[str] = "Task"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Task
 
     id: Union[str, TaskId] = None
     response: Optional[str] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1094,6 +1946,16 @@ class Task(DatasetProperty):
 
         if self.response is not None and not isinstance(self.response, str):
             self.response = str(self.response)
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -1105,13 +1967,16 @@ class AddressingGap(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMOTIVATION["AddressingGap"]
-    class_class_curie: ClassVar[str] = "d4dmotivation:AddressingGap"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["AddressingGap"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:AddressingGap"
     class_name: ClassVar[str] = "AddressingGap"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.AddressingGap
 
     id: Union[str, AddressingGapId] = None
     response: Optional[str] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1121,6 +1986,16 @@ class AddressingGap(DatasetProperty):
 
         if self.response is not None and not isinstance(self.response, str):
             self.response = str(self.response)
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -1133,8 +2008,8 @@ class Creator(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMOTIVATION["Creator"]
-    class_class_curie: ClassVar[str] = "d4dmotivation:Creator"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Creator"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Creator"
     class_name: ClassVar[str] = "Creator"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Creator
 
@@ -1142,6 +2017,9 @@ class Creator(DatasetProperty):
     principal_investigator: Optional[Union[str, PersonId]] = None
     affiliation: Optional[Union[str, OrganizationId]] = None
     credit_roles: Optional[Union[Union[str, "CRediTRoleEnum"], list[Union[str, "CRediTRoleEnum"]]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1159,6 +2037,16 @@ class Creator(DatasetProperty):
             self.credit_roles = [self.credit_roles] if self.credit_roles is not None else []
         self.credit_roles = [v if isinstance(v, CRediTRoleEnum) else CRediTRoleEnum(v) for v in self.credit_roles]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -1170,14 +2058,17 @@ class FundingMechanism(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMOTIVATION["FundingMechanism"]
-    class_class_curie: ClassVar[str] = "d4dmotivation:FundingMechanism"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["FundingMechanism"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:FundingMechanism"
     class_name: ClassVar[str] = "FundingMechanism"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.FundingMechanism
 
     id: Union[str, FundingMechanismId] = None
     grantor: Optional[Union[str, GrantorId]] = None
     grant: Optional[Union[str, GrantId]] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1191,6 +2082,16 @@ class FundingMechanism(DatasetProperty):
         if self.grant is not None and not isinstance(self.grant, GrantId):
             self.grant = GrantId(self.grant)
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -1202,18 +2103,26 @@ class Grantor(Organization):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMOTIVATION["Grantor"]
-    class_class_curie: ClassVar[str] = "d4dmotivation:Grantor"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Grantor"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Grantor"
     class_name: ClassVar[str] = "Grantor"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Grantor
 
     id: Union[str, GrantorId] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
             self.MissingRequiredField("id")
         if not isinstance(self.id, GrantorId):
             self.id = GrantorId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -1226,13 +2135,15 @@ class Grant(NamedThing):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMOTIVATION["Grant"]
-    class_class_curie: ClassVar[str] = "d4dmotivation:Grant"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Grant"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Grant"
     class_name: ClassVar[str] = "Grant"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Grant
 
     id: Union[str, GrantId] = None
     grant_number: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1242,6 +2153,12 @@ class Grant(NamedThing):
 
         if self.grant_number is not None and not isinstance(self.grant_number, str):
             self.grant_number = str(self.grant_number)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -1253,8 +2170,8 @@ class Instance(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["Instance"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:Instance"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Instance"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Instance"
     class_name: ClassVar[str] = "Instance"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Instance
 
@@ -1267,6 +2184,9 @@ class Instance(DatasetProperty):
     label_description: Optional[str] = None
     sampling_strategies: Optional[Union[Union[str, SamplingStrategyId], list[Union[str, SamplingStrategyId]]]] = empty_list()
     missing_information: Optional[Union[Union[str, MissingInfoId], list[Union[str, MissingInfoId]]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1300,6 +2220,16 @@ class Instance(DatasetProperty):
             self.missing_information = [self.missing_information] if self.missing_information is not None else []
         self.missing_information = [v if isinstance(v, MissingInfoId) else MissingInfoId(v) for v in self.missing_information]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -1311,8 +2241,8 @@ class SamplingStrategy(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["SamplingStrategy"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:SamplingStrategy"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["SamplingStrategy"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:SamplingStrategy"
     class_name: ClassVar[str] = "SamplingStrategy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.SamplingStrategy
 
@@ -1324,6 +2254,9 @@ class SamplingStrategy(DatasetProperty):
     representative_verification: Optional[Union[str, list[str]]] = empty_list()
     why_not_representative: Optional[Union[str, list[str]]] = empty_list()
     strategies: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1359,6 +2292,16 @@ class SamplingStrategy(DatasetProperty):
             self.strategies = [self.strategies] if self.strategies is not None else []
         self.strategies = [v if isinstance(v, str) else str(v) for v in self.strategies]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -1369,14 +2312,17 @@ class MissingInfo(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["MissingInfo"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:MissingInfo"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["MissingInfo"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:MissingInfo"
     class_name: ClassVar[str] = "MissingInfo"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.MissingInfo
 
     id: Union[str, MissingInfoId] = None
     missing: Optional[Union[str, list[str]]] = empty_list()
     why_missing: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1392,6 +2338,16 @@ class MissingInfo(DatasetProperty):
             self.why_missing = [self.why_missing] if self.why_missing is not None else []
         self.why_missing = [v if isinstance(v, str) else str(v) for v in self.why_missing]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -1402,13 +2358,15 @@ class Relationships(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["Relationships"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:Relationships"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Relationships"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Relationships"
     class_name: ClassVar[str] = "Relationships"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Relationships
 
     id: Union[str, RelationshipsId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1420,6 +2378,13 @@ class Relationships(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1430,13 +2395,15 @@ class Splits(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["Splits"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:Splits"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Splits"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Splits"
     class_name: ClassVar[str] = "Splits"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Splits
 
     id: Union[str, SplitsId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1448,6 +2415,13 @@ class Splits(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1458,13 +2432,15 @@ class DataAnomaly(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["DataAnomaly"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:DataAnomaly"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["DataAnomaly"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:DataAnomaly"
     class_name: ClassVar[str] = "DataAnomaly"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DataAnomaly
 
     id: Union[str, DataAnomalyId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1475,6 +2451,13 @@ class DataAnomaly(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -1487,8 +2470,8 @@ class ExternalResource(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["ExternalResource"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:ExternalResource"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ExternalResource"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ExternalResource"
     class_name: ClassVar[str] = "ExternalResource"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ExternalResource
 
@@ -1497,6 +2480,9 @@ class ExternalResource(DatasetProperty):
     future_guarantees: Optional[Union[str, list[str]]] = empty_list()
     archival: Optional[Union[Union[bool, Bool], list[Union[bool, Bool]]]] = empty_list()
     restrictions: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1520,6 +2506,16 @@ class ExternalResource(DatasetProperty):
             self.restrictions = [self.restrictions] if self.restrictions is not None else []
         self.restrictions = [v if isinstance(v, str) else str(v) for v in self.restrictions]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -1531,14 +2527,16 @@ class Confidentiality(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["Confidentiality"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:Confidentiality"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Confidentiality"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Confidentiality"
     class_name: ClassVar[str] = "Confidentiality"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Confidentiality
 
     id: Union[str, ConfidentialityId] = None
     confidential_elements_present: Optional[Union[bool, Bool]] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1553,6 +2551,13 @@ class Confidentiality(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1564,14 +2569,17 @@ class ContentWarning(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["ContentWarning"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:ContentWarning"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ContentWarning"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ContentWarning"
     class_name: ClassVar[str] = "ContentWarning"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ContentWarning
 
     id: Union[str, ContentWarningId] = None
     content_warnings_present: Optional[Union[bool, Bool]] = None
     warnings: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1586,6 +2594,16 @@ class ContentWarning(DatasetProperty):
             self.warnings = [self.warnings] if self.warnings is not None else []
         self.warnings = [v if isinstance(v, str) else str(v) for v in self.warnings]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -1597,8 +2615,8 @@ class Subpopulation(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["Subpopulation"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:Subpopulation"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Subpopulation"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Subpopulation"
     class_name: ClassVar[str] = "Subpopulation"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Subpopulation
 
@@ -1606,6 +2624,9 @@ class Subpopulation(DatasetProperty):
     subpopulation_elements_present: Optional[Union[bool, Bool]] = None
     identification: Optional[Union[str, list[str]]] = empty_list()
     distribution: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1624,6 +2645,16 @@ class Subpopulation(DatasetProperty):
             self.distribution = [self.distribution] if self.distribution is not None else []
         self.distribution = [v if isinstance(v, str) else str(v) for v in self.distribution]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -1635,14 +2666,16 @@ class Deidentification(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["Deidentification"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:Deidentification"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Deidentification"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Deidentification"
     class_name: ClassVar[str] = "Deidentification"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Deidentification
 
     id: Union[str, DeidentificationId] = None
     identifiable_elements_present: Optional[Union[bool, Bool]] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1657,6 +2690,13 @@ class Deidentification(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1668,14 +2708,16 @@ class SensitiveElement(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["SensitiveElement"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:SensitiveElement"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["SensitiveElement"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:SensitiveElement"
     class_name: ClassVar[str] = "SensitiveElement"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.SensitiveElement
 
     id: Union[str, SensitiveElementId] = None
     sensitive_elements_present: Optional[Union[bool, Bool]] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1690,6 +2732,13 @@ class SensitiveElement(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1701,8 +2750,8 @@ class DatasetRelationship(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DCOMPOSITION["DatasetRelationship"]
-    class_class_curie: ClassVar[str] = "d4dcomposition:DatasetRelationship"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["DatasetRelationship"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:DatasetRelationship"
     class_name: ClassVar[str] = "DatasetRelationship"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DatasetRelationship
 
@@ -1710,6 +2759,8 @@ class DatasetRelationship(DatasetProperty):
     target_dataset: str = None
     relationship_type: Union[str, "DatasetRelationshipTypeEnum"] = None
     description: Optional[str] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1730,6 +2781,13 @@ class DatasetRelationship(DatasetProperty):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1741,8 +2799,8 @@ class InstanceAcquisition(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["collection/InstanceAcquisition"]
-    class_class_curie: ClassVar[str] = "data_sheets_schema:collection/InstanceAcquisition"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["InstanceAcquisition"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:InstanceAcquisition"
     class_name: ClassVar[str] = "InstanceAcquisition"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.InstanceAcquisition
 
@@ -1752,6 +2810,8 @@ class InstanceAcquisition(DatasetProperty):
     was_reported_by_subjects: Optional[Union[bool, Bool]] = None
     was_inferred_derived: Optional[Union[bool, Bool]] = None
     was_validated_verified: Optional[Union[bool, Bool]] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1775,6 +2835,13 @@ class InstanceAcquisition(DatasetProperty):
         if self.was_validated_verified is not None and not isinstance(self.was_validated_verified, Bool):
             self.was_validated_verified = Bool(self.was_validated_verified)
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1786,13 +2853,15 @@ class CollectionMechanism(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["collection/CollectionMechanism"]
-    class_class_curie: ClassVar[str] = "data_sheets_schema:collection/CollectionMechanism"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["CollectionMechanism"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:CollectionMechanism"
     class_name: ClassVar[str] = "CollectionMechanism"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CollectionMechanism
 
     id: Union[str, CollectionMechanismId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1804,6 +2873,13 @@ class CollectionMechanism(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1814,13 +2890,15 @@ class DataCollector(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["collection/DataCollector"]
-    class_class_curie: ClassVar[str] = "data_sheets_schema:collection/DataCollector"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["DataCollector"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:DataCollector"
     class_name: ClassVar[str] = "DataCollector"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DataCollector
 
     id: Union[str, DataCollectorId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1831,6 +2909,13 @@ class DataCollector(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -1843,13 +2928,15 @@ class CollectionTimeframe(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["collection/CollectionTimeframe"]
-    class_class_curie: ClassVar[str] = "data_sheets_schema:collection/CollectionTimeframe"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["CollectionTimeframe"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:CollectionTimeframe"
     class_name: ClassVar[str] = "CollectionTimeframe"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CollectionTimeframe
 
     id: Union[str, CollectionTimeframeId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1860,6 +2947,13 @@ class CollectionTimeframe(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -1872,13 +2966,15 @@ class DirectCollection(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["collection/DirectCollection"]
-    class_class_curie: ClassVar[str] = "data_sheets_schema:collection/DirectCollection"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["DirectCollection"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:DirectCollection"
     class_name: ClassVar[str] = "DirectCollection"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DirectCollection
 
     id: Union[str, DirectCollectionId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1890,6 +2986,13 @@ class DirectCollection(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1900,13 +3003,15 @@ class PreprocessingStrategy(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DPREPROCESSING["PreprocessingStrategy"]
-    class_class_curie: ClassVar[str] = "d4dpreprocessing:PreprocessingStrategy"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["PreprocessingStrategy"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:PreprocessingStrategy"
     class_name: ClassVar[str] = "PreprocessingStrategy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.PreprocessingStrategy
 
     id: Union[str, PreprocessingStrategyId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1918,6 +3023,13 @@ class PreprocessingStrategy(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -1928,13 +3040,15 @@ class CleaningStrategy(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DPREPROCESSING["CleaningStrategy"]
-    class_class_curie: ClassVar[str] = "d4dpreprocessing:CleaningStrategy"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["CleaningStrategy"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:CleaningStrategy"
     class_name: ClassVar[str] = "CleaningStrategy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CleaningStrategy
 
     id: Union[str, CleaningStrategyId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1945,6 +3059,13 @@ class CleaningStrategy(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -1957,8 +3078,8 @@ class LabelingStrategy(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DPREPROCESSING["LabelingStrategy"]
-    class_class_curie: ClassVar[str] = "d4dpreprocessing:LabelingStrategy"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["LabelingStrategy"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:LabelingStrategy"
     class_name: ClassVar[str] = "LabelingStrategy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.LabelingStrategy
 
@@ -1968,6 +3089,8 @@ class LabelingStrategy(DatasetProperty):
     annotations_per_item: Optional[int] = None
     inter_annotator_agreement: Optional[str] = None
     annotator_demographics: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -1992,6 +3115,13 @@ class LabelingStrategy(DatasetProperty):
             self.annotator_demographics = [self.annotator_demographics] if self.annotator_demographics is not None else []
         self.annotator_demographics = [v if isinstance(v, str) else str(v) for v in self.annotator_demographics]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2003,13 +3133,15 @@ class RawData(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DPREPROCESSING["RawData"]
-    class_class_curie: ClassVar[str] = "d4dpreprocessing:RawData"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["RawData"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:RawData"
     class_name: ClassVar[str] = "RawData"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.RawData
 
     id: Union[str, RawDataId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2021,6 +3153,13 @@ class RawData(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2031,13 +3170,15 @@ class ExistingUse(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DUSES["ExistingUse"]
-    class_class_curie: ClassVar[str] = "d4duses:ExistingUse"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ExistingUse"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ExistingUse"
     class_name: ClassVar[str] = "ExistingUse"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ExistingUse
 
     id: Union[str, ExistingUseId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2048,6 +3189,13 @@ class ExistingUse(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2060,13 +3208,15 @@ class UseRepository(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DUSES["UseRepository"]
-    class_class_curie: ClassVar[str] = "d4duses:UseRepository"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["UseRepository"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:UseRepository"
     class_name: ClassVar[str] = "UseRepository"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.UseRepository
 
     id: Union[str, UseRepositoryId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2078,6 +3228,13 @@ class UseRepository(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2088,13 +3245,15 @@ class OtherTask(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DUSES["OtherTask"]
-    class_class_curie: ClassVar[str] = "d4duses:OtherTask"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["OtherTask"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:OtherTask"
     class_name: ClassVar[str] = "OtherTask"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.OtherTask
 
     id: Union[str, OtherTaskId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2105,6 +3264,13 @@ class OtherTask(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2117,13 +3283,15 @@ class FutureUseImpact(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DUSES["FutureUseImpact"]
-    class_class_curie: ClassVar[str] = "d4duses:FutureUseImpact"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["FutureUseImpact"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:FutureUseImpact"
     class_name: ClassVar[str] = "FutureUseImpact"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.FutureUseImpact
 
     id: Union[str, FutureUseImpactId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2135,6 +3303,13 @@ class FutureUseImpact(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2145,13 +3320,15 @@ class DiscouragedUse(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DUSES["DiscouragedUse"]
-    class_class_curie: ClassVar[str] = "d4duses:DiscouragedUse"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["DiscouragedUse"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:DiscouragedUse"
     class_name: ClassVar[str] = "DiscouragedUse"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DiscouragedUse
 
     id: Union[str, DiscouragedUseId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2162,6 +3339,13 @@ class DiscouragedUse(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2174,14 +3358,16 @@ class IntendedUse(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DUSES["IntendedUse"]
-    class_class_curie: ClassVar[str] = "d4duses:IntendedUse"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["IntendedUse"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:IntendedUse"
     class_name: ClassVar[str] = "IntendedUse"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.IntendedUse
 
     id: Union[str, IntendedUseId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
     use_category: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2197,6 +3383,13 @@ class IntendedUse(DatasetProperty):
             self.use_category = [self.use_category] if self.use_category is not None else []
         self.use_category = [v if isinstance(v, str) else str(v) for v in self.use_category]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2208,14 +3401,16 @@ class ProhibitedUse(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DUSES["ProhibitedUse"]
-    class_class_curie: ClassVar[str] = "d4duses:ProhibitedUse"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ProhibitedUse"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ProhibitedUse"
     class_name: ClassVar[str] = "ProhibitedUse"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ProhibitedUse
 
     id: Union[str, ProhibitedUseId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
     prohibition_reason: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2231,6 +3426,13 @@ class ProhibitedUse(DatasetProperty):
             self.prohibition_reason = [self.prohibition_reason] if self.prohibition_reason is not None else []
         self.prohibition_reason = [v if isinstance(v, str) else str(v) for v in self.prohibition_reason]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2242,13 +3444,15 @@ class ThirdPartySharing(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DDISTRIBUTION["ThirdPartySharing"]
-    class_class_curie: ClassVar[str] = "d4ddistribution:ThirdPartySharing"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ThirdPartySharing"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ThirdPartySharing"
     class_name: ClassVar[str] = "ThirdPartySharing"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ThirdPartySharing
 
     id: Union[str, ThirdPartySharingId] = None
     description: Optional[Union[bool, Bool]] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2258,6 +3462,13 @@ class ThirdPartySharing(DatasetProperty):
 
         if self.description is not None and not isinstance(self.description, Bool):
             self.description = Bool(self.description)
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2269,13 +3480,15 @@ class DistributionFormat(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DDISTRIBUTION["DistributionFormat"]
-    class_class_curie: ClassVar[str] = "d4ddistribution:DistributionFormat"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["DistributionFormat"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:DistributionFormat"
     class_name: ClassVar[str] = "DistributionFormat"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DistributionFormat
 
     id: Union[str, DistributionFormatId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2287,6 +3500,13 @@ class DistributionFormat(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2297,13 +3517,15 @@ class DistributionDate(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DDISTRIBUTION["DistributionDate"]
-    class_class_curie: ClassVar[str] = "d4ddistribution:DistributionDate"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["DistributionDate"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:DistributionDate"
     class_name: ClassVar[str] = "DistributionDate"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DistributionDate
 
     id: Union[str, DistributionDateId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2315,6 +3537,13 @@ class DistributionDate(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2325,13 +3554,15 @@ class Maintainer(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMAINTENANCE["Maintainer"]
-    class_class_curie: ClassVar[str] = "d4dmaintenance:Maintainer"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Maintainer"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Maintainer"
     class_name: ClassVar[str] = "Maintainer"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Maintainer
 
     id: Union[str, MaintainerId] = None
     description: Optional[Union[Union[str, "CreatorOrMaintainerEnum"], list[Union[str, "CreatorOrMaintainerEnum"]]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2343,6 +3574,13 @@ class Maintainer(DatasetProperty):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, CreatorOrMaintainerEnum) else CreatorOrMaintainerEnum(v) for v in self.description]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2353,13 +3591,15 @@ class Erratum(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMAINTENANCE["Erratum"]
-    class_class_curie: ClassVar[str] = "d4dmaintenance:Erratum"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["Erratum"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:Erratum"
     class_name: ClassVar[str] = "Erratum"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Erratum
 
     id: Union[str, ErratumId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2370,6 +3610,13 @@ class Erratum(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2382,13 +3629,15 @@ class UpdatePlan(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMAINTENANCE["UpdatePlan"]
-    class_class_curie: ClassVar[str] = "d4dmaintenance:UpdatePlan"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["UpdatePlan"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:UpdatePlan"
     class_name: ClassVar[str] = "UpdatePlan"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.UpdatePlan
 
     id: Union[str, UpdatePlanId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2399,6 +3648,13 @@ class UpdatePlan(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2412,13 +3668,15 @@ class RetentionLimits(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMAINTENANCE["RetentionLimits"]
-    class_class_curie: ClassVar[str] = "d4dmaintenance:RetentionLimits"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["RetentionLimits"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:RetentionLimits"
     class_name: ClassVar[str] = "RetentionLimits"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.RetentionLimits
 
     id: Union[str, RetentionLimitsId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2429,6 +3687,13 @@ class RetentionLimits(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2441,13 +3706,15 @@ class VersionAccess(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMAINTENANCE["VersionAccess"]
-    class_class_curie: ClassVar[str] = "d4dmaintenance:VersionAccess"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["VersionAccess"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:VersionAccess"
     class_name: ClassVar[str] = "VersionAccess"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.VersionAccess
 
     id: Union[str, VersionAccessId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2458,6 +3725,13 @@ class VersionAccess(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2470,13 +3744,15 @@ class ExtensionMechanism(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DMAINTENANCE["ExtensionMechanism"]
-    class_class_curie: ClassVar[str] = "d4dmaintenance:ExtensionMechanism"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ExtensionMechanism"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ExtensionMechanism"
     class_name: ClassVar[str] = "ExtensionMechanism"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ExtensionMechanism
 
     id: Union[str, ExtensionMechanismId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2487,6 +3763,13 @@ class ExtensionMechanism(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2500,8 +3783,8 @@ class EthicalReview(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DETHICS["EthicalReview"]
-    class_class_curie: ClassVar[str] = "d4dethics:EthicalReview"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["EthicalReview"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:EthicalReview"
     class_name: ClassVar[str] = "EthicalReview"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.EthicalReview
 
@@ -2509,6 +3792,8 @@ class EthicalReview(DatasetProperty):
     description: Optional[Union[str, list[str]]] = empty_list()
     contact_person: Optional[Union[str, PersonId]] = None
     reviewing_organization: Optional[Union[str, OrganizationId]] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2526,6 +3811,13 @@ class EthicalReview(DatasetProperty):
         if self.reviewing_organization is not None and not isinstance(self.reviewing_organization, OrganizationId):
             self.reviewing_organization = OrganizationId(self.reviewing_organization)
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2538,13 +3830,15 @@ class DataProtectionImpact(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DETHICS["DataProtectionImpact"]
-    class_class_curie: ClassVar[str] = "d4dethics:DataProtectionImpact"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["DataProtectionImpact"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:DataProtectionImpact"
     class_name: ClassVar[str] = "DataProtectionImpact"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DataProtectionImpact
 
     id: Union[str, DataProtectionImpactId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2555,6 +3849,13 @@ class DataProtectionImpact(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2567,13 +3868,15 @@ class CollectionNotification(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DETHICS["CollectionNotification"]
-    class_class_curie: ClassVar[str] = "d4dethics:CollectionNotification"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["CollectionNotification"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:CollectionNotification"
     class_name: ClassVar[str] = "CollectionNotification"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CollectionNotification
 
     id: Union[str, CollectionNotificationId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2584,6 +3887,13 @@ class CollectionNotification(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2596,13 +3906,15 @@ class CollectionConsent(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DETHICS["CollectionConsent"]
-    class_class_curie: ClassVar[str] = "d4dethics:CollectionConsent"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["CollectionConsent"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:CollectionConsent"
     class_name: ClassVar[str] = "CollectionConsent"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CollectionConsent
 
     id: Union[str, CollectionConsentId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2613,6 +3925,13 @@ class CollectionConsent(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2625,13 +3944,15 @@ class ConsentRevocation(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DETHICS["ConsentRevocation"]
-    class_class_curie: ClassVar[str] = "d4dethics:ConsentRevocation"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ConsentRevocation"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ConsentRevocation"
     class_name: ClassVar[str] = "ConsentRevocation"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ConsentRevocation
 
     id: Union[str, ConsentRevocationId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2642,6 +3963,13 @@ class ConsentRevocation(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2654,8 +3982,8 @@ class HumanSubjectResearch(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DHUMAN["HumanSubjectResearch"]
-    class_class_curie: ClassVar[str] = "d4dhuman:HumanSubjectResearch"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["HumanSubjectResearch"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:HumanSubjectResearch"
     class_name: ClassVar[str] = "HumanSubjectResearch"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.HumanSubjectResearch
 
@@ -2665,6 +3993,9 @@ class HumanSubjectResearch(DatasetProperty):
     ethics_review_board: Optional[Union[str, list[str]]] = empty_list()
     special_populations: Optional[Union[str, list[str]]] = empty_list()
     regulatory_compliance: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2691,6 +4022,16 @@ class HumanSubjectResearch(DatasetProperty):
             self.regulatory_compliance = [self.regulatory_compliance] if self.regulatory_compliance is not None else []
         self.regulatory_compliance = [v if isinstance(v, str) else str(v) for v in self.regulatory_compliance]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -2701,8 +4042,8 @@ class InformedConsent(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DHUMAN["InformedConsent"]
-    class_class_curie: ClassVar[str] = "d4dhuman:InformedConsent"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["InformedConsent"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:InformedConsent"
     class_name: ClassVar[str] = "InformedConsent"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.InformedConsent
 
@@ -2712,6 +4053,9 @@ class InformedConsent(DatasetProperty):
     consent_documentation: Optional[Union[str, list[str]]] = empty_list()
     withdrawal_mechanism: Optional[Union[str, list[str]]] = empty_list()
     consent_scope: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2738,6 +4082,16 @@ class InformedConsent(DatasetProperty):
             self.consent_scope = [self.consent_scope] if self.consent_scope is not None else []
         self.consent_scope = [v if isinstance(v, str) else str(v) for v in self.consent_scope]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -2748,8 +4102,8 @@ class ParticipantPrivacy(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DHUMAN["ParticipantPrivacy"]
-    class_class_curie: ClassVar[str] = "d4dhuman:ParticipantPrivacy"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ParticipantPrivacy"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ParticipantPrivacy"
     class_name: ClassVar[str] = "ParticipantPrivacy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ParticipantPrivacy
 
@@ -2758,6 +4112,9 @@ class ParticipantPrivacy(DatasetProperty):
     reidentification_risk: Optional[Union[str, list[str]]] = empty_list()
     privacy_techniques: Optional[Union[str, list[str]]] = empty_list()
     data_linkage: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2781,6 +4138,16 @@ class ParticipantPrivacy(DatasetProperty):
             self.data_linkage = [self.data_linkage] if self.data_linkage is not None else []
         self.data_linkage = [v if isinstance(v, str) else str(v) for v in self.data_linkage]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -2791,8 +4158,8 @@ class HumanSubjectCompensation(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DHUMAN["HumanSubjectCompensation"]
-    class_class_curie: ClassVar[str] = "d4dhuman:HumanSubjectCompensation"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["HumanSubjectCompensation"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:HumanSubjectCompensation"
     class_name: ClassVar[str] = "HumanSubjectCompensation"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.HumanSubjectCompensation
 
@@ -2801,6 +4168,9 @@ class HumanSubjectCompensation(DatasetProperty):
     compensation_type: Optional[Union[str, list[str]]] = empty_list()
     compensation_amount: Optional[Union[str, list[str]]] = empty_list()
     compensation_rationale: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2823,6 +4193,16 @@ class HumanSubjectCompensation(DatasetProperty):
             self.compensation_rationale = [self.compensation_rationale] if self.compensation_rationale is not None else []
         self.compensation_rationale = [v if isinstance(v, str) else str(v) for v in self.compensation_rationale]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -2833,8 +4213,8 @@ class VulnerablePopulations(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DHUMAN["VulnerablePopulations"]
-    class_class_curie: ClassVar[str] = "d4dhuman:VulnerablePopulations"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["VulnerablePopulations"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:VulnerablePopulations"
     class_name: ClassVar[str] = "VulnerablePopulations"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.VulnerablePopulations
 
@@ -2843,6 +4223,9 @@ class VulnerablePopulations(DatasetProperty):
     special_protections: Optional[Union[str, list[str]]] = empty_list()
     assent_procedures: Optional[Union[str, list[str]]] = empty_list()
     guardian_consent: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2865,6 +4248,16 @@ class VulnerablePopulations(DatasetProperty):
             self.guardian_consent = [self.guardian_consent] if self.guardian_consent is not None else []
         self.guardian_consent = [v if isinstance(v, str) else str(v) for v in self.guardian_consent]
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
         super().__post_init__(**kwargs)
 
 
@@ -2876,8 +4269,8 @@ class LicenseAndUseTerms(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DDATAGOVERNANCE["LicenseAndUseTerms"]
-    class_class_curie: ClassVar[str] = "d4ddatagovernance:LicenseAndUseTerms"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["LicenseAndUseTerms"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:LicenseAndUseTerms"
     class_name: ClassVar[str] = "LicenseAndUseTerms"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.LicenseAndUseTerms
 
@@ -2885,6 +4278,8 @@ class LicenseAndUseTerms(DatasetProperty):
     description: Optional[Union[str, list[str]]] = empty_list()
     data_use_permission: Optional[Union[Union[str, "DataUsePermissionEnum"], list[Union[str, "DataUsePermissionEnum"]]]] = empty_list()
     contact_person: Optional[Union[str, PersonId]] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2903,6 +4298,13 @@ class LicenseAndUseTerms(DatasetProperty):
         if self.contact_person is not None and not isinstance(self.contact_person, PersonId):
             self.contact_person = PersonId(self.contact_person)
 
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
         super().__post_init__(**kwargs)
 
 
@@ -2915,13 +4317,15 @@ class IPRestrictions(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DDATAGOVERNANCE["IPRestrictions"]
-    class_class_curie: ClassVar[str] = "d4ddatagovernance:IPRestrictions"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["IPRestrictions"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:IPRestrictions"
     class_name: ClassVar[str] = "IPRestrictions"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.IPRestrictions
 
     id: Union[str, IPRestrictionsId] = None
     description: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2932,6 +4336,13 @@ class IPRestrictions(DatasetProperty):
         if not isinstance(self.description, list):
             self.description = [self.description] if self.description is not None else []
         self.description = [v if isinstance(v, str) else str(v) for v in self.description]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -2946,8 +4357,8 @@ class ExportControlRegulatoryRestrictions(DatasetProperty):
     """
     _inherited_slots: ClassVar[list[str]] = []
 
-    class_class_uri: ClassVar[URIRef] = D4DDATAGOVERNANCE["ExportControlRegulatoryRestrictions"]
-    class_class_curie: ClassVar[str] = "d4ddatagovernance:ExportControlRegulatoryRestrictions"
+    class_class_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA["ExportControlRegulatoryRestrictions"]
+    class_class_curie: ClassVar[str] = "data_sheets_schema:ExportControlRegulatoryRestrictions"
     class_name: ClassVar[str] = "ExportControlRegulatoryRestrictions"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ExportControlRegulatoryRestrictions
 
@@ -2959,6 +4370,8 @@ class ExportControlRegulatoryRestrictions(DatasetProperty):
     other_compliance: Optional[Union[str, list[str]]] = empty_list()
     confidentiality_level: Optional[Union[str, "ConfidentialityLevelEnum"]] = None
     governance_committee_contact: Optional[Union[str, PersonId]] = None
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -2988,6 +4401,13 @@ class ExportControlRegulatoryRestrictions(DatasetProperty):
 
         if self.governance_committee_contact is not None and not isinstance(self.governance_committee_contact, PersonId):
             self.governance_committee_contact = PersonId(self.governance_committee_contact)
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
 
         super().__post_init__(**kwargs)
 
@@ -3020,6 +4440,9 @@ class VariableMetadata(DatasetProperty):
     measurement_technique: Optional[str] = None
     derivation: Optional[str] = None
     quality_notes: Optional[Union[str, list[str]]] = empty_list()
+    used_software: Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]] = empty_list()
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -3074,6 +4497,16 @@ class VariableMetadata(DatasetProperty):
         if not isinstance(self.quality_notes, list):
             self.quality_notes = [self.quality_notes] if self.quality_notes is not None else []
         self.quality_notes = [v if isinstance(v, str) else str(v) for v in self.quality_notes]
+
+        if not isinstance(self.used_software, list):
+            self.used_software = [self.used_software] if self.used_software is not None else []
+        self.used_software = [v if isinstance(v, SoftwareId) else SoftwareId(v) for v in self.used_software]
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -3806,6 +5239,76 @@ slots.doi = Slot(uri=BIBO.doi, name="doi", curie=BIBO.curie('doi'),
 slots.datasetCollection__resources = Slot(uri=DATA_SHEETS_SCHEMA.resources, name="datasetCollection__resources", curie=DATA_SHEETS_SCHEMA.curie('resources'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetCollection__resources, domain=None, range=Optional[Union[Union[str, DatasetId], list[Union[str, DatasetId]]]])
 
+slots.datasetCollection__compression = Slot(uri=DCAT.compressFormat, name="datasetCollection__compression", curie=DCAT.curie('compressFormat'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__compression, domain=None, range=Optional[Union[str, "CompressionEnum"]])
+
+slots.datasetCollection__conforms_to = Slot(uri=DCTERMS.conformsTo, name="datasetCollection__conforms_to", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__conforms_to, domain=None, range=Optional[str])
+
+slots.datasetCollection__conforms_to_class = Slot(uri=DCTERMS.conformsTo, name="datasetCollection__conforms_to_class", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__conforms_to_class, domain=None, range=Optional[str])
+
+slots.datasetCollection__conforms_to_schema = Slot(uri=DCTERMS.conformsTo, name="datasetCollection__conforms_to_schema", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__conforms_to_schema, domain=None, range=Optional[str])
+
+slots.datasetCollection__created_by = Slot(uri=PAV.createdBy, name="datasetCollection__created_by", curie=PAV.curie('createdBy'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__created_by, domain=None, range=Optional[str])
+
+slots.datasetCollection__created_on = Slot(uri=PAV.createdOn, name="datasetCollection__created_on", curie=PAV.curie('createdOn'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__created_on, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.datasetCollection__doi = Slot(uri=BIBO.doi, name="datasetCollection__doi", curie=BIBO.curie('doi'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__doi, domain=None, range=Optional[str],
+                   pattern=re.compile(r'10\.\d{4,}\/.+'))
+
+slots.datasetCollection__download_url = Slot(uri=DCAT.downloadURL, name="datasetCollection__download_url", curie=DCAT.curie('downloadURL'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__download_url, domain=None, range=Optional[Union[str, URI]])
+
+slots.datasetCollection__issued = Slot(uri=DCTERMS.issued, name="datasetCollection__issued", curie=DCTERMS.curie('issued'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__issued, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.datasetCollection__keywords = Slot(uri=DCAT.keyword, name="datasetCollection__keywords", curie=DCAT.curie('keyword'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__keywords, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.datasetCollection__language = Slot(uri=DCTERMS.language, name="datasetCollection__language", curie=DCTERMS.curie('language'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__language, domain=None, range=Optional[str])
+
+slots.datasetCollection__last_updated_on = Slot(uri=PAV.lastUpdatedOn, name="datasetCollection__last_updated_on", curie=PAV.curie('lastUpdatedOn'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__last_updated_on, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.datasetCollection__license = Slot(uri=DCTERMS.license, name="datasetCollection__license", curie=DCTERMS.curie('license'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__license, domain=None, range=Optional[str])
+
+slots.datasetCollection__modified_by = Slot(uri=OSLC.modifiedBy, name="datasetCollection__modified_by", curie=OSLC.curie('modifiedBy'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__modified_by, domain=None, range=Optional[str])
+
+slots.datasetCollection__page = Slot(uri=DCAT.landingPage, name="datasetCollection__page", curie=DCAT.curie('landingPage'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__page, domain=None, range=Optional[str])
+
+slots.datasetCollection__publisher = Slot(uri=DCTERMS.publisher, name="datasetCollection__publisher", curie=DCTERMS.curie('publisher'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__publisher, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.datasetCollection__status = Slot(uri=BIBO.status, name="datasetCollection__status", curie=BIBO.curie('status'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__status, domain=None, range=Optional[str])
+
+slots.datasetCollection__title = Slot(uri=DCTERMS.title, name="datasetCollection__title", curie=DCTERMS.curie('title'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__title, domain=None, range=Optional[str])
+
+slots.datasetCollection__version = Slot(uri=PAV.version, name="datasetCollection__version", curie=PAV.curie('version'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__version, domain=None, range=Optional[str])
+
+slots.datasetCollection__was_derived_from = Slot(uri=PROV.wasDerivedFrom, name="datasetCollection__was_derived_from", curie=PROV.curie('wasDerivedFrom'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__was_derived_from, domain=None, range=Optional[str])
+
+slots.datasetCollection__id = Slot(uri=SCHEMA.identifier, name="datasetCollection__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__id, domain=None, range=URIRef)
+
+slots.datasetCollection__name = Slot(uri=SCHEMA.name, name="datasetCollection__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__name, domain=None, range=Optional[str])
+
+slots.datasetCollection__description = Slot(uri=SCHEMA.description, name="datasetCollection__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetCollection__description, domain=None, range=Optional[str])
+
 slots.dataset__purposes = Slot(uri=DATA_SHEETS_SCHEMA.purposes, name="dataset__purposes", curie=DATA_SHEETS_SCHEMA.curie('purposes'),
                    model_uri=DATA_SHEETS_SCHEMA.dataset__purposes, domain=None, range=Optional[Union[Union[str, PurposeId], list[Union[str, PurposeId]]]])
 
@@ -3965,11 +5468,364 @@ slots.dataset__parent_datasets = Slot(uri=SCHEMA.isPartOf, name="dataset__parent
 slots.dataset__related_datasets = Slot(uri=DATA_SHEETS_SCHEMA.related_datasets, name="dataset__related_datasets", curie=DATA_SHEETS_SCHEMA.curie('related_datasets'),
                    model_uri=DATA_SHEETS_SCHEMA.dataset__related_datasets, domain=None, range=Optional[Union[Union[str, DatasetRelationshipId], list[Union[str, DatasetRelationshipId]]]])
 
+slots.dataset__bytes = Slot(uri=DCAT.byteSize, name="dataset__bytes", curie=DCAT.curie('byteSize'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__bytes, domain=None, range=Optional[int])
+
+slots.dataset__dialect = Slot(uri=CSVW.dialect, name="dataset__dialect", curie=CSVW.curie('dialect'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__dialect, domain=None, range=Optional[str])
+
+slots.dataset__encoding = Slot(uri=DCAT.mediaType, name="dataset__encoding", curie=DCAT.curie('mediaType'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__encoding, domain=None, range=Optional[Union[str, "EncodingEnum"]])
+
+slots.dataset__format = Slot(uri=DCTERMS.format, name="dataset__format", curie=DCTERMS.curie('format'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__format, domain=None, range=Optional[Union[str, "FormatEnum"]])
+
+slots.dataset__hash = Slot(uri=DCTERMS.identifier, name="dataset__hash", curie=DCTERMS.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__hash, domain=None, range=Optional[str])
+
+slots.dataset__md5 = Slot(uri=DCTERMS.identifier, name="dataset__md5", curie=DCTERMS.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__md5, domain=None, range=Optional[str])
+
+slots.dataset__media_type = Slot(uri=DCAT.mediaType, name="dataset__media_type", curie=DCAT.curie('mediaType'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__media_type, domain=None, range=Optional[Union[str, "MediaTypeEnum"]])
+
+slots.dataset__path = Slot(uri=SCHEMA.contentUrl, name="dataset__path", curie=SCHEMA.curie('contentUrl'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__path, domain=None, range=Optional[str])
+
+slots.dataset__sha256 = Slot(uri=DCTERMS.identifier, name="dataset__sha256", curie=DCTERMS.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__sha256, domain=None, range=Optional[str])
+
+slots.dataset__compression = Slot(uri=DCAT.compressFormat, name="dataset__compression", curie=DCAT.curie('compressFormat'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__compression, domain=None, range=Optional[Union[str, "CompressionEnum"]])
+
+slots.dataset__conforms_to = Slot(uri=DCTERMS.conformsTo, name="dataset__conforms_to", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__conforms_to, domain=None, range=Optional[str])
+
+slots.dataset__conforms_to_class = Slot(uri=DCTERMS.conformsTo, name="dataset__conforms_to_class", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__conforms_to_class, domain=None, range=Optional[str])
+
+slots.dataset__conforms_to_schema = Slot(uri=DCTERMS.conformsTo, name="dataset__conforms_to_schema", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__conforms_to_schema, domain=None, range=Optional[str])
+
+slots.dataset__created_by = Slot(uri=PAV.createdBy, name="dataset__created_by", curie=PAV.curie('createdBy'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__created_by, domain=None, range=Optional[str])
+
+slots.dataset__created_on = Slot(uri=PAV.createdOn, name="dataset__created_on", curie=PAV.curie('createdOn'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__created_on, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.dataset__doi = Slot(uri=BIBO.doi, name="dataset__doi", curie=BIBO.curie('doi'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__doi, domain=None, range=Optional[str],
+                   pattern=re.compile(r'10\.\d{4,}\/.+'))
+
+slots.dataset__download_url = Slot(uri=DCAT.downloadURL, name="dataset__download_url", curie=DCAT.curie('downloadURL'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__download_url, domain=None, range=Optional[Union[str, URI]])
+
+slots.dataset__issued = Slot(uri=DCTERMS.issued, name="dataset__issued", curie=DCTERMS.curie('issued'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__issued, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.dataset__keywords = Slot(uri=DCAT.keyword, name="dataset__keywords", curie=DCAT.curie('keyword'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__keywords, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.dataset__language = Slot(uri=DCTERMS.language, name="dataset__language", curie=DCTERMS.curie('language'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__language, domain=None, range=Optional[str])
+
+slots.dataset__last_updated_on = Slot(uri=PAV.lastUpdatedOn, name="dataset__last_updated_on", curie=PAV.curie('lastUpdatedOn'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__last_updated_on, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.dataset__license = Slot(uri=DCTERMS.license, name="dataset__license", curie=DCTERMS.curie('license'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__license, domain=None, range=Optional[str])
+
+slots.dataset__modified_by = Slot(uri=OSLC.modifiedBy, name="dataset__modified_by", curie=OSLC.curie('modifiedBy'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__modified_by, domain=None, range=Optional[str])
+
+slots.dataset__page = Slot(uri=DCAT.landingPage, name="dataset__page", curie=DCAT.curie('landingPage'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__page, domain=None, range=Optional[str])
+
+slots.dataset__publisher = Slot(uri=DCTERMS.publisher, name="dataset__publisher", curie=DCTERMS.curie('publisher'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__publisher, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.dataset__status = Slot(uri=BIBO.status, name="dataset__status", curie=BIBO.curie('status'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__status, domain=None, range=Optional[str])
+
+slots.dataset__title = Slot(uri=DCTERMS.title, name="dataset__title", curie=DCTERMS.curie('title'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__title, domain=None, range=Optional[str])
+
+slots.dataset__version = Slot(uri=PAV.version, name="dataset__version", curie=PAV.curie('version'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__version, domain=None, range=Optional[str])
+
+slots.dataset__was_derived_from = Slot(uri=PROV.wasDerivedFrom, name="dataset__was_derived_from", curie=PROV.curie('wasDerivedFrom'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__was_derived_from, domain=None, range=Optional[str])
+
+slots.dataset__id = Slot(uri=SCHEMA.identifier, name="dataset__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__id, domain=None, range=URIRef)
+
+slots.dataset__name = Slot(uri=SCHEMA.name, name="dataset__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__name, domain=None, range=Optional[str])
+
+slots.dataset__description = Slot(uri=SCHEMA.description, name="dataset__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataset__description, domain=None, range=Optional[str])
+
 slots.dataSubset__is_data_split = Slot(uri=DATA_SHEETS_SCHEMA.is_data_split, name="dataSubset__is_data_split", curie=DATA_SHEETS_SCHEMA.curie('is_data_split'),
                    model_uri=DATA_SHEETS_SCHEMA.dataSubset__is_data_split, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.dataSubset__is_subpopulation = Slot(uri=DATA_SHEETS_SCHEMA.is_subpopulation, name="dataSubset__is_subpopulation", curie=DATA_SHEETS_SCHEMA.curie('is_subpopulation'),
                    model_uri=DATA_SHEETS_SCHEMA.dataSubset__is_subpopulation, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.dataSubset__bytes = Slot(uri=DCAT.byteSize, name="dataSubset__bytes", curie=DCAT.curie('byteSize'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__bytes, domain=None, range=Optional[int])
+
+slots.dataSubset__dialect = Slot(uri=CSVW.dialect, name="dataSubset__dialect", curie=CSVW.curie('dialect'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__dialect, domain=None, range=Optional[str])
+
+slots.dataSubset__encoding = Slot(uri=DCAT.mediaType, name="dataSubset__encoding", curie=DCAT.curie('mediaType'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__encoding, domain=None, range=Optional[Union[str, "EncodingEnum"]])
+
+slots.dataSubset__format = Slot(uri=DCTERMS.format, name="dataSubset__format", curie=DCTERMS.curie('format'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__format, domain=None, range=Optional[Union[str, "FormatEnum"]])
+
+slots.dataSubset__hash = Slot(uri=DCTERMS.identifier, name="dataSubset__hash", curie=DCTERMS.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__hash, domain=None, range=Optional[str])
+
+slots.dataSubset__md5 = Slot(uri=DCTERMS.identifier, name="dataSubset__md5", curie=DCTERMS.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__md5, domain=None, range=Optional[str])
+
+slots.dataSubset__media_type = Slot(uri=DCAT.mediaType, name="dataSubset__media_type", curie=DCAT.curie('mediaType'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__media_type, domain=None, range=Optional[Union[str, "MediaTypeEnum"]])
+
+slots.dataSubset__path = Slot(uri=SCHEMA.contentUrl, name="dataSubset__path", curie=SCHEMA.curie('contentUrl'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__path, domain=None, range=Optional[str])
+
+slots.dataSubset__sha256 = Slot(uri=DCTERMS.identifier, name="dataSubset__sha256", curie=DCTERMS.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__sha256, domain=None, range=Optional[str])
+
+slots.dataSubset__purposes = Slot(uri=DATA_SHEETS_SCHEMA.purposes, name="dataSubset__purposes", curie=DATA_SHEETS_SCHEMA.curie('purposes'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__purposes, domain=None, range=Optional[Union[Union[str, PurposeId], list[Union[str, PurposeId]]]])
+
+slots.dataSubset__tasks = Slot(uri=DATA_SHEETS_SCHEMA.tasks, name="dataSubset__tasks", curie=DATA_SHEETS_SCHEMA.curie('tasks'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__tasks, domain=None, range=Optional[Union[Union[str, TaskId], list[Union[str, TaskId]]]])
+
+slots.dataSubset__addressing_gaps = Slot(uri=DATA_SHEETS_SCHEMA.addressing_gaps, name="dataSubset__addressing_gaps", curie=DATA_SHEETS_SCHEMA.curie('addressing_gaps'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__addressing_gaps, domain=None, range=Optional[Union[Union[str, AddressingGapId], list[Union[str, AddressingGapId]]]])
+
+slots.dataSubset__creators = Slot(uri=DATA_SHEETS_SCHEMA.creators, name="dataSubset__creators", curie=DATA_SHEETS_SCHEMA.curie('creators'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__creators, domain=None, range=Optional[Union[Union[str, CreatorId], list[Union[str, CreatorId]]]])
+
+slots.dataSubset__funders = Slot(uri=DATA_SHEETS_SCHEMA.funders, name="dataSubset__funders", curie=DATA_SHEETS_SCHEMA.curie('funders'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__funders, domain=None, range=Optional[Union[Union[str, FundingMechanismId], list[Union[str, FundingMechanismId]]]])
+
+slots.dataSubset__subsets = Slot(uri=DCAT.distribution, name="dataSubset__subsets", curie=DCAT.curie('distribution'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__subsets, domain=None, range=Optional[Union[Union[str, DataSubsetId], list[Union[str, DataSubsetId]]]])
+
+slots.dataSubset__instances = Slot(uri=DATA_SHEETS_SCHEMA.instances, name="dataSubset__instances", curie=DATA_SHEETS_SCHEMA.curie('instances'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__instances, domain=None, range=Optional[Union[Union[str, InstanceId], list[Union[str, InstanceId]]]])
+
+slots.dataSubset__anomalies = Slot(uri=DATA_SHEETS_SCHEMA.anomalies, name="dataSubset__anomalies", curie=DATA_SHEETS_SCHEMA.curie('anomalies'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__anomalies, domain=None, range=Optional[Union[Union[str, DataAnomalyId], list[Union[str, DataAnomalyId]]]])
+
+slots.dataSubset__external_resources = Slot(uri=DATA_SHEETS_SCHEMA.external_resources, name="dataSubset__external_resources", curie=DATA_SHEETS_SCHEMA.curie('external_resources'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__external_resources, domain=None, range=Optional[Union[Union[str, ExternalResourceId], list[Union[str, ExternalResourceId]]]])
+
+slots.dataSubset__confidential_elements = Slot(uri=DATA_SHEETS_SCHEMA.confidential_elements, name="dataSubset__confidential_elements", curie=DATA_SHEETS_SCHEMA.curie('confidential_elements'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__confidential_elements, domain=None, range=Optional[Union[Union[str, ConfidentialityId], list[Union[str, ConfidentialityId]]]])
+
+slots.dataSubset__content_warnings = Slot(uri=DATA_SHEETS_SCHEMA.content_warnings, name="dataSubset__content_warnings", curie=DATA_SHEETS_SCHEMA.curie('content_warnings'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__content_warnings, domain=None, range=Optional[Union[Union[str, ContentWarningId], list[Union[str, ContentWarningId]]]])
+
+slots.dataSubset__subpopulations = Slot(uri=DATA_SHEETS_SCHEMA.subpopulations, name="dataSubset__subpopulations", curie=DATA_SHEETS_SCHEMA.curie('subpopulations'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__subpopulations, domain=None, range=Optional[Union[Union[str, SubpopulationId], list[Union[str, SubpopulationId]]]])
+
+slots.dataSubset__sensitive_elements = Slot(uri=DATA_SHEETS_SCHEMA.sensitive_elements, name="dataSubset__sensitive_elements", curie=DATA_SHEETS_SCHEMA.curie('sensitive_elements'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__sensitive_elements, domain=None, range=Optional[Union[Union[str, SensitiveElementId], list[Union[str, SensitiveElementId]]]])
+
+slots.dataSubset__acquisition_methods = Slot(uri=DATA_SHEETS_SCHEMA.acquisition_methods, name="dataSubset__acquisition_methods", curie=DATA_SHEETS_SCHEMA.curie('acquisition_methods'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__acquisition_methods, domain=None, range=Optional[Union[Union[str, InstanceAcquisitionId], list[Union[str, InstanceAcquisitionId]]]])
+
+slots.dataSubset__collection_mechanisms = Slot(uri=DATA_SHEETS_SCHEMA.collection_mechanisms, name="dataSubset__collection_mechanisms", curie=DATA_SHEETS_SCHEMA.curie('collection_mechanisms'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__collection_mechanisms, domain=None, range=Optional[Union[Union[str, CollectionMechanismId], list[Union[str, CollectionMechanismId]]]])
+
+slots.dataSubset__sampling_strategies = Slot(uri=DATA_SHEETS_SCHEMA.sampling_strategies, name="dataSubset__sampling_strategies", curie=DATA_SHEETS_SCHEMA.curie('sampling_strategies'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__sampling_strategies, domain=None, range=Optional[Union[Union[str, SamplingStrategyId], list[Union[str, SamplingStrategyId]]]])
+
+slots.dataSubset__data_collectors = Slot(uri=DATA_SHEETS_SCHEMA.data_collectors, name="dataSubset__data_collectors", curie=DATA_SHEETS_SCHEMA.curie('data_collectors'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__data_collectors, domain=None, range=Optional[Union[Union[str, DataCollectorId], list[Union[str, DataCollectorId]]]])
+
+slots.dataSubset__collection_timeframes = Slot(uri=DATA_SHEETS_SCHEMA.collection_timeframes, name="dataSubset__collection_timeframes", curie=DATA_SHEETS_SCHEMA.curie('collection_timeframes'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__collection_timeframes, domain=None, range=Optional[Union[Union[str, CollectionTimeframeId], list[Union[str, CollectionTimeframeId]]]])
+
+slots.dataSubset__ethical_reviews = Slot(uri=DATA_SHEETS_SCHEMA.ethical_reviews, name="dataSubset__ethical_reviews", curie=DATA_SHEETS_SCHEMA.curie('ethical_reviews'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__ethical_reviews, domain=None, range=Optional[Union[Union[str, EthicalReviewId], list[Union[str, EthicalReviewId]]]])
+
+slots.dataSubset__data_protection_impacts = Slot(uri=DATA_SHEETS_SCHEMA.data_protection_impacts, name="dataSubset__data_protection_impacts", curie=DATA_SHEETS_SCHEMA.curie('data_protection_impacts'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__data_protection_impacts, domain=None, range=Optional[Union[Union[str, DataProtectionImpactId], list[Union[str, DataProtectionImpactId]]]])
+
+slots.dataSubset__human_subject_research = Slot(uri=DATA_SHEETS_SCHEMA.human_subject_research, name="dataSubset__human_subject_research", curie=DATA_SHEETS_SCHEMA.curie('human_subject_research'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__human_subject_research, domain=None, range=Optional[Union[str, HumanSubjectResearchId]])
+
+slots.dataSubset__informed_consent = Slot(uri=DATA_SHEETS_SCHEMA.informed_consent, name="dataSubset__informed_consent", curie=DATA_SHEETS_SCHEMA.curie('informed_consent'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__informed_consent, domain=None, range=Optional[Union[Union[str, InformedConsentId], list[Union[str, InformedConsentId]]]])
+
+slots.dataSubset__participant_privacy = Slot(uri=DATA_SHEETS_SCHEMA.participant_privacy, name="dataSubset__participant_privacy", curie=DATA_SHEETS_SCHEMA.curie('participant_privacy'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__participant_privacy, domain=None, range=Optional[Union[Union[str, ParticipantPrivacyId], list[Union[str, ParticipantPrivacyId]]]])
+
+slots.dataSubset__participant_compensation = Slot(uri=DATA_SHEETS_SCHEMA.participant_compensation, name="dataSubset__participant_compensation", curie=DATA_SHEETS_SCHEMA.curie('participant_compensation'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__participant_compensation, domain=None, range=Optional[Union[str, HumanSubjectCompensationId]])
+
+slots.dataSubset__vulnerable_populations = Slot(uri=DATA_SHEETS_SCHEMA.vulnerable_populations, name="dataSubset__vulnerable_populations", curie=DATA_SHEETS_SCHEMA.curie('vulnerable_populations'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__vulnerable_populations, domain=None, range=Optional[Union[str, VulnerablePopulationsId]])
+
+slots.dataSubset__preprocessing_strategies = Slot(uri=DATA_SHEETS_SCHEMA.preprocessing_strategies, name="dataSubset__preprocessing_strategies", curie=DATA_SHEETS_SCHEMA.curie('preprocessing_strategies'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__preprocessing_strategies, domain=None, range=Optional[Union[Union[str, PreprocessingStrategyId], list[Union[str, PreprocessingStrategyId]]]])
+
+slots.dataSubset__cleaning_strategies = Slot(uri=DATA_SHEETS_SCHEMA.cleaning_strategies, name="dataSubset__cleaning_strategies", curie=DATA_SHEETS_SCHEMA.curie('cleaning_strategies'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__cleaning_strategies, domain=None, range=Optional[Union[Union[str, CleaningStrategyId], list[Union[str, CleaningStrategyId]]]])
+
+slots.dataSubset__labeling_strategies = Slot(uri=DATA_SHEETS_SCHEMA.labeling_strategies, name="dataSubset__labeling_strategies", curie=DATA_SHEETS_SCHEMA.curie('labeling_strategies'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__labeling_strategies, domain=None, range=Optional[Union[Union[str, LabelingStrategyId], list[Union[str, LabelingStrategyId]]]])
+
+slots.dataSubset__raw_sources = Slot(uri=DATA_SHEETS_SCHEMA.raw_sources, name="dataSubset__raw_sources", curie=DATA_SHEETS_SCHEMA.curie('raw_sources'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__raw_sources, domain=None, range=Optional[Union[Union[str, RawDataId], list[Union[str, RawDataId]]]])
+
+slots.dataSubset__existing_uses = Slot(uri=DATA_SHEETS_SCHEMA.existing_uses, name="dataSubset__existing_uses", curie=DATA_SHEETS_SCHEMA.curie('existing_uses'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__existing_uses, domain=None, range=Optional[Union[Union[str, ExistingUseId], list[Union[str, ExistingUseId]]]])
+
+slots.dataSubset__use_repository = Slot(uri=DATA_SHEETS_SCHEMA.use_repository, name="dataSubset__use_repository", curie=DATA_SHEETS_SCHEMA.curie('use_repository'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__use_repository, domain=None, range=Optional[Union[Union[str, UseRepositoryId], list[Union[str, UseRepositoryId]]]])
+
+slots.dataSubset__other_tasks = Slot(uri=DATA_SHEETS_SCHEMA.other_tasks, name="dataSubset__other_tasks", curie=DATA_SHEETS_SCHEMA.curie('other_tasks'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__other_tasks, domain=None, range=Optional[Union[Union[str, OtherTaskId], list[Union[str, OtherTaskId]]]])
+
+slots.dataSubset__future_use_impacts = Slot(uri=DATA_SHEETS_SCHEMA.future_use_impacts, name="dataSubset__future_use_impacts", curie=DATA_SHEETS_SCHEMA.curie('future_use_impacts'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__future_use_impacts, domain=None, range=Optional[Union[Union[str, FutureUseImpactId], list[Union[str, FutureUseImpactId]]]])
+
+slots.dataSubset__discouraged_uses = Slot(uri=DATA_SHEETS_SCHEMA.discouraged_uses, name="dataSubset__discouraged_uses", curie=DATA_SHEETS_SCHEMA.curie('discouraged_uses'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__discouraged_uses, domain=None, range=Optional[Union[Union[str, DiscouragedUseId], list[Union[str, DiscouragedUseId]]]])
+
+slots.dataSubset__intended_uses = Slot(uri=DATA_SHEETS_SCHEMA.intended_uses, name="dataSubset__intended_uses", curie=DATA_SHEETS_SCHEMA.curie('intended_uses'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__intended_uses, domain=None, range=Optional[Union[Union[str, IntendedUseId], list[Union[str, IntendedUseId]]]])
+
+slots.dataSubset__prohibited_uses = Slot(uri=DATA_SHEETS_SCHEMA.prohibited_uses, name="dataSubset__prohibited_uses", curie=DATA_SHEETS_SCHEMA.curie('prohibited_uses'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__prohibited_uses, domain=None, range=Optional[Union[Union[str, ProhibitedUseId], list[Union[str, ProhibitedUseId]]]])
+
+slots.dataSubset__distribution_formats = Slot(uri=DATA_SHEETS_SCHEMA.distribution_formats, name="dataSubset__distribution_formats", curie=DATA_SHEETS_SCHEMA.curie('distribution_formats'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__distribution_formats, domain=None, range=Optional[Union[Union[str, DistributionFormatId], list[Union[str, DistributionFormatId]]]])
+
+slots.dataSubset__distribution_dates = Slot(uri=DATA_SHEETS_SCHEMA.distribution_dates, name="dataSubset__distribution_dates", curie=DATA_SHEETS_SCHEMA.curie('distribution_dates'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__distribution_dates, domain=None, range=Optional[Union[Union[str, DistributionDateId], list[Union[str, DistributionDateId]]]])
+
+slots.dataSubset__license_and_use_terms = Slot(uri=DATA_SHEETS_SCHEMA.license_and_use_terms, name="dataSubset__license_and_use_terms", curie=DATA_SHEETS_SCHEMA.curie('license_and_use_terms'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__license_and_use_terms, domain=None, range=Optional[Union[str, LicenseAndUseTermsId]])
+
+slots.dataSubset__ip_restrictions = Slot(uri=DATA_SHEETS_SCHEMA.ip_restrictions, name="dataSubset__ip_restrictions", curie=DATA_SHEETS_SCHEMA.curie('ip_restrictions'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__ip_restrictions, domain=None, range=Optional[Union[str, IPRestrictionsId]])
+
+slots.dataSubset__regulatory_restrictions = Slot(uri=DATA_SHEETS_SCHEMA.regulatory_restrictions, name="dataSubset__regulatory_restrictions", curie=DATA_SHEETS_SCHEMA.curie('regulatory_restrictions'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__regulatory_restrictions, domain=None, range=Optional[Union[str, ExportControlRegulatoryRestrictionsId]])
+
+slots.dataSubset__maintainers = Slot(uri=DATA_SHEETS_SCHEMA.maintainers, name="dataSubset__maintainers", curie=DATA_SHEETS_SCHEMA.curie('maintainers'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__maintainers, domain=None, range=Optional[Union[Union[str, MaintainerId], list[Union[str, MaintainerId]]]])
+
+slots.dataSubset__errata = Slot(uri=DATA_SHEETS_SCHEMA.errata, name="dataSubset__errata", curie=DATA_SHEETS_SCHEMA.curie('errata'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__errata, domain=None, range=Optional[Union[Union[str, ErratumId], list[Union[str, ErratumId]]]])
+
+slots.dataSubset__updates = Slot(uri=DATA_SHEETS_SCHEMA.updates, name="dataSubset__updates", curie=DATA_SHEETS_SCHEMA.curie('updates'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__updates, domain=None, range=Optional[Union[str, UpdatePlanId]])
+
+slots.dataSubset__retention_limit = Slot(uri=DATA_SHEETS_SCHEMA.retention_limit, name="dataSubset__retention_limit", curie=DATA_SHEETS_SCHEMA.curie('retention_limit'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__retention_limit, domain=None, range=Optional[Union[str, RetentionLimitsId]])
+
+slots.dataSubset__version_access = Slot(uri=DATA_SHEETS_SCHEMA.version_access, name="dataSubset__version_access", curie=DATA_SHEETS_SCHEMA.curie('version_access'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__version_access, domain=None, range=Optional[Union[str, VersionAccessId]])
+
+slots.dataSubset__extension_mechanism = Slot(uri=DATA_SHEETS_SCHEMA.extension_mechanism, name="dataSubset__extension_mechanism", curie=DATA_SHEETS_SCHEMA.curie('extension_mechanism'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__extension_mechanism, domain=None, range=Optional[Union[str, ExtensionMechanismId]])
+
+slots.dataSubset__variables = Slot(uri=SCHEMA.variableMeasured, name="dataSubset__variables", curie=SCHEMA.curie('variableMeasured'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__variables, domain=None, range=Optional[Union[Union[str, VariableMetadataId], list[Union[str, VariableMetadataId]]]])
+
+slots.dataSubset__is_deidentified = Slot(uri=DATA_SHEETS_SCHEMA.is_deidentified, name="dataSubset__is_deidentified", curie=DATA_SHEETS_SCHEMA.curie('is_deidentified'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__is_deidentified, domain=None, range=Optional[Union[str, DeidentificationId]])
+
+slots.dataSubset__is_tabular = Slot(uri=DATA_SHEETS_SCHEMA.is_tabular, name="dataSubset__is_tabular", curie=DATA_SHEETS_SCHEMA.curie('is_tabular'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__is_tabular, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.dataSubset__citation = Slot(uri=SCHEMA.citation, name="dataSubset__citation", curie=SCHEMA.curie('citation'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__citation, domain=None, range=Optional[str])
+
+slots.dataSubset__parent_datasets = Slot(uri=SCHEMA.isPartOf, name="dataSubset__parent_datasets", curie=SCHEMA.curie('isPartOf'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__parent_datasets, domain=None, range=Optional[Union[Union[str, DatasetId], list[Union[str, DatasetId]]]])
+
+slots.dataSubset__related_datasets = Slot(uri=DATA_SHEETS_SCHEMA.related_datasets, name="dataSubset__related_datasets", curie=DATA_SHEETS_SCHEMA.curie('related_datasets'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__related_datasets, domain=None, range=Optional[Union[Union[str, DatasetRelationshipId], list[Union[str, DatasetRelationshipId]]]])
+
+slots.dataSubset__compression = Slot(uri=DCAT.compressFormat, name="dataSubset__compression", curie=DCAT.curie('compressFormat'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__compression, domain=None, range=Optional[Union[str, "CompressionEnum"]])
+
+slots.dataSubset__conforms_to = Slot(uri=DCTERMS.conformsTo, name="dataSubset__conforms_to", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__conforms_to, domain=None, range=Optional[str])
+
+slots.dataSubset__conforms_to_class = Slot(uri=DCTERMS.conformsTo, name="dataSubset__conforms_to_class", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__conforms_to_class, domain=None, range=Optional[str])
+
+slots.dataSubset__conforms_to_schema = Slot(uri=DCTERMS.conformsTo, name="dataSubset__conforms_to_schema", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__conforms_to_schema, domain=None, range=Optional[str])
+
+slots.dataSubset__created_by = Slot(uri=PAV.createdBy, name="dataSubset__created_by", curie=PAV.curie('createdBy'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__created_by, domain=None, range=Optional[str])
+
+slots.dataSubset__created_on = Slot(uri=PAV.createdOn, name="dataSubset__created_on", curie=PAV.curie('createdOn'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__created_on, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.dataSubset__doi = Slot(uri=BIBO.doi, name="dataSubset__doi", curie=BIBO.curie('doi'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__doi, domain=None, range=Optional[str],
+                   pattern=re.compile(r'10\.\d{4,}\/.+'))
+
+slots.dataSubset__download_url = Slot(uri=DCAT.downloadURL, name="dataSubset__download_url", curie=DCAT.curie('downloadURL'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__download_url, domain=None, range=Optional[Union[str, URI]])
+
+slots.dataSubset__issued = Slot(uri=DCTERMS.issued, name="dataSubset__issued", curie=DCTERMS.curie('issued'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__issued, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.dataSubset__keywords = Slot(uri=DCAT.keyword, name="dataSubset__keywords", curie=DCAT.curie('keyword'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__keywords, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.dataSubset__language = Slot(uri=DCTERMS.language, name="dataSubset__language", curie=DCTERMS.curie('language'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__language, domain=None, range=Optional[str])
+
+slots.dataSubset__last_updated_on = Slot(uri=PAV.lastUpdatedOn, name="dataSubset__last_updated_on", curie=PAV.curie('lastUpdatedOn'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__last_updated_on, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.dataSubset__license = Slot(uri=DCTERMS.license, name="dataSubset__license", curie=DCTERMS.curie('license'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__license, domain=None, range=Optional[str])
+
+slots.dataSubset__modified_by = Slot(uri=OSLC.modifiedBy, name="dataSubset__modified_by", curie=OSLC.curie('modifiedBy'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__modified_by, domain=None, range=Optional[str])
+
+slots.dataSubset__page = Slot(uri=DCAT.landingPage, name="dataSubset__page", curie=DCAT.curie('landingPage'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__page, domain=None, range=Optional[str])
+
+slots.dataSubset__publisher = Slot(uri=DCTERMS.publisher, name="dataSubset__publisher", curie=DCTERMS.curie('publisher'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__publisher, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.dataSubset__status = Slot(uri=BIBO.status, name="dataSubset__status", curie=BIBO.curie('status'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__status, domain=None, range=Optional[str])
+
+slots.dataSubset__title = Slot(uri=DCTERMS.title, name="dataSubset__title", curie=DCTERMS.curie('title'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__title, domain=None, range=Optional[str])
+
+slots.dataSubset__version = Slot(uri=PAV.version, name="dataSubset__version", curie=PAV.curie('version'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__version, domain=None, range=Optional[str])
+
+slots.dataSubset__was_derived_from = Slot(uri=PROV.wasDerivedFrom, name="dataSubset__was_derived_from", curie=PROV.curie('wasDerivedFrom'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__was_derived_from, domain=None, range=Optional[str])
+
+slots.dataSubset__id = Slot(uri=SCHEMA.identifier, name="dataSubset__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__id, domain=None, range=URIRef)
+
+slots.dataSubset__name = Slot(uri=SCHEMA.name, name="dataSubset__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__name, domain=None, range=Optional[str])
+
+slots.dataSubset__description = Slot(uri=SCHEMA.description, name="dataSubset__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataSubset__description, domain=None, range=Optional[str])
 
 slots.namedThing__id = Slot(uri=SCHEMA.identifier, name="namedThing__id", curie=SCHEMA.curie('identifier'),
                    model_uri=DATA_SHEETS_SCHEMA.namedThing__id, domain=None, range=URIRef)
@@ -3980,8 +5836,26 @@ slots.namedThing__name = Slot(uri=SCHEMA.name, name="namedThing__name", curie=SC
 slots.namedThing__description = Slot(uri=SCHEMA.description, name="namedThing__description", curie=SCHEMA.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.namedThing__description, domain=None, range=Optional[str])
 
+slots.organization__id = Slot(uri=SCHEMA.identifier, name="organization__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.organization__id, domain=None, range=URIRef)
+
+slots.organization__name = Slot(uri=SCHEMA.name, name="organization__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.organization__name, domain=None, range=Optional[str])
+
+slots.organization__description = Slot(uri=SCHEMA.description, name="organization__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.organization__description, domain=None, range=Optional[str])
+
 slots.datasetProperty__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="datasetProperty__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetProperty__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.datasetProperty__id = Slot(uri=SCHEMA.identifier, name="datasetProperty__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetProperty__id, domain=None, range=URIRef)
+
+slots.datasetProperty__name = Slot(uri=SCHEMA.name, name="datasetProperty__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetProperty__name, domain=None, range=Optional[str])
+
+slots.datasetProperty__description = Slot(uri=SCHEMA.description, name="datasetProperty__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetProperty__description, domain=None, range=Optional[str])
 
 slots.software__version = Slot(uri=SCHEMA.softwareVersion, name="software__version", curie=SCHEMA.curie('softwareVersion'),
                    model_uri=DATA_SHEETS_SCHEMA.software__version, domain=None, range=Optional[str])
@@ -3992,6 +5866,15 @@ slots.software__license = Slot(uri=SCHEMA.license, name="software__license", cur
 slots.software__url = Slot(uri=SCHEMA.url, name="software__url", curie=SCHEMA.curie('url'),
                    model_uri=DATA_SHEETS_SCHEMA.software__url, domain=None, range=Optional[str])
 
+slots.software__id = Slot(uri=SCHEMA.identifier, name="software__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.software__id, domain=None, range=URIRef)
+
+slots.software__name = Slot(uri=SCHEMA.name, name="software__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.software__name, domain=None, range=Optional[str])
+
+slots.software__description = Slot(uri=SCHEMA.description, name="software__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.software__description, domain=None, range=Optional[str])
+
 slots.person__affiliation = Slot(uri=SCHEMA.affiliation, name="person__affiliation", curie=SCHEMA.curie('affiliation'),
                    model_uri=DATA_SHEETS_SCHEMA.person__affiliation, domain=None, range=Optional[Union[Union[str, OrganizationId], list[Union[str, OrganizationId]]]])
 
@@ -4001,6 +5884,85 @@ slots.person__email = Slot(uri=SCHEMA.email, name="person__email", curie=SCHEMA.
 slots.person__orcid = Slot(uri=SCHEMA.identifier, name="person__orcid", curie=SCHEMA.curie('identifier'),
                    model_uri=DATA_SHEETS_SCHEMA.person__orcid, domain=None, range=Optional[str],
                    pattern=re.compile(r'^\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$'))
+
+slots.person__id = Slot(uri=SCHEMA.identifier, name="person__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.person__id, domain=None, range=URIRef)
+
+slots.person__name = Slot(uri=SCHEMA.name, name="person__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.person__name, domain=None, range=Optional[str])
+
+slots.person__description = Slot(uri=SCHEMA.description, name="person__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.person__description, domain=None, range=Optional[str])
+
+slots.information__compression = Slot(uri=DCAT.compressFormat, name="information__compression", curie=DCAT.curie('compressFormat'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__compression, domain=None, range=Optional[Union[str, "CompressionEnum"]])
+
+slots.information__conforms_to = Slot(uri=DCTERMS.conformsTo, name="information__conforms_to", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__conforms_to, domain=None, range=Optional[str])
+
+slots.information__conforms_to_class = Slot(uri=DCTERMS.conformsTo, name="information__conforms_to_class", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__conforms_to_class, domain=None, range=Optional[str])
+
+slots.information__conforms_to_schema = Slot(uri=DCTERMS.conformsTo, name="information__conforms_to_schema", curie=DCTERMS.curie('conformsTo'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__conforms_to_schema, domain=None, range=Optional[str])
+
+slots.information__created_by = Slot(uri=PAV.createdBy, name="information__created_by", curie=PAV.curie('createdBy'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__created_by, domain=None, range=Optional[str])
+
+slots.information__created_on = Slot(uri=PAV.createdOn, name="information__created_on", curie=PAV.curie('createdOn'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__created_on, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.information__doi = Slot(uri=BIBO.doi, name="information__doi", curie=BIBO.curie('doi'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__doi, domain=None, range=Optional[str],
+                   pattern=re.compile(r'10\.\d{4,}\/.+'))
+
+slots.information__download_url = Slot(uri=DCAT.downloadURL, name="information__download_url", curie=DCAT.curie('downloadURL'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__download_url, domain=None, range=Optional[Union[str, URI]])
+
+slots.information__issued = Slot(uri=DCTERMS.issued, name="information__issued", curie=DCTERMS.curie('issued'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__issued, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.information__keywords = Slot(uri=DCAT.keyword, name="information__keywords", curie=DCAT.curie('keyword'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__keywords, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.information__language = Slot(uri=DCTERMS.language, name="information__language", curie=DCTERMS.curie('language'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__language, domain=None, range=Optional[str])
+
+slots.information__last_updated_on = Slot(uri=PAV.lastUpdatedOn, name="information__last_updated_on", curie=PAV.curie('lastUpdatedOn'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__last_updated_on, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.information__license = Slot(uri=DCTERMS.license, name="information__license", curie=DCTERMS.curie('license'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__license, domain=None, range=Optional[str])
+
+slots.information__modified_by = Slot(uri=OSLC.modifiedBy, name="information__modified_by", curie=OSLC.curie('modifiedBy'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__modified_by, domain=None, range=Optional[str])
+
+slots.information__page = Slot(uri=DCAT.landingPage, name="information__page", curie=DCAT.curie('landingPage'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__page, domain=None, range=Optional[str])
+
+slots.information__publisher = Slot(uri=DCTERMS.publisher, name="information__publisher", curie=DCTERMS.curie('publisher'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__publisher, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.information__status = Slot(uri=BIBO.status, name="information__status", curie=BIBO.curie('status'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__status, domain=None, range=Optional[str])
+
+slots.information__title = Slot(uri=DCTERMS.title, name="information__title", curie=DCTERMS.curie('title'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__title, domain=None, range=Optional[str])
+
+slots.information__version = Slot(uri=PAV.version, name="information__version", curie=PAV.curie('version'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__version, domain=None, range=Optional[str])
+
+slots.information__was_derived_from = Slot(uri=PROV.wasDerivedFrom, name="information__was_derived_from", curie=PROV.curie('wasDerivedFrom'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__was_derived_from, domain=None, range=Optional[str])
+
+slots.information__id = Slot(uri=SCHEMA.identifier, name="information__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__id, domain=None, range=URIRef)
+
+slots.information__name = Slot(uri=SCHEMA.name, name="information__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__name, domain=None, range=Optional[str])
+
+slots.information__description = Slot(uri=SCHEMA.description, name="information__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.information__description, domain=None, range=Optional[str])
 
 slots.formatDialect__comment_prefix = Slot(uri=DATA_SHEETS_SCHEMA.comment_prefix, name="formatDialect__comment_prefix", curie=DATA_SHEETS_SCHEMA.curie('comment_prefix'),
                    model_uri=DATA_SHEETS_SCHEMA.formatDialect__comment_prefix, domain=None, range=Optional[str])
@@ -4020,11 +5982,47 @@ slots.formatDialect__quote_char = Slot(uri=DATA_SHEETS_SCHEMA.quote_char, name="
 slots.purpose__response = Slot(uri=DCTERMS.description, name="purpose__response", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.purpose__response, domain=None, range=Optional[str])
 
+slots.purpose__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="purpose__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.purpose__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.purpose__id = Slot(uri=SCHEMA.identifier, name="purpose__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.purpose__id, domain=None, range=URIRef)
+
+slots.purpose__name = Slot(uri=SCHEMA.name, name="purpose__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.purpose__name, domain=None, range=Optional[str])
+
+slots.purpose__description = Slot(uri=SCHEMA.description, name="purpose__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.purpose__description, domain=None, range=Optional[str])
+
 slots.task__response = Slot(uri=DCTERMS.description, name="task__response", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.task__response, domain=None, range=Optional[str])
 
+slots.task__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="task__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.task__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.task__id = Slot(uri=SCHEMA.identifier, name="task__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.task__id, domain=None, range=URIRef)
+
+slots.task__name = Slot(uri=SCHEMA.name, name="task__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.task__name, domain=None, range=Optional[str])
+
+slots.task__description = Slot(uri=SCHEMA.description, name="task__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.task__description, domain=None, range=Optional[str])
+
 slots.addressingGap__response = Slot(uri=DCTERMS.description, name="addressingGap__response", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.addressingGap__response, domain=None, range=Optional[str])
+
+slots.addressingGap__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="addressingGap__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.addressingGap__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.addressingGap__id = Slot(uri=SCHEMA.identifier, name="addressingGap__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.addressingGap__id, domain=None, range=URIRef)
+
+slots.addressingGap__name = Slot(uri=SCHEMA.name, name="addressingGap__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.addressingGap__name, domain=None, range=Optional[str])
+
+slots.addressingGap__description = Slot(uri=SCHEMA.description, name="addressingGap__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.addressingGap__description, domain=None, range=Optional[str])
 
 slots.creator__principal_investigator = Slot(uri=DCTERMS.creator, name="creator__principal_investigator", curie=DCTERMS.curie('creator'),
                    model_uri=DATA_SHEETS_SCHEMA.creator__principal_investigator, domain=None, range=Optional[Union[str, PersonId]])
@@ -4032,8 +6030,20 @@ slots.creator__principal_investigator = Slot(uri=DCTERMS.creator, name="creator_
 slots.creator__affiliation = Slot(uri=SCHEMA.affiliation, name="creator__affiliation", curie=SCHEMA.curie('affiliation'),
                    model_uri=DATA_SHEETS_SCHEMA.creator__affiliation, domain=None, range=Optional[Union[str, OrganizationId]])
 
-slots.creator__credit_roles = Slot(uri=D4DMOTIVATION.credit_roles, name="creator__credit_roles", curie=D4DMOTIVATION.curie('credit_roles'),
+slots.creator__credit_roles = Slot(uri=DATA_SHEETS_SCHEMA.credit_roles, name="creator__credit_roles", curie=DATA_SHEETS_SCHEMA.curie('credit_roles'),
                    model_uri=DATA_SHEETS_SCHEMA.creator__credit_roles, domain=None, range=Optional[Union[Union[str, "CRediTRoleEnum"], list[Union[str, "CRediTRoleEnum"]]]])
+
+slots.creator__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="creator__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.creator__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.creator__id = Slot(uri=SCHEMA.identifier, name="creator__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.creator__id, domain=None, range=URIRef)
+
+slots.creator__name = Slot(uri=SCHEMA.name, name="creator__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.creator__name, domain=None, range=Optional[str])
+
+slots.creator__description = Slot(uri=SCHEMA.description, name="creator__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.creator__description, domain=None, range=Optional[str])
 
 slots.fundingMechanism__grantor = Slot(uri=SCHEMA.funder, name="fundingMechanism__grantor", curie=SCHEMA.curie('funder'),
                    model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__grantor, domain=None, range=Optional[Union[str, GrantorId]])
@@ -4041,8 +6051,38 @@ slots.fundingMechanism__grantor = Slot(uri=SCHEMA.funder, name="fundingMechanism
 slots.fundingMechanism__grant = Slot(uri=SCHEMA.funding, name="fundingMechanism__grant", curie=SCHEMA.curie('funding'),
                    model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__grant, domain=None, range=Optional[Union[str, GrantId]])
 
+slots.fundingMechanism__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="fundingMechanism__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.fundingMechanism__id = Slot(uri=SCHEMA.identifier, name="fundingMechanism__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__id, domain=None, range=URIRef)
+
+slots.fundingMechanism__name = Slot(uri=SCHEMA.name, name="fundingMechanism__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__name, domain=None, range=Optional[str])
+
+slots.fundingMechanism__description = Slot(uri=SCHEMA.description, name="fundingMechanism__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__description, domain=None, range=Optional[str])
+
+slots.grantor__id = Slot(uri=SCHEMA.identifier, name="grantor__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.grantor__id, domain=None, range=URIRef)
+
+slots.grantor__name = Slot(uri=SCHEMA.name, name="grantor__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.grantor__name, domain=None, range=Optional[str])
+
+slots.grantor__description = Slot(uri=SCHEMA.description, name="grantor__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.grantor__description, domain=None, range=Optional[str])
+
 slots.grant__grant_number = Slot(uri=SCHEMA.identifier, name="grant__grant_number", curie=SCHEMA.curie('identifier'),
                    model_uri=DATA_SHEETS_SCHEMA.grant__grant_number, domain=None, range=Optional[str])
+
+slots.grant__id = Slot(uri=SCHEMA.identifier, name="grant__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.grant__id, domain=None, range=URIRef)
+
+slots.grant__name = Slot(uri=SCHEMA.name, name="grant__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.grant__name, domain=None, range=Optional[str])
+
+slots.grant__description = Slot(uri=SCHEMA.description, name="grant__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.grant__description, domain=None, range=Optional[str])
 
 slots.instance__data_topic = Slot(uri=DCAT.theme, name="instance__data_topic", curie=DCAT.curie('theme'),
                    model_uri=DATA_SHEETS_SCHEMA.instance__data_topic, domain=None, range=Optional[Union[str, URIorCURIE]])
@@ -4056,38 +6096,62 @@ slots.instance__data_substrate = Slot(uri=DCTERMS.format, name="instance__data_s
 slots.instance__counts = Slot(uri=SCHEMA.numberOfItems, name="instance__counts", curie=SCHEMA.curie('numberOfItems'),
                    model_uri=DATA_SHEETS_SCHEMA.instance__counts, domain=None, range=Optional[int])
 
-slots.instance__label = Slot(uri=D4DCOMPOSITION.label, name="instance__label", curie=D4DCOMPOSITION.curie('label'),
+slots.instance__label = Slot(uri=DATA_SHEETS_SCHEMA.label, name="instance__label", curie=DATA_SHEETS_SCHEMA.curie('label'),
                    model_uri=DATA_SHEETS_SCHEMA.instance__label, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.instance__label_description = Slot(uri=SCHEMA.description, name="instance__label_description", curie=SCHEMA.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.instance__label_description, domain=None, range=Optional[str])
 
-slots.instance__sampling_strategies = Slot(uri=D4DCOMPOSITION.sampling_strategies, name="instance__sampling_strategies", curie=D4DCOMPOSITION.curie('sampling_strategies'),
+slots.instance__sampling_strategies = Slot(uri=DATA_SHEETS_SCHEMA.sampling_strategies, name="instance__sampling_strategies", curie=DATA_SHEETS_SCHEMA.curie('sampling_strategies'),
                    model_uri=DATA_SHEETS_SCHEMA.instance__sampling_strategies, domain=None, range=Optional[Union[Union[str, SamplingStrategyId], list[Union[str, SamplingStrategyId]]]])
 
-slots.instance__missing_information = Slot(uri=D4DCOMPOSITION.missing_information, name="instance__missing_information", curie=D4DCOMPOSITION.curie('missing_information'),
+slots.instance__missing_information = Slot(uri=DATA_SHEETS_SCHEMA.missing_information, name="instance__missing_information", curie=DATA_SHEETS_SCHEMA.curie('missing_information'),
                    model_uri=DATA_SHEETS_SCHEMA.instance__missing_information, domain=None, range=Optional[Union[Union[str, MissingInfoId], list[Union[str, MissingInfoId]]]])
 
-slots.samplingStrategy__is_sample = Slot(uri=D4DCOMPOSITION.is_sample, name="samplingStrategy__is_sample", curie=D4DCOMPOSITION.curie('is_sample'),
+slots.instance__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="instance__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.instance__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.instance__id = Slot(uri=SCHEMA.identifier, name="instance__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.instance__id, domain=None, range=URIRef)
+
+slots.instance__name = Slot(uri=SCHEMA.name, name="instance__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.instance__name, domain=None, range=Optional[str])
+
+slots.instance__description = Slot(uri=SCHEMA.description, name="instance__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.instance__description, domain=None, range=Optional[str])
+
+slots.samplingStrategy__is_sample = Slot(uri=DATA_SHEETS_SCHEMA.is_sample, name="samplingStrategy__is_sample", curie=DATA_SHEETS_SCHEMA.curie('is_sample'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__is_sample, domain=None, range=Optional[Union[Union[bool, Bool], list[Union[bool, Bool]]]])
 
-slots.samplingStrategy__is_random = Slot(uri=D4DCOMPOSITION.is_random, name="samplingStrategy__is_random", curie=D4DCOMPOSITION.curie('is_random'),
+slots.samplingStrategy__is_random = Slot(uri=DATA_SHEETS_SCHEMA.is_random, name="samplingStrategy__is_random", curie=DATA_SHEETS_SCHEMA.curie('is_random'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__is_random, domain=None, range=Optional[Union[Union[bool, Bool], list[Union[bool, Bool]]]])
 
-slots.samplingStrategy__source_data = Slot(uri=D4DCOMPOSITION.source_data, name="samplingStrategy__source_data", curie=D4DCOMPOSITION.curie('source_data'),
+slots.samplingStrategy__source_data = Slot(uri=DATA_SHEETS_SCHEMA.source_data, name="samplingStrategy__source_data", curie=DATA_SHEETS_SCHEMA.curie('source_data'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__source_data, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.samplingStrategy__is_representative = Slot(uri=D4DCOMPOSITION.is_representative, name="samplingStrategy__is_representative", curie=D4DCOMPOSITION.curie('is_representative'),
+slots.samplingStrategy__is_representative = Slot(uri=DATA_SHEETS_SCHEMA.is_representative, name="samplingStrategy__is_representative", curie=DATA_SHEETS_SCHEMA.curie('is_representative'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__is_representative, domain=None, range=Optional[Union[Union[bool, Bool], list[Union[bool, Bool]]]])
 
-slots.samplingStrategy__representative_verification = Slot(uri=D4DCOMPOSITION.representative_verification, name="samplingStrategy__representative_verification", curie=D4DCOMPOSITION.curie('representative_verification'),
+slots.samplingStrategy__representative_verification = Slot(uri=DATA_SHEETS_SCHEMA.representative_verification, name="samplingStrategy__representative_verification", curie=DATA_SHEETS_SCHEMA.curie('representative_verification'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__representative_verification, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.samplingStrategy__why_not_representative = Slot(uri=D4DCOMPOSITION.why_not_representative, name="samplingStrategy__why_not_representative", curie=D4DCOMPOSITION.curie('why_not_representative'),
+slots.samplingStrategy__why_not_representative = Slot(uri=DATA_SHEETS_SCHEMA.why_not_representative, name="samplingStrategy__why_not_representative", curie=DATA_SHEETS_SCHEMA.curie('why_not_representative'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__why_not_representative, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.samplingStrategy__strategies = Slot(uri=D4DCOMPOSITION.strategies, name="samplingStrategy__strategies", curie=D4DCOMPOSITION.curie('strategies'),
+slots.samplingStrategy__strategies = Slot(uri=DATA_SHEETS_SCHEMA.strategies, name="samplingStrategy__strategies", curie=DATA_SHEETS_SCHEMA.curie('strategies'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__strategies, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.samplingStrategy__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="samplingStrategy__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.samplingStrategy__id = Slot(uri=SCHEMA.identifier, name="samplingStrategy__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__id, domain=None, range=URIRef)
+
+slots.samplingStrategy__name = Slot(uri=SCHEMA.name, name="samplingStrategy__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__name, domain=None, range=Optional[str])
+
+slots.samplingStrategy__description = Slot(uri=SCHEMA.description, name="samplingStrategy__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__description, domain=None, range=Optional[str])
 
 slots.missingInfo__missing = Slot(uri=DCTERMS.description, name="missingInfo__missing", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.missingInfo__missing, domain=None, range=Optional[Union[str, list[str]]])
@@ -4095,14 +6159,53 @@ slots.missingInfo__missing = Slot(uri=DCTERMS.description, name="missingInfo__mi
 slots.missingInfo__why_missing = Slot(uri=DCTERMS.description, name="missingInfo__why_missing", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.missingInfo__why_missing, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.missingInfo__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="missingInfo__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.missingInfo__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.missingInfo__id = Slot(uri=SCHEMA.identifier, name="missingInfo__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.missingInfo__id, domain=None, range=URIRef)
+
+slots.missingInfo__name = Slot(uri=SCHEMA.name, name="missingInfo__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.missingInfo__name, domain=None, range=Optional[str])
+
+slots.missingInfo__description = Slot(uri=SCHEMA.description, name="missingInfo__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.missingInfo__description, domain=None, range=Optional[str])
+
 slots.relationships__description = Slot(uri=DCTERMS.description, name="relationships__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.relationships__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.relationships__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="relationships__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.relationships__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.relationships__id = Slot(uri=SCHEMA.identifier, name="relationships__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.relationships__id, domain=None, range=URIRef)
+
+slots.relationships__name = Slot(uri=SCHEMA.name, name="relationships__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.relationships__name, domain=None, range=Optional[str])
 
 slots.splits__description = Slot(uri=DCTERMS.description, name="splits__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.splits__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.splits__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="splits__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.splits__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.splits__id = Slot(uri=SCHEMA.identifier, name="splits__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.splits__id, domain=None, range=URIRef)
+
+slots.splits__name = Slot(uri=SCHEMA.name, name="splits__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.splits__name, domain=None, range=Optional[str])
+
 slots.dataAnomaly__description = Slot(uri=DCTERMS.description, name="dataAnomaly__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.dataAnomaly__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.dataAnomaly__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="dataAnomaly__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataAnomaly__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.dataAnomaly__id = Slot(uri=SCHEMA.identifier, name="dataAnomaly__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataAnomaly__id, domain=None, range=URIRef)
+
+slots.dataAnomaly__name = Slot(uri=SCHEMA.name, name="dataAnomaly__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataAnomaly__name, domain=None, range=Optional[str])
 
 slots.externalResource__external_resources = Slot(uri=DCTERMS.references, name="externalResource__external_resources", curie=DCTERMS.curie('references'),
                    model_uri=DATA_SHEETS_SCHEMA.externalResource__external_resources, domain=None, range=Optional[Union[str, list[str]]])
@@ -4110,25 +6213,58 @@ slots.externalResource__external_resources = Slot(uri=DCTERMS.references, name="
 slots.externalResource__future_guarantees = Slot(uri=DCTERMS.description, name="externalResource__future_guarantees", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.externalResource__future_guarantees, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.externalResource__archival = Slot(uri=D4DCOMPOSITION.archival, name="externalResource__archival", curie=D4DCOMPOSITION.curie('archival'),
+slots.externalResource__archival = Slot(uri=DATA_SHEETS_SCHEMA.archival, name="externalResource__archival", curie=DATA_SHEETS_SCHEMA.curie('archival'),
                    model_uri=DATA_SHEETS_SCHEMA.externalResource__archival, domain=None, range=Optional[Union[Union[bool, Bool], list[Union[bool, Bool]]]])
 
 slots.externalResource__restrictions = Slot(uri=DCTERMS.accessRights, name="externalResource__restrictions", curie=DCTERMS.curie('accessRights'),
                    model_uri=DATA_SHEETS_SCHEMA.externalResource__restrictions, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.confidentiality__confidential_elements_present = Slot(uri=D4DCOMPOSITION.confidential_elements_present, name="confidentiality__confidential_elements_present", curie=D4DCOMPOSITION.curie('confidential_elements_present'),
+slots.externalResource__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="externalResource__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.externalResource__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.externalResource__id = Slot(uri=SCHEMA.identifier, name="externalResource__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.externalResource__id, domain=None, range=URIRef)
+
+slots.externalResource__name = Slot(uri=SCHEMA.name, name="externalResource__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.externalResource__name, domain=None, range=Optional[str])
+
+slots.externalResource__description = Slot(uri=SCHEMA.description, name="externalResource__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.externalResource__description, domain=None, range=Optional[str])
+
+slots.confidentiality__confidential_elements_present = Slot(uri=DATA_SHEETS_SCHEMA.confidential_elements_present, name="confidentiality__confidential_elements_present", curie=DATA_SHEETS_SCHEMA.curie('confidential_elements_present'),
                    model_uri=DATA_SHEETS_SCHEMA.confidentiality__confidential_elements_present, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.confidentiality__description = Slot(uri=DCTERMS.description, name="confidentiality__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.confidentiality__description, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.contentWarning__content_warnings_present = Slot(uri=D4DCOMPOSITION.content_warnings_present, name="contentWarning__content_warnings_present", curie=D4DCOMPOSITION.curie('content_warnings_present'),
+slots.confidentiality__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="confidentiality__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.confidentiality__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.confidentiality__id = Slot(uri=SCHEMA.identifier, name="confidentiality__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.confidentiality__id, domain=None, range=URIRef)
+
+slots.confidentiality__name = Slot(uri=SCHEMA.name, name="confidentiality__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.confidentiality__name, domain=None, range=Optional[str])
+
+slots.contentWarning__content_warnings_present = Slot(uri=DATA_SHEETS_SCHEMA.content_warnings_present, name="contentWarning__content_warnings_present", curie=DATA_SHEETS_SCHEMA.curie('content_warnings_present'),
                    model_uri=DATA_SHEETS_SCHEMA.contentWarning__content_warnings_present, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.contentWarning__warnings = Slot(uri=DCTERMS.description, name="contentWarning__warnings", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.contentWarning__warnings, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.subpopulation__subpopulation_elements_present = Slot(uri=D4DCOMPOSITION.subpopulation_elements_present, name="subpopulation__subpopulation_elements_present", curie=D4DCOMPOSITION.curie('subpopulation_elements_present'),
+slots.contentWarning__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="contentWarning__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.contentWarning__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.contentWarning__id = Slot(uri=SCHEMA.identifier, name="contentWarning__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.contentWarning__id, domain=None, range=URIRef)
+
+slots.contentWarning__name = Slot(uri=SCHEMA.name, name="contentWarning__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.contentWarning__name, domain=None, range=Optional[str])
+
+slots.contentWarning__description = Slot(uri=SCHEMA.description, name="contentWarning__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.contentWarning__description, domain=None, range=Optional[str])
+
+slots.subpopulation__subpopulation_elements_present = Slot(uri=DATA_SHEETS_SCHEMA.subpopulation_elements_present, name="subpopulation__subpopulation_elements_present", curie=DATA_SHEETS_SCHEMA.curie('subpopulation_elements_present'),
                    model_uri=DATA_SHEETS_SCHEMA.subpopulation__subpopulation_elements_present, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.subpopulation__identification = Slot(uri=DCTERMS.description, name="subpopulation__identification", curie=DCTERMS.curie('description'),
@@ -4137,59 +6273,161 @@ slots.subpopulation__identification = Slot(uri=DCTERMS.description, name="subpop
 slots.subpopulation__distribution = Slot(uri=DCTERMS.description, name="subpopulation__distribution", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.subpopulation__distribution, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.deidentification__identifiable_elements_present = Slot(uri=D4DCOMPOSITION.identifiable_elements_present, name="deidentification__identifiable_elements_present", curie=D4DCOMPOSITION.curie('identifiable_elements_present'),
+slots.subpopulation__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="subpopulation__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.subpopulation__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.subpopulation__id = Slot(uri=SCHEMA.identifier, name="subpopulation__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.subpopulation__id, domain=None, range=URIRef)
+
+slots.subpopulation__name = Slot(uri=SCHEMA.name, name="subpopulation__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.subpopulation__name, domain=None, range=Optional[str])
+
+slots.subpopulation__description = Slot(uri=SCHEMA.description, name="subpopulation__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.subpopulation__description, domain=None, range=Optional[str])
+
+slots.deidentification__identifiable_elements_present = Slot(uri=DATA_SHEETS_SCHEMA.identifiable_elements_present, name="deidentification__identifiable_elements_present", curie=DATA_SHEETS_SCHEMA.curie('identifiable_elements_present'),
                    model_uri=DATA_SHEETS_SCHEMA.deidentification__identifiable_elements_present, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.deidentification__description = Slot(uri=DCTERMS.description, name="deidentification__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.deidentification__description, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.sensitiveElement__sensitive_elements_present = Slot(uri=D4DCOMPOSITION.sensitive_elements_present, name="sensitiveElement__sensitive_elements_present", curie=D4DCOMPOSITION.curie('sensitive_elements_present'),
+slots.deidentification__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="deidentification__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.deidentification__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.deidentification__id = Slot(uri=SCHEMA.identifier, name="deidentification__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.deidentification__id, domain=None, range=URIRef)
+
+slots.deidentification__name = Slot(uri=SCHEMA.name, name="deidentification__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.deidentification__name, domain=None, range=Optional[str])
+
+slots.sensitiveElement__sensitive_elements_present = Slot(uri=DATA_SHEETS_SCHEMA.sensitive_elements_present, name="sensitiveElement__sensitive_elements_present", curie=DATA_SHEETS_SCHEMA.curie('sensitive_elements_present'),
                    model_uri=DATA_SHEETS_SCHEMA.sensitiveElement__sensitive_elements_present, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.sensitiveElement__description = Slot(uri=DCTERMS.description, name="sensitiveElement__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.sensitiveElement__description, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.datasetRelationship__target_dataset = Slot(uri=D4DCOMPOSITION.target_dataset, name="datasetRelationship__target_dataset", curie=D4DCOMPOSITION.curie('target_dataset'),
+slots.sensitiveElement__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="sensitiveElement__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.sensitiveElement__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.sensitiveElement__id = Slot(uri=SCHEMA.identifier, name="sensitiveElement__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.sensitiveElement__id, domain=None, range=URIRef)
+
+slots.sensitiveElement__name = Slot(uri=SCHEMA.name, name="sensitiveElement__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.sensitiveElement__name, domain=None, range=Optional[str])
+
+slots.datasetRelationship__target_dataset = Slot(uri=DATA_SHEETS_SCHEMA.target_dataset, name="datasetRelationship__target_dataset", curie=DATA_SHEETS_SCHEMA.curie('target_dataset'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetRelationship__target_dataset, domain=None, range=str)
 
-slots.datasetRelationship__relationship_type = Slot(uri=D4DCOMPOSITION.relationship_type, name="datasetRelationship__relationship_type", curie=D4DCOMPOSITION.curie('relationship_type'),
+slots.datasetRelationship__relationship_type = Slot(uri=DATA_SHEETS_SCHEMA.relationship_type, name="datasetRelationship__relationship_type", curie=DATA_SHEETS_SCHEMA.curie('relationship_type'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetRelationship__relationship_type, domain=None, range=Union[str, "DatasetRelationshipTypeEnum"])
 
-slots.datasetRelationship__description = Slot(uri=D4DCOMPOSITION.description, name="datasetRelationship__description", curie=D4DCOMPOSITION.curie('description'),
+slots.datasetRelationship__description = Slot(uri=DATA_SHEETS_SCHEMA.description, name="datasetRelationship__description", curie=DATA_SHEETS_SCHEMA.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetRelationship__description, domain=None, range=Optional[str])
+
+slots.datasetRelationship__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="datasetRelationship__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetRelationship__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.datasetRelationship__id = Slot(uri=SCHEMA.identifier, name="datasetRelationship__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetRelationship__id, domain=None, range=URIRef)
+
+slots.datasetRelationship__name = Slot(uri=SCHEMA.name, name="datasetRelationship__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetRelationship__name, domain=None, range=Optional[str])
 
 slots.instanceAcquisition__description = Slot(uri=DCTERMS.description, name="instanceAcquisition__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__description, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.instanceAcquisition__was_directly_observed = Slot(uri=DATA_SHEETS_SCHEMA['collection/was_directly_observed'], name="instanceAcquisition__was_directly_observed", curie=DATA_SHEETS_SCHEMA.curie('collection/was_directly_observed'),
+slots.instanceAcquisition__was_directly_observed = Slot(uri=DATA_SHEETS_SCHEMA.was_directly_observed, name="instanceAcquisition__was_directly_observed", curie=DATA_SHEETS_SCHEMA.curie('was_directly_observed'),
                    model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__was_directly_observed, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.instanceAcquisition__was_reported_by_subjects = Slot(uri=DATA_SHEETS_SCHEMA['collection/was_reported_by_subjects'], name="instanceAcquisition__was_reported_by_subjects", curie=DATA_SHEETS_SCHEMA.curie('collection/was_reported_by_subjects'),
+slots.instanceAcquisition__was_reported_by_subjects = Slot(uri=DATA_SHEETS_SCHEMA.was_reported_by_subjects, name="instanceAcquisition__was_reported_by_subjects", curie=DATA_SHEETS_SCHEMA.curie('was_reported_by_subjects'),
                    model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__was_reported_by_subjects, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.instanceAcquisition__was_inferred_derived = Slot(uri=PROV.wasDerivedFrom, name="instanceAcquisition__was_inferred_derived", curie=PROV.curie('wasDerivedFrom'),
                    model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__was_inferred_derived, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.instanceAcquisition__was_validated_verified = Slot(uri=DATA_SHEETS_SCHEMA['collection/was_validated_verified'], name="instanceAcquisition__was_validated_verified", curie=DATA_SHEETS_SCHEMA.curie('collection/was_validated_verified'),
+slots.instanceAcquisition__was_validated_verified = Slot(uri=DATA_SHEETS_SCHEMA.was_validated_verified, name="instanceAcquisition__was_validated_verified", curie=DATA_SHEETS_SCHEMA.curie('was_validated_verified'),
                    model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__was_validated_verified, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.instanceAcquisition__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="instanceAcquisition__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.instanceAcquisition__id = Slot(uri=SCHEMA.identifier, name="instanceAcquisition__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__id, domain=None, range=URIRef)
+
+slots.instanceAcquisition__name = Slot(uri=SCHEMA.name, name="instanceAcquisition__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__name, domain=None, range=Optional[str])
 
 slots.collectionMechanism__description = Slot(uri=DCTERMS.description, name="collectionMechanism__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.collectionMechanism__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.collectionMechanism__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="collectionMechanism__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionMechanism__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.collectionMechanism__id = Slot(uri=SCHEMA.identifier, name="collectionMechanism__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionMechanism__id, domain=None, range=URIRef)
+
+slots.collectionMechanism__name = Slot(uri=SCHEMA.name, name="collectionMechanism__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionMechanism__name, domain=None, range=Optional[str])
+
 slots.dataCollector__description = Slot(uri=DCTERMS.description, name="dataCollector__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.dataCollector__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.dataCollector__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="dataCollector__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataCollector__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.dataCollector__id = Slot(uri=SCHEMA.identifier, name="dataCollector__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataCollector__id, domain=None, range=URIRef)
+
+slots.dataCollector__name = Slot(uri=SCHEMA.name, name="dataCollector__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataCollector__name, domain=None, range=Optional[str])
 
 slots.collectionTimeframe__description = Slot(uri=DCTERMS.temporal, name="collectionTimeframe__description", curie=DCTERMS.curie('temporal'),
                    model_uri=DATA_SHEETS_SCHEMA.collectionTimeframe__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.collectionTimeframe__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="collectionTimeframe__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionTimeframe__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.collectionTimeframe__id = Slot(uri=SCHEMA.identifier, name="collectionTimeframe__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionTimeframe__id, domain=None, range=URIRef)
+
+slots.collectionTimeframe__name = Slot(uri=SCHEMA.name, name="collectionTimeframe__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionTimeframe__name, domain=None, range=Optional[str])
+
 slots.directCollection__description = Slot(uri=DCTERMS.source, name="directCollection__description", curie=DCTERMS.curie('source'),
                    model_uri=DATA_SHEETS_SCHEMA.directCollection__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.directCollection__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="directCollection__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.directCollection__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.directCollection__id = Slot(uri=SCHEMA.identifier, name="directCollection__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.directCollection__id, domain=None, range=URIRef)
+
+slots.directCollection__name = Slot(uri=SCHEMA.name, name="directCollection__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.directCollection__name, domain=None, range=Optional[str])
 
 slots.preprocessingStrategy__description = Slot(uri=DCTERMS.description, name="preprocessingStrategy__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.preprocessingStrategy__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.preprocessingStrategy__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="preprocessingStrategy__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.preprocessingStrategy__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.preprocessingStrategy__id = Slot(uri=SCHEMA.identifier, name="preprocessingStrategy__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.preprocessingStrategy__id, domain=None, range=URIRef)
+
+slots.preprocessingStrategy__name = Slot(uri=SCHEMA.name, name="preprocessingStrategy__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.preprocessingStrategy__name, domain=None, range=Optional[str])
+
 slots.cleaningStrategy__description = Slot(uri=DCTERMS.description, name="cleaningStrategy__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.cleaningStrategy__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.cleaningStrategy__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="cleaningStrategy__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.cleaningStrategy__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.cleaningStrategy__id = Slot(uri=SCHEMA.identifier, name="cleaningStrategy__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.cleaningStrategy__id, domain=None, range=URIRef)
+
+slots.cleaningStrategy__name = Slot(uri=SCHEMA.name, name="cleaningStrategy__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.cleaningStrategy__name, domain=None, range=Optional[str])
 
 slots.labelingStrategy__description = Slot(uri=DCTERMS.description, name="labelingStrategy__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__description, domain=None, range=Optional[Union[str, list[str]]])
@@ -4197,71 +6435,233 @@ slots.labelingStrategy__description = Slot(uri=DCTERMS.description, name="labeli
 slots.labelingStrategy__annotation_platform = Slot(uri=SCHEMA.instrument, name="labelingStrategy__annotation_platform", curie=SCHEMA.curie('instrument'),
                    model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__annotation_platform, domain=None, range=Optional[str])
 
-slots.labelingStrategy__annotations_per_item = Slot(uri=D4DPREPROCESSING.annotations_per_item, name="labelingStrategy__annotations_per_item", curie=D4DPREPROCESSING.curie('annotations_per_item'),
+slots.labelingStrategy__annotations_per_item = Slot(uri=DATA_SHEETS_SCHEMA.annotations_per_item, name="labelingStrategy__annotations_per_item", curie=DATA_SHEETS_SCHEMA.curie('annotations_per_item'),
                    model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__annotations_per_item, domain=None, range=Optional[int])
 
 slots.labelingStrategy__inter_annotator_agreement = Slot(uri=SCHEMA.measurementMethod, name="labelingStrategy__inter_annotator_agreement", curie=SCHEMA.curie('measurementMethod'),
                    model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__inter_annotator_agreement, domain=None, range=Optional[str])
 
-slots.labelingStrategy__annotator_demographics = Slot(uri=D4DPREPROCESSING.annotator_demographics, name="labelingStrategy__annotator_demographics", curie=D4DPREPROCESSING.curie('annotator_demographics'),
+slots.labelingStrategy__annotator_demographics = Slot(uri=DATA_SHEETS_SCHEMA.annotator_demographics, name="labelingStrategy__annotator_demographics", curie=DATA_SHEETS_SCHEMA.curie('annotator_demographics'),
                    model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__annotator_demographics, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.labelingStrategy__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="labelingStrategy__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.labelingStrategy__id = Slot(uri=SCHEMA.identifier, name="labelingStrategy__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__id, domain=None, range=URIRef)
+
+slots.labelingStrategy__name = Slot(uri=SCHEMA.name, name="labelingStrategy__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__name, domain=None, range=Optional[str])
 
 slots.rawData__description = Slot(uri=PROV.wasDerivedFrom, name="rawData__description", curie=PROV.curie('wasDerivedFrom'),
                    model_uri=DATA_SHEETS_SCHEMA.rawData__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.rawData__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="rawData__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.rawData__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.rawData__id = Slot(uri=SCHEMA.identifier, name="rawData__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.rawData__id, domain=None, range=URIRef)
+
+slots.rawData__name = Slot(uri=SCHEMA.name, name="rawData__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.rawData__name, domain=None, range=Optional[str])
+
 slots.existingUse__description = Slot(uri=DCTERMS.description, name="existingUse__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.existingUse__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.existingUse__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="existingUse__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.existingUse__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.existingUse__id = Slot(uri=SCHEMA.identifier, name="existingUse__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.existingUse__id, domain=None, range=URIRef)
+
+slots.existingUse__name = Slot(uri=SCHEMA.name, name="existingUse__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.existingUse__name, domain=None, range=Optional[str])
 
 slots.useRepository__description = Slot(uri=SCHEMA.url, name="useRepository__description", curie=SCHEMA.curie('url'),
                    model_uri=DATA_SHEETS_SCHEMA.useRepository__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.useRepository__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="useRepository__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.useRepository__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.useRepository__id = Slot(uri=SCHEMA.identifier, name="useRepository__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.useRepository__id, domain=None, range=URIRef)
+
+slots.useRepository__name = Slot(uri=SCHEMA.name, name="useRepository__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.useRepository__name, domain=None, range=Optional[str])
+
 slots.otherTask__description = Slot(uri=DCTERMS.description, name="otherTask__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.otherTask__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.otherTask__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="otherTask__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.otherTask__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.otherTask__id = Slot(uri=SCHEMA.identifier, name="otherTask__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.otherTask__id, domain=None, range=URIRef)
+
+slots.otherTask__name = Slot(uri=SCHEMA.name, name="otherTask__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.otherTask__name, domain=None, range=Optional[str])
 
 slots.futureUseImpact__description = Slot(uri=DCTERMS.description, name="futureUseImpact__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.futureUseImpact__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.futureUseImpact__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="futureUseImpact__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.futureUseImpact__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.futureUseImpact__id = Slot(uri=SCHEMA.identifier, name="futureUseImpact__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.futureUseImpact__id, domain=None, range=URIRef)
+
+slots.futureUseImpact__name = Slot(uri=SCHEMA.name, name="futureUseImpact__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.futureUseImpact__name, domain=None, range=Optional[str])
+
 slots.discouragedUse__description = Slot(uri=DCTERMS.description, name="discouragedUse__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.discouragedUse__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.discouragedUse__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="discouragedUse__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.discouragedUse__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.discouragedUse__id = Slot(uri=SCHEMA.identifier, name="discouragedUse__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.discouragedUse__id, domain=None, range=URIRef)
+
+slots.discouragedUse__name = Slot(uri=SCHEMA.name, name="discouragedUse__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.discouragedUse__name, domain=None, range=Optional[str])
 
 slots.intendedUse__description = Slot(uri=DCTERMS.description, name="intendedUse__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.intendedUse__description, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.intendedUse__use_category = Slot(uri=D4DUSES.use_category, name="intendedUse__use_category", curie=D4DUSES.curie('use_category'),
+slots.intendedUse__use_category = Slot(uri=DATA_SHEETS_SCHEMA.use_category, name="intendedUse__use_category", curie=DATA_SHEETS_SCHEMA.curie('use_category'),
                    model_uri=DATA_SHEETS_SCHEMA.intendedUse__use_category, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.intendedUse__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="intendedUse__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.intendedUse__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.intendedUse__id = Slot(uri=SCHEMA.identifier, name="intendedUse__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.intendedUse__id, domain=None, range=URIRef)
+
+slots.intendedUse__name = Slot(uri=SCHEMA.name, name="intendedUse__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.intendedUse__name, domain=None, range=Optional[str])
 
 slots.prohibitedUse__description = Slot(uri=DCTERMS.description, name="prohibitedUse__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.prohibitedUse__description, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.prohibitedUse__prohibition_reason = Slot(uri=D4DUSES.prohibition_reason, name="prohibitedUse__prohibition_reason", curie=D4DUSES.curie('prohibition_reason'),
+slots.prohibitedUse__prohibition_reason = Slot(uri=DATA_SHEETS_SCHEMA.prohibition_reason, name="prohibitedUse__prohibition_reason", curie=DATA_SHEETS_SCHEMA.curie('prohibition_reason'),
                    model_uri=DATA_SHEETS_SCHEMA.prohibitedUse__prohibition_reason, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.prohibitedUse__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="prohibitedUse__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.prohibitedUse__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.prohibitedUse__id = Slot(uri=SCHEMA.identifier, name="prohibitedUse__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.prohibitedUse__id, domain=None, range=URIRef)
+
+slots.prohibitedUse__name = Slot(uri=SCHEMA.name, name="prohibitedUse__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.prohibitedUse__name, domain=None, range=Optional[str])
 
 slots.thirdPartySharing__description = Slot(uri=DCTERMS.accessRights, name="thirdPartySharing__description", curie=DCTERMS.curie('accessRights'),
                    model_uri=DATA_SHEETS_SCHEMA.thirdPartySharing__description, domain=None, range=Optional[Union[bool, Bool]])
 
+slots.thirdPartySharing__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="thirdPartySharing__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.thirdPartySharing__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.thirdPartySharing__id = Slot(uri=SCHEMA.identifier, name="thirdPartySharing__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.thirdPartySharing__id, domain=None, range=URIRef)
+
+slots.thirdPartySharing__name = Slot(uri=SCHEMA.name, name="thirdPartySharing__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.thirdPartySharing__name, domain=None, range=Optional[str])
+
 slots.distributionFormat__description = Slot(uri=DCAT.accessURL, name="distributionFormat__description", curie=DCAT.curie('accessURL'),
                    model_uri=DATA_SHEETS_SCHEMA.distributionFormat__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.distributionFormat__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="distributionFormat__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.distributionFormat__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.distributionFormat__id = Slot(uri=SCHEMA.identifier, name="distributionFormat__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.distributionFormat__id, domain=None, range=URIRef)
+
+slots.distributionFormat__name = Slot(uri=SCHEMA.name, name="distributionFormat__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.distributionFormat__name, domain=None, range=Optional[str])
 
 slots.distributionDate__description = Slot(uri=DCTERMS.available, name="distributionDate__description", curie=DCTERMS.curie('available'),
                    model_uri=DATA_SHEETS_SCHEMA.distributionDate__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.distributionDate__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="distributionDate__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.distributionDate__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.distributionDate__id = Slot(uri=SCHEMA.identifier, name="distributionDate__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.distributionDate__id, domain=None, range=URIRef)
+
+slots.distributionDate__name = Slot(uri=SCHEMA.name, name="distributionDate__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.distributionDate__name, domain=None, range=Optional[str])
+
 slots.maintainer__description = Slot(uri=SCHEMA.maintainer, name="maintainer__description", curie=SCHEMA.curie('maintainer'),
                    model_uri=DATA_SHEETS_SCHEMA.maintainer__description, domain=None, range=Optional[Union[Union[str, "CreatorOrMaintainerEnum"], list[Union[str, "CreatorOrMaintainerEnum"]]]])
+
+slots.maintainer__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="maintainer__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.maintainer__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.maintainer__id = Slot(uri=SCHEMA.identifier, name="maintainer__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.maintainer__id, domain=None, range=URIRef)
+
+slots.maintainer__name = Slot(uri=SCHEMA.name, name="maintainer__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.maintainer__name, domain=None, range=Optional[str])
 
 slots.erratum__description = Slot(uri=DCTERMS.description, name="erratum__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.erratum__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.erratum__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="erratum__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.erratum__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.erratum__id = Slot(uri=SCHEMA.identifier, name="erratum__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.erratum__id, domain=None, range=URIRef)
+
+slots.erratum__name = Slot(uri=SCHEMA.name, name="erratum__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.erratum__name, domain=None, range=Optional[str])
+
 slots.updatePlan__description = Slot(uri=PAV.lastUpdateOn, name="updatePlan__description", curie=PAV.curie('lastUpdateOn'),
                    model_uri=DATA_SHEETS_SCHEMA.updatePlan__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.updatePlan__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="updatePlan__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.updatePlan__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.updatePlan__id = Slot(uri=SCHEMA.identifier, name="updatePlan__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.updatePlan__id, domain=None, range=URIRef)
+
+slots.updatePlan__name = Slot(uri=SCHEMA.name, name="updatePlan__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.updatePlan__name, domain=None, range=Optional[str])
 
 slots.retentionLimits__description = Slot(uri=DCTERMS.description, name="retentionLimits__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.retentionLimits__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.retentionLimits__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="retentionLimits__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.retentionLimits__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.retentionLimits__id = Slot(uri=SCHEMA.identifier, name="retentionLimits__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.retentionLimits__id, domain=None, range=URIRef)
+
+slots.retentionLimits__name = Slot(uri=SCHEMA.name, name="retentionLimits__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.retentionLimits__name, domain=None, range=Optional[str])
+
 slots.versionAccess__description = Slot(uri=PAV.previousVersion, name="versionAccess__description", curie=PAV.curie('previousVersion'),
                    model_uri=DATA_SHEETS_SCHEMA.versionAccess__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.versionAccess__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="versionAccess__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.versionAccess__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.versionAccess__id = Slot(uri=SCHEMA.identifier, name="versionAccess__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.versionAccess__id, domain=None, range=URIRef)
+
+slots.versionAccess__name = Slot(uri=SCHEMA.name, name="versionAccess__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.versionAccess__name, domain=None, range=Optional[str])
+
 slots.extensionMechanism__description = Slot(uri=DCTERMS.description, name="extensionMechanism__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.extensionMechanism__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.extensionMechanism__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="extensionMechanism__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.extensionMechanism__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.extensionMechanism__id = Slot(uri=SCHEMA.identifier, name="extensionMechanism__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.extensionMechanism__id, domain=None, range=URIRef)
+
+slots.extensionMechanism__name = Slot(uri=SCHEMA.name, name="extensionMechanism__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.extensionMechanism__name, domain=None, range=Optional[str])
 
 slots.ethicalReview__description = Slot(uri=DCTERMS.description, name="ethicalReview__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.ethicalReview__description, domain=None, range=Optional[Union[str, list[str]]])
@@ -4272,83 +6672,188 @@ slots.ethicalReview__contact_person = Slot(uri=SCHEMA.contactPoint, name="ethica
 slots.ethicalReview__reviewing_organization = Slot(uri=SCHEMA.provider, name="ethicalReview__reviewing_organization", curie=SCHEMA.curie('provider'),
                    model_uri=DATA_SHEETS_SCHEMA.ethicalReview__reviewing_organization, domain=None, range=Optional[Union[str, OrganizationId]])
 
+slots.ethicalReview__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="ethicalReview__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.ethicalReview__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.ethicalReview__id = Slot(uri=SCHEMA.identifier, name="ethicalReview__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.ethicalReview__id, domain=None, range=URIRef)
+
+slots.ethicalReview__name = Slot(uri=SCHEMA.name, name="ethicalReview__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.ethicalReview__name, domain=None, range=Optional[str])
+
 slots.dataProtectionImpact__description = Slot(uri=DCTERMS.description, name="dataProtectionImpact__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.dataProtectionImpact__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.dataProtectionImpact__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="dataProtectionImpact__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataProtectionImpact__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.dataProtectionImpact__id = Slot(uri=SCHEMA.identifier, name="dataProtectionImpact__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataProtectionImpact__id, domain=None, range=URIRef)
+
+slots.dataProtectionImpact__name = Slot(uri=SCHEMA.name, name="dataProtectionImpact__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.dataProtectionImpact__name, domain=None, range=Optional[str])
 
 slots.collectionNotification__description = Slot(uri=DCTERMS.description, name="collectionNotification__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.collectionNotification__description, domain=None, range=Optional[Union[str, list[str]]])
 
+slots.collectionNotification__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="collectionNotification__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionNotification__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.collectionNotification__id = Slot(uri=SCHEMA.identifier, name="collectionNotification__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionNotification__id, domain=None, range=URIRef)
+
+slots.collectionNotification__name = Slot(uri=SCHEMA.name, name="collectionNotification__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionNotification__name, domain=None, range=Optional[str])
+
 slots.collectionConsent__description = Slot(uri=DCTERMS.description, name="collectionConsent__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.collectionConsent__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.collectionConsent__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="collectionConsent__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionConsent__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.collectionConsent__id = Slot(uri=SCHEMA.identifier, name="collectionConsent__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionConsent__id, domain=None, range=URIRef)
+
+slots.collectionConsent__name = Slot(uri=SCHEMA.name, name="collectionConsent__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.collectionConsent__name, domain=None, range=Optional[str])
 
 slots.consentRevocation__description = Slot(uri=DCTERMS.description, name="consentRevocation__description", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.consentRevocation__description, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.humanSubjectResearch__involves_human_subjects = Slot(uri=D4DHUMAN.involves_human_subjects, name="humanSubjectResearch__involves_human_subjects", curie=D4DHUMAN.curie('involves_human_subjects'),
+slots.consentRevocation__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="consentRevocation__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.consentRevocation__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.consentRevocation__id = Slot(uri=SCHEMA.identifier, name="consentRevocation__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.consentRevocation__id, domain=None, range=URIRef)
+
+slots.consentRevocation__name = Slot(uri=SCHEMA.name, name="consentRevocation__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.consentRevocation__name, domain=None, range=Optional[str])
+
+slots.humanSubjectResearch__involves_human_subjects = Slot(uri=DATA_SHEETS_SCHEMA.involves_human_subjects, name="humanSubjectResearch__involves_human_subjects", curie=DATA_SHEETS_SCHEMA.curie('involves_human_subjects'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__involves_human_subjects, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.humanSubjectResearch__irb_approval = Slot(uri=D4DHUMAN.irb_approval, name="humanSubjectResearch__irb_approval", curie=D4DHUMAN.curie('irb_approval'),
+slots.humanSubjectResearch__irb_approval = Slot(uri=DATA_SHEETS_SCHEMA.irb_approval, name="humanSubjectResearch__irb_approval", curie=DATA_SHEETS_SCHEMA.curie('irb_approval'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__irb_approval, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.humanSubjectResearch__ethics_review_board = Slot(uri=D4DHUMAN.ethics_review_board, name="humanSubjectResearch__ethics_review_board", curie=D4DHUMAN.curie('ethics_review_board'),
+slots.humanSubjectResearch__ethics_review_board = Slot(uri=DATA_SHEETS_SCHEMA.ethics_review_board, name="humanSubjectResearch__ethics_review_board", curie=DATA_SHEETS_SCHEMA.curie('ethics_review_board'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__ethics_review_board, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.humanSubjectResearch__special_populations = Slot(uri=D4DHUMAN.special_populations, name="humanSubjectResearch__special_populations", curie=D4DHUMAN.curie('special_populations'),
+slots.humanSubjectResearch__special_populations = Slot(uri=DATA_SHEETS_SCHEMA.special_populations, name="humanSubjectResearch__special_populations", curie=DATA_SHEETS_SCHEMA.curie('special_populations'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__special_populations, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.humanSubjectResearch__regulatory_compliance = Slot(uri=D4DHUMAN.regulatory_compliance, name="humanSubjectResearch__regulatory_compliance", curie=D4DHUMAN.curie('regulatory_compliance'),
+slots.humanSubjectResearch__regulatory_compliance = Slot(uri=DATA_SHEETS_SCHEMA.regulatory_compliance, name="humanSubjectResearch__regulatory_compliance", curie=DATA_SHEETS_SCHEMA.curie('regulatory_compliance'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__regulatory_compliance, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.informedConsent__consent_obtained = Slot(uri=D4DHUMAN.consent_obtained, name="informedConsent__consent_obtained", curie=D4DHUMAN.curie('consent_obtained'),
+slots.humanSubjectResearch__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="humanSubjectResearch__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.humanSubjectResearch__id = Slot(uri=SCHEMA.identifier, name="humanSubjectResearch__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__id, domain=None, range=URIRef)
+
+slots.humanSubjectResearch__name = Slot(uri=SCHEMA.name, name="humanSubjectResearch__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__name, domain=None, range=Optional[str])
+
+slots.humanSubjectResearch__description = Slot(uri=SCHEMA.description, name="humanSubjectResearch__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__description, domain=None, range=Optional[str])
+
+slots.informedConsent__consent_obtained = Slot(uri=DATA_SHEETS_SCHEMA.consent_obtained, name="informedConsent__consent_obtained", curie=DATA_SHEETS_SCHEMA.curie('consent_obtained'),
                    model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_obtained, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.informedConsent__consent_type = Slot(uri=D4DHUMAN.consent_type, name="informedConsent__consent_type", curie=D4DHUMAN.curie('consent_type'),
+slots.informedConsent__consent_type = Slot(uri=DATA_SHEETS_SCHEMA.consent_type, name="informedConsent__consent_type", curie=DATA_SHEETS_SCHEMA.curie('consent_type'),
                    model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_type, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.informedConsent__consent_documentation = Slot(uri=D4DHUMAN.consent_documentation, name="informedConsent__consent_documentation", curie=D4DHUMAN.curie('consent_documentation'),
+slots.informedConsent__consent_documentation = Slot(uri=DATA_SHEETS_SCHEMA.consent_documentation, name="informedConsent__consent_documentation", curie=DATA_SHEETS_SCHEMA.curie('consent_documentation'),
                    model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_documentation, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.informedConsent__withdrawal_mechanism = Slot(uri=D4DHUMAN.withdrawal_mechanism, name="informedConsent__withdrawal_mechanism", curie=D4DHUMAN.curie('withdrawal_mechanism'),
+slots.informedConsent__withdrawal_mechanism = Slot(uri=DATA_SHEETS_SCHEMA.withdrawal_mechanism, name="informedConsent__withdrawal_mechanism", curie=DATA_SHEETS_SCHEMA.curie('withdrawal_mechanism'),
                    model_uri=DATA_SHEETS_SCHEMA.informedConsent__withdrawal_mechanism, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.informedConsent__consent_scope = Slot(uri=D4DHUMAN.consent_scope, name="informedConsent__consent_scope", curie=D4DHUMAN.curie('consent_scope'),
+slots.informedConsent__consent_scope = Slot(uri=DATA_SHEETS_SCHEMA.consent_scope, name="informedConsent__consent_scope", curie=DATA_SHEETS_SCHEMA.curie('consent_scope'),
                    model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_scope, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.participantPrivacy__anonymization_method = Slot(uri=D4DHUMAN.anonymization_method, name="participantPrivacy__anonymization_method", curie=D4DHUMAN.curie('anonymization_method'),
+slots.informedConsent__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="informedConsent__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.informedConsent__id = Slot(uri=SCHEMA.identifier, name="informedConsent__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__id, domain=None, range=URIRef)
+
+slots.informedConsent__name = Slot(uri=SCHEMA.name, name="informedConsent__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__name, domain=None, range=Optional[str])
+
+slots.informedConsent__description = Slot(uri=SCHEMA.description, name="informedConsent__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__description, domain=None, range=Optional[str])
+
+slots.participantPrivacy__anonymization_method = Slot(uri=DATA_SHEETS_SCHEMA.anonymization_method, name="participantPrivacy__anonymization_method", curie=DATA_SHEETS_SCHEMA.curie('anonymization_method'),
                    model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__anonymization_method, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.participantPrivacy__reidentification_risk = Slot(uri=D4DHUMAN.reidentification_risk, name="participantPrivacy__reidentification_risk", curie=D4DHUMAN.curie('reidentification_risk'),
+slots.participantPrivacy__reidentification_risk = Slot(uri=DATA_SHEETS_SCHEMA.reidentification_risk, name="participantPrivacy__reidentification_risk", curie=DATA_SHEETS_SCHEMA.curie('reidentification_risk'),
                    model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__reidentification_risk, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.participantPrivacy__privacy_techniques = Slot(uri=D4DHUMAN.privacy_techniques, name="participantPrivacy__privacy_techniques", curie=D4DHUMAN.curie('privacy_techniques'),
+slots.participantPrivacy__privacy_techniques = Slot(uri=DATA_SHEETS_SCHEMA.privacy_techniques, name="participantPrivacy__privacy_techniques", curie=DATA_SHEETS_SCHEMA.curie('privacy_techniques'),
                    model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__privacy_techniques, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.participantPrivacy__data_linkage = Slot(uri=D4DHUMAN.data_linkage, name="participantPrivacy__data_linkage", curie=D4DHUMAN.curie('data_linkage'),
+slots.participantPrivacy__data_linkage = Slot(uri=DATA_SHEETS_SCHEMA.data_linkage, name="participantPrivacy__data_linkage", curie=DATA_SHEETS_SCHEMA.curie('data_linkage'),
                    model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__data_linkage, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.humanSubjectCompensation__compensation_provided = Slot(uri=D4DHUMAN.compensation_provided, name="humanSubjectCompensation__compensation_provided", curie=D4DHUMAN.curie('compensation_provided'),
+slots.participantPrivacy__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="participantPrivacy__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.participantPrivacy__id = Slot(uri=SCHEMA.identifier, name="participantPrivacy__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__id, domain=None, range=URIRef)
+
+slots.participantPrivacy__name = Slot(uri=SCHEMA.name, name="participantPrivacy__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__name, domain=None, range=Optional[str])
+
+slots.participantPrivacy__description = Slot(uri=SCHEMA.description, name="participantPrivacy__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__description, domain=None, range=Optional[str])
+
+slots.humanSubjectCompensation__compensation_provided = Slot(uri=DATA_SHEETS_SCHEMA.compensation_provided, name="humanSubjectCompensation__compensation_provided", curie=DATA_SHEETS_SCHEMA.curie('compensation_provided'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_provided, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.humanSubjectCompensation__compensation_type = Slot(uri=D4DHUMAN.compensation_type, name="humanSubjectCompensation__compensation_type", curie=D4DHUMAN.curie('compensation_type'),
+slots.humanSubjectCompensation__compensation_type = Slot(uri=DATA_SHEETS_SCHEMA.compensation_type, name="humanSubjectCompensation__compensation_type", curie=DATA_SHEETS_SCHEMA.curie('compensation_type'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_type, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.humanSubjectCompensation__compensation_amount = Slot(uri=D4DHUMAN.compensation_amount, name="humanSubjectCompensation__compensation_amount", curie=D4DHUMAN.curie('compensation_amount'),
+slots.humanSubjectCompensation__compensation_amount = Slot(uri=DATA_SHEETS_SCHEMA.compensation_amount, name="humanSubjectCompensation__compensation_amount", curie=DATA_SHEETS_SCHEMA.curie('compensation_amount'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_amount, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.humanSubjectCompensation__compensation_rationale = Slot(uri=D4DHUMAN.compensation_rationale, name="humanSubjectCompensation__compensation_rationale", curie=D4DHUMAN.curie('compensation_rationale'),
+slots.humanSubjectCompensation__compensation_rationale = Slot(uri=DATA_SHEETS_SCHEMA.compensation_rationale, name="humanSubjectCompensation__compensation_rationale", curie=DATA_SHEETS_SCHEMA.curie('compensation_rationale'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_rationale, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.vulnerablePopulations__vulnerable_groups_included = Slot(uri=D4DHUMAN.vulnerable_groups_included, name="vulnerablePopulations__vulnerable_groups_included", curie=D4DHUMAN.curie('vulnerable_groups_included'),
+slots.humanSubjectCompensation__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="humanSubjectCompensation__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.humanSubjectCompensation__id = Slot(uri=SCHEMA.identifier, name="humanSubjectCompensation__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__id, domain=None, range=URIRef)
+
+slots.humanSubjectCompensation__name = Slot(uri=SCHEMA.name, name="humanSubjectCompensation__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__name, domain=None, range=Optional[str])
+
+slots.humanSubjectCompensation__description = Slot(uri=SCHEMA.description, name="humanSubjectCompensation__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__description, domain=None, range=Optional[str])
+
+slots.vulnerablePopulations__vulnerable_groups_included = Slot(uri=DATA_SHEETS_SCHEMA.vulnerable_groups_included, name="vulnerablePopulations__vulnerable_groups_included", curie=DATA_SHEETS_SCHEMA.curie('vulnerable_groups_included'),
                    model_uri=DATA_SHEETS_SCHEMA.vulnerablePopulations__vulnerable_groups_included, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.vulnerablePopulations__special_protections = Slot(uri=D4DHUMAN.special_protections, name="vulnerablePopulations__special_protections", curie=D4DHUMAN.curie('special_protections'),
+slots.vulnerablePopulations__special_protections = Slot(uri=DATA_SHEETS_SCHEMA.special_protections, name="vulnerablePopulations__special_protections", curie=DATA_SHEETS_SCHEMA.curie('special_protections'),
                    model_uri=DATA_SHEETS_SCHEMA.vulnerablePopulations__special_protections, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.vulnerablePopulations__assent_procedures = Slot(uri=D4DHUMAN.assent_procedures, name="vulnerablePopulations__assent_procedures", curie=D4DHUMAN.curie('assent_procedures'),
+slots.vulnerablePopulations__assent_procedures = Slot(uri=DATA_SHEETS_SCHEMA.assent_procedures, name="vulnerablePopulations__assent_procedures", curie=DATA_SHEETS_SCHEMA.curie('assent_procedures'),
                    model_uri=DATA_SHEETS_SCHEMA.vulnerablePopulations__assent_procedures, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.vulnerablePopulations__guardian_consent = Slot(uri=D4DHUMAN.guardian_consent, name="vulnerablePopulations__guardian_consent", curie=D4DHUMAN.curie('guardian_consent'),
+slots.vulnerablePopulations__guardian_consent = Slot(uri=DATA_SHEETS_SCHEMA.guardian_consent, name="vulnerablePopulations__guardian_consent", curie=DATA_SHEETS_SCHEMA.curie('guardian_consent'),
                    model_uri=DATA_SHEETS_SCHEMA.vulnerablePopulations__guardian_consent, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.vulnerablePopulations__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="vulnerablePopulations__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.vulnerablePopulations__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.vulnerablePopulations__id = Slot(uri=SCHEMA.identifier, name="vulnerablePopulations__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.vulnerablePopulations__id, domain=None, range=URIRef)
+
+slots.vulnerablePopulations__name = Slot(uri=SCHEMA.name, name="vulnerablePopulations__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.vulnerablePopulations__name, domain=None, range=Optional[str])
+
+slots.vulnerablePopulations__description = Slot(uri=SCHEMA.description, name="vulnerablePopulations__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.vulnerablePopulations__description, domain=None, range=Optional[str])
 
 slots.licenseAndUseTerms__description = Slot(uri=DCTERMS.license, name="licenseAndUseTerms__description", curie=DCTERMS.curie('license'),
                    model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__description, domain=None, range=Optional[Union[str, list[str]]])
@@ -4359,29 +6864,56 @@ slots.licenseAndUseTerms__data_use_permission = Slot(uri=DUO['0000001'], name="l
 slots.licenseAndUseTerms__contact_person = Slot(uri=SCHEMA.contactPoint, name="licenseAndUseTerms__contact_person", curie=SCHEMA.curie('contactPoint'),
                    model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__contact_person, domain=None, range=Optional[Union[str, PersonId]])
 
+slots.licenseAndUseTerms__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="licenseAndUseTerms__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.licenseAndUseTerms__id = Slot(uri=SCHEMA.identifier, name="licenseAndUseTerms__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__id, domain=None, range=URIRef)
+
+slots.licenseAndUseTerms__name = Slot(uri=SCHEMA.name, name="licenseAndUseTerms__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__name, domain=None, range=Optional[str])
+
 slots.iPRestrictions__description = Slot(uri=DCTERMS.rights, name="iPRestrictions__description", curie=DCTERMS.curie('rights'),
                    model_uri=DATA_SHEETS_SCHEMA.iPRestrictions__description, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.iPRestrictions__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="iPRestrictions__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.iPRestrictions__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.iPRestrictions__id = Slot(uri=SCHEMA.identifier, name="iPRestrictions__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.iPRestrictions__id, domain=None, range=URIRef)
+
+slots.iPRestrictions__name = Slot(uri=SCHEMA.name, name="iPRestrictions__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.iPRestrictions__name, domain=None, range=Optional[str])
 
 slots.exportControlRegulatoryRestrictions__description = Slot(uri=DCTERMS.accessRights, name="exportControlRegulatoryRestrictions__description", curie=DCTERMS.curie('accessRights'),
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__description, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.exportControlRegulatoryRestrictions__gdpr_compliant = Slot(uri=D4DDATAGOVERNANCE.gdpr_compliant, name="exportControlRegulatoryRestrictions__gdpr_compliant", curie=D4DDATAGOVERNANCE.curie('gdpr_compliant'),
+slots.exportControlRegulatoryRestrictions__gdpr_compliant = Slot(uri=DATA_SHEETS_SCHEMA.gdpr_compliant, name="exportControlRegulatoryRestrictions__gdpr_compliant", curie=DATA_SHEETS_SCHEMA.curie('gdpr_compliant'),
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__gdpr_compliant, domain=None, range=Optional[Union[str, "ComplianceStatusEnum"]])
 
-slots.exportControlRegulatoryRestrictions__hipaa_compliant = Slot(uri=D4DDATAGOVERNANCE.hipaa_compliant, name="exportControlRegulatoryRestrictions__hipaa_compliant", curie=D4DDATAGOVERNANCE.curie('hipaa_compliant'),
+slots.exportControlRegulatoryRestrictions__hipaa_compliant = Slot(uri=DATA_SHEETS_SCHEMA.hipaa_compliant, name="exportControlRegulatoryRestrictions__hipaa_compliant", curie=DATA_SHEETS_SCHEMA.curie('hipaa_compliant'),
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__hipaa_compliant, domain=None, range=Optional[Union[str, "ComplianceStatusEnum"]])
 
-slots.exportControlRegulatoryRestrictions__eu_ai_act_risk_category = Slot(uri=D4DDATAGOVERNANCE.eu_ai_act_risk_category, name="exportControlRegulatoryRestrictions__eu_ai_act_risk_category", curie=D4DDATAGOVERNANCE.curie('eu_ai_act_risk_category'),
+slots.exportControlRegulatoryRestrictions__eu_ai_act_risk_category = Slot(uri=DATA_SHEETS_SCHEMA.eu_ai_act_risk_category, name="exportControlRegulatoryRestrictions__eu_ai_act_risk_category", curie=DATA_SHEETS_SCHEMA.curie('eu_ai_act_risk_category'),
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__eu_ai_act_risk_category, domain=None, range=Optional[Union[str, "AIActRiskEnum"]])
 
-slots.exportControlRegulatoryRestrictions__other_compliance = Slot(uri=D4DDATAGOVERNANCE.other_compliance, name="exportControlRegulatoryRestrictions__other_compliance", curie=D4DDATAGOVERNANCE.curie('other_compliance'),
+slots.exportControlRegulatoryRestrictions__other_compliance = Slot(uri=DATA_SHEETS_SCHEMA.other_compliance, name="exportControlRegulatoryRestrictions__other_compliance", curie=DATA_SHEETS_SCHEMA.curie('other_compliance'),
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__other_compliance, domain=None, range=Optional[Union[str, list[str]]])
 
-slots.exportControlRegulatoryRestrictions__confidentiality_level = Slot(uri=D4DDATAGOVERNANCE.confidentiality_level, name="exportControlRegulatoryRestrictions__confidentiality_level", curie=D4DDATAGOVERNANCE.curie('confidentiality_level'),
+slots.exportControlRegulatoryRestrictions__confidentiality_level = Slot(uri=DATA_SHEETS_SCHEMA.confidentiality_level, name="exportControlRegulatoryRestrictions__confidentiality_level", curie=DATA_SHEETS_SCHEMA.curie('confidentiality_level'),
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__confidentiality_level, domain=None, range=Optional[Union[str, "ConfidentialityLevelEnum"]])
 
 slots.exportControlRegulatoryRestrictions__governance_committee_contact = Slot(uri=SCHEMA.contactPoint, name="exportControlRegulatoryRestrictions__governance_committee_contact", curie=SCHEMA.curie('contactPoint'),
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__governance_committee_contact, domain=None, range=Optional[Union[str, PersonId]])
+
+slots.exportControlRegulatoryRestrictions__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="exportControlRegulatoryRestrictions__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.exportControlRegulatoryRestrictions__id = Slot(uri=SCHEMA.identifier, name="exportControlRegulatoryRestrictions__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__id, domain=None, range=URIRef)
+
+slots.exportControlRegulatoryRestrictions__name = Slot(uri=SCHEMA.name, name="exportControlRegulatoryRestrictions__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__name, domain=None, range=Optional[str])
 
 slots.variableMetadata__variable_name = Slot(uri=SCHEMA.name, name="variableMetadata__variable_name", curie=SCHEMA.curie('name'),
                    model_uri=DATA_SHEETS_SCHEMA.variableMetadata__variable_name, domain=None, range=str)
@@ -4410,10 +6942,10 @@ slots.variableMetadata__examples = Slot(uri=SKOS.example, name="variableMetadata
 slots.variableMetadata__is_identifier = Slot(uri=CSVW.primaryKey, name="variableMetadata__is_identifier", curie=CSVW.curie('primaryKey'),
                    model_uri=DATA_SHEETS_SCHEMA.variableMetadata__is_identifier, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.variableMetadata__is_sensitive = Slot(uri=D4DVARIABLES.is_sensitive, name="variableMetadata__is_sensitive", curie=D4DVARIABLES.curie('is_sensitive'),
+slots.variableMetadata__is_sensitive = Slot(uri=DATA_SHEETS_SCHEMA.is_sensitive, name="variableMetadata__is_sensitive", curie=DATA_SHEETS_SCHEMA.curie('is_sensitive'),
                    model_uri=DATA_SHEETS_SCHEMA.variableMetadata__is_sensitive, domain=None, range=Optional[Union[bool, Bool]])
 
-slots.variableMetadata__precision = Slot(uri=D4DVARIABLES.precision, name="variableMetadata__precision", curie=D4DVARIABLES.curie('precision'),
+slots.variableMetadata__precision = Slot(uri=DATA_SHEETS_SCHEMA.precision, name="variableMetadata__precision", curie=DATA_SHEETS_SCHEMA.curie('precision'),
                    model_uri=DATA_SHEETS_SCHEMA.variableMetadata__precision, domain=None, range=Optional[int])
 
 slots.variableMetadata__measurement_technique = Slot(uri=SCHEMA.measurementTechnique, name="variableMetadata__measurement_technique", curie=SCHEMA.curie('measurementTechnique'),
@@ -4422,5 +6954,18 @@ slots.variableMetadata__measurement_technique = Slot(uri=SCHEMA.measurementTechn
 slots.variableMetadata__derivation = Slot(uri=PROV.wasDerivedFrom, name="variableMetadata__derivation", curie=PROV.curie('wasDerivedFrom'),
                    model_uri=DATA_SHEETS_SCHEMA.variableMetadata__derivation, domain=None, range=Optional[str])
 
-slots.variableMetadata__quality_notes = Slot(uri=D4DVARIABLES.quality_notes, name="variableMetadata__quality_notes", curie=D4DVARIABLES.curie('quality_notes'),
+slots.variableMetadata__quality_notes = Slot(uri=DATA_SHEETS_SCHEMA.quality_notes, name="variableMetadata__quality_notes", curie=DATA_SHEETS_SCHEMA.curie('quality_notes'),
                    model_uri=DATA_SHEETS_SCHEMA.variableMetadata__quality_notes, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.variableMetadata__used_software = Slot(uri=DATA_SHEETS_SCHEMA.used_software, name="variableMetadata__used_software", curie=DATA_SHEETS_SCHEMA.curie('used_software'),
+                   model_uri=DATA_SHEETS_SCHEMA.variableMetadata__used_software, domain=None, range=Optional[Union[Union[str, SoftwareId], list[Union[str, SoftwareId]]]])
+
+slots.variableMetadata__id = Slot(uri=SCHEMA.identifier, name="variableMetadata__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.variableMetadata__id, domain=None, range=URIRef)
+
+slots.variableMetadata__name = Slot(uri=SCHEMA.name, name="variableMetadata__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.variableMetadata__name, domain=None, range=Optional[str])
+
+slots.variableMetadata__description = Slot(uri=SCHEMA.description, name="variableMetadata__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.variableMetadata__description, domain=None, range=Optional[str])
+

--- a/src/data_sheets_schema/datamodel/data_sheets_schema.py
+++ b/src/data_sheets_schema/datamodel/data_sheets_schema.py
@@ -1,5 +1,5 @@
 # Auto generated from data_sheets_schema.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-11-25T12:07:56
+# Generation date: 2025-12-01T21:10:34
 # Schema: data-sheets-schema
 #
 # id: https://w3id.org/bridge2ai/data-sheets-schema
@@ -3293,39 +3293,44 @@ class CRediTRoleEnum(EnumDefinitionImpl):
 
 class BiasTypeEnum(EnumDefinitionImpl):
     """
-    Types of bias that may be present in datasets
+    Types of bias that may be present in datasets. Values are mapped to the Artificial Intelligence Ontology (AIO)
+    bias taxonomy from BioPortal. See https://bioportal.bioontology.org/ontologies/AIO
     """
     selection_bias = PermissibleValue(
         text="selection_bias",
-        description="Bias arising from non-random selection of data or participants")
+        description="Bias arising from non-random selection of data or participants.")
     measurement_bias = PermissibleValue(
         text="measurement_bias",
-        description="Bias in how data is measured or recorded")
+        description="""Bias in how data is measured or recorded. Occurs when features and labels are proxies for desired quantities, potentially leading to differential performance.""",
+        meaning=AIO["MeasurementBias"])
     historical_bias = PermissibleValue(
         text="historical_bias",
-        description="Bias reflecting historical inequities or societal biases")
+        description="""Bias reflecting historical inequities or societal biases. Long-standing biases encoded in society over time.""",
+        meaning=AIO["HistoricalBias"])
     representation_bias = PermissibleValue(
         text="representation_bias",
-        description="Certain groups are over- or under-represented in the data")
+        description="""Certain groups are over- or under-represented in the data. Results from non-random sampling of subgroups making trends non-generalizable to new populations.""",
+        meaning=AIO["RepresentationBias"])
     aggregation_bias = PermissibleValue(
         text="aggregation_bias",
-        description="Bias from inappropriately combining distinct groups")
+        description="""Bias from inappropriately combining distinct groups. Related to making inferences about individuals based on their group membership.""")
     algorithmic_bias = PermissibleValue(
         text="algorithmic_bias",
-        description="Bias introduced or amplified by algorithmic processing")
+        description="""Bias introduced or amplified by algorithmic processing. Computational bias from data analysis processes and methods.""")
     sampling_bias = PermissibleValue(
         text="sampling_bias",
-        description="Bias from sampling methodology not representative of the population")
+        description="Bias from sampling methodology not representative of the population.")
     annotation_bias = PermissibleValue(
         text="annotation_bias",
-        description="Bias introduced during data labeling or annotation")
+        description="""Bias introduced during data labeling or annotation. Occurs when annotators rely on heuristics or exhibit systematic patterns in labeling.""")
     confirmation_bias = PermissibleValue(
         text="confirmation_bias",
-        description="Bias from seeking data that confirms pre-existing beliefs")
+        description="""Bias from seeking data that confirms pre-existing beliefs. Tendency to prefer information that confirms existing beliefs, influencing the search for, interpretation of, and recall of information.""",
+        meaning=AIO["ConfirmationBias"])
 
     _defn = EnumDefinition(
         name="BiasTypeEnum",
-        description="Types of bias that may be present in datasets",
+        description="""Types of bias that may be present in datasets. Values are mapped to the Artificial Intelligence Ontology (AIO) bias taxonomy from BioPortal. See https://bioportal.bioontology.org/ontologies/AIO""",
     )
 
 class VersionTypeEnum(EnumDefinitionImpl):

--- a/src/data_sheets_schema/schema/D4D_Base_import.yaml
+++ b/src/data_sheets_schema/schema/D4D_Base_import.yaml
@@ -32,6 +32,7 @@ prefixes:
   sh: https://w3id.org/shacl/
   skos: http://www.w3.org/2004/02/skos/core#
   void: http://rdfs.org/ns/void#
+  AIO: https://w3id.org/aio/
 
 default_prefix: data_sheets_schema
 default_range: string
@@ -491,26 +492,64 @@ enums:
         description: Acquisition of the financial support for the project
 
   BiasTypeEnum:
-    description: Types of bias that may be present in datasets
+    description: >-
+      Types of bias that may be present in datasets. Values are mapped to the
+      Artificial Intelligence Ontology (AIO) bias taxonomy from BioPortal.
+      See https://bioportal.bioontology.org/ontologies/AIO
     permissible_values:
       selection_bias:
-        description: Bias arising from non-random selection of data or participants
+        description: >-
+          Bias arising from non-random selection of data or participants.
+        broad_mappings:
+          - AIO:SelectionAndSamplingBias
       measurement_bias:
-        description: Bias in how data is measured or recorded
+        description: >-
+          Bias in how data is measured or recorded. Occurs when features and
+          labels are proxies for desired quantities, potentially leading to
+          differential performance.
+        meaning: AIO:MeasurementBias
       historical_bias:
-        description: Bias reflecting historical inequities or societal biases
+        description: >-
+          Bias reflecting historical inequities or societal biases. Long-standing
+          biases encoded in society over time.
+        meaning: AIO:HistoricalBias
       representation_bias:
-        description: Certain groups are over- or under-represented in the data
+        description: >-
+          Certain groups are over- or under-represented in the data. Results from
+          non-random sampling of subgroups making trends non-generalizable to
+          new populations.
+        meaning: AIO:RepresentationBias
       aggregation_bias:
-        description: Bias from inappropriately combining distinct groups
+        description: >-
+          Bias from inappropriately combining distinct groups. Related to making
+          inferences about individuals based on their group membership.
+        broad_mappings:
+          - AIO:EcologicalFallacyBias
       algorithmic_bias:
-        description: Bias introduced or amplified by algorithmic processing
+        description: >-
+          Bias introduced or amplified by algorithmic processing. Computational
+          bias from data analysis processes and methods.
+        broad_mappings:
+          - AIO:ProcessingBias
+          - AIO:ComputationalBias
       sampling_bias:
-        description: Bias from sampling methodology not representative of the population
+        description: >-
+          Bias from sampling methodology not representative of the population.
+        broad_mappings:
+          - AIO:SelectionAndSamplingBias
       annotation_bias:
-        description: Bias introduced during data labeling or annotation
+        description: >-
+          Bias introduced during data labeling or annotation. Occurs when
+          annotators rely on heuristics or exhibit systematic patterns in
+          labeling.
+        broad_mappings:
+          - AIO:AnnotatorReportingBias
       confirmation_bias:
-        description: Bias from seeking data that confirms pre-existing beliefs
+        description: >-
+          Bias from seeking data that confirms pre-existing beliefs. Tendency
+          to prefer information that confirms existing beliefs, influencing the
+          search for, interpretation of, and recall of information.
+        meaning: AIO:ConfirmationBias
 
   VersionTypeEnum:
     description: >-

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -85,6 +85,9 @@ prefixes:
   shex:
     prefix_prefix: shex
     prefix_reference: http://www.w3.org/ns/shex#
+  AIO:
+    prefix_prefix: AIO
+    prefix_reference: https://w3id.org/aio/
   d4dmotivation:
     prefix_prefix: d4dmotivation
     prefix_reference: https://w3id.org/bridge2ai/data-sheets-schema/motivation#
@@ -632,36 +635,63 @@ enums:
         description: Acquisition of the financial support for the project
   BiasTypeEnum:
     name: BiasTypeEnum
-    description: Types of bias that may be present in datasets
+    description: Types of bias that may be present in datasets. Values are mapped
+      to the Artificial Intelligence Ontology (AIO) bias taxonomy from BioPortal.
+      See https://bioportal.bioontology.org/ontologies/AIO
     from_schema: https://w3id.org/bridge2ai/data-sheets-schema
     permissible_values:
       selection_bias:
         text: selection_bias
-        description: Bias arising from non-random selection of data or participants
+        description: Bias arising from non-random selection of data or participants.
+        broad_mappings:
+        - AIO:SelectionAndSamplingBias
       measurement_bias:
         text: measurement_bias
-        description: Bias in how data is measured or recorded
+        description: Bias in how data is measured or recorded. Occurs when features
+          and labels are proxies for desired quantities, potentially leading to differential
+          performance.
+        meaning: AIO:MeasurementBias
       historical_bias:
         text: historical_bias
-        description: Bias reflecting historical inequities or societal biases
+        description: Bias reflecting historical inequities or societal biases. Long-standing
+          biases encoded in society over time.
+        meaning: AIO:HistoricalBias
       representation_bias:
         text: representation_bias
-        description: Certain groups are over- or under-represented in the data
+        description: Certain groups are over- or under-represented in the data. Results
+          from non-random sampling of subgroups making trends non-generalizable to
+          new populations.
+        meaning: AIO:RepresentationBias
       aggregation_bias:
         text: aggregation_bias
-        description: Bias from inappropriately combining distinct groups
+        description: Bias from inappropriately combining distinct groups. Related
+          to making inferences about individuals based on their group membership.
+        broad_mappings:
+        - AIO:EcologicalFallacyBias
       algorithmic_bias:
         text: algorithmic_bias
-        description: Bias introduced or amplified by algorithmic processing
+        description: Bias introduced or amplified by algorithmic processing. Computational
+          bias from data analysis processes and methods.
+        broad_mappings:
+        - AIO:ProcessingBias
+        - AIO:ComputationalBias
       sampling_bias:
         text: sampling_bias
-        description: Bias from sampling methodology not representative of the population
+        description: Bias from sampling methodology not representative of the population.
+        broad_mappings:
+        - AIO:SelectionAndSamplingBias
       annotation_bias:
         text: annotation_bias
-        description: Bias introduced during data labeling or annotation
+        description: Bias introduced during data labeling or annotation. Occurs when
+          annotators rely on heuristics or exhibit systematic patterns in labeling.
+        broad_mappings:
+        - AIO:AnnotatorReportingBias
       confirmation_bias:
         text: confirmation_bias
-        description: Bias from seeking data that confirms pre-existing beliefs
+        description: Bias from seeking data that confirms pre-existing beliefs. Tendency
+          to prefer information that confirms existing beliefs, influencing the search
+          for, interpretation of, and recall of information.
+        meaning: AIO:ConfirmationBias
   VersionTypeEnum:
     name: VersionTypeEnum
     description: Type of version change using semantic versioning principles. See


### PR DESCRIPTION
- Added AIO prefix (Artificial Intelligence Ontology) to D4D_Base_import.yaml
- Mapped all 9 BiasTypeEnum values to AIO bias taxonomy:
  - 4 exact matches using meaning: (confirmation_bias, historical_bias, measurement_bias, representation_bias)
  - 5 broader mappings using broad_mappings: (selection_bias, sampling_bias, aggregation_bias, algorithmic_bias, annotation_bias)
- Created comprehensive enumeration ontology grounding report documenting:
  - All grounded enumerations (DataUsePermissionEnum with DUO, ConfidentialityLevelEnum with ISO/NIST/TLP, BiasTypeEnum with AIO)
  - Ungrounded enumerations with recommendations (VariableTypeEnum, DatasetRelationshipTypeEnum, etc.)
  - Implementation strategy and impact assessment
- Regenerated schema artifacts (merged YAML, Python model, JSON Schema, OWL, JSON-LD)

AIO provides comprehensive bias taxonomy with 59 bias classes from BioPortal. See docs/enum_ontology_grounding_report.md for complete analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)