### PR TITLE
Make the API generation path fit real records

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -51,9 +52,28 @@ CONCAT_DIR = Path("data/d4d_concatenated")
 
 RUNTIME = "Claude API (direct)"
 PROVIDER = "Anthropic"
-DEFAULT_MAX_TOKENS = 16000
 
-PHASES = ("full", "core", "audit", "reconcile")
+# One artifact per call. An earlier design had a single `reconcile` phase return
+# full + core + report in one JSON object; measured against 112 real records
+# that demands 31k-68k output tokens in a single response, which is not a limit
+# to raise but a shape to abandon. Splitting it also means every phase writes
+# something, so a failure costs one call rather than the whole run.
+PHASES = ("full", "core", "audit", "reconcile_full", "reconcile_core", "report")
+
+# Derived from the largest artifact of each kind across 112 full, 104 core and
+# 97 report records already generated, plus ~40% headroom. A guessed ceiling is
+# how the previous design truncated five of six projects mid-YAML.
+PHASE_MAX_TOKENS = {
+    "full": 64000, "reconcile_full": 64000,
+    "core": 56000, "reconcile_core": 56000,
+    "audit": 12000, "report": 12000,
+}
+DEFAULT_MAX_TOKENS = 64000
+
+# The API is called four to six times per run over minutes; transient 429s and
+# 5xx are expected rather than exceptional.
+MAX_ATTEMPTS = 5
+BACKOFF_BASE_SECONDS = 2
 
 
 @dataclass
@@ -188,12 +208,39 @@ PHASE_INSTRUCTIONS = {
         "list of {severity, record, slot, issue}) and `summary`: any slot whose "
         "value the bundle does not support, any omission the bundle clearly "
         "supports, and any internal inconsistency. Output only JSON."),
-    "reconcile": (
-        "Phase 4. Given the audit findings, emit a JSON object with keys "
-        "`full_yaml`, `core_yaml` and `report_markdown`. The two YAML values are "
-        "the corrected records in full; `report_markdown` is the reconciliation "
-        "report, which must be written even when nothing changed. Output only "
-        "JSON."),
+    "reconcile_full": (
+        "Phase 4a. Apply the audit findings that concern the FULL record and "
+        "emit the corrected full record in its entirety, header block included. "
+        "If no finding requires a change, emit it unchanged. Output only YAML."),
+    "reconcile_core": (
+        "Phase 4b. Apply the audit findings that concern the CORE record and "
+        "emit the corrected core record in its entirety, header block included. "
+        "It must remain consistent with the reconciled full record supplied "
+        "below and assert nothing the full record does not support. If no "
+        "finding requires a change, emit it unchanged. Output only YAML."),
+    "report": (
+        "Phase 4c. Write the reconciliation report as Markdown: what the audit "
+        "found, what was changed in each record and why, and what was left "
+        "as-is and why. Write it even when nothing changed. Output only "
+        "Markdown."),
+}
+
+# What each phase produces, and where it lands. Writing as we go is what makes a
+# mid-run failure cost one call instead of six.
+PHASE_ARTIFACT = {
+    "full": "full", "reconcile_full": "full",
+    "core": "core", "reconcile_core": "core",
+    "report": "report",
+}
+
+# What each phase needs carried forward from earlier ones.
+PHASE_NEEDS = {
+    "full": (),
+    "core": ("Completed full record",),
+    "audit": ("Completed full record", "Completed core record"),
+    "reconcile_full": ("Completed full record", "Audit findings"),
+    "reconcile_core": ("Reconciled full record", "Completed core record", "Audit findings"),
+    "report": ("Audit findings",),
 }
 
 
@@ -281,51 +328,162 @@ def _extract(text: str, kind: str) -> str:
     return (fence.group(1) if fence else text).strip()
 
 
