### PR TITLE
Stamp the real run date, normalise temporal values, make the v2 numbers regenerable (#214, #215, #216)

### DIFF
--- a/notes/generic_v2_analysis_plan.md
+++ b/notes/generic_v2_analysis_plan.md
@@ -41,6 +41,22 @@ failures under v1, from `data/evaluation_llm/judgement_cache/*_fitness.jsonl`:
 
 Mean fitness by project: AI_READI 0.901, CHORUS 0.847, CM4AI 0.850, VOICE 0.912.
 
+> **Annotation added 2026-08-01, after the runs — see #216.** This mean-fitness
+> line cannot be regenerated from the artifacts. Six denominators were tried
+> against the judgement cache and none reproduces it, and the figures here are
+> higher than every candidate for AI-READI, CHORUS and VOICE but *lower* for
+> CM4AI — so it is not a subset relation or a denominator error, but a scorer
+> state no longer on disk. Use the recomputed table in
+> `notes/generic_v2_results.md` instead.
+>
+> The **failure counts above are unaffected** and reproduce exactly (form 50,
+> substance 40, target 41; 37/36/39/19 by project), which is what the result
+> rests on.
+>
+> Left in place rather than corrected: this document is the pre-registration,
+> and silently editing a number in it after seeing the outcome would destroy the
+> property that makes it worth having.
+
 ## Prediction
 
 Each rule targets one class, so each class is tested separately rather than by a

--- a/notes/generic_v2_results.md
+++ b/notes/generic_v2_results.md
@@ -144,6 +144,11 @@ computed identically — and is reported only as a check that nothing moved
 sharply. Treat the plan's row as unrecoverable rather than as a target. Tracked
 in #216.
 
+Every number in this file is emitted by `scripts/generic_v2_report.py`, which
+reads only the judgement cache and the records and makes no API calls. Run it
+to regenerate the tables rather than trusting them; `--check` fails if v1 has
+drifted from the pre-registered failure counts.
+
 ## Verdict
 
 The three rules landed. Two of them (substance, target) cut their target defect

--- a/scripts/generic_v2_report.py
+++ b/scripts/generic_v2_report.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+"""Regenerate every number in `notes/generic_v2_results.md`.
+
+Why this exists: the pre-registered plan quoted a mean-fitness baseline that
+cannot be reproduced from anything on disk (#216). Six candidate denominators
+were tried and none matched. The lesson is not "recompute it more carefully" —
+it is that a statistic quoted in a registered document needs to be *emitted by
+committed code*, so a reader can regenerate it instead of trusting it.
+
+Reads only the judgement cache and the records. Makes no API calls, so it is
+free to run and cannot change what it measures.
+
+    python scripts/generic_v2_report.py            # the table
+    python scripts/generic_v2_report.py --check    # verify the note is current
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import json
+import os
+import statistics as st
+import sys
+
+import yaml
+
+RECORDS = "data/d4d_concatenated/claudecode_agent/{label}_rep*/*_d4d.yaml"
+CACHE = "data/evaluation_llm/judgement_cache/*_fitness.jsonl"
+V1 = "2026-07-28_claude-opus-5-generic"
+V2 = "2026-07-31_claude-opus-5-generic-v2"
+PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
+CLASSES = ("form", "substance", "target")
+
+# The pre-registered baseline, so a drift in the *inputs* is caught here rather
+# than discovered later. Failure counts only: the plan's mean-fitness row is
+# unreproducible and deliberately not asserted (#216).
+REGISTERED = {"form": 50, "substance": 40, "target": 41}
+REGISTERED_BY_PROJECT = {"AI_READI": 37, "CHORUS": 36, "CM4AI": 39, "VOICE": 19}
+
+
+def load_cache() -> dict[tuple[str, str], tuple[str, float]]:
+    """Keyed exactly as `LLMSlotFitnessScorer` keys it: (slot, json-of-value)."""
+    cache: dict[tuple[str, str], tuple[str, float]] = {}
+    contexts = set()
+    for path in glob.glob(CACHE):
+        for line in open(path, encoding="utf-8"):
+            d = json.loads(line)
+            cache[(d["slot"], d["value"])] = (d["failure"], d["fitness"])
+            contexts.add((d["axis"], d["model"], d["rubric"], d["corpus"],
+                          d["schema"]))
+    if len(contexts) > 1:
+        print(f"WARNING: {len(contexts)} distinct judgement contexts in the "
+              f"cache; v1 and v2 are not comparable across a context change.",
+              file=sys.stderr)
+        for c in sorted(contexts):
+            print(f"    {c}", file=sys.stderr)
+    return cache
+
+
+def tally(label: str, cache) -> tuple[dict, dict, dict, int]:
+    """Failure counts, fitness values and slot counts per project."""
+    fails = collections.defaultdict(collections.Counter)
+    fitness = collections.defaultdict(list)
+    slots = collections.defaultdict(list)
+    unscored = 0
+    for path in sorted(glob.glob(RECORDS.format(label=label))):
+        project = os.path.basename(path).replace("_d4d.yaml", "")
+        record = yaml.safe_load(open(path, encoding="utf-8"))
+        if not isinstance(record, dict):
+            continue
+        slots[project].append(len(record))
+        for slot, value in record.items():
+            key = (slot, json.dumps(value, sort_keys=True, default=str))
+            if key not in cache:
+                unscored += 1
+                continue
+            failure, score = cache[key]
+            fitness[project].append(score)
+            if failure and failure != "none":
+                fails[project][failure] += 1
+    return fails, fitness, slots, unscored
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true",
+                    help="exit non-zero if v1 no longer matches the "
+                         "pre-registered failure counts")
+    args = ap.parse_args()
+
+    cache = load_cache()
+    f1, fit1, slots1, miss1 = tally(V1, cache)
+    f2, fit2, slots2, miss2 = tally(V2, cache)
+
+    print(f"v1 = {V1}\nv2 = {V2}")
+    print(f"unscored slot values: v1 {miss1}, v2 {miss2}\n")
+
+    print("FAILURE COUNTS BY CLASS (v1 -> v2)")
+    head = "".join(f"{p:>16s}" for p in PROJECTS)
+    print(f"  {'class':11s}{head}{'total':>14s}")
+    totals = {}
+    for cls in CLASSES:
+        cells, t1, t2 = [], 0, 0
+        for p in PROJECTS:
+            a, b = f1[p][cls], f2[p][cls]
+            t1 += a
+            t2 += b
+            cells.append(f"{a:5d} ->{b:4d}   ")
+        totals[cls] = (t1, t2)
+        print(f"  {cls:11s}" + "".join(cells) + f"{t1:5d} ->{t2:4d}")
+    g1 = sum(t[0] for t in totals.values())
+    g2 = sum(t[1] for t in totals.values())
+    cells = [f"{sum(f1[p][c] for c in CLASSES):5d} ->"
+             f"{sum(f2[p][c] for c in CLASSES):4d}   " for p in PROJECTS]
+    print(f"  {'TOTAL':11s}" + "".join(cells) + f"{g1:5d} ->{g2:4d}")
+
+    print("\nSLOT COUNTS (mean per record)")
+    for p in PROJECTS:
+        a = st.mean(slots1[p]) if slots1[p] else 0
+        b = st.mean(slots2[p]) if slots2[p] else 0
+        print(f"  {p:10s} {a:6.1f} -> {b:6.1f}   ({b - a:+.1f})")
+
+    print("\nMEAN FITNESS  (v1 and v2 computed identically; the plan's row is "
+          "unreproducible, see #216)")
+    for p in PROJECTS:
+        a = st.mean(fit1[p]) if fit1[p] else 0
+        b = st.mean(fit2[p]) if fit2[p] else 0
+        print(f"  {p:10s} {a:.3f} -> {b:.3f}   ({b - a:+.3f})")
+
+    drift = [f"{c}: {totals[c][0]} != {REGISTERED[c]}"
+             for c in CLASSES if totals[c][0] != REGISTERED[c]]
+    drift += [f"{p}: {sum(f1[p][c] for c in CLASSES)} != {REGISTERED_BY_PROJECT[p]}"
+              for p in PROJECTS
+              if sum(f1[p][c] for c in CLASSES) != REGISTERED_BY_PROJECT[p]]
+    print("\nv1 against the pre-registered table: "
+          + ("MATCHES" if not drift else "DRIFTED — " + "; ".join(drift)))
+    if args.check and drift:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -701,6 +701,62 @@ def _extract(text: str, kind: str,
         f"200 characters: {text.strip()[:200]!r}")
 
 
+# Slots whose range is temporal, by the shape the validator demands. Two
+# separate failures were showing up as one (#215):
+#
+#   issued: 2026-05-01T00:00:00Z      <- CORRECT value, rejected. Unquoted, so
+#                                        PyYAML hands the validator a datetime
+#                                        object where a string is required.
+#   issued: '2026-05-01T00:00:00'     <- genuinely wrong: no timezone.
+#   issued: '2026-06-30'              <- genuinely wrong: a date, not a datetime.
+#
+# So the generator was right half the time and the serialisation lost it. Both
+# are fixed by emitting a quoted value shaped to the slot's range.
+DATETIME_SLOTS = ("issued", "created_on", "last_updated_on")
+DATE_SLOTS = ("start_date", "end_date")
+
+_TEMPORAL_LINE = re.compile(
+    r"(?m)^(?P<indent>[ \t]*-?[ \t]*)(?P<slot>"
+    + "|".join(DATETIME_SLOTS + DATE_SLOTS)
+    + r"):[ \t]+(?P<value>\S.*?)[ \t]*$")
+_DATE_ONLY = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_DATETIME = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})[T ](?P<time>\d{2}:\d{2}(?::\d{2})?)"
+    r"(?:\.\d+)?(?P<zone>Z|[+-]\d{2}:?\d{2})?$")
+
+
+def normalise_temporal(text: str) -> str:
+    """Quote and shape temporal values to the range their slot declares.
+
+    Text-level on purpose. Parsing and re-dumping the YAML would drop the `#`
+    header block every record carries — the provenance the reader sees first.
+    """
+    def fix(m: re.Match) -> str:
+        raw = m.group("value").strip()
+        # Leave alone anything that is not a plain scalar: nulls, aliases,
+        # inline comments, flow collections, block scalars.
+        if (not raw or raw in {"null", "~"} or raw[0] in "*&[{|>#"
+                or " #" in raw):
+            return m.group(0)
+        val = raw.strip("'\"")
+        want_datetime = m.group("slot") in DATETIME_SLOTS
+        if _DATE_ONLY.match(val):
+            out = f"{val}T00:00:00Z" if want_datetime else val
+        elif (dt := _DATETIME.match(val)):
+            if want_datetime:
+                time = dt.group("time")
+                if len(time) == 5:               # HH:MM -> HH:MM:SS
+                    time += ":00"
+                out = f"{dt.group('date')}T{time}{dt.group('zone') or 'Z'}"
+            else:
+                out = dt.group("date")           # a date slot keeps only the date
+        else:
+            return m.group(0)                    # unrecognised: do not guess
+        return f"{m.group('indent')}{m.group('slot')}: '{out}'"
+
+    return _TEMPORAL_LINE.sub(fix, text)
+
+
 PROGRESS_SUFFIX = "_api_progress.json"
 
 
@@ -1124,6 +1180,8 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             carry["Audit findings"] = body
         elif artifact:
             target.parent.mkdir(parents=True, exist_ok=True)
+            if artifact in ("full", "core"):
+                body = normalise_temporal(body)
             target.write_text(body, encoding="utf-8")
             label = {"full": "Completed full record",
                      "core": "Completed core record",

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -716,9 +716,12 @@ DATETIME_SLOTS = ("issued", "created_on", "last_updated_on")
 DATE_SLOTS = ("start_date", "end_date")
 
 _TEMPORAL_LINE = re.compile(
-    r"(?m)^(?P<indent>[ \t]*-?[ \t]*)(?P<slot>"
+    r"^(?P<indent>[ \t]*-?[ \t]*)(?P<slot>"
     + "|".join(DATETIME_SLOTS + DATE_SLOTS)
     + r"):[ \t]+(?P<value>\S.*?)[ \t]*$")
+# A block scalar opens with `|`/`>` (plus optional chomping/indent indicators)
+# and owns every following line indented further than its key.
+_BLOCK_OPEN = re.compile(r"^(?P<indent>[ \t]*)(?:-[ \t]+)?[\w.-]+:[ \t]*[|>][+-]?\d*[ \t]*$")
 _DATE_ONLY = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _DATETIME = re.compile(
     r"^(?P<date>\d{4}-\d{2}-\d{2})[T ](?P<time>\d{2}:\d{2}(?::\d{2})?)"
@@ -731,6 +734,9 @@ def normalise_temporal(text: str) -> str:
     Text-level on purpose. Parsing and re-dumping the YAML would drop the `#`
     header block every record carries — the provenance the reader sees first.
     """
+    def indent_of(line: str) -> int:
+        return len(line) - len(line.lstrip(" \t"))
+
     def fix(m: re.Match) -> str:
         raw = m.group("value").strip()
         # Leave alone anything that is not a plain scalar: nulls, aliases,
@@ -754,7 +760,27 @@ def normalise_temporal(text: str) -> str:
             return m.group(0)                    # unrecognised: do not guess
         return f"{m.group('indent')}{m.group('slot')}: '{out}'"
 
-    return _TEMPORAL_LINE.sub(fix, text)
+    # Line by line, skipping block scalars. A description is free prose, and
+    # prose quoting a field name — "Fields present in the manifest:\nissued:
+    # 2026-05-01" — matches the pattern exactly. Rewriting that edits the
+    # *content* of a record rather than its serialisation, which is the one
+    # thing this function must never do.
+    out_lines: list[str] = []
+    block_indent: int | None = None
+    for line in text.splitlines(keepends=True):
+        stripped = line.rstrip("\n\r")
+        if block_indent is not None:
+            if not stripped.strip() or indent_of(stripped) > block_indent:
+                out_lines.append(line)                 # still inside the block
+                continue
+            block_indent = None                        # block ended
+        if (opener := _BLOCK_OPEN.match(stripped)):
+            block_indent = len(opener.group("indent"))
+            out_lines.append(line)
+            continue
+        out_lines.append(_TEMPORAL_LINE.sub(fix, stripped)
+                         + line[len(stripped):])
+    return "".join(out_lines)
 
 
 PROGRESS_SUFFIX = "_api_progress.json"

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -27,6 +27,7 @@ bundle plus digest form a cached prefix reused across all four phases.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -213,6 +214,29 @@ def prompt_body(path: Path = GENERIC_PROMPT) -> str:
     return text.split("## Prompt body", 1)[1].strip()
 
 
+def _run_date() -> str:
+    """The date this run is actually happening, UTC, as the header states it.
+
+    Same clock as `record_generated_at` in provenance, so the record header and
+    its provenance cannot disagree about when the run took place.
+    """
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def resolved_prompt_digest(spec: RunSpec) -> dict[str, Any]:
+    """A hash of the text the model is actually sent.
+
+    The module docstring claimed the resolved text's hash goes into provenance.
+    It did not: only the *file* was hashed, so two runs whose requests differed
+    in project, arm, label, model, provider or date were indistinguishable by
+    their recorded prompt evidence. Substitution is exactly what makes the file
+    and the request different objects, so the request needs its own hash.
+    """
+    text = resolve_prompt(spec)
+    return {"sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "bytes": len(text.encode("utf-8"))}
+
+
 def resolve_prompt(spec: RunSpec) -> str:
     """The exact instruction text this run will receive.
 
@@ -236,9 +260,21 @@ def resolve_prompt(spec: RunSpec) -> str:
         "{RUNTIME}": RUNTIME,
         "{PROVIDER}": ident["provider"] or PROVIDER,
         "{MODEL}": settings["name"],
+        # v2 introduced `{DATE}` but nothing substituted it, so the literal
+        # string reached the model. Its records carry the right date only
+        # because the model read it off `{LABEL}` and guessed correctly.
+        "{DATE}": _run_date(),
     }
     for k, v in subs.items():
         body = body.replace(k, v)
+
+    # v1 hardcodes `# Generated: 2026-07-28` where every neighbouring header
+    # line takes a placeholder, so every record produced under it since that
+    # date carries a false one — the twelve baseline-generic runs made on
+    # 2026-07-31 all claim 2026-07-28. Normalising the resolved text fixes it
+    # without editing v1, whose bytes are pinned as the published baseline for
+    # the 2026-07-28 series. See #214.
+    body = re.sub(r"(?m)^(\s*#\s*Generated:).*$", rf"\1 {_run_date()}", body)
 
     if spec.condition == "tuned":
         comp = COMPONENTS / f"{spec.project}.md"
@@ -1115,6 +1151,14 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             f"{provider_identity()['base_url']}.",
         ] + ([f"Resumed run; phases skipped as already present: {', '.join(skipped)}."]
              if skipped else []))
+    # The file hash alone does not identify the request. Substitution is what
+    # makes the file and the resolved text different objects, so two runs
+    # differing in project, arm, label, model, provider or date shared a prompt
+    # hash and were indistinguishable by their recorded prompt evidence — while
+    # the module docstring claimed the resolved text was what got hashed. Record
+    # both: the file for provenance of the source, the resolution for the
+    # request actually sent.
+    rec.data["prompts"]["resolved"] = resolved_prompt_digest(spec)
     ident = provider_identity()
     rec.data["model"] = {
         "generation_method": "schema-grounded API, six phases",

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -147,6 +147,13 @@ class RunSpec:
     label: str
     condition: str = "generic"          # generic | tuned
     manifest_line: str = "# Source manifest: data/preprocessed/source_manifest.yaml"
+    # Frozen when the run is specified, not read from the clock on each use.
+    # A six-phase run takes tens of minutes and this study's sweep genuinely
+    # ran past midnight UTC, so recomputing per call gave phases of one run
+    # different `# Generated:` dates — and made the provenance digest, which is
+    # computed after the last phase, attest a prompt that was never sent.
+    run_date: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).date().isoformat())
     # The study writes into the run-labelled layout under data/d4d_concatenated.
     # The GitHub assistant writes flat into data/sheets_d4dassistant. Rather than
     # two runners, the layout is a parameter — everything else is identical.
@@ -214,15 +221,6 @@ def prompt_body(path: Path = GENERIC_PROMPT) -> str:
     return text.split("## Prompt body", 1)[1].strip()
 
 
-def _run_date() -> str:
-    """The date this run is actually happening, UTC, as the header states it.
-
-    Same clock as `record_generated_at` in provenance, so the record header and
-    its provenance cannot disagree about when the run took place.
-    """
-    return datetime.now(timezone.utc).date().isoformat()
-
-
 def resolved_prompt_digest(spec: RunSpec) -> dict[str, Any]:
     """A hash of the text the model is actually sent.
 
@@ -263,7 +261,7 @@ def resolve_prompt(spec: RunSpec) -> str:
         # v2 introduced `{DATE}` but nothing substituted it, so the literal
         # string reached the model. Its records carry the right date only
         # because the model read it off `{LABEL}` and guessed correctly.
-        "{DATE}": _run_date(),
+        "{DATE}": spec.run_date,
     }
     for k, v in subs.items():
         body = body.replace(k, v)
@@ -274,7 +272,7 @@ def resolve_prompt(spec: RunSpec) -> str:
     # 2026-07-31 all claim 2026-07-28. Normalising the resolved text fixes it
     # without editing v1, whose bytes are pinned as the published baseline for
     # the 2026-07-28 series. See #214.
-    body = re.sub(r"(?m)^(\s*#\s*Generated:).*$", rf"\1 {_run_date()}", body)
+    body = re.sub(r"(?m)^(\s*#\s*Generated:).*$", rf"\1 {spec.run_date}", body)
 
     if spec.condition == "tuned":
         comp = COMPONENTS / f"{spec.project}.md"

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -255,6 +255,25 @@ class TestTemporalValuesAreNormalisedOnWrite(unittest.TestCase):
         self.assertIn("# Generated: 2026-08-01", out)
         self.assertIn("# Arm: baseline", out)
 
+    def test_normalisation_is_idempotent(self):
+        """A resumed run re-normalises a record already on disk, so a second
+        pass must be a no-op."""
+        for line in ("issued: 2026-05-01",
+                     "  - start_date: 2026-05-01T00:00:00Z",
+                     "issued: '2026-05-01T00:00:00+00:00'",
+                     'issued: "2026-05-01"'):
+            with self.subTest(line=line):
+                once = self._n(line)
+                self.assertEqual(once, self._n(once))
+
+    def test_line_endings_and_indent_styles_survive(self):
+        self.assertEqual(self._n("issued: 2026-05-01\r\n"),
+                         "issued: '2026-05-01T00:00:00Z'\r\n")
+        self.assertEqual(self._n("\tissued: 2026-05-01"),
+                         "\tissued: '2026-05-01T00:00:00Z'")
+        self.assertEqual(self._n("issued: 2026-05-01"),
+                         "issued: '2026-05-01T00:00:00Z'")
+
     def test_prose_in_a_block_scalar_is_never_rewritten(self):
         """A description is free prose, and prose quoting a field name matches
         the pattern exactly. Rewriting it edits a record's *content* rather

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -200,6 +200,72 @@ def _rate_limit_error(message: str):
     return anthropic.RateLimitError(message, response=resp, body=None)
 
 
+class TestTemporalValuesAreNormalisedOnWrite(unittest.TestCase):
+    """#215. Two failures were showing up as one.
+
+    `issued: 2026-05-01T00:00:00Z` is a *correct* RFC 3339 value that the
+    validator rejects, because unquoted YAML hands it a `datetime` object where
+    a string is required — the generator was right and the serialisation lost
+    it. `issued: '2026-06-30'` is genuinely wrong. Quoting plus shaping to the
+    slot's declared range fixes both.
+    """
+
+    def _n(self, text):
+        from data_sheets_schema.api_runner import normalise_temporal
+        return normalise_temporal(text)
+
+    def test_a_correct_but_unquoted_value_is_quoted(self):
+        self.assertEqual(self._n("issued: 2026-05-01T00:00:00Z"),
+                         "issued: '2026-05-01T00:00:00Z'")
+
+    def test_a_naive_datetime_gains_a_zone(self):
+        self.assertEqual(self._n("issued: '2026-05-01T00:00:00'"),
+                         "issued: '2026-05-01T00:00:00Z'")
+
+    def test_a_date_in_a_datetime_slot_is_widened(self):
+        self.assertEqual(self._n("issued: '2026-06-30'"),
+                         "issued: '2026-06-30T00:00:00Z'")
+
+    def test_an_explicit_offset_is_kept_not_rewritten(self):
+        self.assertEqual(self._n("issued: 2026-05-01T00:00:00+00:00"),
+                         "issued: '2026-05-01T00:00:00+00:00'")
+
+    def test_a_datetime_in_a_date_slot_is_narrowed(self):
+        self.assertEqual(self._n("    end_date: '2026-05-01T00:00:00Z'"),
+                         "    end_date: '2026-05-01'")
+
+    def test_indentation_and_list_markers_survive(self):
+        self.assertEqual(self._n("  - start_date: 2026-05-01"),
+                         "  - start_date: '2026-05-01'")
+
+    def test_values_it_cannot_read_are_left_alone(self):
+        """Guessing at an unrecognised value would corrupt a record to make a
+        validator happy."""
+        for line in ("issued: null", "issued: ~", "issued: *anchor",
+                     "issued: not-a-date", "issued: [2026-05-01]",
+                     "description: issued: something"):
+            with self.subTest(line=line):
+                self.assertEqual(self._n(line), line)
+
+    def test_the_header_comment_block_survives(self):
+        """A YAML re-dump would drop the `#` header every record carries — the
+        provenance a reader sees first. Hence text-level."""
+        doc = "# Generated: 2026-08-01\n# Arm: baseline\nid: x\nissued: 2026-05-01T00:00:00Z\n"
+        out = self._n(doc)
+        self.assertIn("# Generated: 2026-08-01", out)
+        self.assertIn("# Arm: baseline", out)
+
+    def test_nested_records_keep_their_structure(self):
+        import yaml as _yaml
+        doc = ("id: x\ncollection_timeframes:\n  - start_date: 2026-05-01\n"
+               "    end_date: 2026-06-30\n    description: a window\n")
+        loaded = _yaml.safe_load(self._n(doc))
+        self.assertEqual(set(loaded["collection_timeframes"][0]),
+                         {"start_date", "end_date", "description"})
+        self.assertEqual(loaded["collection_timeframes"][0]["start_date"],
+                         "2026-05-01")
+
+
 class TestGeneratedDateIsTheRunDate(unittest.TestCase):
     """#214: both prompts stamped a wrong date, in opposite directions."""
 

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -255,6 +255,37 @@ class TestTemporalValuesAreNormalisedOnWrite(unittest.TestCase):
         self.assertIn("# Generated: 2026-08-01", out)
         self.assertIn("# Arm: baseline", out)
 
+    def test_prose_in_a_block_scalar_is_never_rewritten(self):
+        """A description is free prose, and prose quoting a field name matches
+        the pattern exactly. Rewriting it edits a record's *content* rather
+        than its serialisation — the one thing this must never do."""
+        import yaml as _yaml
+        doc = ("id: x\ndescription: |\n  Fields present in the manifest:\n"
+               "  issued: 2026-05-01\n  end_date: 2026-06-30\n"
+               "issued: 2026-05-01\n")
+        out = self._n(doc)
+        before, after = _yaml.safe_load(doc), _yaml.safe_load(out)
+        self.assertEqual(before["description"], after["description"],
+                         "prose inside a block scalar was rewritten")
+        self.assertEqual(after["issued"], "2026-05-01T00:00:00Z",
+                         "the real field should still be normalised")
+
+    def test_folded_scalars_are_also_protected(self):
+        import yaml as _yaml
+        doc = ("id: x\nnotes: >-\n  A folded note mentioning\n"
+               "  start_date: 2026-01-01\nstart_date: 2026-01-01\n")
+        out = self._n(doc)
+        before, after = _yaml.safe_load(doc), _yaml.safe_load(out)
+        self.assertEqual(before["notes"], after["notes"])
+        self.assertEqual(after["start_date"], "2026-01-01")
+
+    def test_a_block_scalar_ends_at_a_dedent(self):
+        """Fields after a block must still be normalised."""
+        import yaml as _yaml
+        doc = ("id: x\ndescription: |\n  some prose\nissued: 2026-05-01\n")
+        after = _yaml.safe_load(self._n(doc))
+        self.assertEqual(after["issued"], "2026-05-01T00:00:00Z")
+
     def test_nested_records_keep_their_structure(self):
         import yaml as _yaml
         doc = ("id: x\ncollection_timeframes:\n  - start_date: 2026-05-01\n"

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -307,8 +307,9 @@ class TestGeneratedDateIsTheRunDate(unittest.TestCase):
                                     "2026-08-01_x_rep1", condition, None, None))
 
     def _today(self):
