### PR TITLE
Replace the D4D assistant's dead action with the in-repo API path

### DIFF
--- a/.github/D4D_ASSISTANT_README.md
+++ b/.github/D4D_ASSISTANT_README.md
@@ -105,7 +105,7 @@ Only authorized users can trigger the assistant by mentioning `@d4dassistant`.
 
 ## Technical Details
 
-- **Agent**: Powered by Claude Code via `dragon-ai-agent/run-goose-obo` GitHub Action
+- **Agent**: Four-phase generation via `d4d api run` (`src/data_sheets_schema/api_runner.py`), run directly in the workflow. Previously used the `dragon-ai-agent/run-claude-obo` action, which no longer exists — see issue #172.
 - **Schema**: Uses LinkML schema from `src/data_sheets_schema/schema/`
 - **Validation**: Runs `make test-examples` to ensure schema compliance
 - **Examples**: References `src/data/examples/valid/` for guidance

--- a/.github/workflows/d4d-agent.yml
+++ b/.github/workflows/d4d-agent.yml
@@ -180,23 +180,127 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PAT_FOR_PR }}
 
-      - name: Respond with AI Agent
-        uses: dragon-ai-agent/run-claude-obo@v1.0.2
+      # Replaced dragon-ai-agent/run-claude-obo@v1.0.2, whose repository and
+      # organisation now return 404 (issue #172). That action ran an open-ended
+      # agent; this runs the same deterministic four-phase generation the batch
+      # pipeline uses, so the assistant and the study can no longer diverge.
+      #
+      # Narrower on purpose: this generates a datasheet from a declared input
+      # bundle. It does not handle open-ended edit requests. See #172.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install project
+        run: |
+          pipx install poetry
+          poetry install --no-interaction
+
+      - name: Resolve dataset from the request
+        id: resolve
+        env:
+          PROMPT: ${{ needs.check-mention.outputs.prompt }}
+        run: |
+          set -euo pipefail
+          # The dataset is whichever inputs/ directory the request names. Matching
+          # against what exists avoids inventing a name from free text.
+          DATASET=""
+          for d in data/sheets_d4dassistant/inputs/*/; do
+            name=$(basename "$d")
+            if printf '%s' "$PROMPT" | grep -qiE "(^|[^A-Za-z0-9_])${name}([^A-Za-z0-9_]|$)"; then
+              DATASET="$name"; break
+            fi
+          done
+          if [ -z "$DATASET" ]; then
+            echo "no-dataset=true" >> "$GITHUB_OUTPUT"
+            echo "available=$(ls data/sheets_d4dassistant/inputs/ | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BUNDLE=$(find "data/sheets_d4dassistant/inputs/$DATASET" -type f \
+                     \( -name '*.txt' -o -name '*.md' \) | sort | head -1)
+          if [ -z "$BUNDLE" ]; then
+            echo "no-bundle=true" >> "$GITHUB_OUTPUT"
+            echo "dataset=$DATASET" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "dataset=$DATASET" >> "$GITHUB_OUTPUT"
+          echo "bundle=$BUNDLE"   >> "$GITHUB_OUTPUT"
+          echo "label=$(date -u +%Y-%m-%d)_claude-opus-5-assistant" >> "$GITHUB_OUTPUT"
+
+      - name: Report unresolvable request
+        if: steps.resolve.outputs.no-dataset == 'true' || steps.resolve.outputs.no-bundle == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}
+        run: |
+          if [ "${{ steps.resolve.outputs.no-dataset }}" = "true" ]; then
+            MSG="I could not tell which dataset to generate. Name one of these input directories in your request: ${{ steps.resolve.outputs.available }}"
+          else
+            MSG="Found the input directory for **${{ steps.resolve.outputs.dataset }}** but no .txt or .md file inside it, so there is nothing to read."
+          fi
+          gh issue comment "${{ needs.check-mention.outputs.item-number }}" --body "$MSG"
+          exit 1
+
+      - name: Generate datasheet
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        with:
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github-token: ${{ secrets.PAT_FOR_PR }}
-          prompt: ${{ needs.check-mention.outputs.prompt }}
-          user: ${{ needs.check-mention.outputs.user }}
-          item-type: ${{ needs.check-mention.outputs.item-type }}
-          item-number: ${{ needs.check-mention.outputs.item-number }}
-          controllers: ${{ needs.check-mention.outputs.controllers }}
-          agent-name: 'd4dassistant'
-          branch-prefix: 'd4dassistant'
-          robot-version: 'v1.9.7'
-          enable-robot: 'true'
-          enable-obo-scripts: 'true'
-          enable-python-tools: 'true'
-          python-packages: 'aurelian jinja2-cli "wrapt>=1.17.2"'
-          claude-allowed-tools: '["Read", "Glob", "Grep", "FileEdit", "Edit", "Edit(*)", "Write", "Bash", "Bash(git:*)", "Bash(gh:*)", "Bash(poetry:*)", "Bash(make:*)", "Bash(python:*)", "Bash(uv:*)", "Bash(echo:*)", "Bash(cat:*)", "Bash(mkdir:*)", "Bash(grep:*)", "Bash(head:*)", "Bash(tail:*)", "Bash(sort:*)", "Bash(curl:*)", "mcp__github__*", "mcp__artl__*", "WebSearch", "WebFetch"]'
+        run: |
+          set -euo pipefail
+          poetry run d4d api run \
+            --project "${{ steps.resolve.outputs.dataset }}" \
+            --bundle  "${{ steps.resolve.outputs.bundle }}" \
+            --out-dir data/sheets_d4dassistant \
+            --label   "${{ steps.resolve.outputs.label }}" \
+            --yes
+
+      - name: Validate against the schema
+        run: |
+          set -euo pipefail
+          D=${{ steps.resolve.outputs.dataset }}
+          poetry run linkml-validate \
+            -s src/data_sheets_schema/schema/data_sheets_schema_all.yaml \
+            -C Dataset "data/sheets_d4dassistant/${D}_d4d.yaml"
+
+      - name: Open a pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}
+        run: |
+          set -euo pipefail
+          D=${{ steps.resolve.outputs.dataset }}
+          BRANCH="d4dassistant/${D}-$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name  "d4dassistant"
+          git config user.email "d4dassistant@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add "data/sheets_d4dassistant/${D}_d4d.yaml" \
+                  "data/sheets_d4dassistant/${D}_d4d_core.yaml" \
+                  "data/sheets_d4dassistant/${D}_reconciliation.md" \
+                  "data/sheets_d4dassistant/${D}_d4d_metadata.yaml"
+          git commit -m "Add ${D} datasheet generated by the D4D assistant
+
+          Four-phase generation from data/sheets_d4dassistant/inputs/${D}/,
+          via the same deterministic path the batch pipeline uses. Requested in
+          #${{ needs.check-mention.outputs.item-number }}."
+          git push -u origin "$BRANCH"
+          URL=$(gh pr create \
+            --title "Add ${D} datasheet (D4D assistant)" \
+            --body "Generated from \`data/sheets_d4dassistant/inputs/${D}/\` in response to #${{ needs.check-mention.outputs.item-number }}.
+
+          Four-phase generation (full, core, audit, reconcile) on the model pinned in \`.github/workflows/d4d_assistant_deterministic.config\`. \`${D}_d4d_metadata.yaml\` records the input, prompt and schema-digest hashes, the git commit, and per-phase token usage.
+
+          Validated against \`Dataset\` before this PR was opened." \
+            --head "$BRANCH")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Report back on the issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FOR_PR }}
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            gh issue comment "${{ needs.check-mention.outputs.item-number }}" \
+              --body "Generated the **${{ steps.resolve.outputs.dataset }}** datasheet: ${{ steps.pr.outputs.url }}"
+          else
+            gh issue comment "${{ needs.check-mention.outputs.item-number }}" \
+              --body "Generation failed. [Run log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -65,18 +65,28 @@ class RunSpec:
     label: str
     condition: str = "generic"          # generic | tuned
     manifest_line: str = "# Source manifest: data/preprocessed/source_manifest.yaml"
+    # The study writes into the run-labelled layout under data/d4d_concatenated.
+    # The GitHub assistant writes flat into data/sheets_d4dassistant. Rather than
+    # two runners, the layout is a parameter — everything else is identical.
+    out_dir: Path | None = None
 
     @property
     def full_path(self) -> Path:
+        if self.out_dir:
+            return self.out_dir / f"{self.project}_d4d.yaml"
         return CONCAT_DIR / self.method / self.label / f"{self.project}_d4d.yaml"
 
     @property
     def core_path(self) -> Path:
+        if self.out_dir:
+            return self.out_dir / f"{self.project}_d4d_core.yaml"
         return (CONCAT_DIR / f"{self.method}_core" / self.label /
                 f"{self.project}_d4d_core.yaml")
 
     @property
     def report_path(self) -> Path:
+        if self.out_dir:
+            return self.out_dir / f"{self.project}_reconciliation.md"
         return (CONCAT_DIR / f"{self.method}_core" / self.label /
                 f"{self.project}_reconciliation.md")
 
@@ -333,7 +343,9 @@ def execute(spec: RunSpec, *, dry_run: bool = False) -> dict[str, Any]:
     }
     rec.data["api_usage"] = usage
     rec.data["record_generated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    rec.write(record_path(spec.method, spec.label, spec.project))
+    prov_path = (spec.out_dir / f"{spec.project}_d4d_metadata.yaml" if spec.out_dir
+                 else record_path(spec.method, spec.label, spec.project))
+    rec.write(prov_path)
 
     return {"label": spec.label, "project": spec.project, "usage": usage,
             "outputs": {k: str(v) for k, v in

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -23,13 +23,31 @@ ARMS = {
 }
 
 
-def _spec(project, arm, label, condition):
+def _spec(project, arm, label, condition, bundle=None, out_dir=None):
+    """Resolve a run spec.
+
+    `project` is a free string rather than a click.Choice because the GitHub
+    assistant generates datasheets for datasets outside the four study
+    projects. A known project resolves its bundle by convention; anything else
+    must declare one, which is checked in `_require_bundle`.
+    """
     from data_sheets_schema.api_runner import RunSpec
     display, method, pattern, manifest = ARMS[arm]
+    resolved = (Path(bundle) if bundle else
+                Path("data/preprocessed/concatenated") / pattern.format(p=project))
     return RunSpec(project=project, arm=display, method=method,
-                   bundle=Path("data/preprocessed/concatenated") /
-                          pattern.format(p=project),
-                   label=label, condition=condition, manifest_line=manifest)
+                   bundle=resolved, label=label, condition=condition,
+                   manifest_line=manifest,
+                   out_dir=Path(out_dir) if out_dir else None)
+
+
+def _require_bundle(spec, project, bundle):
+    if bundle is None and project not in PROJECTS:
+        raise click.ClickException(
+            f"{project!r} is not one of the known projects ({', '.join(PROJECTS)}), "
+            "so its bundle cannot be resolved by convention. Pass --bundle.")
+    if not spec.bundle.exists():
+        raise click.ClickException(f"bundle not found: {spec.bundle}")
 
 
 @click.group()
@@ -38,19 +56,23 @@ def api():
 
 
 @api.command("plan")
-@click.option("--project", type=click.Choice(PROJECTS), required=True)
+@click.option("--project", required=True,
+              help="AI_READI|CHORUS|CM4AI|VOICE, or any dataset name with --bundle")
 @click.option("--arm", type=click.Choice(sorted(ARMS)), default="baseline",
               show_default=True)
 @click.option("--label", required=True, help="run label, e.g. 2026-07-29_claude-opus-5-api-generic_rep1")
 @click.option("--condition", type=click.Choice(["generic", "tuned"]),
               default="generic", show_default=True)
+@click.option("--bundle", type=click.Path(), default=None,
+              help="explicit input bundle; required for datasets outside PROJECTS")
+@click.option("--out-dir", type=click.Path(), default=None,
+              help="flat output directory (the assistant layout)")
 @click.option("--json", "as_json", is_flag=True, help="emit the full plan as JSON")
-def plan_cmd(project, arm, label, condition, as_json):
+def plan_cmd(project, arm, label, condition, bundle, out_dir, as_json):
     """Render every phase without calling the API — no key, no charge."""
     from data_sheets_schema.api_runner import plan
-    spec = _spec(project, arm, label, condition)
-    if not spec.bundle.exists():
-        raise click.ClickException(f"bundle not found: {spec.bundle}")
+    spec = _spec(project, arm, label, condition, bundle, out_dir)
+    _require_bundle(spec, project, bundle)
     p = plan(spec)
     if as_json:
         click.echo(json.dumps(p, indent=2))
@@ -72,19 +94,23 @@ def plan_cmd(project, arm, label, condition, as_json):
 
 
 @api.command("run")
-@click.option("--project", type=click.Choice(PROJECTS), required=True)
+@click.option("--project", required=True,
+              help="AI_READI|CHORUS|CM4AI|VOICE, or any dataset name with --bundle")
 @click.option("--arm", type=click.Choice(sorted(ARMS)), default="baseline",
               show_default=True)
 @click.option("--label", required=True)
 @click.option("--condition", type=click.Choice(["generic", "tuned"]),
               default="generic", show_default=True)
+@click.option("--bundle", type=click.Path(), default=None,
+              help="explicit input bundle; required for datasets outside PROJECTS")
+@click.option("--out-dir", type=click.Path(), default=None,
+              help="flat output directory (the assistant layout)")
 @click.option("--yes", is_flag=True, help="skip the cost confirmation")
-def run_cmd(project, arm, label, condition, yes):
+def run_cmd(project, arm, label, condition, bundle, out_dir, yes):
     """Execute all four phases and write outputs plus a live provenance record."""
     from data_sheets_schema.api_runner import execute, plan
-    spec = _spec(project, arm, label, condition)
-    if not spec.bundle.exists():
-        raise click.ClickException(f"bundle not found: {spec.bundle}")
+    spec = _spec(project, arm, label, condition, bundle, out_dir)
+    _require_bundle(spec, project, bundle)
     if spec.full_path.exists():
         raise click.ClickException(
             f"{spec.full_path} already exists; a run label is never reused")


### PR DESCRIPTION
Fixes #172.

## The problem

The assistant cannot run. `respond-to-mention` fails at job setup:

```
Getting action download info
##[error]Repository access blocked
```

It depends on `dragon-ai-agent/run-claude-obo@v1.0.2`, and both that repository and the `dragon-ai-agent` organisation return **404**.

This stayed invisible because `check-mention` runs on every issue and comment, almost never finds `@d4dassistant`, and skips `respond-to-mention` — which GitHub reports as a **successful run**. All of the last 60 runs show that job skipped. The first one that actually executed (#171) failed immediately.

## The fix — option 3 from #172

The job now runs `d4d api run`, added in #164, which implements the same four-phase generation the batch pipeline uses and reads model settings from the same `d4d_assistant_deterministic.config`. No third-party action, and two generation implementations collapse into one, so the assistant and the study cannot drift apart again — which they already had, on the pinned model.

New steps: set up Python → install → resolve dataset → generate → validate against `Dataset` → open a PR → comment back on the issue.

## Supporting changes

- **`RunSpec.out_dir`** — the study writes into the run-labelled layout under `data/d4d_concatenated`; the assistant writes flat into `data/sheets_d4dassistant`. Making the layout a parameter avoids a second runner. The provenance record follows it and lands as `{dataset}_d4d_metadata.yaml`, the filename the assistant config already specified.
- **`--project` is no longer a `click.Choice`** — the assistant generates datasheets for datasets outside the four study projects. Known projects still resolve their bundle by convention; anything else must pass `--bundle`, enforced up front rather than failing later on a missing path.

## Design choices worth reviewing

- **Dataset resolution matches against directories that exist** under `inputs/`, rather than parsing a name out of free text. A request that names nothing recognisable gets a comment listing the available inputs instead of a guess.
- **The failure path comments back.** The old action's silent death is exactly what made this bug survive; `if: always()` posts either the PR link or a link to the run log.

## Scope reduction — deliberate, and worth a second opinion

This is **narrower than the old action**. It generates a datasheet from a declared input bundle; it does not service open-ended edit requests, and `d4d_assistant_edit.md` describes behaviour this does not implement. The old action ran a general agent with a broad tool allowlist.

That is a real reduction in capability. It is proposed because deterministic generation is what the assistant is actually used for and what can be verified, but if open-ended editing matters, this needs `anthropics/claude-code-action` instead (option 1 in #172).

## Verification

- Workflow YAML parses; all nine steps resolve.
- Dataset-resolution shell logic tested locally against the real `inputs/` tree — correctly resolves `CHORUS` and its bundle from the #171 request text.
- `d4d api plan` exercised with the assistant layout: writes to `data/sheets_d4dassistant/`, ~109k input tokens for CHORUS.
- 488 tests pass.

**Not verified:** no call has been made against the live API, so the end-to-end path is still untested (#170). Merging this makes #171 re-runnable, which would be the real test.