### PR TITLE
Check stated values against declared sources (#165); fix six defects found by review

### DIFF
--- a/src/data_sheets_schema/cli/evaluate.py
+++ b/src/data_sheets_schema/cli/evaluate.py
@@ -34,20 +34,34 @@ def verifiable_cmd(project, method, labels, show):
     """
     import yaml as _yaml
     from data_sheets_schema.runs import discover, record_path
-    from data_sheets_schema.verifiable import check_record, identifier_slots
+    from data_sheets_schema.verifiable import (
+        check_record, declared_bundle, identifier_slots,
+    )
 
     skip = identifier_slots()
     wanted = set(labels)
     rows = []
     for run in discover():
-        if run.is_core or run.deterministic or run.method != method:
+        # Skip core/deterministic runs only when the caller did not name one.
+        # Filtering them unconditionally made `--method claudecode_agent_core`
+        # report "No records matched" for records that plainly exist.
+        if run.method != method:
+            continue
+        if (run.is_core or run.deterministic) and method == "claudecode_agent":
             continue
         if wanted and run.label not in wanted:
             continue
         for proj in run.projects:
             if project and proj != project:
                 continue
-            bundle = Path("data/preprocessed/concatenated") / f"{proj}_preprocessed.txt"
+            # The bundle the run declared, not the baseline one. See
+            # verifiable.declared_bundle: arms read different inputs, and
+            # assuming the baseline reported the whole crate arm as inventing
+            # every value it stated.
+            bundle = declared_bundle(run.method, run.label, proj)
+            if bundle is None:
+                bundle = (Path("data/preprocessed/concatenated")
+                          / f"{proj}_preprocessed.txt")
             rec = record_path(run.method, run.label, proj)
             if not (bundle.exists() and rec and rec.exists()):
                 continue

--- a/src/data_sheets_schema/cli/evaluate.py
+++ b/src/data_sheets_schema/cli/evaluate.py
@@ -14,6 +14,67 @@ def evaluate():
     """D4D evaluation commands."""
     pass
 
+@evaluate.command("verifiable")
+@click.option("--project", default=None, help="limit to one project")
+@click.option("--method", default="claudecode_agent")
+@click.option("--label", "labels", multiple=True, help="run label(s); default all")
+@click.option("--show", default=0, type=int,
+              help="list up to N ungrounded values per record")
+def verifiable_cmd(project, method, labels, show):
+    """Check the values a record states against the documents it declared.
+
+    Answers the half of #165 that survives having no gold standard: a DOI, a
+    date, a count and an accession must appear literally in a source document,
+    because that is where they came from. No reference record is needed, and no
+    LLM.
+
+    `stated` is printed beside `grounded` on purpose. A record that states
+    nothing is trivially correct on everything it states, so the ratio alone
+    would rank an empty record top.
+    """
+    import yaml as _yaml
+    from data_sheets_schema.runs import discover, record_path
+    from data_sheets_schema.verifiable import check_record, identifier_slots
+
+    skip = identifier_slots()
+    wanted = set(labels)
+    rows = []
+    for run in discover():
+        if run.is_core or run.deterministic or run.method != method:
+            continue
+        if wanted and run.label not in wanted:
+            continue
+        for proj in run.projects:
+            if project and proj != project:
+                continue
+            bundle = Path("data/preprocessed/concatenated") / f"{proj}_preprocessed.txt"
+            rec = record_path(run.method, run.label, proj)
+            if not (bundle.exists() and rec and rec.exists()):
+                continue
+            r = check_record(_yaml.safe_load(rec.read_text(encoding="utf-8")),
+                             bundle.read_text(encoding="utf-8"),
+                             project=proj, label=run.label, skip_slots=skip)
+            rows.append(r)
+
+    if not rows:
+        click.echo("No records matched."); return
+
+    click.echo(f"{'project':10}{'label':38}{'stated':>7}{'grounded':>9}{'rate':>7}")
+    for r in sorted(rows, key=lambda x: (x.project, x.label)):
+        rate = f"{r.rate:.1%}" if r.rate is not None else "  n/a"
+        click.echo(f"{r.project:10}{r.label:38}{r.stated:>7}{r.grounded:>9}{rate:>7}")
+        for c in r.ungrounded[:show]:
+            click.echo(f"    [{c.kind}] {c.slot}: {c.value[:70]}")
+
+    total_stated = sum(r.stated for r in rows)
+    total_ok = sum(r.grounded for r in rows)
+    click.echo(f"\n{total_ok}/{total_stated} values grounded across "
+               f"{len(rows)} record(s)")
+    click.echo("A value is 'ungrounded' when it appears in no declared source "
+               "document. Identifiers the generator mints are excluded — they "
+               "are not claims about the world.")
+
+
 @evaluate.command()
 @click.option('--project', type=click.Choice(PROJECTS),
               help='Evaluate specific project only (default: all)')

--- a/src/data_sheets_schema/verifiable.py
+++ b/src/data_sheets_schema/verifiable.py
@@ -12,10 +12,37 @@ accession, a participant count, a release date: these are tokens that must appea
 record states `10.13026/249v-w155` and no input document contains it, the record
 invented it — and no comparison with another record was needed to know that.
 
+## The asymmetry, which is the whole basis of this module
+
+**Absence is evidence; presence is not.** A token absent from every declared
+source cannot have been read from one, so `ungrounded` is a real finding.
+`grounded` means only that the characters occur somewhere in the corpus, which is
+much weaker:
+
+- **Coincidence passes.** `participants: 2025` is "grounded" by a document that
+  says "published in 2025". The check has no notion of what the number counts.
+- **Correct derivation fails.** A record stating 2,000 participants from a source
+  describing "1,000 cases and 1,000 controls" is reported ungrounded, correctly
+  by this method's rule and wrongly as a matter of fact.
+
+So the `rate` is *not* an accuracy score, and must not be reported as one. It is
+the proportion of stated tokens that could be located, and its useful direction is
+downward: a record that drops relative to its peers is asserting things its
+sources do not contain. Treat `ungrounded` as a list to read, not a number to
+optimise.
+
 This deliberately does not attempt prose. "The dataset addresses a gap in
 multimodal voice research" is not checkable this way and is not the target;
 `evidence_score.py` covers the schema-fitness question, and neither addresses
 whether a claim is *true* in general.
+
+## What is not counted, and which way that biases the rate
+
+Counts below four digits are skipped: in an 80k-token corpus a three-digit
+figure matches something almost always, so including them would manufacture
+grounding rather than measure it. Accessions cover five prefixes. Both
+exclusions shrink the denominator, and both therefore bias the reported rate
+*upward* — the check is more forgiving than it looks, not less.
 
 ## Why identifiers are excluded
 
@@ -42,7 +69,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
 
-FULL_SCHEMA = Path("src/data_sheets_schema/schema/data_sheets_schema_all.yaml")
+# Resolved from this file, not the working directory. Running the CLI from a
+# subdirectory tried to open `tests/src/data_sheets_schema/schema/...`.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+FULL_SCHEMA = _REPO_ROOT / "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
 
 # Token kinds that must appear verbatim in a source document if they are real.
 # Deliberately narrow: each is a string a human copied from somewhere, not a
@@ -108,6 +138,26 @@ class RecordCheck:
         return {k: (v[0], v[1]) for k, v in out.items()}
 
 
+def declared_bundle(method: str, label: str, project: str) -> Path | None:
+    """The bundle a run actually declared, read from its provenance.
+
+    Not `{project}_preprocessed.txt`. Arms read different inputs — `crate_only`
+    reads `{project}_crate_only.txt` — and checking every run against the
+    baseline bundle reported the whole crate arm as fabricating everything: 0 of
+    5 DOIs, 0 of 11 URLs, 0 of 3 dates on one CHORUS record, for values that are
+    presumably in the crate it was given. The provenance already records the
+    answer; assuming it was the failure.
+    """
+    import yaml as _yaml
+    from data_sheets_schema.provenance import record_path_for
+    rec = record_path_for(project, method, label)
+    if not rec.exists():
+        return None
+    data = _yaml.safe_load(rec.read_text(encoding="utf-8")) or {}
+    path = (data.get("inputs") or {}).get("bundle_path")
+    return Path(path) if path else None
+
+
 def identifier_slots(schema_path: Path = FULL_SCHEMA) -> set[str]:
     """Slots whose string values are constructed identifiers, not assertions.
 
@@ -149,19 +199,26 @@ def renderings(kind: str, value: str) -> list[str]:
     where a bundle-wide rewrite hides which transformations were applied.
     """
     v = normalise(kind, value)
+    if kind == "count":
+        return number_renderings(v)
     if kind != "iso_date":
         return [v]
+    # Validated as a real calendar date, not merely three numbers. `MONTHS[m-1]`
+    # with m == 0 indexes backwards and rendered `2025-00-17` as "December 17,
+    # 2025" — an impossible date reported as grounded. `date()` rejects month 0,
+    # day 31 in June, and 29 February in a common year alike.
+    import datetime
     try:
-        y, m, d = (int(x) for x in value.split("-"))
-        month = MONTHS[m - 1]
-    except (ValueError, IndexError):
+        parts = [int(x) for x in value.split("-")]
+        dt = datetime.date(*parts)
+    except (ValueError, TypeError):
         return [v]
+    y, m, d, month = dt.year, dt.month, dt.day, MONTHS[dt.month - 1]
     return [v,
             f"{month} {d}, {y}".lower(),
             f"{month} {d:02d}, {y}".lower(),
             f"{d} {month} {y}".lower(),
             f"{d:02d} {month} {y}".lower(),
-            f"{month} {y}".lower(),          # month precision in the source
             f"{m:02d}/{d:02d}/{y}",
             f"{m}/{d}/{y}",
             f"{y}/{m:02d}/{d:02d}"]
@@ -239,10 +296,61 @@ def check_record(record: dict[str, Any], bundle: str, *,
     haystack = normalise_bundle(bundle)
     result = RecordCheck(project=project, label=label)
     for claim in extract(record, skip_slots=skip_slots):
-        claim.grounded = any(r in haystack
-                             for r in renderings(claim.kind, claim.value))
+        claim.grounded = any(
+            grounded_in(claim.kind, r, haystack)
+            for r in renderings(claim.kind, claim.value))
         result.claims.append(claim)
     return result
+
+
+# A token must not match inside a longer one. `10.1234/x` found inside
+# `10.1234/xyz`, or `1234` inside `12345`, reports a fabricated value as
+# grounded — the failure this module exists to catch, produced by the module
+# itself. Characters that can legitimately continue each kind of token.
+# A period is ambiguous: `10.1234/x.5` continues the DOI, `10.1234/x.` ends a
+# sentence. So a dot counts as continuation only when a word character follows
+# it — otherwise a DOI at the end of a sentence would never be found.
+_CONTINUES = {
+    "doi": r"(?:[\w/:-]|\.\w)",
+    "url": r"(?:[\w/:%?=&#-]|\.\w)",
+    "accession": r"[\w-]",
+    "count": r"[\d,]",
+    "iso_date": r"[\d-]",
+}
+# What may *precede* is narrower than what may follow. A slash is a path
+# separator, not part of the token: the VOICE bundle carries
+# `zenodo.org/doi/10.5281/zenodo.12760724`, and treating `/` as continuation
+# meant a DOI inside a URL path was never found — a real DOI reported as
+# invented. Only characters that would make it a *different, longer* identifier
+# are excluded.
+_PRECEDES = {
+    "doi": r"[\w.-]",
+    "url": r"[\w.-]",
+    "accession": r"[\w-]",
+    "count": r"[\d,]",
+    "iso_date": r"[\d-]",
+}
+
+
+def grounded_in(kind: str, rendering: str, haystack: str) -> bool:
+    """Is this rendering present as a whole token, not inside a longer one?"""
+    after = _CONTINUES.get(kind, r"\w")
+    before = _PRECEDES.get(kind, r"\w")
+    pat = re.compile(rf"(?<!{before}){re.escape(rendering)}(?!{after})")
+    return bool(pat.search(haystack))
+
+
+def number_renderings(value: str) -> list[str]:
+    """A figure as a document might write it, with and without separators.
+
+    `61937` appears in the VOICE bundle as `61,937` and was reported as invented.
+    Sources group thousands; records do not.
+    """
+    digits = value.replace(",", "")
+    if not digits.isdigit():
+        return [value]
+    grouped = f"{int(digits):,}"
+    return list(dict.fromkeys([digits, grouped, grouped.replace(",", " ")]))
 
 
 def normalise_bundle(bundle: str) -> str:

--- a/src/data_sheets_schema/verifiable.py
+++ b/src/data_sheets_schema/verifiable.py
@@ -150,12 +150,23 @@ def declared_bundle(method: str, label: str, project: str) -> Path | None:
     """
     import yaml as _yaml
     from data_sheets_schema.provenance import record_path_for
-    rec = record_path_for(project, method, label)
+
+    # Both the lookup and the result are resolved from the repository root, not
+    # the working directory. `FULL_SCHEMA` above was fixed for this and the
+    # assumption crept back in a few lines below it. The failure is silent: the
+    # record is not found, None is returned, and the caller falls back to the
+    # baseline bundle — which is exactly the wrong-sources bug this function
+    # exists to prevent, now producing a plausible number from the wrong input.
+    rec = record_path_for(project, method, label,
+                          _REPO_ROOT / "data/d4d_concatenated")
     if not rec.exists():
         return None
     data = _yaml.safe_load(rec.read_text(encoding="utf-8")) or {}
     path = (data.get("inputs") or {}).get("bundle_path")
-    return Path(path) if path else None
+    if not path:
+        return None
+    p = Path(path)
+    return p if p.is_absolute() else _REPO_ROOT / p
 
 
 def identifier_slots(schema_path: Path = FULL_SCHEMA) -> set[str]:
@@ -314,7 +325,9 @@ _CONTINUES = {
     "doi": r"(?:[\w/:-]|\.\w)",
     "url": r"(?:[\w/:%?=&#-]|\.\w)",
     "accession": r"[\w-]",
-    "count": r"[\d,]",
+    # A dot continues a count only when a digit follows: `1234.5` is a different
+    # quantity, while `1234.` ends a sentence. Same shape as the DOI rule.
+    "count": r"(?:[\d,]|\.\d)",
     "iso_date": r"[\d-]",
 }
 # What may *precede* is narrower than what may follow. A slash is a path
@@ -327,7 +340,8 @@ _PRECEDES = {
     "doi": r"[\w.-]",
     "url": r"[\w.-]",
     "accession": r"[\w-]",
-    "count": r"[\d,]",
+    # Letters too: `v1234` is a version identifier, not the count 1234.
+    "count": r"[\w,.]",
     "iso_date": r"[\d-]",
 }
 

--- a/src/data_sheets_schema/verifiable.py
+++ b/src/data_sheets_schema/verifiable.py
@@ -1,0 +1,258 @@
+"""Check the values a record states against the documents it was given.
+
+The surviving half of #165. Agreement between replicates measures
+self-consistency: a prompt that reliably produces the same wrong answer scores
+perfectly. The obvious remedy — compare against `curated` as a gold standard — is
+refuted, because those records were ChatGPT-generated and document superseded
+releases (#177). So correctness has to be grounded in something else.
+
+Some values can be checked without any reference record at all. A DOI, an
+accession, a participant count, a release date: these are tokens that must appear
+*literally* in a source document, because that is where they came from. If a
+record states `10.13026/249v-w155` and no input document contains it, the record
+invented it — and no comparison with another record was needed to know that.
+
+This deliberately does not attempt prose. "The dataset addresses a gap in
+multimodal voice research" is not checkable this way and is not the target;
+`evidence_score.py` covers the schema-fitness question, and neither addresses
+whether a claim is *true* in general.
+
+## Why identifiers are excluded
+
+Measured on VOICE: `id` holds 181 URLs of which 7 appear in the bundle (4%);
+every other URL-bearing slot runs 80-100%. `id` is a *constructed* identifier —
+LinkML requires one and the generator mints it — so checking it against the
+source would report 174 fabrications that are nothing of the kind. The exclusion
+is read from the schema (`identifier: true`), not hardcoded, so a schema that
+marks another slot as an identifier is handled without changing this file.
+
+## The denominator trap
+
+A record that states nothing is trivially correct on everything it states. So
+:func:`check_record` reports ``stated`` alongside ``grounded``, and no caller
+should read the ratio without the count. The same trap is written into
+`notes/generic_v2_analysis_plan.md`, and it is the reason the metric here is a
+pair rather than a percentage.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+FULL_SCHEMA = Path("src/data_sheets_schema/schema/data_sheets_schema_all.yaml")
+
+# Token kinds that must appear verbatim in a source document if they are real.
+# Deliberately narrow: each is a string a human copied from somewhere, not a
+# phrasing the model could reasonably vary.
+PATTERNS: dict[str, re.Pattern] = {
+    "doi": re.compile(r"10\.\d{4,9}/[-._;()/:A-Za-z0-9]+"),
+    "url": re.compile(r"https?://[^\s'\"<>)]+"),
+    "iso_date": re.compile(r"\b\d{4}-\d{2}-\d{2}\b"),
+    # Four digits or more. Below that, coincidental matches in unrelated text
+    # swamp the signal — "3 sites" appears in almost any corpus.
+    "count": re.compile(r"\b\d{4,}\b"),
+    "accession": re.compile(r"\b(?:GSE|SRR|PRJNA|SAMN|E-MTAB-)\d+\b"),
+}
+
+
+@dataclass
+class Claim:
+    """One checkable token, and where the record states it."""
+
+    kind: str
+    value: str
+    slot: str
+    grounded: bool | None = None      # None until checked
+
+    @property
+    def normalised(self) -> str:
+        return normalise(self.kind, self.value)
+
+
+@dataclass
+class RecordCheck:
+    project: str
+    label: str
+    claims: list[Claim] = field(default_factory=list)
+
+    @property
+    def stated(self) -> int:
+        return len(self.claims)
+
+    @property
+    def grounded(self) -> int:
+        return sum(1 for c in self.claims if c.grounded)
+
+    @property
+    def ungrounded(self) -> list[Claim]:
+        return [c for c in self.claims if c.grounded is False]
+
+    @property
+    def rate(self) -> float | None:
+        """Fraction grounded — **meaningless without `stated`**.
+
+        Returns None rather than 1.0 for a record that states nothing, so a
+        caller cannot accidentally rank an empty record top.
+        """
+        return (self.grounded / self.stated) if self.stated else None
+
+    def by_kind(self) -> dict[str, tuple[int, int]]:
+        out: dict[str, list[int]] = {}
+        for c in self.claims:
+            slot = out.setdefault(c.kind, [0, 0])
+            slot[0] += 1
+            slot[1] += 1 if c.grounded else 0
+        return {k: (v[0], v[1]) for k, v in out.items()}
+
+
+def identifier_slots(schema_path: Path = FULL_SCHEMA) -> set[str]:
+    """Slots whose string values are constructed identifiers, not assertions.
+
+    Two kinds, both read from the schema rather than listed here:
+
+    - slots marked ``identifier: true`` — `id`;
+    - **class-ranged slots**. When a slot's range is a class, a bare string in
+      it is a reference to an instance, not a literal claim. The generator mints
+      those URIs: `principal_investigator: https://b2ai-voice.org/person/
+      bensoussan-yael` is a `Person` reference, and demanding it appear in a
+      source document reported 17 fabrications on one VOICE record that were
+      nothing of the kind.
+
+    A dict in such a slot is still walked — the *fields inside* a nested Person
+    are ordinary assertions. Only the identifier string is exempt.
+    """
+    from linkml_runtime import SchemaView
+    sv = SchemaView(str(schema_path))
+    classes = set(sv.all_classes())
+    out = {s.name for s in sv.all_slots().values() if s.identifier}
+    out |= {s.name for s in sv.all_slots().values() if s.range in classes}
+    return out
+
+
+MONTHS = ("January", "February", "March", "April", "May", "June", "July",
+          "August", "September", "October", "November", "December")
+
+
+def renderings(kind: str, value: str) -> list[str]:
+    """Every spelling a source document might plausibly use for one token.
+
+    Dates are the case that forced this. A record states `2025-01-17` while the
+    document says "January 17, 2025" — the same fact, and a single normalised
+    form counted it as fabricated. Measured on VOICE that misreported 17 dates,
+    which would have been published as invented values.
+
+    Checking several renderings is more honest than rewriting the bundle into a
+    canonical form: it makes the accepted variation explicit and enumerable,
+    where a bundle-wide rewrite hides which transformations were applied.
+    """
+    v = normalise(kind, value)
+    if kind != "iso_date":
+        return [v]
+    try:
+        y, m, d = (int(x) for x in value.split("-"))
+        month = MONTHS[m - 1]
+    except (ValueError, IndexError):
+        return [v]
+    return [v,
+            f"{month} {d}, {y}".lower(),
+            f"{month} {d:02d}, {y}".lower(),
+            f"{d} {month} {y}".lower(),
+            f"{d:02d} {month} {y}".lower(),
+            f"{month} {y}".lower(),          # month precision in the source
+            f"{m:02d}/{d:02d}/{y}",
+            f"{m}/{d}/{y}",
+            f"{y}/{m:02d}/{d:02d}"]
+
+
+def normalise(kind: str, value: str) -> str:
+    """Reduce a token to the form a source document would plausibly carry.
+
+    Only differences that never change identity: a DOI's resolver prefix, a
+    URL's scheme and trailing slash, case. Anything more aggressive would start
+    equating tokens that genuinely differ, which is the failure this is meant to
+    detect.
+    """
+    v = value.strip().rstrip(".,;)]").lower()
+    # Applied to both kinds, and identically to the bundle. Stripping the
+    # resolver from DOIs but not from DOI-shaped URLs made the two sides
+    # asymmetric, so `https://doi.org/10.18130/V3/HIGT4C` could never match a
+    # bundle that plainly contained it — 27 URLs on CM4AI alone were reported as
+    # invented when they were present.
+    v = re.sub(r"^https?://", "", v)
+    v = re.sub(r"^(?:dx\.)?doi\.org/|^doi:", "", v)
+    return v.rstrip("/")
+
+
+def extract(record: dict[str, Any], *,
+            skip_slots: set[str] | None = None) -> Iterator[Claim]:
+    """Every checkable token in a record, with the slot that states it."""
+    skip = skip_slots if skip_slots is not None else identifier_slots()
+
+    def walk(node: Any, slot: str = "") -> Iterator[Claim]:
+        if isinstance(node, dict):
+            for k, v in node.items():
+                # A class-ranged slot holding a *string* is an identifier
+                # reference; the same slot holding a dict is a nested object
+                # whose fields are ordinary assertions and must still be checked.
+                if k in skip and not isinstance(v, (dict, list)):
+                    continue
+                if k in skip and isinstance(v, list) and all(
+                        not isinstance(x, dict) for x in v):
+                    continue
+                yield from walk(v, k)
+        elif isinstance(node, list):
+            for v in node:
+                yield from walk(v, slot)
+        elif isinstance(node, (str, int, float)):
+            text = str(node)
+            # Deduplicated by *span*, not by value. Specific kinds are matched
+            # first and the characters they consume are withheld from the rest:
+            # `https://doi.org/10.x/y` matches the URL pattern too, and
+            # `10.13026/249v-w155` contains `13026`, which the count pattern
+            # would claim as a separate figure. Both inflated `stated` and
+            # depressed the rate by counting one fact twice — once grounded and
+            # once not. Value-level dedup does not catch the second case,
+            # because the two tokens normalise differently.
+            taken: list[tuple[int, int]] = []
+
+            def _overlaps(a: int, b: int) -> bool:
+                return any(a < end and start < b for start, end in taken)
+
+            for kind in ("accession", "doi", "url", "iso_date", "count"):
+                for m in PATTERNS[kind].finditer(text):
+                    if _overlaps(m.start(), m.end()):
+                        continue
+                    taken.append((m.start(), m.end()))
+                    yield Claim(kind=kind, value=m.group(),
+                                slot=slot or "(root)")
+
+    yield from walk(record)
+
+
+def check_record(record: dict[str, Any], bundle: str, *,
+                 project: str = "", label: str = "",
+                 skip_slots: set[str] | None = None) -> RecordCheck:
+    """Which of a record's checkable tokens appear in the bundle it declared."""
+    haystack = normalise_bundle(bundle)
+    result = RecordCheck(project=project, label=label)
+    for claim in extract(record, skip_slots=skip_slots):
+        claim.grounded = any(r in haystack
+                             for r in renderings(claim.kind, claim.value))
+        result.claims.append(claim)
+    return result
+
+
+def normalise_bundle(bundle: str) -> str:
+    """The bundle in the same normalised form the claims are reduced to.
+
+    Built once per check rather than per claim: a record states hundreds of
+    tokens and the bundle runs to 80k+ tokens, so normalising it repeatedly is
+    the difference between a second and a minute.
+    """
+    t = bundle.lower()
+    t = re.sub(r"https?://", "", t)
+    t = re.sub(r"(?:dx\.)?doi\.org/|doi:", "", t)
+    return t

--- a/tests/test_evaluation/test_verifiable.py
+++ b/tests/test_evaluation/test_verifiable.py
@@ -37,9 +37,12 @@ class TestDateRenderings(unittest.TestCase):
         self.assertIn("january 17, 2025", r)
         self.assertIn("17 january 2025", r)
 
-    def test_month_precision_is_accepted(self):
-        """Sources often give only 'June 2026' for a dated release."""
-        self.assertIn("june 2026", renderings("iso_date", "2026-06-17"))
+    def test_month_precision_is_no_longer_accepted(self):
+        """'June 2026' once grounded 2026-06-17 — and every other day in June,
+        so a fabricated day was undetectable. Raised by review; the trade is
+        that a source giving only month precision now reads as ungrounded,
+        which is the safer direction for a check whose signal is absence."""
+        self.assertNotIn("june 2026", renderings("iso_date", "2026-06-17"))
 
     def test_a_malformed_date_degrades_to_the_literal(self):
         self.assertEqual(renderings("iso_date", "not-a-date"), ["not-a-date"])
@@ -193,8 +196,190 @@ class TestAgainstTheCorpus(unittest.TestCase):
                 with self.subTest(project=project, rep=rep):
                     r = self._check(project, rep)
                     if r.stated:
-                        self.assertGreaterEqual(r.rate, 0.85)
+                        # 0.70, not 0.85. Boundary-aware matching removed ~1000
+                        # false groundings and the corpus moved 87.3% -> 79.9%;
+                        # a floor set against the inflated figure would fail on
+                        # the honest one.
+                        self.assertGreaterEqual(r.rate, 0.70)
 
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTokenBoundaries(unittest.TestCase):
+    """A token must not match inside a longer one.
+
+    Raised by an independent review. Substring search reported a fabricated
+    value as grounded — the failure this module exists to catch, produced by the
+    module itself. Removing it moved the corpus from 87.3% to 79.9%, so roughly a
+    thousand "grounded" values were never located at all.
+    """
+
+    def _grounded(self, kind, value, bundle):
+        from data_sheets_schema.verifiable import check_record
+        slot = {"doi": "doi", "url": "page", "count": "counts",
+                "accession": "accession", "iso_date": "issued"}[kind]
+        return check_record({slot: value}, bundle, skip_slots=set()).grounded == 1
+
+    def test_a_doi_does_not_match_a_longer_doi(self):
+        self.assertFalse(self._grounded("doi", "10.1234/x", "see 10.1234/xyz"))
+        self.assertTrue(self._grounded("doi", "10.1234/x", "see 10.1234/x."))
+
+    def test_a_url_does_not_match_a_longer_path(self):
+        self.assertFalse(self._grounded("url", "https://example.org/a",
+                                        "https://example.org/abc"))
+        self.assertTrue(self._grounded("url", "https://example.org/a",
+                                       "visit https://example.org/a for more"))
+
+    def test_a_number_does_not_match_a_longer_number(self):
+        self.assertFalse(self._grounded("count", "1234", "value 12345"))
+        self.assertFalse(self._grounded("count", "1234", "value 912345"))
+        self.assertTrue(self._grounded("count", "1234", "value 1234 total"))
+
+    def test_an_accession_does_not_match_a_longer_one(self):
+        self.assertFalse(self._grounded("accession", "GSE123", "GSE1234"))
+        self.assertTrue(self._grounded("accession", "GSE123", "see GSE123)"))
+
+
+class TestThousandsSeparators(unittest.TestCase):
+    """Sources group thousands; records do not.
+
+    `61937` was reported invented while the VOICE bundle plainly said `61,937`.
+    """
+
+    def test_a_grouped_figure_in_the_source_grounds_a_bare_one(self):
+        from data_sheets_schema.verifiable import check_record
+        r = check_record({"counts": "61937"}, "a total of 61,937 recordings",
+                         skip_slots=set())
+        self.assertEqual(r.grounded, 1)
+
+    def test_a_bare_figure_in_the_source_also_grounds(self):
+        from data_sheets_schema.verifiable import check_record
+        self.assertEqual(
+            check_record({"counts": "61937"}, "61937 recordings",
+                         skip_slots=set()).grounded, 1)
+
+    def test_renderings_include_both_forms(self):
+        from data_sheets_schema.verifiable import number_renderings
+        self.assertIn("61937", number_renderings("61937"))
+        self.assertIn("61,937", number_renderings("61937"))
+
+
+class TestDateValidity(unittest.TestCase):
+    """Three numbers are not a date."""
+
+    def test_month_zero_does_not_wrap_to_december(self):
+        """`MONTHS[m - 1]` with m == 0 indexed backwards, rendering
+        `2025-00-17` as 'December 17, 2025' and grounding an impossible date."""
+        from data_sheets_schema.verifiable import check_record, renderings
+        self.assertEqual(renderings("iso_date", "2025-00-17"), ["2025-00-17"])
+        self.assertEqual(
+            check_record({"issued": "2025-00-17"}, "December 17, 2025",
+                         skip_slots=set()).grounded, 0)
+
+    def test_an_impossible_day_is_not_expanded(self):
+        from data_sheets_schema.verifiable import renderings
+        self.assertEqual(renderings("iso_date", "2025-02-30"), ["2025-02-30"])
+        self.assertEqual(renderings("iso_date", "2025-06-31"), ["2025-06-31"])
+
+    def test_a_leap_day_is_valid_only_in_a_leap_year(self):
+        from data_sheets_schema.verifiable import renderings
+        self.assertIn("february 29, 2024", renderings("iso_date", "2024-02-29"))
+        self.assertEqual(renderings("iso_date", "2025-02-29"), ["2025-02-29"])
+
+    def test_a_month_only_source_no_longer_grounds_a_full_date(self):
+        """'June 2026' grounded 2026-06-17 — and every other day in June, so
+        day-level fabrication was undetectable."""
+        from data_sheets_schema.verifiable import check_record
+        self.assertEqual(
+            check_record({"issued": "2026-06-17"}, "released in June 2026",
+                         skip_slots=set()).grounded, 0)
+
+
+class TestKnownLimits(unittest.TestCase):
+    """Documented weaknesses, pinned so they are not mistaken for guarantees."""
+
+    def test_presence_is_not_correctness(self):
+        """A coincidental match grounds a wrong value. The rate is not an
+        accuracy score, and the docstring says so."""
+        from data_sheets_schema.verifiable import check_record
+        r = check_record({"counts": "2025"}, "the paper was published in 2025",
+                         skip_slots=set())
+        self.assertEqual(r.grounded, 1, "documented limitation, not a bug")
+
+    def test_small_counts_are_not_checked_and_that_inflates_the_rate(self):
+        from data_sheets_schema.verifiable import extract
+        self.assertEqual(list(extract({"counts": "833"}, skip_slots=set())), [])
+
+    def test_the_module_documents_the_asymmetry(self):
+        from data_sheets_schema import verifiable
+        doc = verifiable.__doc__ or ""
+        self.assertIn("Absence is evidence; presence is not", doc)
+        self.assertIn("bias the reported rate", doc)
+
+
+class TestWorksFromAnyDirectory(unittest.TestCase):
+    """Paths resolved from the module, not the working directory."""
+
+    def test_the_schema_path_is_absolute(self):
+        from data_sheets_schema.verifiable import FULL_SCHEMA
+        self.assertTrue(FULL_SCHEMA.is_absolute())
+
+    def test_identifier_slots_works_from_a_foreign_cwd(self):
+        import os
+        import tempfile
+        from data_sheets_schema.verifiable import identifier_slots
+        cwd = os.getcwd()
+        try:
+            os.chdir(tempfile.mkdtemp())
+            self.assertIn("id", identifier_slots())
+        finally:
+            os.chdir(cwd)
+
+
+class TestTheDeclaredBundleIsUsed(unittest.TestCase):
+    """Different arms read different inputs.
+
+    Checking every run against `{project}_preprocessed.txt` reported the whole
+    crate arm as inventing everything — 0 of 5 DOIs, 0 of 11 URLs on one CHORUS
+    record — because `crate_only` declares `{project}_crate_only.txt`. The
+    provenance records which bundle was read; assuming it was the failure.
+    """
+
+    def test_the_crate_arm_declares_a_different_bundle(self):
+        from data_sheets_schema.verifiable import declared_bundle
+        b = declared_bundle("claudecode_agent_crate_only",
+                            "2026-07-28_claude-opus-5-crateonly_rep2", "CHORUS")
+        if b is None:
+            self.skipTest("crate arm not present")
+        self.assertIn("crate_only", str(b))
+
+    def test_the_baseline_arm_declares_the_preprocessed_bundle(self):
+        from data_sheets_schema.verifiable import declared_bundle
+        b = declared_bundle("claudecode_agent",
+                            "2026-07-28_claude-opus-5-generic_rep1", "CHORUS")
+        if b is None:
+            self.skipTest("generic arm not present")
+        self.assertIn("preprocessed", str(b))
+
+    def test_a_run_without_provenance_returns_none(self):
+        from data_sheets_schema.verifiable import declared_bundle
+        self.assertIsNone(declared_bundle("nope", "nope", "nope"))
+
+    def test_the_crate_arm_is_not_reported_as_wholly_ungrounded(self):
+        """The regression this guards: 18.8% for a record whose values were
+        presumably in the crate it was actually given."""
+        import yaml
+        from data_sheets_schema.verifiable import (
+            check_record, declared_bundle, identifier_slots)
+        from data_sheets_schema.runs import record_path
+        method = "claudecode_agent_crate_only"
+        label = "2026-07-28_claude-opus-5-crateonly_rep2"
+        b = declared_bundle(method, label, "CHORUS")
+        rec = record_path(method, label, "CHORUS")
+        if not (b and b.exists() and rec and rec.exists()):
+            self.skipTest("crate arm not present")
+        r = check_record(yaml.safe_load(rec.read_text()), b.read_text(),
+                         skip_slots=identifier_slots())
+        self.assertGreater(r.rate, 0.5)

--- a/tests/test_evaluation/test_verifiable.py
+++ b/tests/test_evaluation/test_verifiable.py
@@ -1,0 +1,200 @@
+"""Values a record states, checked against the documents it was given (#165).
+
+Every assertion here exists because the naive version of this check was wrong in
+a way that would have been published as a fabrication. Four separate
+classification bugs turned up while measuring the corpus, each inflating the
+apparent error rate:
+
+  1. `2025-01-17` vs "January 17, 2025" — a date in another format;
+  2. `https://doi.org/10.x/y` normalised asymmetrically against the bundle;
+  3. the same token counted as both a DOI and a URL;
+  4. constructed identifiers in class-ranged slots demanded to appear in sources.
+
+The corpus rate moved from 78%–97% to 90%–100% as they were fixed. A checker
+whose false positives dominate is worse than none, because the real findings are
+buried among them.
+"""
+
+import unittest
+from pathlib import Path
+
+from data_sheets_schema.verifiable import (
+    Claim,
+    RecordCheck,
+    check_record,
+    extract,
+    identifier_slots,
+    normalise,
+    renderings,
+)
+
+
+class TestDateRenderings(unittest.TestCase):
+    """A date in the source's format is not a fabrication."""
+
+    def test_iso_date_matches_a_written_month(self):
+        r = renderings("iso_date", "2025-01-17")
+        self.assertIn("january 17, 2025", r)
+        self.assertIn("17 january 2025", r)
+
+    def test_month_precision_is_accepted(self):
+        """Sources often give only 'June 2026' for a dated release."""
+        self.assertIn("june 2026", renderings("iso_date", "2026-06-17"))
+
+    def test_a_malformed_date_degrades_to_the_literal(self):
+        self.assertEqual(renderings("iso_date", "not-a-date"), ["not-a-date"])
+
+    def test_non_dates_have_a_single_rendering(self):
+        self.assertEqual(len(renderings("doi", "10.1234/x")), 1)
+
+
+class TestNormalisationIsSymmetric(unittest.TestCase):
+    """The claim and the bundle must be reduced the same way."""
+
+    def test_a_doi_url_and_a_bare_doi_agree(self):
+        self.assertEqual(normalise("url", "https://doi.org/10.18130/V3/HIGT4C"),
+                         normalise("doi", "10.18130/V3/HIGT4C"))
+
+    def test_resolver_prefixes_are_stripped(self):
+        for form in ("doi:10.1234/x", "https://doi.org/10.1234/x",
+                     "https://dx.doi.org/10.1234/x", "10.1234/x"):
+            with self.subTest(form=form):
+                self.assertEqual(normalise("doi", form), "10.1234/x")
+
+    def test_url_scheme_and_trailing_slash_do_not_matter(self):
+        self.assertEqual(normalise("url", "https://Example.org/a/"),
+                         normalise("url", "http://example.org/a"))
+
+    def test_trailing_punctuation_is_stripped(self):
+        self.assertEqual(normalise("doi", "10.1234/x,"), "10.1234/x")
+
+
+class TestNoDoubleCounting(unittest.TestCase):
+    """One fact must not be counted twice, once grounded and once not."""
+
+    def test_a_doi_url_yields_one_claim(self):
+        claims = list(extract({"citation": "https://doi.org/10.18130/V3/HIGT4C"},
+                              skip_slots=set()))
+        self.assertEqual(len(claims), 1)
+        self.assertEqual(claims[0].kind, "doi")
+
+    def test_distinct_tokens_still_yield_distinct_claims(self):
+        claims = list(extract(
+            {"a": "10.1234/x and https://example.org/p and 2025-01-17"},
+            skip_slots=set()))
+        self.assertEqual({c.kind for c in claims}, {"doi", "url", "iso_date"})
+
+
+class TestConstructedIdentifiersAreExempt(unittest.TestCase):
+    """A minted URI is not a claim about the world."""
+
+    def test_identifier_and_class_ranged_slots_are_exempt(self):
+        skip = identifier_slots()
+        self.assertIn("id", skip)
+        self.assertIn("principal_investigator", skip,
+                      "a Person reference is minted, not asserted")
+
+    def test_a_bare_string_in_a_class_ranged_slot_is_skipped(self):
+        claims = list(extract(
+            {"principal_investigator": "https://b2ai-voice.org/person/x"}))
+        self.assertEqual(claims, [])
+
+    def test_but_a_nested_object_is_still_checked(self):
+        """Only the identifier is exempt; the fields inside it are assertions."""
+        claims = list(extract(
+            {"principal_investigator": {"id": "https://b2ai-voice.org/person/x",
+                                        "page": "https://real.example/bio"}}))
+        self.assertEqual([c.value for c in claims],
+                         ["https://real.example/bio"])
+
+    def test_a_list_of_nested_objects_is_checked(self):
+        claims = list(extract({"creators": [{"page": "https://a.example/1"},
+                                            {"page": "https://a.example/2"}]}))
+        self.assertEqual(len(claims), 2)
+
+
+class TestGrounding(unittest.TestCase):
+
+    def test_a_value_present_in_the_bundle_is_grounded(self):
+        r = check_record({"doi": "10.13026/249v-w155"},
+                         "see 10.13026/249v-w155 for details", skip_slots=set())
+        self.assertEqual(r.grounded, 1)
+        self.assertEqual(r.ungrounded, [])
+
+    def test_a_value_absent_from_the_bundle_is_not(self):
+        r = check_record({"doi": "10.9999/invented"}, "unrelated text",
+                         skip_slots=set())
+        self.assertEqual(r.grounded, 0)
+        self.assertEqual(len(r.ungrounded), 1)
+
+    def test_a_date_in_the_sources_format_is_grounded(self):
+        r = check_record({"issued": "2025-01-17"},
+                         "Released January 17, 2025.", skip_slots=set())
+        self.assertEqual(r.grounded, 1)
+
+
+class TestTheDenominatorTrap(unittest.TestCase):
+    """A record that states nothing must not rank top."""
+
+    def test_an_empty_record_has_no_rate(self):
+        r = check_record({}, "any bundle")
+        self.assertEqual(r.stated, 0)
+        self.assertIsNone(r.rate, "an empty record must not score 100%")
+
+    def test_stated_is_reported_alongside_grounded(self):
+        r = check_record({"doi": "10.1234/x"}, "10.1234/x", skip_slots=set())
+        self.assertEqual((r.stated, r.grounded), (1, 1))
+
+    def test_a_sparse_correct_record_does_not_beat_a_full_one_on_count(self):
+        sparse = check_record({"doi": "10.1234/x"}, "10.1234/x", skip_slots=set())
+        full = check_record({"doi": "10.1234/x", "a": "10.5678/y",
+                             "b": "10.9012/z"},
+                            "10.1234/x 10.5678/y 10.9012/z", skip_slots=set())
+        self.assertEqual(sparse.rate, full.rate)
+        self.assertGreater(full.stated, sparse.stated,
+                           "the pair, not the ratio, separates them")
+
+
+class TestAgainstTheCorpus(unittest.TestCase):
+
+    def _check(self, project, rep):
+        import yaml
+        b = Path(f"data/preprocessed/concatenated/{project}_preprocessed.txt")
+        f = Path(f"data/d4d_concatenated/claudecode_agent/"
+                 f"2026-07-28_claude-opus-5-generic_rep{rep}/{project}_d4d.yaml")
+        if not (b.exists() and f.exists()):
+            self.skipTest("corpus not present")
+        return check_record(yaml.safe_load(f.read_text()), b.read_text(),
+                            project=project, label=f"rep{rep}")
+
+    def test_dois_are_grounded_across_the_corpus(self):
+        """No fabricated DOI was found in any record; a regression here is the
+        clearest possible signal that generation has started inventing."""
+        for project in ("AI_READI", "CM4AI", "VOICE"):
+            with self.subTest(project=project):
+                r = self._check(project, 1)
+                stated, grounded = r.by_kind().get("doi", (0, 0))
+                if stated:
+                    self.assertEqual(grounded, stated)
+
+    def test_the_known_voice_finding_is_still_detected(self):
+        """VOICE rep2 states three release dates absent from its bundle in any
+        format. This is the check's first real positive; if it stops firing,
+        the checker has been broken rather than the record fixed."""
+        r = self._check("VOICE", 2)
+        missing = {c.value for c in r.ungrounded if c.kind == "iso_date"}
+        self.assertTrue({"2025-08-18", "2025-12-16", "2025-12-17"} <= missing)
+
+    def test_no_record_falls_below_the_measured_floor(self):
+        """Guards against a normalisation regression reintroducing false
+        positives: four such bugs moved the corpus from 78% to 90%."""
+        for project in ("AI_READI", "CHORUS", "CM4AI", "VOICE"):
+            for rep in (1, 2, 3):
+                with self.subTest(project=project, rep=rep):
+                    r = self._check(project, rep)
+                    if r.stated:
+                        self.assertGreaterEqual(r.rate, 0.85)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation/test_verifiable.py
+++ b/tests/test_evaluation/test_verifiable.py
@@ -383,3 +383,73 @@ class TestTheDeclaredBundleIsUsed(unittest.TestCase):
         r = check_record(yaml.safe_load(rec.read_text()), b.read_text(),
                          skip_slots=identifier_slots())
         self.assertGreater(r.rate, 0.5)
+
+
+class TestCountBoundaryEdges(unittest.TestCase):
+    """A count must not ground inside a different quantity (#211).
+
+    The first boundary fix used `[\\d,]`, which stopped `1234` matching `12345`
+    but left `1234.5` (a different number) and `v1234` (a version string) both
+    grounding — the same false-grounding class the work was meant to remove.
+    """
+
+    def _g(self, value, bundle):
+        from data_sheets_schema.verifiable import check_record
+        return check_record({"counts": value}, bundle,
+                            skip_slots=set()).grounded == 1
+
+    def test_a_decimal_is_a_different_quantity(self):
+        self.assertFalse(self._g("1234", "value 1234.5"))
+        self.assertFalse(self._g("1234", "1234.5 kg"))
+
+    def test_a_version_string_does_not_ground_a_count(self):
+        self.assertFalse(self._g("1234", "v1234"))
+        self.assertFalse(self._g("1234", "rev1234"))
+
+    def test_a_sentence_ending_period_still_grounds(self):
+        self.assertTrue(self._g("1234", "there were 1234."))
+
+    def test_bracketed_and_grouped_forms_ground(self):
+        self.assertTrue(self._g("1234", "(1234)"))
+        self.assertTrue(self._g("1234", "total 1,234 items"))
+
+    def test_a_longer_number_still_does_not_ground(self):
+        self.assertFalse(self._g("1234", "12345"))
+        self.assertFalse(self._g("1234", "912345"))
+
+
+class TestDeclaredBundleIsRootRelative(unittest.TestCase):
+    """Resolved from the repository, not the working directory (#212).
+
+    The failure was silent: the provenance record was not found, None was
+    returned, and the caller fell back to the baseline bundle — the
+    wrong-sources bug this function exists to prevent, producing a
+    plausible-looking number from the wrong input.
+    """
+
+    def test_it_returns_an_absolute_path(self):
+        from data_sheets_schema.verifiable import declared_bundle
+        b = declared_bundle("claudecode_agent",
+                            "2026-07-28_claude-opus-5-generic_rep1", "CHORUS")
+        if b is None:
+            self.skipTest("run not present")
+        self.assertTrue(b.is_absolute())
+        self.assertTrue(b.exists())
+
+    def test_it_works_from_a_foreign_directory(self):
+        import os
+        import tempfile
+        from data_sheets_schema.verifiable import declared_bundle
+        cwd = os.getcwd()
+        try:
+            os.chdir(tempfile.mkdtemp())
+            b = declared_bundle("claudecode_agent",
+                                "2026-07-28_claude-opus-5-generic_rep1",
+                                "CHORUS")
+            if b is None:
+                self.skipTest("run not present")
+            self.assertTrue(b.exists(),
+                            "silently falling back to the baseline bundle is "
+                            "the bug this guards")
+        finally:
+            os.chdir(cwd)


### PR DESCRIPTION
Implements the half of #165 that survives having no gold standard, then fixes six
defects an independent review found in it.

## The check

Agreement measures self-consistency: a prompt that reliably produces the same
wrong answer scores perfectly. The proposed remedy — compare against `curated` —
is refuted, since those records were ChatGPT-generated and document superseded
releases (#177).

Some values need no reference record. A DOI, an accession, a count, a release
date must appear *literally* in a source document, because that is where they
came from. Mechanical, no LLM.

**Corpus: 11,952 of 13,387 values located across 87 records (89.3%).**

It demonstrates the issue's thesis rather than merely addressing it. Ungrounded
values *recur across runs and conditions* — VOICE states `2025-12-16` in 53
records and `2025-08-18` in 48, neither present in its bundle in any format.
**Three-way agreement cannot see any of it**, because the runs agree with each
other. That is the failure #165 was raised about, now measured.

## What the review found

An unbiased Codex review (deliberately given no hints about the design or the
bugs already fixed) found five mechanical defects and one framing error. Every
high-severity finding was accurate.

**Token boundaries.** `r in haystack` had none: `10.1234/x` grounded by
`10.1234/xyz`, `1234` by `12345`, `GSE123` by `GSE1234`. A fabricated value
reported as grounded — the failure this module exists to catch, produced by the
module itself. Matching is now boundary-aware per kind, asymmetrically: a dot
continues a DOI only when a word character follows, so a DOI ending a sentence is
still found.

**Thousands separators.** `61937` reported invented while the bundle says
`61,937`, with the line cited.

**Presence is not correctness.** The deepest finding, and a framing error rather
than a bug. `participants: 2025` is "grounded" by "published in 2025"; a record
correctly deriving 2,000 from "1,000 cases and 1,000 controls" reads as
ungrounded. The module now states the asymmetry at the top — **absence is
evidence, presence is not** — documents the rate as not an accuracy score, and
`ungrounded` as a list to read rather than a number to optimise.

**Invalid dates.** `MONTHS[m - 1]` with month `0` indexed backwards, rendering
`2025-00-17` as "December 17, 2025" and grounding an impossible date. Now parsed
with `datetime.date`. Month-only renderings dropped: "June 2026" grounded
`2026-06-17` *and every other day in June*.

**Working directory** and **a CLI filter** that hid explicitly-named methods.

## One the review did not reach

Chasing a record scoring 18.8% found I was checking *every* run against
`{project}_preprocessed.txt`, while the crate arm declares
`{project}_crate_only.txt`. The whole arm read as inventing everything — 0 of 5
DOIs, 0 of 11 URLs on one CHORUS record. Each run's declared bundle is in its
provenance; assuming it was the failure. Worst record is now 61.7%.

## The number moved twice

**87.3% → 79.9% → 89.3%.** The middle figure is the honest one for the middle
code: boundary matching removed ~1,000 false groundings, then the bundle fix
restored real ones. The original 87.3% was inflated by loose matching *and*
deflated by the wrong sources — two errors partly cancelling.

The VOICE finding survives all of it. What changed is that it is no longer
surrounded by false company.

## Documented, not fixed

Three limits bias the rate *upward*, and the alternatives are worse: counts below
four digits are skipped, since in an 80k-token corpus a three-digit figure
matches something almost always; accessions cover five prefixes; matching is
case-insensitive. All three are stated in the module docstring and pinned by
test, so they read as known limits rather than guarantees.

## Verification

- `794 passed, 3 skipped`
- Boundary cases pinned in both directions — a prefix must not ground, an exact
  match at a sentence end must
- DOIs are 100% located in every project; a regression there is the clearest
  signal generation has begun inventing
- The known VOICE finding is pinned, so a future change that silences it fails

Closes #165.
