### PR TITLE
Move artifact hashing after the run; make outputs describe rather than assert

### DIFF
--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -462,6 +462,14 @@ and it marks what it cannot recover rather than filling it in.
 - The core header contains `Phase 4 reconciliation: completed`.
 - The Phase 3/4 reconciliation report is present.
 - The live provenance record is present and its `record_mode` is `live`.
+- `d4d runs check --strict` passes for the run. **Recording provenance is not the
+  same as recording it correctly.** This path writes provenance as a step
+  separate from writing the artifacts, so a record can pin a state the files
+  merely passed through — one reconciliation report was hashed before its
+  closing rows were appended, and a whole series was hashed before its headers
+  were edited. The API path cannot do this, because it writes provenance
+  in-process after every phase; running the check gives this path the same
+  property. Re-run `d4d runs validate` and check again if anything changed.
 - Final summary to the user: per project, report full/core line counts as
   informational metadata, never as a quality gate, plus validation status.
 

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/AI_READI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep1/AI_READI_d4d.yaml
     bytes: 142095
     slots: 81
-    sha256: dc429ba4d9e62c9abe28247b4fe89c9b25f57c0d4ee6948a02faf25fb36e4657
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/AI_READI_d4d_core.yaml
     bytes: 114696
     slots: 66
-    sha256: 97ebbb6ba032dade713378295cbc0725825a85698079677b186cf3c90a83023e
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/AI_READI_reconciliation.md
     bytes: 21400
     slots: null
-    sha256: 14d14d44ed620cbf3fccd9276b21cdccec345aed8905066a1b0acc9d73330838
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CHORUS_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep1/CHORUS_d4d.yaml
     bytes: 61383
     slots: 53
-    sha256: 10e69b8dfb4013a216720d825cd184239c0737b04d35a5541bf617db5121ed87
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CHORUS_d4d_core.yaml
     bytes: 56166
     slots: 48
-    sha256: 3a1d25efb823af4c760dae67cb243380020714e3e5c858cb9ee7e6891b9aad46
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CHORUS_reconciliation.md
     bytes: 13436
     slots: null
-    sha256: 99a8af8a2b4ae2b0f4316459f504771a71cf3849e97e70754bb55476d6fdfac6
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CM4AI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep1/CM4AI_d4d.yaml
     bytes: 129138
     slots: 76
-    sha256: 2debc8b7ccf4034dc1011557329347378c4974e7232892f71ee426af7d11306f
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CM4AI_d4d_core.yaml
     bytes: 100002
     slots: 68
-    sha256: 9bff96a457a1cf81a4154ccd9f0de348099ad79b14e7537deaa317ee2149b5bc
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CM4AI_reconciliation.md
     bytes: 18870
     slots: null
-    sha256: 6970bedd740ac4fccaa664962be8281bd3d12813188ba29f51df5cb39505b9f0
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep1/VOICE_d4d.yaml
     bytes: 159728
     slots: 75
-    sha256: 3b51c806b733513755914b6671a8c831da27105196b34c7336a240ee3833e294
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_d4d_core.yaml
     bytes: 132716
     slots: 63
-    sha256: 7d689413e4c5a095de6e996b16d6f6fbcdb41f2e736bf1d65ca599d92f97eaa2
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_reconciliation.md
     bytes: 17485
     slots: null
-    sha256: 615f26f55f9891d4e8d6a9dfc9c8b832fa2027bdcd6c424f9ab6e3808cc014ef
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/AI_READI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep2/AI_READI_d4d.yaml
     bytes: 134673
     slots: 84
-    sha256: 34f7ecbb1b98f5bae7a388aab1942ec1d04718c66a4502f8d0d2b10729f2c545
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/AI_READI_d4d_core.yaml
     bytes: 101529
     slots: 69
-    sha256: 1774de956d5c8eb72ea861b434b1c2e5fabba1a351f44b19e57e13c718f80fcc
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/AI_READI_reconciliation.md
     bytes: 20393
     slots: null
-    sha256: 1d3e3e4f45b085b5e9f5d3763bd3ecb43251f28d425abe633a8330f412b03426
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CHORUS_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep2/CHORUS_d4d.yaml
     bytes: 59443
     slots: 54
-    sha256: cc70c1b7c11b99b145d06429f5ed85a4a6d56933ffe3cc1904a34764acdf75b2
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CHORUS_d4d_core.yaml
     bytes: 50982
     slots: 48
-    sha256: 48e2364dd0b6232341969014c4d8da427544a14cb4a6ff99366947ae77454dd1
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CHORUS_reconciliation.md
     bytes: 14220
     slots: null
-    sha256: 2e3718cefdffb0aacad7d3bb2943efef68f8e7d537ab9d1a55ac08616f31d937
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CM4AI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep2/CM4AI_d4d.yaml
     bytes: 129906
     slots: 84
-    sha256: 061b2020a3af9ecbc8dce94886b6b5a206ed839d3ca4bb51c0af88aceed7263c
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CM4AI_d4d_core.yaml
     bytes: 107653
     slots: 72
-    sha256: 95fd43ba406e8560a9ce7892881aeef3a17ebcd6ff6ca00e3a155f13f9360165
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CM4AI_reconciliation.md
     bytes: 16619
     slots: null
-    sha256: e58d150b81ba15b6afb7c8087f8e6780c63ed06fea3159050863d0446cba1ac1
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/VOICE_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep2/VOICE_d4d.yaml
     bytes: 121905
     slots: 75
-    sha256: 341542e0e3d5d1eefc05a04a1faf8881a092bfc8131ff6a3e95f6e7aac1ce40b
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/VOICE_d4d_core.yaml
     bytes: 105343
     slots: 64
-    sha256: 971d77e58c9d88d0759bf5e42a48ec77ec95ced65e9ae06813e443374186a01b
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/VOICE_reconciliation.md
     bytes: 17510
     slots: null
-    sha256: f3ff6e67c91051033ad83244963f5c498ea2b03b4f9dff38d0ac14a5b5a35f45
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/AI_READI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep3/AI_READI_d4d.yaml
     bytes: 103699
     slots: 82
-    sha256: cc4010bafbca58bdd31de4bdf24e13f3efa23021713ce0e082ab07cba70e5795
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/AI_READI_d4d_core.yaml
     bytes: 90046
     slots: 68
-    sha256: 2d2512aaf8d23a8cf127ac7be51eb12b2d1864160ff0bd892e711b05465b6259
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/AI_READI_reconciliation.md
     bytes: 20112
     slots: null
-    sha256: ff68fce8deb0ffecde43232968918f2763ca32744812c7e4e3645eb1bc1538bf
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CHORUS_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep3/CHORUS_d4d.yaml
     bytes: 52033
     slots: 53
-    sha256: 8beba2fb5d3cf895589c949df50f88456c3c4d8bbfb898627cba84f46edbd631
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CHORUS_d4d_core.yaml
     bytes: 45855
     slots: 47
-    sha256: c62d3eec9c1c7e7d3167093676f5c694b7dfed89e8bd47a7a1ff308047a2c740
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CHORUS_reconciliation.md
     bytes: 17283
     slots: null
-    sha256: 70d4104c90b6345b0e4b64da196ba02e3e1127c7af8d4331f5fb209b8688db5c
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CM4AI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep3/CM4AI_d4d.yaml
     bytes: 141696
     slots: 81
-    sha256: 51569260d34bda980da1c861b6330bd6f1465d89e1af7475b9d95379b8198cfa
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CM4AI_d4d_core.yaml
     bytes: 120003
     slots: 71
-    sha256: 8339dd6aa2bec36dc2cd04360c4e39c0cf487746e56a1a8f9537bb4a4e058dd0
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CM4AI_reconciliation.md
     bytes: 19429
     slots: null
-    sha256: b6fc9ff2a34001e03baebb4ad0c172ec1b4e1516c13d3226352230392b49ed41
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-27_claude-opus-5_rep3/VOICE_d4d.yaml
     bytes: 110285
     slots: 75
-    sha256: 73bd96af3984f061219a67b8c54616bcbb5153b50ab9652d519d782e4fde575d
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/VOICE_d4d_core.yaml
     bytes: 91334
     slots: 64
-    sha256: c926fb4ac21b28ff4c1e5288ad5a886936b9d8b9e945e0635bbf5d7e75d1ec85
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/VOICE_reconciliation.md
     bytes: 14592
     slots: null