-def execute(spec: RunSpec, *, dry_run: bool = False) -> dict[str, Any]:
-    """Run all four phases and write the outputs plus a live provenance record."""
+PROGRESS_SUFFIX = "_api_progress.json"
+
+
+def _progress_path(spec: RunSpec) -> Path:
+    base = spec.out_dir or spec.full_path.parent
+    return base / f"{spec.project}{PROGRESS_SUFFIX}"
+
+
+def _load_progress(spec: RunSpec) -> dict[str, Any]:
+    p = _progress_path(spec)
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}          # a corrupt progress file means redo, never crash
+
+
+def _save_progress(spec: RunSpec, completed: list[str],
+                   audit: str | None) -> None:
+    p = _progress_path(spec)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {"completed": completed, "label": spec.label}
+    if audit:
+        data["Audit findings"] = audit
+    p.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _artifact_path(spec: RunSpec, artifact: str) -> Path:
+    return {"full": spec.full_path, "core": spec.core_path,
+            "report": spec.report_path}[artifact]
+
+
+def _call_with_retry(client, *, model, max_tokens, temperature, system, messages,
+                     sleep=time.sleep):
+    """One API call, retrying transient failures.
+
+    Retries rate limits, connection errors and 5xx. Does not retry 4xx other
+    than 429: an invalid key or a malformed request will fail identically on
+    every attempt, and retrying only multiplies the delay before the operator
+    sees the real problem.
+    """
+    import anthropic
+    last: Exception | None = None
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            return client.messages.create(
+                model=model, max_tokens=max_tokens, temperature=temperature,
+                system=system, messages=messages)
+        except Exception as exc:                      # noqa: BLE001 - re-raised
+            transient = isinstance(exc, (
+                getattr(anthropic, "RateLimitError", ()),
+                getattr(anthropic, "APIConnectionError", ()),
+                getattr(anthropic, "InternalServerError", ()),
+            ))
+            status = getattr(exc, "status_code", None)
+            if status is not None and 500 <= status < 600:
+                transient = True
+            if not transient or attempt == MAX_ATTEMPTS:
+                raise
+            last = exc
+            sleep(BACKOFF_BASE_SECONDS ** attempt)
+    raise last  # unreachable; keeps type checkers honest
+
+
+def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
+            client=None) -> dict[str, Any]:
+    """Run the phases, writing each artifact as it completes.
+
+    ``resume`` skips phases whose artifact already exists, so a run that failed
+    at phase 5 costs one call to finish rather than six. Set it False to force
+    a clean regeneration.
+    """
     if dry_run:
         return plan(spec)
 
-    # record_path_for, not runs.record_path: the latter returns Path | None
-    # because it locates an existing record, and we are choosing where to write
-    # a new one.
     from data_sheets_schema.provenance import build_record, record_path_for
 
     settings = _model_settings()
-    client = _client()
-    carry: dict[str, str] = {}
+    client = client or _client()
     usage: list[dict[str, Any]] = []
-    results: dict[str, str] = {}
+    skipped: list[str] = []
+    carry: dict[str, str] = {}
+
+    # Resume from an explicit progress file rather than inferring from
+    # artifacts. A `full` record on disk may be pre- or post-reconciliation and
+    # nothing in the file distinguishes them, so guessing would silently skip
+    # reconciliation or redo it.
+    progress = _load_progress(spec) if resume else {}
+    done = set(progress.get("completed", []))
+    carry: dict[str, str] = {}
+    if "Audit findings" in progress:
+        carry["Audit findings"] = progress["Audit findings"]
+    for artifact, name in (("full", "Completed full record"),
+                           ("core", "Completed core record")):
+        path = _artifact_path(spec, artifact)
+        if path.exists():
+            carry[name] = path.read_text(encoding="utf-8")
+    if "reconcile_full" in done and "Completed full record" in carry:
+        carry["Reconciled full record"] = carry["Completed full record"]
 
     for ph in PHASES:
-        req = build_phase(spec, ph, carry=carry)
-        resp = client.messages.create(
+        artifact = PHASE_ARTIFACT.get(ph)
+        target = _artifact_path(spec, artifact) if artifact else None
+
+        if ph in done:
+            skipped.append(ph)
+            continue
+
+        needed = {k: carry[k] for k in PHASE_NEEDS[ph] if k in carry}
+        req = build_phase(spec, ph, carry=needed)
+        resp = _call_with_retry(
+            client,
             model=settings["name"],
-            max_tokens=settings["max_tokens"],
+            max_tokens=PHASE_MAX_TOKENS.get(ph, settings["max_tokens"]),
             temperature=settings["temperature"],
             system=req.system,
-            messages=req.messages,
-        )
-        text = "".join(b.text for b in resp.content if getattr(b, "type", "") == "text")
-        results[ph] = text
-        usage.append({"phase": ph,
-                      "input_tokens": getattr(resp.usage, "input_tokens", None),
-                      "output_tokens": getattr(resp.usage, "output_tokens", None),
-                      "cache_read": getattr(resp.usage, "cache_read_input_tokens", None),
-                      "cache_write": getattr(resp.usage, "cache_creation_input_tokens", None)})
-        if ph == "full":
-            carry = {"Completed full record": _extract(text, "yaml")}
-        elif ph == "core":
-            carry = dict(carry, **{"Completed core record": _extract(text, "yaml")})
-        elif ph == "audit":
-            carry = dict(carry, **{"Audit findings": _extract(text, "json")})
+            messages=req.messages)
 
-    final = json.loads(_extract(results["reconcile"], "json"))
-    for path, key in ((spec.full_path, "full_yaml"),
-                      (spec.core_path, "core_yaml"),
-                      (spec.report_path, "report_markdown")):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(final[key], encoding="utf-8")
+        text = "".join(b.text for b in resp.content
+                       if getattr(b, "type", "") == "text")
+        usage.append({
+            "phase": ph,
+            "input_tokens": getattr(resp.usage, "input_tokens", None),
+            "output_tokens": getattr(resp.usage, "output_tokens", None),
+            "cache_read": getattr(resp.usage, "cache_read_input_tokens", None),
+            "cache_write": getattr(resp.usage, "cache_creation_input_tokens", None),
+            "max_tokens": PHASE_MAX_TOKENS.get(ph, settings["max_tokens"]),
+            "stop_reason": getattr(resp, "stop_reason", None),
+        })
+
+        # A truncated record is worse than none: it validates as broken YAML or,
+        # worse, as a shorter valid record. Fail loudly rather than write it.
+        if getattr(resp, "stop_reason", None) == "max_tokens":
+            raise RuntimeError(
+                f"phase {ph!r} hit max_tokens "
+                f"({PHASE_MAX_TOKENS.get(ph)}); output truncated. Raise the "
+                f"limit for this phase rather than writing a partial record.")
+
+        body = _extract(text, "json" if ph == "audit" else
+                        ("md" if ph == "report" else "yaml"))
+        if ph == "audit":
+            carry["Audit findings"] = body
+        elif artifact:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(body, encoding="utf-8")
+            label = {"full": "Completed full record",
+                     "core": "Completed core record",
+                     "report": "Reconciliation report"}[artifact]
+            if ph == "reconcile_full":
+                label = "Reconciled full record"
+            carry[label] = body
+
+        done.add(ph)
+        _save_progress(spec, [x for x in PHASES if x in done],
+                       carry.get("Audit findings"))
 
     rec = build_record(
         spec.project, spec.method, spec.label, mode="live",
@@ -336,21 +494,26 @@ def execute(spec: RunSpec, *, dry_run: bool = False) -> dict[str, Any]:
             f"Generated via {RUNTIME}; temperature {settings['temperature']} was "
             "set on the request and is therefore observed, not asserted.",
             f"Model settings read from {settings['config_path']}.",
-        ])
+        ] + ([f"Resumed run; phases skipped as already present: {', '.join(skipped)}."]
+             if skipped else []))
     rec.data["model"] = {
-        "generation_method": "schema-grounded API, four phases",
+        "generation_method": "schema-grounded API, six phases",
         "agent_runtime": RUNTIME, "provider": PROVIDER,
         "model": settings["name"], "temperature": settings["temperature"],
-        "max_tokens": settings["max_tokens"],
+        "max_tokens_by_phase": PHASE_MAX_TOKENS,
         "temperature_basis": "set on the API request and observed",
     }
     rec.data["api_usage"] = usage