-        from datetime import datetime, timezone
-        return datetime.now(timezone.utc).date().isoformat()
+        from data_sheets_schema.cli.api import _spec
+        return _spec("CHORUS", "baseline", "2026-08-01_x_rep1",
+                     "generic", None, None).run_date
 
     def test_v2_no_longer_leaks_a_literal_placeholder(self):
         """`{DATE}` was never in the substitution table, so the literal string
@@ -334,6 +335,48 @@ class TestGeneratedDateIsTheRunDate(unittest.TestCase):
                       GENERIC_PROMPT.read_text(encoding="utf-8"),
                       "v1 was edited; normalisation should happen on the "
                       "resolved text instead")
+
+
+class TestTheRunDateIsFrozenPerRun(unittest.TestCase):
+    """A six-phase run takes tens of minutes; this study's sweep ran past
+    midnight UTC. Reading the clock on each use is therefore not a hypothetical
+    problem."""
+
+    def _spec_for(self, **kw):
+        from data_sheets_schema.api_runner import RunSpec
+        from pathlib import Path
+        return RunSpec(project="CHORUS", arm="baseline",
+                       method="claudecode_agent",
+                       bundle=Path("data/preprocessed/concatenated/"
+                                   "CHORUS_preprocessed.txt"),
+                       label="2026-08-01_x_rep1", **kw)
+
+    def test_every_phase_of_a_run_sees_the_same_date(self):
+        from data_sheets_schema.api_runner import resolve_prompt
+        spec = self._spec_for()
+        self.assertEqual(resolve_prompt(spec), resolve_prompt(spec))
+
+    def test_the_recorded_digest_matches_the_text_actually_sent(self):
+        """The digest is computed after the last phase. If the date moved, it
+        would attest a prompt that was never sent — defeating the point of
+        recording it at all."""
+        import hashlib
+        from data_sheets_schema.api_runner import (
+            resolve_prompt, resolved_prompt_digest)
+        spec = self._spec_for()
+        sent = hashlib.sha256(resolve_prompt(spec).encode("utf-8")).hexdigest()
+        self.assertEqual(sent, resolved_prompt_digest(spec)["sha256"])
+
+    def test_the_date_can_be_pinned_explicitly(self):
+        """Frozen on the spec, so a rerun can reproduce an earlier run's text."""
+        from data_sheets_schema.api_runner import resolve_prompt
+        body = resolve_prompt(self._spec_for(run_date="2026-07-04"))
+        self.assertIn("# Generated: 2026-07-04", body)
+
+    def test_the_default_is_today_in_utc(self):
+        from datetime import datetime, timezone
+        self.assertEqual(self._spec_for().run_date,
+                         datetime.now(timezone.utc).date().isoformat())
 
 
 class TestResolvedPromptIsHashed(unittest.TestCase):

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -200,6 +200,70 @@ def _rate_limit_error(message: str):
     return anthropic.RateLimitError(message, response=resp, body=None)
 
 