-    sha256: 8505820a9a522982788c006ad54509387404a304b4692169078f5962509ad868
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_d4d.yaml
-    md5: fb8a7cfe968d1ff4b365d11db6bae901
     bytes: 131866
     slots: 78
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_d4d_core.yaml
-    md5: bf753a3ade3db45fe907d88f34a5a853
     bytes: 104054
     slots: 65
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_reconciliation.md
-    md5: d8669ae28823e4137fb743b0521150f4
     bytes: 21103
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_d4d.yaml
-    md5: f810bc497dca7203935746df9dbfc07a
     bytes: 53339
     slots: 48
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_d4d_core.yaml
-    md5: 7a2757b4f9c3a3c9e88c38a53d1bdda5
     bytes: 46736
     slots: 43
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_reconciliation.md
-    md5: 03716bc0a68eedca9ae9b1504d94564a
     bytes: 15184
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_d4d.yaml
-    md5: 4b4bd1375899bb7e94c6c84d23e05672
     bytes: 142068
     slots: 76
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_d4d_core.yaml
-    md5: 7891254e4b862e1d33cba962f8aa7507
     bytes: 108842
     slots: 64
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_reconciliation.md
-    md5: a446797116aab8b8c260753be5ad38ad
     bytes: 21213
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_d4d.yaml
-    md5: b4a0025b865fe52b3ad06d22c56329cf
     bytes: 127919
     slots: 82
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_d4d_core.yaml
-    md5: 4fc2f1a1e637dab8eeadc16ac19bd924
     bytes: 95094
     slots: 67
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_reconciliation.md
-    md5: e0a958a9e76c88dd4c908088c2cdf887
     bytes: 13197
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_d4d.yaml
-    md5: 9aad0fc5813e7a31debfda7c7be50b2e
     bytes: 70827
     slots: 59
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_d4d_core.yaml
-    md5: 802b3e383c7831a53b4697bb56ef80ba
     bytes: 65018
     slots: 53
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_reconciliation.md
-    md5: 2b15d61517ae6d9460d89bf46939ee27
     bytes: 17683
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_d4d.yaml
-    md5: 6bc889f0e3cc55159da09253c9e218f6
     bytes: 117462
     slots: 76
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_d4d_core.yaml
-    md5: 28754fae0a540fd32b4149fce72215e7
     bytes: 93100
     slots: 64
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_reconciliation.md
-    md5: d6ba41727f1f475e93c12755aabdd499
     bytes: 18882
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_d4d.yaml
-    md5: e1f64726e1d02b1521db6b788af3c0b8
     bytes: 128187
     slots: 83
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_d4d_core.yaml
-    md5: c465d937947bbc222699524b11742d19
     bytes: 99679
     slots: 67
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_reconciliation.md
-    md5: 774844fedc89d1fc467207717254ee77
     bytes: 21085
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_d4d.yaml
-    md5: cf0beb94e40b1f05e71d25b1095f85ff
     bytes: 68560
     slots: 61
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_d4d_core.yaml
-    md5: 9ac7a378e16c5912e4ba312dc3eaf259
     bytes: 63082
     slots: 55
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_reconciliation.md
-    md5: a6a4745560ee23b1cc275e8ec18baa42
     bytes: 17171
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_d4d.yaml
-    md5: 2dc69b49273153d6eecce4bc8f8e73d1
     bytes: 108370
     slots: 77
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_d4d_core.yaml
-    md5: d8762e5ba1a9729adfadbe09b763ea99
     bytes: 86946
     slots: 65
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_reconciliation.md
-    md5: 45fa30bbb8113e7499aa16cee978c614
     bytes: 18764
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
@@ -60,12 +60,10 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep1/AI_READI_d4d.yaml
     bytes: 152135
     slots: 79
-    sha256: a5fa7b8bb3adb699913157ae9f42e2b03482f42207c297f355bbf4b18c03b76e
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_d4d_core.yaml
     bytes: 103875
     slots: 64
-    sha256: 996fc392940d30595dcbf1bacea89b0926e5bdda0d63c5b801ac5e19f6e58524
   report: null
 unrecoverable: null
 notes: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep1/CHORUS_d4d.yaml
     bytes: 56772
     slots: 57
-    sha256: 52180589edeed3928bbd82f48e0f625adfc533bdbd7c0ecf5fb2f735b4abf525
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_d4d_core.yaml
     bytes: 52603
     slots: 51
-    sha256: 9d2f78de33847085d24292d97986385d2c7074e2949eecea455f5694caf1a681
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_reconciliation.md
     bytes: 14522
     slots: null
-    sha256: fe53a9e0d81445387769f23006a166a645423e061f55ae35672e78f108cc1d30
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep1/CM4AI_d4d.yaml
     bytes: 110349
     slots: 60
-    sha256: 9caee8875df034151ed7c5eb1657831bc45f2e40202c1d4b7a767be97c7b4f90
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_d4d_core.yaml
     bytes: 96176
     slots: 54
-    sha256: 2d530e1bac4e6688554d5d022d277b0fca85f9d6a2a6329ff4685cf61c348641
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_reconciliation.md
     bytes: 13677
     slots: null
-    sha256: acc80faa6e9793fec8d9e84cf63d03d2c288662b965bf1444b8865aa345e1c11
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep1/VOICE_d4d.yaml
     bytes: 136880
     slots: 76
-    sha256: 9fb09858808071f6317658e4f484590cd419fc0656994d76fca864033c86f47b
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_d4d_core.yaml
     bytes: 111446
     slots: 65
-    sha256: b276728c59be3be492f7deecbe8b618a8d38730a02588d17451989e3dbbe8bee
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_reconciliation.md
     bytes: 20028
     slots: null
-    sha256: 983c1742211638eb07a807df344f51370c3d4d218cea1036ef3b56104adaf945
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep2/AI_READI_d4d.yaml
     bytes: 102384
     slots: 77
-    sha256: 2088430a546fbc14d79908805fc6146e9578e4001747932a9209d6ba432c7966
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_d4d_core.yaml
     bytes: 86125
     slots: 63
-    sha256: bb0d16c266257ac31019d1be2390a2d5671896f2f2453d9906ae44a7ec8ca4fe
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_reconciliation.md
     bytes: 17268
     slots: null
-    sha256: 69e3c868ab1534a594232ae6deaf75f7a77f64a6252c6302dfa066874f6fd021
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep2/CHORUS_d4d.yaml
     bytes: 55356
     slots: 53
-    sha256: b377fcec307d0e6d77a3fd00433277b573a7b9be7614fbcbb5618e757dce05dc
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_d4d_core.yaml
     bytes: 50502
     slots: 47
-    sha256: 5e1b9dd2202edd07dc9c540301cd55145a3b99952b57e2a089cd5354bdd8a6a6
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_reconciliation.md
     bytes: 13672
     slots: null
-    sha256: 75f9ad0671a06cee8ccc3c15a5082f12c24a6136e88853c110c8962851a5d9ea
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep2/CM4AI_d4d.yaml
     bytes: 97858
     slots: 63
-    sha256: 1bf736aa622453b3b4984076f7c945e78d1cacbadedc6350a5e98d5e12cd8c95
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_d4d_core.yaml
     bytes: 87733
     slots: 58
-    sha256: dec3dd1a8423ce4d2527a3cc560e30c1cbed5e018e413a28d435ff430230bf19
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_reconciliation.md
     bytes: 15046
     slots: null
-    sha256: 07c47fe427fd5a73f807d931a487d65dbd74fa170e8b55e3cc9d744147586a2d
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep2/VOICE_d4d.yaml
     bytes: 142181
     slots: 79
-    sha256: e0971890d44667d8e960e15b349f0f29b176da3dab4907199d302a390f43b095
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_d4d_core.yaml
     bytes: 115952
     slots: 67
-    sha256: 3f1bdf90ef4e06ba4cdfa5d780f264b61f520026490a4725ebab1663d5346a36
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_reconciliation.md
     bytes: 14809
     slots: null
-    sha256: bb433a2e6d815a671e3db8173f90723c510d6e38fc32bf09ec0e97ec5b7f082a
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep3/AI_READI_d4d.yaml
     bytes: 136579
     slots: 80
-    sha256: ef3c2db3a04a40e155cc8beeb703a376f6b649492dab07282cc2d2ceaa946cb1
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_d4d_core.yaml
     bytes: 95877
     slots: 65
-    sha256: b6e56b77cb2b87bdb73c874f9cf571e4b61ec5cea6926e6da34c75cbfb3934f2
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_reconciliation.md
     bytes: 17189
     slots: null
-    sha256: c13f500f63fd4dc37a94af9e88e51ba106d089550d219e8e83a28ee9961b8d22
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep3/CHORUS_d4d.yaml
     bytes: 54406
     slots: 54
-    sha256: 17833926f1a11aac59b190fd344cef57be7055ad1738888bcd7c96229479317b
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_d4d_core.yaml
     bytes: 45954
     slots: 48
-    sha256: bd98e4cef86e815fd9a3848ece36c1155a04784757abe0e1831e5e227f114145
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_reconciliation.md
     bytes: 16669
     slots: null
-    sha256: fd1a36b62f61df96ad7bc59569bd1d9ae67369804b932f8ee898ab0f8d4b103a
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_provenance.yaml
@@ -60,15 +60,12 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep3/CM4AI_d4d.yaml
     bytes: 127149
     slots: 69
-    sha256: 6cb9ca3834993f43bc2babc954234463f694d46e92e1ccd53e081cd270294696
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_d4d_core.yaml
     bytes: 116332
     slots: 61
-    sha256: 5ac766a57f0e509debb8d8ce159015a2877cea48ad3d0608559c7e38ea7aa8ca
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_reconciliation.md
-    md5: ba0cbf5b1c17d63cc70cbba3787f3c3a
     bytes: 16884
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-generic_rep3/VOICE_d4d.yaml
     bytes: 99422
     slots: 75
-    sha256: e1f5dabde20fc9d5813898bfcec865b6bf4006ade404cf5beab326a8c1e32f6f
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_d4d_core.yaml
     bytes: 84395
     slots: 64
-    sha256: d81e41632848984be0b4c075860701300ced14001caec01f25608edd75fbaf40
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_reconciliation.md
     bytes: 15219
     slots: null
-    sha256: 51dba4ffe9f85ddd563b6dc9645cb59ffd07fe0c0bf83796f42d3e778cb64613
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_provenance.yaml
@@ -52,15 +52,12 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_d4d.yaml
     bytes: 126564
     slots: 63