+    rec.data["phases_skipped"] = skipped or None
     rec.data["record_generated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    _progress_path(spec).unlink(missing_ok=True)   # run completed
+
     prov_path = (spec.out_dir / f"{spec.project}_d4d_metadata.yaml" if spec.out_dir
                  else record_path_for(spec.project, spec.method, spec.label))
     rec.write(prov_path)
 
     return {"label": spec.label, "project": spec.project, "usage": usage,
-            "outputs": {k: str(v) for k, v in
-                        (("full", spec.full_path), ("core", spec.core_path),
-                         ("report", spec.report_path))}}
+            "skipped": skipped,
+            "outputs": {"full": str(spec.full_path), "core": str(spec.core_path),
+                        "report": str(spec.report_path)}}

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -1,6 +1,7 @@
 """API generation commands — four-phase D4D runs over the Anthropic API."""
 
 import json
+import sys
 from pathlib import Path
 
 import click
@@ -128,3 +129,76 @@ def run_cmd(project, arm, label, condition, bundle, out_dir, yes):
     click.echo(f"✓ {res['project']} {res['label']}")
     for k, v in res["outputs"].items():
         click.echo(f"   {k:6} {v}")
+
+
+@api.command("batch")
+@click.option("--projects", default="AI_READI,CHORUS,CM4AI,VOICE", show_default=True,
+              help="comma-separated")
+@click.option("--arm", type=click.Choice(sorted(ARMS)), default="baseline",
+              show_default=True)
+@click.option("--condition", type=click.Choice(["generic", "tuned"]),
+              default="generic", show_default=True)
+@click.option("--replicates", type=int, default=3, show_default=True)
+@click.option("--label-prefix", required=True,
+              help="e.g. 2026-07-29_claude-opus-5-api-generic; _rep{N} is appended")
+@click.option("--dry-run", is_flag=True, help="cost the sweep without calling the API")
+@click.option("--continue-on-error", is_flag=True,
+              help="keep going after a failed run instead of stopping")
+@click.option("--yes", is_flag=True)
+def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
+              continue_on_error, yes):
+    """Run a sweep of projects x replicates, reporting cumulative cost.
+
+    Each run resumes independently, so a sweep interrupted partway costs only
+    the unfinished phases to complete rather than restarting.
+    """
+    from data_sheets_schema.api_runner import execute, plan
+
+    names = [p.strip() for p in projects.split(",") if p.strip()]
+    specs = []
+    for p in names:
+        for n in range(1, replicates + 1):
+            s = _spec(p, arm, f"{label_prefix}_rep{n}", condition)
+            if not s.bundle.exists():
+                raise click.ClickException(
+                    f"bundle not found for {p}: {s.bundle}")
+            specs.append(s)
+
+    plans = [plan(s) for s in specs]
+    total = sum(x["approx_total_input_tokens"] for x in plans)
+    click.echo(f"📦 {len(specs)} runs — {len(names)} projects x {replicates} "
+               f"replicates, arm={arm}, condition={condition}")
+    for s, x in zip(specs, plans):
+        click.echo(f"   {s.project:9} {s.label:44} ~{x['approx_total_input_tokens']:>8,} tok")
+    click.echo(f"   {'TOTAL':9} {'':44} ~{total:>8,} input tokens (uncached)")
+
+    if dry_run:
+        return
+    if not yes and not click.confirm(f"Run {len(specs)} billed generations?"):
+        click.echo("aborted")
+        return
+
+    ok, failed, spent_in, spent_out = [], [], 0, 0
+    for i, s in enumerate(specs, 1):
+        click.echo(f"\n[{i}/{len(specs)}] {s.project} {s.label}")
+        try:
+            res = execute(s)
+            spent_in += sum(u["input_tokens"] or 0 for u in res["usage"])
+            spent_out += sum(u["output_tokens"] or 0 for u in res["usage"])
+            cached = sum(u["cache_read"] or 0 for u in res["usage"])
+            note = f"  (resumed, skipped {len(res['skipped'])})" if res["skipped"] else ""
+            click.echo(f"   ✓ in={spent_in:,} out={spent_out:,} cache_read={cached:,}{note}")
+            ok.append(s.label)
+        except Exception as exc:                       # noqa: BLE001
+            click.echo(f"   ❌ {type(exc).__name__}: {exc}", err=True)
+            failed.append((s.project, s.label, str(exc)))
+            if not continue_on_error:
+                click.echo("stopping; re-run to resume unfinished phases", err=True)
+                break
+
+    click.echo(f"\n{len(ok)} succeeded, {len(failed)} failed")
+    click.echo(f"tokens: {spent_in:,} in, {spent_out:,} out")
+    for p, lbl, err in failed:
+        click.echo(f"   {p} {lbl}: {err[:90]}")
+    if failed:
+        sys.exit(1)

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from data_sheets_schema import schema_digest
 from data_sheets_schema.api_runner import (
     GENERIC_PROMPT,
+    PHASE_INSTRUCTIONS,
     PHASES,
     RUNTIME,
     RunSpec,
@@ -115,7 +116,7 @@ class TestPhaseAssembly(unittest.TestCase):
         self.assertIn("CoreDataset", req.cached_blocks[0]["text"])
 
     def test_other_phases_use_the_full_class_digest(self):
-        for ph in ("full", "audit", "reconcile"):
+        for ph in ("full", "audit", "reconcile_full", "report"):
             req = build_phase(spec(), ph, carry={})
             self.assertIn("`Dataset`", req.cached_blocks[0]["text"], ph)
 
@@ -185,23 +186,29 @@ class FakeResponse:
 
 
 class FakeMessages:
-    """Returns a plausible payload per phase, in call order."""
+    """Returns a plausible payload per phase, keyed by the instruction sent."""
 
-    def __init__(self):
+    def __init__(self, fail_on=None, exc=None):
         self.calls = []
+        self.fail_on, self.exc = fail_on, exc
 
     def create(self, **kw):
         self.calls.append(kw)
-        n = len(self.calls)
-        if n in (1, 2):
-            return FakeResponse("```yaml\nid: x\nname: X\n```")
-        if n == 3:
+        blob = " ".join(p.get("text", "") for p in kw["messages"][0]["content"])
+        # Match the actual instruction text. Substring-matching "Phase 3" fails:
+        # the prompt body itself enumerates all four playbook phases, so every
+        # request contains every phase number.
+        phase = next((ph for ph, instr in PHASE_INSTRUCTIONS.items()
+                      if instr in blob), None)
+        if phase is None:
+            raise AssertionError("could not identify the phase from the request")
+        if self.fail_on == phase:
+            raise self.exc or RuntimeError("boom")
+        if phase == "audit":
             return FakeResponse('{"findings": [], "summary": "none"}')
-        return FakeResponse(json.dumps({
-            "full_yaml": "# header\nid: x\nname: X\n",
-            "core_yaml": "# header\nid: x\n",
-            "report_markdown": "# Reconciliation\nNo discrepancies.\n",
-        }))
+        if phase == "report":
+            return FakeResponse("# Reconciliation\nNo discrepancies.\n")
+        return FakeResponse(f"```yaml\n# {phase}\nid: x\nname: X\n```")
 
 
 class FakeClient:
@@ -229,14 +236,20 @@ class TestExecuteOffline(unittest.TestCase):
         api_runner._client = lambda: FakeClient()
         self.addCleanup(lambda: setattr(api_runner, "_client", self._client))
 
-    def test_execute_writes_all_four_artifacts(self):
+    def test_execute_writes_every_artifact(self):
         s = spec(out_dir=self.out)
         res = self.api.execute(s)
         for p in (s.full_path, s.core_path, s.report_path):
             self.assertTrue(p.exists(), f"missing {p}")
         self.assertTrue((self.out / "CHORUS_d4d_metadata.yaml").exists(),
                         "provenance record not written")
-        self.assertEqual(len(res["usage"]), 4)
+        self.assertEqual(len(res["usage"]), 6)
+
+    def test_progress_file_is_removed_on_success(self):
+        s = spec(out_dir=self.out)
+        self.api.execute(s)
+        self.assertFalse(self.api._progress_path(s).exists(),
+                         "a completed run must not leave resume state behind")
 
     def test_provenance_record_is_live_and_names_the_prompt(self):
         import yaml as _yaml
@@ -249,17 +262,128 @@ class TestExecuteOffline(unittest.TestCase):
                          "set on the API request and observed")
         self.assertEqual(len(d["prompts"]["files"]), 1)
         self.assertEqual(len(d["prompts"]["files"][0]["sha256"]), 64)