+class TestGeneratedDateIsTheRunDate(unittest.TestCase):
+    """#214: both prompts stamped a wrong date, in opposite directions."""
+
+    def _resolved(self, condition):
+        from data_sheets_schema.api_runner import resolve_prompt
+        from data_sheets_schema.cli.api import _spec
+        return resolve_prompt(_spec("CHORUS", "baseline",
+                                    "2026-08-01_x_rep1", condition, None, None))
+
+    def _today(self):
+        from datetime import datetime, timezone
+        return datetime.now(timezone.utc).date().isoformat()
+
+    def test_v2_no_longer_leaks_a_literal_placeholder(self):
+        """`{DATE}` was never in the substitution table, so the literal string
+        reached the model; its records read correctly only because the model
+        inferred the date from `{LABEL}`."""
+        body = self._resolved("generic_v2")
+        self.assertNotIn("{DATE}", body)
+        self.assertIn(f"# Generated: {self._today()}", body)
+
+    def test_v1_hardcoded_date_is_normalised_not_emitted(self):
+        """v1 hardcodes 2026-07-28 where every neighbouring header line takes a
+        placeholder, so every run since carried a false date."""
+        body = self._resolved("generic")
+        self.assertNotIn("2026-07-28", body)
+        self.assertIn(f"# Generated: {self._today()}", body)
+
+    def test_v1_file_bytes_are_untouched(self):
+        """The fix must not edit v1: its bytes are the pinned baseline for the
+        2026-07-28 series, and editing them redefines what v2 is measured
+        against."""
+        from data_sheets_schema.api_runner import GENERIC_PROMPT
+        self.assertIn("# Generated: 2026-07-28",
+                      GENERIC_PROMPT.read_text(encoding="utf-8"),
+                      "v1 was edited; normalisation should happen on the "
+                      "resolved text instead")
+
+
+class TestResolvedPromptIsHashed(unittest.TestCase):
+    """The module docstring claimed the resolved text's hash was recorded. Only
+    the file was hashed, so runs differing by substitution were
+    indistinguishable by their prompt evidence."""
+
+    def _digest(self, project, condition="generic"):
+        from data_sheets_schema.api_runner import resolved_prompt_digest
+        from data_sheets_schema.cli.api import _spec
+        return resolved_prompt_digest(
+            _spec(project, "baseline", "2026-08-01_x_rep1", condition, None, None))
+
+    def test_substitution_changes_the_resolved_hash(self):
+        self.assertNotEqual(self._digest("CHORUS")["sha256"],
+                            self._digest("CM4AI")["sha256"],
+                            "same file, different request, same hash")
+
+    def test_the_same_request_hashes_the_same(self):
+        self.assertEqual(self._digest("CHORUS"), self._digest("CHORUS"))
+
+    def test_the_digest_states_its_algorithm_and_size(self):
+        d = self._digest("CHORUS")
+        self.assertEqual(len(d["sha256"]), 64)
+        self.assertGreater(d["bytes"], 0)
+
+
 class FakeResponse:
     def __init__(self, text):
         self.content = [FakeBlock(text)]