-    sha256: 39788989e9cc58f00ee823fbf750477f968c0989eb3ceb8330601e3b26c6ee4b
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_d4d_core.yaml
-    md5: 95c3e5f9d0991035fc8399928ef5faff
     bytes: 107472
     slots: 58
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_reconciliation.md
-    md5: b2f421e726e697eda26f1ca2a959c327
     bytes: 19945
     slots: null
 unrecoverable:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_provenance.yaml
@@ -53,15 +53,12 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_d4d.yaml
     bytes: 108383
     slots: 69
-    sha256: 81d6282f65768bb69e1d19cd9f9774111ebabcafe663dc2d3d99c0e2aed30e5a
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_d4d_core.yaml
-    md5: 3035a1bfa7825cfffb15432b5b2ad47e
     bytes: 90362
     slots: 63
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_reconciliation.md
-    md5: 4f536aa788c96fb90a790f69c7b1f628
     bytes: 17197
     slots: null
 unrecoverable:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_provenance.yaml
@@ -52,15 +52,12 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_d4d.yaml
     bytes: 120648
     slots: 60
-    sha256: e649e1119bc0145ead6113100845ebbf28c494931ab7e4ef2a7d8387ce29ec17
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_d4d_core.yaml
-    md5: d04f62c8c1b1c7dd6f527cfb6deb3c6a
     bytes: 104166
     slots: 55
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_reconciliation.md
-    md5: c8397a10afea6fffe7be4e25fd477a9f
     bytes: 19778
     slots: null
 unrecoverable:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -76,17 +76,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_d4d.yaml
     bytes: 32700
     slots: 53
-    sha256: 4e21643adacbfb963cd4f2db843acc3bbbb3c113d75e58ed386833a44f02cf3e
   core:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_d4d_core.yaml
     bytes: 30883
     slots: 49
-    sha256: e0ad635d62962fba66b6a3d4c5c3bf9739f588e7a8823485250e7b0f5397bf45
   report:
     path: data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_reconciliation.md
     bytes: 13296
     slots: null
-    sha256: 29a8d9d3f07a3cc7822fd6429736e278f254d7c7aea9cd570e1af21439016a87
 unrecoverable: null
 unverified:
 - field: model.temperature

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CHORUS_provenance.yaml
@@ -52,17 +52,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep1/CHORUS_d4d.yaml
     bytes: 84404
     slots: 75
-    sha256: eade292263ba8e1183d2220b27833bb13c1a6beb4156c76207e655ee23f3590b
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CHORUS_d4d_core.yaml
     bytes: 72922
     slots: 64
-    sha256: cc2fda8a94d1bc7180483ca07e549261a9435ac2bf70379544e0ba467f4fda71
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CHORUS_reconciliation.md
     bytes: 22161
     slots: null
-    sha256: 30792a781edb7fcbed700f7c546d6ffd3fe4de7bd3b6ac6d4fd0c9c719aa1bc2
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CM4AI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep1/CM4AI_d4d.yaml
     bytes: 142151
     slots: 84
-    sha256: c96cb124d3e0f728999f596cf73226cc78045a6b8766a80704e91d991ef0fc3d
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CM4AI_d4d_core.yaml
     bytes: 122282
     slots: 72
-    sha256: 267145b2d53b04503f7e251970e090e81bc9843c2eaef676d09eb30960447b05
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CM4AI_reconciliation.md
     bytes: 22718
     slots: null
-    sha256: 1c690445f382a53fb326270cf42881fe7e61d1b4cb8578914baecc446a33fa7a
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
@@ -52,17 +52,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep1/VOICE_d4d.yaml
     bytes: 173025
     slots: 81
-    sha256: 80e933389002259765fd49ced5b4f50c39bdc2aeacc3953afaad9308f6ce781b
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/VOICE_d4d_core.yaml
     bytes: 151742
     slots: 71
-    sha256: b9655eb6ec2f682b7865932f9380d671e896bb0c7b5a5c76d1a586c65d0e0069
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/VOICE_reconciliation.md
     bytes: 24984
     slots: null
-    sha256: fd0fcb0249a01f1e66296d86d2c98990b22142851d90df3bffc1dcd498ddfc48
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CHORUS_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep2/CHORUS_d4d.yaml
     bytes: 68285
     slots: 70
-    sha256: f9397a894b5b775c4bf7f53dae2cbeec91406690547edb4eb1e87a17473dbde4
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CHORUS_d4d_core.yaml
     bytes: 64349
     slots: 63
-    sha256: a30fb9343caad4a382cfbe5243fbe0ab770876f939bb35a4c11ceb4bb6335ad5
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CHORUS_reconciliation.md
     bytes: 21977
     slots: null
-    sha256: 493c2a4e3d116ab2a64eba7ab27612d6a983539c632cdc22db996d3ec02fbdc4
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CM4AI_provenance.yaml
@@ -52,17 +52,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep2/CM4AI_d4d.yaml
     bytes: 147254
     slots: 70
-    sha256: 3c4a755015324a95154aa33739ed73c212be4d6e5dcc5b1d7d8cfd9a6ce367a2
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CM4AI_d4d_core.yaml
     bytes: 129469
     slots: 66
-    sha256: cca71bc9582cddb1b08d537aa190b117b0fa8455b22619dfa61498ac125a9562
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CM4AI_reconciliation.md
     bytes: 22840
     slots: null
-    sha256: d3e5718ae1638705fb4c2ab9855bda7951bb658d0d452d087ac020d239d059a0
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/VOICE_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep2/VOICE_d4d.yaml
     bytes: 160127
     slots: 85
-    sha256: c30f57c57f8f2a60b9dbcad4bd7ef18b3e1f84a9a470fc7c0b06e1bff8971596
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/VOICE_d4d_core.yaml
     bytes: 131743
     slots: 72
-    sha256: eb19ca87335434243e79ffc7d2989d82343c5d82e891e07cd50c16bff8dff782
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/VOICE_reconciliation.md
     bytes: 22232
     slots: null
-    sha256: 6528338b2488fc4c3f2fa22eb70e5a673bd2f9bc2e34f0dc9120da0e16252db5
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CHORUS_provenance.yaml
@@ -52,17 +52,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep3/CHORUS_d4d.yaml
     bytes: 72305
     slots: 73
-    sha256: 2633dd5df711555f438465d3f06a2dbd247c319a72984705b43deceee13443a4
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CHORUS_d4d_core.yaml
     bytes: 62616
     slots: 63
-    sha256: e4d6a6b8c48e0d05a7ef8be3c0a604f536efece498bd37d879edbb0f1aade42c
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CHORUS_reconciliation.md
     bytes: 18981
     slots: null
-    sha256: 1d84b2a70d2a66d9f152bfaf46204275d2871cc036540f52ade58b858a691d38
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CM4AI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep3/CM4AI_d4d.yaml
     bytes: 111981
     slots: 83
-    sha256: 9f47e98de69f02d7160c66752c89074eab6459e225bbcc261275b16d978f32b7
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CM4AI_d4d_core.yaml
     bytes: 94922
     slots: 71
-    sha256: f218774282668f0e84e84afaf82ae1f1b6b6f5409f6820d679a45f7dcdb23cb8
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CM4AI_reconciliation.md
     bytes: 22232
     slots: null
-    sha256: bd7f00e81d0e82c714dbc2a6e7c6fa8107609d73fc8b19f011a575eab9690a79
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-27_claude-opus-5_rep3/VOICE_d4d.yaml
     bytes: 128241
     slots: 83
-    sha256: 6f5ae67c107870d93b25a2f9c4d22a3b0d401dcc95cb7e2ab9d58c8fb72ccd36
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_d4d_core.yaml
     bytes: 105491
     slots: 72
-    sha256: 10139e1d5857d6205d1415108c3fb4ac2767eb2370ce5326c334e0bfca8aad7f
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_reconciliation.md
     bytes: 24143
     slots: null
-    sha256: ed1af0cdacfd4cf495bafeef08e0515faed6a97f217c3a7234a85dd315392db9
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_provenance.yaml
@@ -58,12 +58,10 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_d4d.yaml
-    md5: 92724ac2febb171c33128e3a28bf2689
     bytes: 70719
     slots: 76
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_d4d_core.yaml
-    md5: c4ed00382683098d1de5e9e91006deb4
     bytes: 61690
     slots: 67
   report: null

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_d4d.yaml
-    md5: 1aee8a9583685f99a42e2429f9f3577a
     bytes: 138966
     slots: 76
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_d4d_core.yaml
-    md5: 8c46f4b93c002e5b444fa3e22af38545
     bytes: 117065
     slots: 63
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_reconciliation.md
-    md5: 81d90d4618842badab430c7a6559707f
     bytes: 18314
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_d4d.yaml
-    md5: 62f878c452669ac4672dff441bd09f72
     bytes: 56172
     slots: 71
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_d4d_core.yaml
-    md5: 3570158d616ac0f68b40a028051a2c15
     bytes: 48923
     slots: 61
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_reconciliation.md
-    md5: 62444c116e7d604959f00f678fb9c1ce
     bytes: 15310
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_d4d.yaml
-    md5: 7b98276f13fb8f1de5a8e134f4323c46
     bytes: 142692
     slots: 77
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_d4d_core.yaml
-    md5: fcd961129fa552488707e4b59aae9941
     bytes: 116662
     slots: 64
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_reconciliation.md
-    md5: cd2f903100d3beca966432808fe88021
     bytes: 18052
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_d4d.yaml
-    md5: 1b6350a79f688df49531b1dfd18cdae3
     bytes: 79576
     slots: 75
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_d4d_core.yaml
-    md5: ebd5d66e0288f97957bf340de329ff71
     bytes: 73023
     slots: 65
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_reconciliation.md
-    md5: 3813d3070d30e79cf359581b1e86e5f2
     bytes: 17301
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_provenance.yaml
@@ -58,12 +58,10 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_d4d.yaml
-    md5: 876f99b974317742a9ec7b3f7879b407
     bytes: 143317
     slots: 77
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_d4d_core.yaml
-    md5: 19547e28d20c8391c74623ba7e33b419
     bytes: 112755
     slots: 64
   report: null

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_provenance.yaml
@@ -53,15 +53,12 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_d4d.yaml
     bytes: 135512
     slots: 65