-        self.assertEqual(len(d["api_usage"]), 4)
+        self.assertEqual(len(d["api_usage"]), 6)
 
     def test_every_phase_sends_the_cached_prefix(self):
         s = spec(out_dir=self.out)
         client = FakeClient()
         self.api._client = lambda: client
         self.api.execute(s)
-        self.assertEqual(len(client.messages.calls), 4)
+        self.assertEqual(len(client.messages.calls), 6)
         for kw in client.messages.calls:
             parts = kw["messages"][0]["content"]
             cached = [p for p in parts if p.get("cache_control")]
             self.assertEqual(len(cached), 2)
             self.assertEqual(kw["temperature"], 0.0)
             self.assertEqual(kw["model"], "claude-opus-5")
+            # every phase must be given a limit large enough for its artifact
+            self.assertGreaterEqual(kw["max_tokens"], 12000)
+
+
+class TestResumeAndRetry(unittest.TestCase):
+    """A six-phase run costs real money; a failure must not discard the rest."""
+
+    def setUp(self):
+        import tempfile
+        from data_sheets_schema import api_runner
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.out = Path(self.tmp.name) / "out"
+        self.api = api_runner
+
+    def test_failure_midway_keeps_completed_artifacts(self):
+        s = spec(out_dir=self.out)
+        client = FakeClient()
+        client.messages = FakeMessages(fail_on="reconcile_core")
+        with self.assertRaises(RuntimeError):
+            self.api.execute(s, client=client)
+        self.assertTrue(s.full_path.exists(), "phase 1 output was discarded")
+        self.assertTrue(s.core_path.exists(), "phase 2 output was discarded")
+        self.assertTrue(self.api._progress_path(s).exists(),
+                        "no resume state written")
+
+    def test_resume_skips_completed_phases(self):
+        s = spec(out_dir=self.out)
+        first = FakeClient(); first.messages = FakeMessages(fail_on="report")
+        with self.assertRaises(RuntimeError):
+            self.api.execute(s, client=first)
+        done_first = len(first.messages.calls)
+
+        second = FakeClient()
+        res = self.api.execute(s, client=second)
+        self.assertLess(len(second.messages.calls), done_first,
+                        "resume re-ran work that was already paid for")
+        self.assertTrue(res["skipped"], "nothing reported as skipped")
+        self.assertTrue(s.report_path.exists())
+
+    def test_resume_false_redoes_everything(self):
+        s = spec(out_dir=self.out)
+        self.api.execute(s, client=FakeClient())
+        again = FakeClient()
+        self.api.execute(s, client=again, resume=False)
+        self.assertEqual(len(again.messages.calls), 6)
+
+    def test_corrupt_progress_file_is_ignored_not_fatal(self):
+        s = spec(out_dir=self.out)
+        p = self.api._progress_path(s)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{not json", encoding="utf-8")
+        res = self.api.execute(s, client=FakeClient())
+        self.assertEqual(len(res["usage"]), 6)
+
+    def test_truncated_output_raises_rather_than_writing(self):
+        """A truncated record can validate while being silently incomplete."""
+        class Truncated(FakeResponse):
+            def __init__(self, text):
+                super().__init__(text)
+                self.stop_reason = "max_tokens"
+
+        class TruncMessages(FakeMessages):
+            def create(self, **kw):
+                super().create(**kw)
+                return Truncated("```yaml\nid: x\n```")
+
+        s = spec(out_dir=self.out)
+        client = FakeClient(); client.messages = TruncMessages()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.api.execute(s, client=client)
+        self.assertIn("max_tokens", str(ctx.exception))
+        self.assertFalse(s.full_path.exists(), "truncated record was written")
+
+    def test_transient_errors_are_retried(self):
+        import anthropic
+        calls = {"n": 0}
+
+        def flaky(**kw):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise anthropic.APIConnectionError(request=None)
+            return FakeResponse("```yaml\nid: x\n```")
+
+        client = FakeClient()
+        client.messages.create = flaky
+        out = self.api._call_with_retry(
+            client, model="m", max_tokens=100, temperature=0.0,
+            system="s", messages=[{"role": "user", "content": []}],
+            sleep=lambda _: None)
+        self.assertEqual(calls["n"], 3)
+        self.assertIsNotNone(out)
+
+    def test_auth_errors_are_not_retried(self):
+        """An invalid key fails identically every time; retrying just delays it."""
+        calls = {"n": 0}
+
+        def bad_key(**kw):
+            calls["n"] += 1
+            err = Exception("invalid x-api-key")
+            err.status_code = 401
+            raise err
+
+        client = FakeClient()
+        client.messages.create = bad_key
+        with self.assertRaises(Exception):
+            self.api._call_with_retry(
+                client, model="m", max_tokens=100, temperature=0.0,
+                system="s", messages=[{"role": "user", "content": []}],
+                sleep=lambda _: None)
+        self.assertEqual(calls["n"], 1)


### PR DESCRIPTION
Readiness audit of the API path against the 112 records already generated. It would have failed on almost every project.

## 1. Phase 4 was structurally impossible

It returned `full_yaml` + `core_yaml` + `report_markdown` in one JSON object — all three artifacts in a single response:

| project | phase-4 output | over the old 16k ceiling |
|---|---|---|
| CHORUS | ~30,974 tok | 1.9× |
| CM4AI | ~55,050 tok | 3.4× |
| VOICE | ~67,088 tok | 4.2× |
| AI-READI | ~67,736 tok | 4.2× |

Not a limit to raise — a shape to abandon. Split into `reconcile_full`, `reconcile_core`, `report`: one artifact per call, six phases total.

## 2. `max_tokens: 16000` truncated five of six projects

Real records run 14k–43k output tokens. Now derived per phase from the largest artifact of each kind already generated (112 full, 104 core, 97 report) plus ~40% headroom — 64000 / 56000 / 12000 — rather than guessed.

A `stop_reason` of `max_tokens` now **raises instead of writing**. A truncated datasheet parses as valid YAML while silently missing most of its content; that is worse than no output, because it validates.

## 3. A failure discarded every paid call

Nothing was written until phase 4 parsed, so a phase-5 failure forfeited five calls. Each phase now writes as it completes, with progress in `{project}_api_progress.json`.

**Progress is recorded, not inferred.** A `full` record on disk may be pre- or post-reconciliation and nothing in the file distinguishes them — inferring would either skip reconciliation silently or redo it. The file is deleted on success; a corrupt one means redo rather than crash.

## 4. `d4d api batch`, retry, cost reporting

Sweeps projects × replicates with cumulative token reporting; each run resumes independently, so an interrupted sweep costs only unfinished phases.

Retries 429 / connection / 5xx with exponential backoff. **Does not retry auth or other 4xx** — an invalid key fails identically every attempt, and retrying only delays the operator seeing the real problem. That is not hypothetical: the live run in #171 failed on exactly that.

## Cost, six phases, uncached

```
full baseline sweep (4 projects x 3 replicates): ~11,052,426 input tokens
```

Higher than the four-phase estimate because reconciliation is now three calls carrying the record forward. Prefix caching applies to the bundle and digest on every phase.

## A test bug this exposed

The fake client identified phases by substring-matching `"Phase 3"` — but the prompt body enumerates all four playbook phases, so **every** request matched and the fake reported every call as the audit phase. Tests passed while exercising one phase six times. It now matches the actual instruction text.

## Verification

499 tests pass. New coverage: resume after mid-run failure, `resume=False` forcing a redo, corrupt progress file, truncation raising rather than writing, transient retry, auth not retried.

**Still unverified:** no live API call has succeeded — the repo key returns 401 (#170, #171). Response parsing and cache-hit behaviour remain untested against real output.