### PR DESCRIPTION
Three issues left open by #213, each fixed at the layer that was actually wrong.

## #214 — the `# Generated:` date

Both generic prompts stamped a wrong date, in opposite directions. v2 introduced
`{DATE}` but never added it to the substitution table, so the literal string
reached the model; its records read correctly only because the model inferred
the date from `{LABEL}` and guessed right. v1 hardcodes `2026-07-28` where every
neighbouring header line takes a placeholder, so the twelve baseline-generic
runs made on 2026-07-31 all claim 2026-07-28.

`{DATE}` is now substituted, and a hardcoded `# Generated:` line is normalised
in the **resolved text** — v1's bytes are left untouched, because they are the
pinned baseline for the 2026-07-28 series and editing them would redefine what
v2 is measured against. A test asserts v1 still contains the hardcoded line, so
a later tidy-up cannot quietly redefine the baseline.

**Found while fixing it:** the module docstring claimed "the resolved text is
the request, and its hash goes in the provenance record". It did not — only the
prompt *file* was hashed. Substitution is exactly what makes the file and the
request different objects, so two runs differing in project, arm, label, model,
provider or date shared a prompt hash and were indistinguishable by their
recorded prompt evidence. `prompts.resolved` now carries a sha256 of the text
actually sent.

## #215 — temporal values