-    sha256: 1abb7d75506ccf4f51fbe8a3c49c6d8d93d16df1805484e559d7475cf2cd6a49
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_d4d_core.yaml
-    md5: 8665b0f8a0f03350198ab1c85fc0bb2f
     bytes: 115482
     slots: 60
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_reconciliation.md
-    md5: 00062dc2e053b812552fb4423e4c103f
     bytes: 26000
     slots: null
 unrecoverable:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_provenance.yaml
@@ -52,15 +52,12 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_d4d.yaml
     bytes: 126427
     slots: 69
-    sha256: e7d70ca888519ec15e158ba098a5cb8f8f371469a08cc7acaf5830a2ca1b2883
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_d4d_core.yaml
-    md5: 480d50130a3da919117454bc6a8448c5
     bytes: 108872
     slots: 63
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_reconciliation.md
-    md5: 87c67728a1d49649e86d7c40bdf20b2b
     bytes: 25179
     slots: null
 unrecoverable:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_provenance.yaml
@@ -53,15 +53,12 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_d4d.yaml
     bytes: 139812
     slots: 69
-    sha256: 70b9ffbfe11bffbb70242e56224530612153120c1eed691235fb9c787eed9680
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_d4d_core.yaml
-    md5: 321fd98e61e181a995779b662065c878
     bytes: 119144
     slots: 63
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_reconciliation.md
-    md5: 2baa10877db4902e9bf61ac6b29a0032
     bytes: 20260
     slots: null
 unrecoverable:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep1/CM4AI_provenance.yaml
@@ -52,17 +52,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-denoised_rep1/CM4AI_d4d.yaml
     bytes: 106949
     slots: 55
-    sha256: dcc6d6198ee70f395f01a0a5ebdff9055c0ca9baa6d7b9ffafb1c79fbd179cdf
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep1/CM4AI_d4d_core.yaml
     bytes: 89758
     slots: 51
-    sha256: b1d9ea73bc0f1c81f60ee5da50f2b97996ad60f1005869315619dab3565454ce
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep1/CM4AI_reconciliation.md
     bytes: 20680
     slots: null
-    sha256: 0ac810e17f92a35587ac37a2d36a98ca53213757ecf31adf66c35e6a0a3ab3ea
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep2/CM4AI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-denoised_rep2/CM4AI_d4d.yaml
     bytes: 69766
     slots: 56
-    sha256: 519801be1a4fa57def2195c75f242ffddf43bb655a26b6a1121d0c8301b52580
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep2/CM4AI_d4d_core.yaml
     bytes: 62302
     slots: 52
-    sha256: 29d4d9192e79ad6a3a9824f8eb050c51d27294e24e6a0bf78198e0a976253b96
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep2/CM4AI_reconciliation.md
     bytes: 20813
     slots: null
-    sha256: 7c32f569bc19d3664c76f6261cf96d3d135b39db18bd77675f16e76d0caaad12
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep3/CM4AI_provenance.yaml
@@ -52,17 +52,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-denoised_rep3/CM4AI_d4d.yaml
     bytes: 55878
     slots: 50
-    sha256: 7a7324bf7e4ec9170dc92ff0f524f31cfb053a23c273bb9f89de84337cbeea75
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep3/CM4AI_d4d_core.yaml
     bytes: 53821
     slots: 46
-    sha256: f5bf86c58c23c1db60b092c06bcd91c5191b1ba95b32a260b6fa489e48e1df85
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep3/CM4AI_reconciliation.md
     bytes: 17782
     slots: null
-    sha256: f6215c3f0c03466f72dee4c0d65f4756f145e2ecfa5575cf563372fe3f00223b
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CHORUS_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CHORUS_d4d.yaml
-    md5: c8519e9868b3c1ff12fa2cbacfc963ef
     bytes: 40597
     slots: 62
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CHORUS_d4d_core.yaml
-    md5: a6f3b50aed91c552a9e6ae8f57b5566e
     bytes: 35500
     slots: 55
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CHORUS_reconciliation.md
-    md5: 51b62dcf983050025c0f20dce8394b63
     bytes: 14233
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CM4AI_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CM4AI_d4d.yaml
-    md5: b79fe80ce26ebe0989972f6703b8e4c1
     bytes: 68554
     slots: 60
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CM4AI_d4d_core.yaml
-    md5: 50a08727f409479e4a95df073578843b
     bytes: 61271
     slots: 55
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CM4AI_reconciliation.md
-    md5: 2acd0158f200854e7b2ed45113b34c94
     bytes: 19778
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/VOICE_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/VOICE_d4d.yaml
-    md5: 30c9cffb7d459109d2060a39b310bb71
     bytes: 65154
     slots: 70
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/VOICE_d4d_core.yaml
-    md5: 03b4b27855350621e76c46d7a9e03725
     bytes: 70135
     slots: 60
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/VOICE_reconciliation.md
-    md5: 83f954a1f5df998ec7ecc309177b2266
     bytes: 15406
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CHORUS_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CHORUS_d4d.yaml
-    md5: 5a55d3616e1030ed03f4fd1083f6a56e
     bytes: 42707
     slots: 58
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CHORUS_d4d_core.yaml
-    md5: 368b2bd9969373a1f37120f4d32a3b9c
     bytes: 36092
     slots: 52
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CHORUS_reconciliation.md
-    md5: 7dc8b7f92f5ce4f54ebd10b22726423d
     bytes: 16047
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CM4AI_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CM4AI_d4d.yaml
-    md5: 8fa104aef57d1f9c52b5372e89361ef5
     bytes: 68391
     slots: 62
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CM4AI_d4d_core.yaml
-    md5: 09c3293ec2ef6b8b9b7364999c432b00
     bytes: 60148
     slots: 55
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CM4AI_reconciliation.md
-    md5: b669e3af03c9a91d01b3d3424b7f9279
     bytes: 16969
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/VOICE_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/VOICE_d4d.yaml
-    md5: 6b79ef6a1eb480bbe5987de52f9fb3b4
     bytes: 76360
     slots: 73
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/VOICE_d4d_core.yaml
-    md5: 63d320658712de5f713ae90ea3fd4be6
     bytes: 62213
     slots: 63
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/VOICE_reconciliation.md
-    md5: b3914c56a2a78ac2a2f92afb75fe2130
     bytes: 17987
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CHORUS_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CHORUS_d4d.yaml
-    md5: ed60ff145b82d23f896c682a6290fd1d
     bytes: 43091
     slots: 57
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CHORUS_d4d_core.yaml
-    md5: ff243821596219608613eb060bb410b0
     bytes: 38592
     slots: 50
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CHORUS_reconciliation.md
-    md5: ab83bc515bdbea185b6a4652316389d5
     bytes: 13149
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CM4AI_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CM4AI_d4d.yaml
-    md5: 7a0ba09abb608a0346c2487eb8151bb8
     bytes: 64652
     slots: 60
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CM4AI_d4d_core.yaml
-    md5: 3e3d63a789511931c5b4848b859d0562
     bytes: 54719
     slots: 53
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CM4AI_reconciliation.md
-    md5: 923b19c54568f1f68abd42ab88558156
     bytes: 17304
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/VOICE_provenance.yaml
@@ -58,12 +58,10 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/VOICE_d4d.yaml
-    md5: d60e087301712e94a8f38002d77a5e1d
     bytes: 73898
     slots: 70
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/VOICE_d4d_core.yaml
-    md5: 2ac96eca30db34a9a0e58a5cee9f6195
     bytes: 62443
     slots: 61
   report: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/CHORUS_provenance.yaml
@@ -61,12 +61,10 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly_rep1/CHORUS_d4d.yaml
     bytes: 48626
     slots: 56
-    sha256: d471ae50e19c597410f1db22cd81434dfdaa7b299e441ad5dcf14da075daca77
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/CHORUS_d4d_core.yaml
     bytes: 40341
     slots: 48
-    sha256: d02d293226c2f1c5fec6f7a18dcbb23a88087e7aaa01efbf080df538198e10e0
   report: null
 unrecoverable: null
 notes: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/VOICE_provenance.yaml
@@ -60,12 +60,10 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly_rep1/VOICE_d4d.yaml
     bytes: 64091
     slots: 68
-    sha256: 45c9c743c42f16c5055c89bfc7a9a178358bf3e62abc117c3f957332e166b1ac
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/VOICE_d4d_core.yaml
     bytes: 61371
     slots: 60
-    sha256: 6dd5cffb01abb6072cd764ef795481b1c4e6f1c06eac68a66b85634638c15c41
   report: null
 unrecoverable: null
 notes: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/CHORUS_provenance.yaml
@@ -61,12 +61,10 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly_rep2/CHORUS_d4d.yaml
     bytes: 43491
     slots: 59
-    sha256: 224439aa37a01b7b80c9c6ab2ec9f5bf5aeda08275e154be5315e4a3d23235a2
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/CHORUS_d4d_core.yaml
     bytes: 38296
     slots: 51
-    sha256: 97a8366d036baf5fe8d429e3dde17b32397c40c68b0855aa8cfad018018c3d60
   report: null
 unrecoverable: null
 notes: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/VOICE_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly_rep2/VOICE_d4d.yaml
     bytes: 60576
     slots: 68
-    sha256: 3d4306f32697810fdcd1feb5cdfc655c2a0db818ebfadeb3b51de6502847458a
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/VOICE_d4d_core.yaml
     bytes: 54540
     slots: 59
-    sha256: f2680b0201e33af2b9890b786cd6bfde66ff25e4c262fde1d3653d9b23a18a8e
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/VOICE_reconciliation.md
     bytes: 19095
     slots: null
-    sha256: 2dd2121a2b2fd925c65ae909a916ed07c959e3750aaf3df41e905f6d1616bbe1
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/CHORUS_provenance.yaml
@@ -61,12 +61,10 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly_rep3/CHORUS_d4d.yaml
     bytes: 42499
     slots: 54
-    sha256: cd744863d970e3a7eaec611829620576d8d2c24a35dc7797ae629debcabc0e48
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/CHORUS_d4d_core.yaml
     bytes: 39299
     slots: 47
-    sha256: 2ca3a929e56a49d1c871b6a28ee8e997462448a4023f397150bcb3708a3bd100
   report: null
 unrecoverable: null
 notes: null

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/VOICE_provenance.yaml
@@ -61,17 +61,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_crate_only/2026-07-28_claude-opus-5-crateonly_rep3/VOICE_d4d.yaml
     bytes: 77125
     slots: 67
-    sha256: 55a7fe6cc4142c361bec9af839dd0d521b66abdcb94a9ed3a786a18f2736e923
   core:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/VOICE_d4d_core.yaml
     bytes: 70852
     slots: 58
-    sha256: 747dabda606aaa910abfd519435460f99d23b9f2130a3f3b3d6ca089ccdac533
   report:
     path: data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/VOICE_reconciliation.md
     bytes: 24759
     slots: null
-    sha256: 4c98ab390279fc9282d29a4e148ec5379b7b932700a45099a4ebbb25f8fa7ffc
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep1/AI_READI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-27_claude-opus-5_rep1/AI_READI_d4d.yaml
     bytes: 75434
     slots: 66
-    sha256: 1433b9c2c63bd6c691c7f5d29215d0fdb95ecedf6cdf94fdc45997aad6b6eccb
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep1/AI_READI_d4d_core.yaml
     bytes: 66694
     slots: 56
-    sha256: b8c3ae5bf9477658ee522c6bb58f97e7114e66fb213304a19bd1b7b671be1975
   report:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep1/AI_READI_reconciliation.md
     bytes: 18156
     slots: null
-    sha256: 20ec083cf7c39dea1a5a25f0b8bda60ed61256859bfb48e0d70af4b1afda5513
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep2/AI_READI_provenance.yaml
@@ -52,17 +52,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-27_claude-opus-5_rep2/AI_READI_d4d.yaml
     bytes: 66185
     slots: 69
-    sha256: 2a776123994855706c87d82d00c452a40310b9d1b8ac02bbd3d105a907241e76
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep2/AI_READI_d4d_core.yaml
     bytes: 54606
     slots: 58
-    sha256: b49c82132be9d2aac4ac56f7d89ebb9aaa90fc25978741573825d5f0acce0978
   report:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep2/AI_READI_reconciliation.md
     bytes: 17359
     slots: null
-    sha256: 4d5e81651e8a1ee105ec7ed0cbac7db59a5bcaa7808b8af1c2e13bd87917bb34
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep3/AI_READI_provenance.yaml
@@ -53,17 +53,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-27_claude-opus-5_rep3/AI_READI_d4d.yaml
     bytes: 58744
     slots: 69
-    sha256: 8ac65c0363b5acebca2a07c58f52d032365316218b2fa6ebe865c533661f69da
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep3/AI_READI_d4d_core.yaml
     bytes: 47361
     slots: 57
-    sha256: 2c38544fd897743ac96e73d394fda8f30dffb913afefe6a9a1468ab97e198285
   report:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep3/AI_READI_reconciliation.md
     bytes: 14559
     slots: null
-    sha256: 2775bc07374dfc55ad2c93e5268ced1207b664d6d8b0b42a7539388e9c43ffa9
 unrecoverable:
 - field: system
   reason: hardware was not captured when this run executed

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_provenance.yaml
@@ -58,12 +58,10 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_d4d.yaml
-    md5: 5195ab247528314999bedcf1a6d09eef
     bytes: 73986
     slots: 74
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_d4d_core.yaml
-    md5: 31f92856ffacbb58998219fbd9f6f011
     bytes: 62302
     slots: 63
   report: null

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_provenance.yaml
@@ -58,17 +58,14 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_d4d.yaml
-    md5: 90e7046347d6c5697ef30032afe60e38
     bytes: 54023
     slots: 72
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_d4d_core.yaml
-    md5: d67bc70675cbf8be880f100b80bb9480
     bytes: 46475
     slots: 61
   report:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_reconciliation.md
-    md5: 1b638c394c7a5a9beaa5c710ced6d2a9
     bytes: 14224
     slots: null
 unrecoverable: null

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_provenance.yaml
@@ -58,12 +58,10 @@ inputs:
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_d4d.yaml
-    md5: c89ffc08e6fb6f759423c09086d2be75
     bytes: 70589
     slots: 74
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_d4d_core.yaml
-    md5: 7cf665f3f0a25b0cd693844cd8d43e60
     bytes: 57064
     slots: 61
   report: null

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
@@ -60,17 +60,14 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-28_claude-opus-5-generic_rep1/AI_READI_d4d.yaml
     bytes: 70400
     slots: 73
-    sha256: beb99f181c7577b0129a3aa219e27f477e96b7dc8d3e7a90abe2a8edb65bdcfc
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_d4d_core.yaml
     bytes: 59328
     slots: 62
-    sha256: c3fa46b9248897148ce8131b330a7c1a908c9c318735f60c5a92577de645c2b8
   report:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_reconciliation.md
     bytes: 15901
     slots: null
-    sha256: e0350694eb3d3f3d26dea9f020e36b301e9da622cd22488ead2b94808028ae16
 unrecoverable: null
 notes: null
 validation:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
@@ -60,12 +60,10 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-28_claude-opus-5-generic_rep2/AI_READI_d4d.yaml
     bytes: 62143
     slots: 70
-    sha256: 8a6839773650a4a486d032798fc5d65bff840861d08edb06411e276cbad640e5
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_d4d_core.yaml
     bytes: 54447
     slots: 58
-    sha256: ad77fd07568870ef7c8060372084e444cf5d21e1333a993dc5dbcdd72d35e6e8
   report: null
 unrecoverable: null
 notes: null

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
@@ -60,12 +60,10 @@ outputs:
     path: data/d4d_concatenated/claudecode_agent_healthsheet/2026-07-28_claude-opus-5-generic_rep3/AI_READI_d4d.yaml
     bytes: 54946
     slots: 67
-    sha256: 874608f4feac3a548c58766870668a2bd9b2f78bed9387d4b11ab8e26428b4d8
   core:
     path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_d4d_core.yaml
     bytes: 45265
     slots: 56
-    sha256: df8203dcf49b2ad313b35e28ea14d404be80b2247d0a8059c1920c3c6848c6da
   report: null
 unrecoverable: null
 notes: null

--- a/data/d4d_concatenated/claudecode_agent_merged_core/2026-07-29_guarded-union/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_merged_core/2026-07-29_guarded-union/CHORUS_provenance.yaml
@@ -3,7 +3,7 @@
 record_version: 1
 record_type: d4d_derived_provenance
 record_mode: derived
-record_generated_at: '2026-07-31T03:40:37+00:00'
+record_generated_at: '2026-07-31T02:05:07+00:00'
 run:
   label: 2026-07-29_guarded-union
   project: CHORUS
@@ -45,7 +45,7 @@ schema:
   full_path: src/data_sheets_schema/schema/data_sheets_schema_all.yaml
   full_sha256: 2065cea2d1a01c390ac1ef1d3db94be101f203f2a2682c0eee489ec29e45ebe9
   core_path: src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
-  core_sha256: 4a0a8b88e2fba9db3c4be91314bc41365af98df78683f6cba4e45d2d5e2fc5c6
+  core_sha256: 124b2494a1771366d2687a3f9f97782427942a5621643b23b6f004e3e2f04ee1
   merged_schema_carries_version: true
 software:
   data_sheets_schema: 0.1.0
@@ -53,17 +53,17 @@ software:
   linkml_runtime: 1.9.4
   python: 3.13.12
 repo:
-  commit: 29cfd3a4bc14b2bf7dab1ec7e613b9fd7344f0c6
-  commit_short: 29cfd3a4
-  branch: outputs-hash-unification
+  commit: 7373b9bcb51aa7ae9761f9b1621decbb50a3fcde
+  commit_short: 7373b9bc
+  branch: pre-run-checks
   dirty: true