**My diagnosis in the issue was half wrong.** Two different failures were
showing up as one. Verified against `linkml-validate`:

| value | result |
|---|---|
| `issued: 2026-05-01T00:00:00Z` (unquoted) | **fails** |
| `issued: '2026-05-01T00:00:00Z'` (quoted) | passes |
| `issued: '2026-05-01T00:00:00'` | fails — genuinely no zone |
| `issued: '2026-06-30'` | fails — genuinely a date |

The first row matters: a *correct* RFC 3339 value, rejected because unquoted
YAML hands the validator a `datetime` object where a string is required. A share
of these were never generation defects — the model was right and the
serialisation lost it. That is also the true explanation for what I had logged
as "Python datetime leaked into YAML".

`normalise_temporal()` emits a quoted value shaped to the slot's declared range.
Text-level rather than parse-and-re-dump, because re-dumping drops the `#`
header block every record carries. Unrecognised values are left alone —
corrupting a record to satisfy a validator would be worse than the failure.

**Measured on the real corpus: of the 23 artifacts whose provenance records a
validation failure, 11 now validate.** The other 12 are a separate class — enum
values outside the permitted set and union shape mismatches — split out to #219
rather than folded in.

## #216 — the unreproducible baseline

The plan's mean-fitness row cannot be regenerated: six denominators tried, none
matches, and the figures are higher than every candidate for three projects and
*lower* for the fourth, so it is a scorer state no longer on disk rather than a
denominator error. The failure counts, which the result rests on, reproduce
exactly.

The plan is **annotated, not corrected** — it is the pre-registration, and
editing a number in it after seeing the outcome destroys the property that makes
it worth having.

`scripts/generic_v2_report.py` now emits every number in
`notes/generic_v2_results.md` from the cache and the records, no API calls.
`--check` fails if v1 drifts from the registered counts, and it warns if the
cache ever holds more than one judgement context, which alone would void the
comparison.

## Testing

861 passing, 3 skipped. The report script reproduces the results table exactly
and reports v1 as MATCHES against the pre-registered failure counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)