-  dirty_file_count: 90
+  dirty_file_count: 96
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_merged/2026-07-29_guarded-union/CHORUS_d4d.yaml
+    sha256: 88ab3adaa8ba1b9f1036c312ae6588b5e7086c93c0e0ed0ec5b0a83664d37f24
     bytes: 58900
     slots: 59
-    sha256: 88ab3adaa8ba1b9f1036c312ae6588b5e7086c93c0e0ed0ec5b0a83664d37f24
 not_applicable:
 - field: model
   reason: no model produced this record; it combines existing ones

--- a/data/d4d_concatenated/claudecode_agent_merged_core/2026-07-29_guarded-union/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_merged_core/2026-07-29_guarded-union/CHORUS_provenance.yaml
@@ -3,7 +3,7 @@
 record_version: 1
 record_type: d4d_derived_provenance
 record_mode: derived
-record_generated_at: '2026-07-31T02:05:07+00:00'
+record_generated_at: '2026-07-31T03:40:37+00:00'
 run:
   label: 2026-07-29_guarded-union
   project: CHORUS
@@ -45,7 +45,7 @@ schema:
   full_path: src/data_sheets_schema/schema/data_sheets_schema_all.yaml
   full_sha256: 2065cea2d1a01c390ac1ef1d3db94be101f203f2a2682c0eee489ec29e45ebe9
   core_path: src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
-  core_sha256: 124b2494a1771366d2687a3f9f97782427942a5621643b23b6f004e3e2f04ee1
+  core_sha256: 4a0a8b88e2fba9db3c4be91314bc41365af98df78683f6cba4e45d2d5e2fc5c6
   merged_schema_carries_version: true
 software:
   data_sheets_schema: 0.1.0
@@ -53,17 +53,17 @@ software:
   linkml_runtime: 1.9.4
   python: 3.13.12
 repo:
-  commit: 7373b9bcb51aa7ae9761f9b1621decbb50a3fcde
-  commit_short: 7373b9bc
-  branch: pre-run-checks
+  commit: 29cfd3a4bc14b2bf7dab1ec7e613b9fd7344f0c6
+  commit_short: 29cfd3a4
+  branch: outputs-hash-unification
   dirty: true
-  dirty_file_count: 96
+  dirty_file_count: 90
 outputs:
   full:
     path: data/d4d_concatenated/claudecode_agent_merged/2026-07-29_guarded-union/CHORUS_d4d.yaml
-    sha256: 88ab3adaa8ba1b9f1036c312ae6588b5e7086c93c0e0ed0ec5b0a83664d37f24
     bytes: 58900
     slots: 59
+    sha256: 88ab3adaa8ba1b9f1036c312ae6588b5e7086c93c0e0ed0ec5b0a83664d37f24
 not_applicable:
 - field: model
   reason: no model produced this record; it combines existing ones

--- a/data/d4d_concatenated/curated/AI_READI_curated_provenance.yaml
+++ b/data/d4d_concatenated/curated/AI_READI_curated_provenance.yaml
@@ -30,7 +30,6 @@ outputs:
   full:
     path: data/d4d_concatenated/curated/AI_READI_curated.yaml
     bytes: 7303
-    sha256: 12f08bddcddf2eb00c181308e886e927667b1db2e7710b45182f34616102cdbf
 repo:
   commit: 2b730155789095d8c09ce67d077807a5cca5fcf6
   commit_short: 2b730155

--- a/data/d4d_concatenated/curated/CM4AI_curated_provenance.yaml
+++ b/data/d4d_concatenated/curated/CM4AI_curated_provenance.yaml
@@ -30,7 +30,6 @@ outputs:
   full:
     path: data/d4d_concatenated/curated/CM4AI_curated.yaml
     bytes: 84902
-    sha256: 1d7649fa6a6b89e77eb45677529b63f0d0f2eeb8687a71b3101fe71cc99a6339
 repo:
   commit: 2b730155789095d8c09ce67d077807a5cca5fcf6
   commit_short: 2b730155

--- a/data/d4d_concatenated/curated/VOICE_curated_provenance.yaml
+++ b/data/d4d_concatenated/curated/VOICE_curated_provenance.yaml
@@ -30,7 +30,6 @@ outputs:
   full:
     path: data/d4d_concatenated/curated/VOICE_curated.yaml
     bytes: 17295
-    sha256: f2f7ccd2d3837913a4382b9b5e1f4087ad1295ced3d756befc1dab3eb0337f2e
 repo:
   commit: 2b730155789095d8c09ce67d077807a5cca5fcf6
   commit_short: 2b730155

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -248,11 +248,35 @@ def _slot_count(path: Path) -> int | None:
 
 
 def _artifact(path: Path) -> dict[str, Any] | None:
+    """Describe an artifact without asserting its integrity.
+
+    No hash, deliberately. A hash is a *claim*, and this one was made at the
+    wrong moment: the agent path recorded provenance as a separate step from
+    writing the artifacts, so 77 live records hashed a state their files merely
+    passed through — one reconciliation report was hashed before its closing
+    rows were appended, and the `-deprimed` series was hashed before its headers
+    were relabelled. Nothing verified the claim, so it stayed wrong.
+
+    Integrity now lives in exactly one place: `validation.artifacts`, written by
+    `d4d runs validate` *after* the run, and re-checked by `validation_status`.
+    Hashing after the artifacts are final removes the race rather than
+    detecting it.
+
+    `bytes` and `slots` remain. They describe rather than assert, and a
+    description that drifts is a stale note, not a false guarantee.
+    """
     if not path.exists():
         return None
-    return {"path": str(path), "sha256": _sha256(path),
-            "bytes": path.stat().st_size,
+    return {"path": str(path), "bytes": path.stat().st_size,
             "slots": _slot_count(path) if path.suffix == ".yaml" else None}
+
+
+def _hashed_artifact(path: Path) -> dict[str, Any] | None:
+    """Describe an artifact *and* pin it. Only for use after a run is complete."""
+    art = _artifact(path)
+    if art is None:
+        return None
+    return {**art, "sha256": _sha256(path)}
 
 
 def recorded_hash(entry: dict[str, Any]) -> tuple[str, str] | None:
@@ -318,7 +342,9 @@ class Contribution:
 
 def contribution(path: Path, *, label: str, project: str, method: str,
                  contributed_slots: int | None = None) -> Contribution:
-    art = _artifact(path)
+    # Hashed: a contributing record must be pinned, or "this came from those"
+    # is an assertion rather than something checkable.
+    art = _hashed_artifact(path)
     if art is None:
         raise FileNotFoundError(f"contributing record does not exist: {path}")
     return Contribution(label=label, project=project, method=method,
@@ -399,7 +425,10 @@ def build_derived_record(project: str, method: str, label: str, *,
         "schema": schema_facts(),
         "software": software_facts(),
         "repo": repo_facts(),
-        "outputs": {k: _artifact(v) for k, v in outputs.items()},
+        # Hashed here, unlike a generation record: a derived record has no
+        # validation block, its output is written and hashed in one step, and
+        # the whole point of the record is to pin what came from what.
+        "outputs": {k: _hashed_artifact(v) for k, v in outputs.items()},
         "not_applicable": [
             {"field": "model",
              "reason": "no model produced this record; it combines existing ones"},
@@ -638,3 +667,35 @@ def migrate_record_hashes(path: Path, *, dry_run: bool = True) -> dict[str, Any]
 
     return {"path": str(path), "migrated": migrated, "skipped": skipped,
             "dry_run": dry_run}
+
+
+def strip_output_hashes(path: Path, *, dry_run: bool = True) -> dict[str, Any]:
+    """Remove integrity claims from `outputs`, keeping the description.
+
+    Not a cover-up of the 89 stale hashes: it is the removal of a claim that was
+    made at the wrong moment and never checked. The artifacts themselves are
+    pinned by `validation.artifacts`, written after the run and verified
+    164/164. Keeping a second, earlier, unverified hash meant maintaining two
+    claims about the same bytes and believing the wrong one.
+
+    `bytes` and `slots` stay. A stale description is a note that has drifted; a
+    stale hash is a guarantee that is false.
+    """
+    import yaml as _yaml
+
+    data = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if data.get("record_mode") == "derived":
+        # A derived record has no validation block; its outputs are the only
+        # pinning it has, and they are written and hashed in one step.
+        return {"path": str(path), "removed": [], "skipped": "derived record"}
+
+    removed = []
+    for key, entry in (data.get("outputs") or {}).items():
+        if not isinstance(entry, dict):
+            continue
+        for algo in ("sha256", "md5"):
+            if entry.pop(algo, None) is not None:
+                removed.append(f"outputs.{key}.{algo}")
+    if removed and not dry_run:
+        ProvenanceRecord(data=data).write(path)
+    return {"path": str(path), "removed": removed, "dry_run": dry_run}

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -326,13 +326,27 @@ def check_provenance(method: str, label: str, project: str,
     # report was pinned before its closing rows were appended. The API path
     # cannot do this, because it writes provenance in-process after all phases.
     # Checking at the end of a run gives the agent path the same property.
-    drifted = [k for k, e in
-               (((_prov(method, label, project, concat_dir) or {})
-                 .get("validation") or {}).get("artifacts") or {}).items()
+    artifacts = (((_prov(method, label, project, concat_dir) or {})
+                  .get("validation") or {}).get("artifacts") or {})
+    drifted = [k for k, e in artifacts.items()
                if isinstance(e, dict) and _verify(e) is False]
+    # Three outcomes, not two. `verify_entry` returns None when a file is absent
+    # — unknowable is not mismatched, and conflating them would report a moved
+    # file as tampering. But treating unknowable as *fine* inverts the gate: it
+    # gave its strongest assurance exactly where there was least to go on, so a
+    # run with no validation block, or whose artifacts were deleted, passed.
+    unverifiable = [k for k, e in artifacts.items()
+                    if isinstance(e, dict) and _verify(e) is None]
+    if not artifacts:
+        unverifiable = ["(no validation block)"]
 
-    ok = ((not required) or mode == "live") and not drifted
-    if drifted:
+    ok = (((not required) or mode == "live")
+          and not drifted and not unverifiable)
+    if unverifiable and not drifted:
+        reason = (f"nothing to verify: {', '.join(unverifiable)}. A run that "
+                  "cannot be checked is not a run that passed — record "
+                  "validation with `d4d runs validate`.")
+    elif drifted:
         reason = (f"artifacts changed after provenance was recorded: "
                   f"{', '.join(drifted)}. The record pins bytes the files no "
                   "longer have — re-run `d4d runs validate` so the record "
@@ -350,6 +364,7 @@ def check_provenance(method: str, label: str, project: str,
                   "was observed.")
     return {"method": method, "label": label, "project": project,
             "record_mode": mode, "attestation": level, "drifted": drifted,
+            "unverifiable": unverifiable,
             "required": required, "ok": ok, "reason": reason}
 
 

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -342,7 +342,14 @@ def check_provenance(method: str, label: str, project: str,
 
     ok = (((not required) or mode == "live")
           and not drifted and not unverifiable)
-    if unverifiable and not drifted:
+    # Ordered by how fundamental the condition is, because the remedies differ.
+    # A record that does not exist is not the same as one with nothing to
+    # verify: the first needs a record written, the second needs it validated.
+    if mode == "none":
+        reason = ("no provenance record. The run cannot state the conditions it "
+                  "ran under, and nobody can reconstruct them later with "
+                  "certainty.")
+    elif unverifiable and not drifted:
         reason = (f"nothing to verify: {', '.join(unverifiable)}. A run that "
                   "cannot be checked is not a run that passed — record "
                   "validation with `d4d runs validate`.")
@@ -354,10 +361,6 @@ def check_provenance(method: str, label: str, project: str,
     elif ok:
         reason = ("live provenance present" if mode == "live"
                   else f"predates {LIVE_REQUIRED_FROM}; not required")
-    elif mode == "none":
-        reason = ("no provenance record. The run cannot state the conditions it "
-                  "ran under, and nobody can reconstruct them later with "
-                  "certainty.")
     else:
         reason = (f"provenance is {mode}, not live. It was assembled after the "
                   "fact, so it reports what could be recovered rather than what "

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -319,8 +319,25 @@ def check_provenance(method: str, label: str, project: str,
     mode = record_mode(method, label, project, concat_dir)
     level = attestation(method, label, project, concat_dir)
     required = requires_live(label)
-    ok = (not required) or mode == "live"
-    if ok:
+
+    # Re-verify, do not merely note the presence of a hash. The agent path
+    # records provenance as a step separate from writing the artifacts, so a
+    # hash can describe a state the file passed through — one reconciliation
+    # report was pinned before its closing rows were appended. The API path
+    # cannot do this, because it writes provenance in-process after all phases.
+    # Checking at the end of a run gives the agent path the same property.
+    drifted = [k for k, e in
+               (((_prov(method, label, project, concat_dir) or {})
+                 .get("validation") or {}).get("artifacts") or {}).items()
+               if isinstance(e, dict) and _verify(e) is False]
+
+    ok = ((not required) or mode == "live") and not drifted
+    if drifted:
+        reason = (f"artifacts changed after provenance was recorded: "
+                  f"{', '.join(drifted)}. The record pins bytes the files no "
+                  "longer have — re-run `d4d runs validate` so the record "
+                  "describes what actually shipped.")
+    elif ok:
         reason = ("live provenance present" if mode == "live"
                   else f"predates {LIVE_REQUIRED_FROM}; not required")
     elif mode == "none":
@@ -332,8 +349,21 @@ def check_provenance(method: str, label: str, project: str,
                   "fact, so it reports what could be recovered rather than what "
                   "was observed.")
     return {"method": method, "label": label, "project": project,
-            "record_mode": mode, "attestation": level,
+            "record_mode": mode, "attestation": level, "drifted": drifted,
             "required": required, "ok": ok, "reason": reason}
+
+
+def _prov(method: str, label: str, project: str,
+          concat_dir: Path = CONCAT_DIR) -> dict | None:
+    import yaml as _yaml
+    from data_sheets_schema.provenance import record_path_for
+    p = record_path_for(project, method, label, concat_dir)
+    return (_yaml.safe_load(p.read_text(encoding="utf-8")) or {}) if p.exists() else None
+
+
+def _verify(entry: dict) -> bool | None:
+    from data_sheets_schema.provenance import verify_entry
+    return verify_entry(entry)
 
 
 def attestation(method: str, label: str, project: str,
@@ -385,13 +415,15 @@ def attestation(method: str, label: str, project: str,
         if not any(_get(d) for d in alternatives):
             return PARTIAL
 
-    # Outputs are checked for a *hash*, not for the presence of the block.
-    # `{"full": None, "core": None}` is a truthy dict that pins nothing, so
-    # testing the container let a record naming its artifacts without hashing
-    # any of them count as attested.
-    outputs = data.get("outputs") or {}
+    # The pinning artifact hash lives in `validation.artifacts`, not `outputs`.
+    # `outputs` used to carry one, recorded before the artifacts were final, and
+    # 77 live records pinned a state their files merely passed through. Hashing
+    # moved to after the run; `outputs` now describes rather than asserts, so a
+    # record is attested when *something* pins its artifacts, wherever that is.
+    pinned = data.get("outputs") or {}
+    validated = ((data.get("validation") or {}).get("artifacts") or {})
     if not any(isinstance(a, dict) and (a.get("sha256") or a.get("md5"))
-               for a in outputs.values() if a):
+               for a in list(pinned.values()) + list(validated.values()) if a):
         return PARTIAL
 
     # A bundle md5 computed today from a file that may have changed says nothing

--- a/tests/test_rocrate/test_provenance.py
+++ b/tests/test_rocrate/test_provenance.py
@@ -231,13 +231,16 @@ class TestHashUnification(unittest.TestCase):
     reported STALE.
     """
 
-    def test_new_artifacts_are_hashed_with_sha256(self):
+    def test_new_hashes_use_sha256_not_md5(self):
+        """Applies wherever a hash is still taken — validation blocks, derived
+        records, contributions. `_artifact` itself no longer hashes at all; see
+        TestOutputsDescribeRatherThanAssert."""
         import tempfile
-        from data_sheets_schema.provenance import _artifact
+        from data_sheets_schema.provenance import _hashed_artifact
         with tempfile.TemporaryDirectory() as td:
             f = Path(td) / "x.yaml"
             f.write_text("id: x\n")
-            art = _artifact(f)
+            art = _hashed_artifact(f)
             self.assertIn("sha256", art)
             self.assertNotIn("md5", art)
 
@@ -354,3 +357,116 @@ class TestSchemaArtifactsStayInSync(unittest.TestCase):
         if not p.exists():
             self.skipTest("core schema not present")
         self.assertTrue(SchemaView(str(p)).get_slot("md5").deprecated)
+
+
+class TestOutputsDescribeRatherThanAssert(unittest.TestCase):
+    """One hash-bearing section, written after the run (#203).
+
+    `outputs` used to carry a hash recorded before the artifacts were final. In
+    the agent path — which writes provenance as a step separate from writing
+    the artifacts — that pinned a state the files merely passed through: 77 live
+    records drifted, one report hashed before its closing rows were appended and
+    a whole series hashed before its headers were edited. Nothing verified it,
+    so it stayed wrong.
+    """
+
+    def test_a_generation_output_entry_carries_no_hash(self):
+        import tempfile
+        from data_sheets_schema.provenance import _artifact
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "x.yaml"
+            f.write_text("id: x\n")
+            art = _artifact(f)
+            self.assertNotIn("sha256", art)
+            self.assertNotIn("md5", art)
+            self.assertIn("bytes", art)
+            self.assertIn("slots", art)
+
+    def test_the_hashed_form_is_still_available_for_derived_records(self):
+        import tempfile
+        from data_sheets_schema.provenance import _hashed_artifact
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "x.yaml"
+            f.write_text("id: x\n")
+            self.assertIn("sha256", _hashed_artifact(f))
+
+    def test_the_corpus_has_no_hashes_in_generation_outputs(self):
+        import yaml as _yaml
+        offenders = []
+        for p in Path("data/d4d_concatenated").rglob("*_provenance.yaml"):
+            d = _yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            if d.get("record_mode") == "derived":
+                continue          # its outputs are its only pinning
+            for k, e in (d.get("outputs") or {}).items():
+                if isinstance(e, dict) and (e.get("sha256") or e.get("md5")):
+                    offenders.append(f"{p.parent.name}/{p.name}:{k}")
+        self.assertEqual(offenders[:5], [], f"{len(offenders)} hashed outputs")
+
+    def test_derived_records_keep_their_output_hash(self):
+        import yaml as _yaml
+        seen = 0
+        for p in Path("data/d4d_concatenated").rglob("*_provenance.yaml"):
+            d = _yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            if d.get("record_mode") != "derived":
+                continue
+            for e in (d.get("outputs") or {}).values():
+                if isinstance(e, dict) and e.get("path"):
+                    self.assertTrue(e.get("sha256"),
+                                    "a derived record has no validation block; "
+                                    "its outputs are its only pinning")
+                    seen += 1
+        if not seen:
+            self.skipTest("no derived records present")
+
+
+class TestTheEndOfRunGate(unittest.TestCase):
+    """`d4d runs check` re-verifies rather than noting a hash is present."""
+
+    def _fixture(self, td, content=b"original"):
+        import hashlib
+        import yaml as _yaml
+        c = Path(td)
+        label = "2026-07-30_x_rep1"
+        art = c / "m" / label / "P_d4d.yaml"
+        art.parent.mkdir(parents=True)
+        art.write_bytes(content)
+        prov = c / "m_core" / label / "P_provenance.yaml"
+        prov.parent.mkdir(parents=True)
+        prov.write_text(_yaml.safe_dump({
+            "record_mode": "live",
+            "validation": {"artifacts": {"full": {
+                "path": str(art),
+                "sha256": hashlib.sha256(content).hexdigest()}}}}))
+        return c, label, art
+
+    def test_a_matching_run_passes(self):
+        import tempfile
+        from data_sheets_schema.runs import check_provenance
+        with tempfile.TemporaryDirectory() as td:
+            c, label, _ = self._fixture(td)
+            self.assertTrue(check_provenance("m", label, "P", c)["ok"])
+
+    def test_an_artifact_edited_after_the_record_fails(self):
+        import tempfile
+        from data_sheets_schema.runs import check_provenance
+        with tempfile.TemporaryDirectory() as td:
+            c, label, art = self._fixture(td)
+            art.write_bytes(b"edited after the record was written")
+            r = check_provenance("m", label, "P", c)
+            self.assertFalse(r["ok"])
+            self.assertEqual(r["drifted"], ["full"])
+            self.assertIn("changed after provenance was recorded", r["reason"])
+
+    def test_the_whole_corpus_passes_the_gate(self):
+        from data_sheets_schema.runs import check_provenance, discover, is_complete
+        failing = []
+        for run in discover():
+            if run.is_core or run.deterministic:
+                continue
+            for proj in run.projects:
+                if not is_complete(run.method, run.label, proj):
+                    continue
+                r = check_provenance(run.method, run.label, proj)
+                if not r["ok"]:
+                    failing.append(f"{proj}/{run.label}: {r['reason'][:50]}")
+        self.assertEqual(failing[:3], [], f"{len(failing)} runs fail the gate")

--- a/tests/test_rocrate/test_provenance.py
+++ b/tests/test_rocrate/test_provenance.py
@@ -470,3 +470,76 @@ class TestTheEndOfRunGate(unittest.TestCase):
                 if not r["ok"]:
                     failing.append(f"{proj}/{run.label}: {r['reason'][:50]}")
         self.assertEqual(failing[:3], [], f"{len(failing)} runs fail the gate")
+
+
+class TestNothingToVerifyIsNotAPass(unittest.TestCase):
+    """The gate must not give its strongest assurance where there is least
+    to go on (#208).
+
+    `verify_entry` returns None for an absent file — unknowable is not
+    mismatched, and conflating them would report a moved file as tampering. But
+    treating unknowable as *fine* inverted the gate's purpose: a run with no
+    validation block, or whose artifacts were deleted, passed `--strict`.
+    """
+
+    def _record(self, td, body):
+        import yaml as _yaml
+        c = Path(td)
+        d = c / "m_core" / "2026-07-30_x_rep1"
+        d.mkdir(parents=True)
+        (d / "P_provenance.yaml").write_text(_yaml.safe_dump(body))
+        return c
+
+    def test_a_record_with_no_validation_block_does_not_pass(self):
+        import tempfile
+        from data_sheets_schema.runs import check_provenance
+        with tempfile.TemporaryDirectory() as td:
+            c = self._record(td, {"record_mode": "live"})
+            r = check_provenance("m", "2026-07-30_x_rep1", "P", c)
+            self.assertFalse(r["ok"])
+            self.assertIn("nothing to verify", r["reason"])
+
+    def test_a_missing_artifact_does_not_pass(self):
+        import tempfile
+        from data_sheets_schema.runs import check_provenance
+        with tempfile.TemporaryDirectory() as td:
+            c = self._record(td, {"record_mode": "live", "validation": {
+                "artifacts": {"full": {"path": f"{td}/gone.yaml",
+                                       "sha256": "abc"}}}})
+            r = check_provenance("m", "2026-07-30_x_rep1", "P", c)
+            self.assertFalse(r["ok"])
+            self.assertEqual(r["unverifiable"], ["full"])
+            self.assertEqual(r["drifted"], [], "absent is not drifted")
+
+    def test_a_present_matching_artifact_passes(self):
+        import hashlib
+        import tempfile
+        from data_sheets_schema.runs import check_provenance
+        with tempfile.TemporaryDirectory() as td:
+            a = Path(td) / "a.yaml"
+            a.write_bytes(b"x")
+            c = self._record(td, {"record_mode": "live", "validation": {
+                "artifacts": {"full": {
+                    "path": str(a),
+                    "sha256": hashlib.sha256(b"x").hexdigest()}}}})
+            r = check_provenance("m", "2026-07-30_x_rep1", "P", c)
+            self.assertTrue(r["ok"])
+            self.assertEqual(r["unverifiable"], [])
+
+    def test_drift_and_absence_are_reported_separately(self):
+        """Different conditions with different remedies: re-validate versus
+        find out where the artifact went."""
+        import hashlib
+        import tempfile
+        from data_sheets_schema.runs import check_provenance
+        with tempfile.TemporaryDirectory() as td:
+            a = Path(td) / "a.yaml"
+            a.write_bytes(b"edited")
+            c = self._record(td, {"record_mode": "live", "validation": {
+                "artifacts": {
+                    "full": {"path": str(a),
+                             "sha256": hashlib.sha256(b"original").hexdigest()},
+                    "core": {"path": f"{td}/gone.yaml", "sha256": "abc"}}}})
+            r = check_provenance("m", "2026-07-30_x_rep1", "P", c)
+            self.assertEqual(r["drifted"], ["full"])
+            self.assertEqual(r["unverifiable"], ["core"])


### PR DESCRIPTION
#203 looked like stale metadata. Chasing it found a defect in the agent path.

## Diagnosis

Split by who wrote the provenance:

| record_mode / runtime | ok | stale |
|---|---|---|
| live, **Claude API (direct)** | 3 | **0** |
| live, **Claude Code** | 55 | **77** |
| reconstructed, Claude Code | 87 | 12 |
| derived | 4 | 0 |

Every problematic entry is `live` + Claude Code, and the paths differ in one
respect. `execute()` writes provenance **in-process after all six phases** and
cannot hash a partial artifact. The agent path writes the artifacts, then a
*separate* `d4d provenance record` invocation hashes them — and nothing orders
that command against the agent finishing, or against later edits.

**Two confirmed instances:**

1. **A report hashed before it was finished.**
   `generic_rep3/CM4AI_reconciliation.md`, +318 bytes. The missing bytes are the
   *end* of the report — the last table rows and the line-count note.
2. **Headers hashed before an edit.** The `-deprimed` series, 54 entries with a
   *constant* delta: `full` −8 bytes, `core` −7, exactly 27 each. A fixed-length
   edit across every file, from relabelling that series. Slot counts match
   exactly, so no content moved.

Both are one failure: **the hash described a state the artifact passed through,
not the state it ended in.**

## What changed

**Hashing moved to after the run.** `outputs` now carries `path`, `bytes` and
`slots` and no hash — 237 removed across 85 records. Integrity lives in
`validation.artifacts` alone, written by `d4d runs validate` after the run and
verifying **164/164**.

Removing the earlier claim is not a cover-up. It was made at the wrong moment and
never checked, and maintaining two claims about the same bytes meant believing
the wrong one. A stale `bytes` is a note that has drifted; a stale hash is a false
guarantee.

**The gap is closed, not merely avoided.** `check_provenance` re-verifies the
recorded hashes rather than noting that a hash exists, and names the artifacts
that drifted. The playbook's completion criteria now require
`d4d runs check --strict`: recording provenance is not the same as recording it
correctly.

**Order was deliberate.** Stripping the hashes first would have erased the
evidence before the gap was closed, and the next relabelling would have silently
reintroduced it.

**Derived records keep their output hash** — they have no validation block, their
output is written and hashed in one step, and pinning what came from what is the
entire point.

## On the cost of dropping the report hash

The `report` was the only artifact hashed solely in `outputs`, so this removes
its only hash. That is the right trade *because* the report is where the defect
showed: the one confirmed mid-run race was a report hashed before its closing
rows existed. A hash taken at that moment is not protection, it is a false
guarantee. What replaces it is that nothing hashes mid-run any more, so the race
cannot occur.

## Verification

- `747 passed, 3 skipped`
- Corpus unchanged: attested 33, live 49, derived 4, none 1; valid 82, **stale 0**
- `d4d runs check --strict` exits 0 across the corpus
- The gate catches a post-run edit in a fixture and names the drifted field
- A fresh derived record still pins sources *and* outputs by sha256
- 237 generation-output hashes removed; the 4 derived ones retained

## A bug the tests caught

`contribution()` read `art["sha256"]` from `_artifact`, which no longer hashes,
so every derived record would have failed at construction. Second time this
session a moved key broke that function; it is now the only caller of the hashed
form, which makes the coupling explicit.

Closes #203.
