### PR TITLE
Profile the sweep's validation failures instead of repairing them (#215)

### DIFF
--- a/notes/validation_profile_2026-07-31.md
+++ b/notes/validation_profile_2026-07-31.md
@@ -50,6 +50,15 @@ and fewer object-ranged slots to get wrong.
 
 ## By cause
 
+**These count records, and a record may have several causes, so they sum to 28
+rather than 23.** Five records carry more than one:
+
+| causes | records |
+|---|---|
+| 1 | 18 |
+| 2 | 4 |
+| 3 | 1 |
+
 | records | cause | fixed forward? |
 |---|---|---|
 | 11 | temporal format | yes — `normalise_temporal()` on write |
@@ -70,10 +79,19 @@ The nine enum failures split into two kinds that deserve different treatment:
 
 ## What a rerun should show
 
-Temporal and enum causes account for 20 of the 23 failures. If the forward fixes
-work, a rerun under the current schema and digest should land near 3 remaining
-failures rather than 23. If it does not, the fixes did not land and this note is
-the baseline that says so.
+**16 of the 23 failing records have *every* cause fixed forward.** So a rerun
+under the current schema and digest should leave **7**, not zero and not 3.
+
+The seven carry at least one cause with no forward fix — wrong type, union shape
+(#226), or unclassified — alongside a temporal or enum one. Fixing dates and
+vocabularies does not clear them.
+
+An earlier draft of this note predicted 3, by adding the *cause* counts
+(11 + 9 = 20) and treating the sum as records. It is not: causes overlap. The
+number is stated here because it is the falsifiable claim the note exists to
+make, and getting it wrong would have read as the fixes underperforming when 7
+is what the evidence predicts. `scripts/validation_profile.py` now computes it
+rather than leaving it to arithmetic in prose.
 
 The residue — wrong type, union shape, and the three unclassified — is
 uninvestigated. #226 covers the union case, which is unsatisfiable by

--- a/notes/validation_profile_2026-07-31.md
+++ b/notes/validation_profile_2026-07-31.md
@@ -1,0 +1,80 @@
+# Validation profile of the 2026-07-31 sweep
+
+Regenerate with `python scripts/validation_profile.py`. No API calls; it reads
+the records and runs `linkml-validate`.
+
+**69 of 92 records validate (75%).** The 23 that do not are the subject of #215,
+and this note explains why they are being measured rather than repaired.
+
+## Why these are not being fixed in place
+
+The obvious move — rewrite `IsNewVersionOf` to `is_new_version_of`, quote the
+dates — is the wrong one, for two reasons.
+
+**It would falsify the experiment.** These records are what the generator
+produced under a stated prompt, model and temperature. That is the observation.
+Editing them to look better makes the corpus a record of what we wish had been
+generated, and every quality figure computed from it becomes uninterpretable.
+
+**It would break provenance.** Each run's record pins its artifacts' hashes.
+Editing the bytes makes those hashes disagree, and `d4d runs check` reports the
+run as *drifted* — trading 23 validation errors for 23 broken provenance
+records, which is a worse claim to make about a study corpus.
+
+The failures are therefore evidence about generation quality, and the response
+is to fix the *generator* and rerun, which is what the forward fixes do.
+
+## By arm
+
+| arm | invalid / total | rate |
+|---|---|---|
+| baseline (`claudecode_agent`) | 8 / 25 | 32% |
+| baseline core | 2 / 25 | 8% |
+| de_novo (`claudecode_agent_crate`) | 5 / 9 | 56% |
+| de_novo core | 3 / 9 | 33% |
+| crate_only | 2 / 9 | 22% |
+| crate_only core | 3 / 9 | 33% |
+| healthsheet | 0 / 3 | 0% |
+| healthsheet core | 0 / 3 | 0% |
+
+**The de_novo arm fails roughly twice as often as baseline** (8/18 = 44% against
+10/50 = 20%), and healthsheet not at all. n is small — 3 records per project per
+arm, and only 3 healthsheet records in total — so this is a signal worth
+following, not a result. The plausible reading is that de_novo's larger, less
+structured bundles give the model more room to invent shapes, but nothing here
+tests that.
+
+Core records fail less often than their full counterparts in every arm, which
+is consistent with `CoreDataset` being the smaller target: 79 slots against 94,
+and fewer object-ranged slots to get wrong.
+
+## By cause
+
+| records | cause | fixed forward? |
+|---|---|---|
+| 11 | temporal format | yes — `normalise_temporal()` on write |
+| 9 | enum value not permitted | yes — DataCite alignment + digest exposure |
+| 3 | wrong type (expected string) | no |
+| 2 | union: no matching shape | no — see #226 |
+| 3 | other | no |
+
+The nine enum failures split into two kinds that deserve different treatment:
+
+- **6 are DataCite spellings** — `IsNewVersionOf` (3), `HasPart` (3),
+  `References` (1), `Continues` (1). The model reached for a vocabulary it knew
+  because the schema digest never showed it the one the slot declares. Now
+  fixed at the source.
+- **2 are inventions** — `related_to`, and the free-text
+  `is a later release in the same series as`. No vocabulary alignment repairs
+  these; they are the model writing prose into an enum.
+
+## What a rerun should show
+
+Temporal and enum causes account for 20 of the 23 failures. If the forward fixes
+work, a rerun under the current schema and digest should land near 3 remaining
+failures rather than 23. If it does not, the fixes did not land and this note is
+the baseline that says so.
+
+The residue — wrong type, union shape, and the three unclassified — is
+uninvestigated. #226 covers the union case, which is unsatisfiable by
+construction and cannot be a generation defect at all.

--- a/scripts/validation_profile.py
+++ b/scripts/validation_profile.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+"""How many generated records validate, and why the rest do not.
+
+Written because #215 has no "fix": the records are what the generator produced,
+so editing them would falsify the experiment and break the artifact hashes their
+provenance pins. The failures are evidence about generation quality, and the
+useful response is to measure them rather than repair them.
+
+Forward fixes exist for two of the three causes — `normalise_temporal()` on
+write, and the DataCite-aligned enum plus its exposure in the schema digest —
+so a rerun should show a different profile. This script is how that gets
+checked.
+
+    python scripts/validation_profile.py                 # the 2026-07-31 sweep
+    python scripts/validation_profile.py --label 2026-08 # any label prefix
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import os
+import re
+import subprocess
+import sys
+
+SCHEMA = {
+    "Dataset": "src/data_sheets_schema/schema/data_sheets_schema_all.yaml",
+    "CoreDataset": "src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml",
+}
+
+
+def classify(error: str) -> str:
+    """The shape of the failure, not its wording."""
+    if "is not a 'date-time'" in error or "is not a 'date'" in error:
+        return "temporal format"
+    if (m := re.search(r"'([^']+)' is not one of", error)):
+        return f"enum value not permitted: {m.group(1)[:40]}"
+    if "is not valid under any of the given schemas" in error:
+        return "union: no matching shape"
+    if (m := re.search(r"is not of type '(\w+)'", error)):
+        return f"wrong type (expected {m.group(1)})"
+    if "is a required property" in error:
+        return "missing required property"
+    return "other"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", default="2026-07-31",
+                    help="label prefix to profile (default: the sweep)")
+    args = ap.parse_args()
+
+    records = sorted(glob.glob(
+        f"data/d4d_concatenated/*/{args.label}*/*_d4d*.yaml"))
+    if not records:
+        print(f"no records under label prefix {args.label!r}", file=sys.stderr)
+        return 1
+
+    by_arm = collections.Counter()
+    failures = collections.Counter()
+    invalid_by_arm = collections.Counter()
+    valid = 0
+
+    for path in records:
+        cls = "CoreDataset" if path.endswith("_core.yaml") else "Dataset"
+        arm = path.split("/")[2]
+        by_arm[arm] += 1
+        r = subprocess.run(
+            ["poetry", "run", "linkml-validate", "-s", SCHEMA[cls],
+             "-C", cls, path],
+            capture_output=True, text=True, timeout=300)
+        if r.returncode == 0:
+            valid += 1
+            continue
+        invalid_by_arm[arm] += 1
+        seen = set()
+        for line in (r.stdout + r.stderr).splitlines():
+            if "ERROR" not in line:
+                continue
+            kind = classify(line)
+            if kind not in seen:            # one vote per record per kind
+                seen.add(kind)
+                failures[kind] += 1
+
+    total = len(records)
+    print(f"label prefix: {args.label}")
+    print(f"{valid}/{total} records validate "
+          f"({valid / total:.0%}), {total - valid} do not\n")
+
+    print("by arm (invalid / total)")
+    for arm in sorted(by_arm):
+        print(f"  {arm:34s} {invalid_by_arm[arm]:3d} / {by_arm[arm]:3d}")
+
+    print("\nfailure kinds (records affected)")
+    for kind, n in failures.most_common():
+        print(f"  {n:3d}  {kind}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation_profile.py
+++ b/scripts/validation_profile.py
@@ -61,6 +61,7 @@ def main() -> int:
     by_arm = collections.Counter()
     failures = collections.Counter()
     invalid_by_arm = collections.Counter()
+    causes_per_record: dict[str, set[str]] = {}
     valid = 0
 
     for path in records:
@@ -83,6 +84,7 @@ def main() -> int:
             if kind not in seen:            # one vote per record per kind
                 seen.add(kind)
                 failures[kind] += 1
+        causes_per_record[path] = seen
 
     total = len(records)
     print(f"label prefix: {args.label}")
@@ -93,9 +95,28 @@ def main() -> int:
     for arm in sorted(by_arm):
         print(f"  {arm:34s} {invalid_by_arm[arm]:3d} / {by_arm[arm]:3d}")
 
-    print("\nfailure kinds (records affected)")
+    print("\nfailure kinds (records affected; a record may have several, so "
+          "these sum to more than the record count)")
     for kind, n in failures.most_common():
         print(f"  {n:3d}  {kind}")
+
+    spread = collections.Counter(len(v) for v in causes_per_record.values())
+    print("\ncauses per failing record")
+    for k in sorted(spread):
+        print(f"  {spread[k]:3d} record(s) with {k} distinct cause(s)")
+
+    # The number that matters is records whose *every* cause has a forward fix.
+    # Summing the cause counts instead overstates it — that error put the
+    # prediction in the first draft of the profile note at 3 when it is 7.
+    fixed_forward = {"temporal format"}
+    clearable = [p for p, kinds in causes_per_record.items()
+                 if kinds and all(k in fixed_forward or k.startswith("enum value")
+                                  for k in kinds)]
+    print(f"\n{len(clearable)} of {len(causes_per_record)} failing records have "
+          f"*every* cause fixed forward (temporal or enum).")
+    print(f"A rerun under the current schema and digest should leave "
+          f"{len(causes_per_record) - len(clearable)}, not zero: the rest carry "
+          f"at least one cause with no forward fix.")
     return 0
 
 


### PR DESCRIPTION
#215 asks what to do about 23 records that fail validation. The answer is
nothing — and that is worth writing down rather than leaving the issue open.

## Why not fix them

**Editing them would falsify the experiment.** These records are what the
generator produced under a stated prompt, model and temperature. That is the
observation. Rewriting `IsNewVersionOf` to `is_new_version_of` makes the corpus
a record of what we wish had been generated, and every quality figure computed
from it becomes uninterpretable.

**It would also break provenance.** Each run pins its artifacts' hashes, so
editing the bytes makes `d4d runs check` report the run as *drifted* — 23
validation errors traded for 23 broken provenance records, which is a worse
claim to make about a study corpus.

The failures are evidence about generation quality. The response is to fix the
generator and rerun, which the forward fixes already do.

## What the profile shows

69/92 validate (75%). Two things not visible from the raw failure list:

| arm | invalid / total |
|---|---|
| baseline | 10 / 50 (20%) |
| **de_novo** | **8 / 18 (44%)** |
| crate_only | 5 / 18 (28%) |
| healthsheet | 0 / 6 (0%) |

**de_novo fails about twice as often as baseline**, healthsheet not at all. n is
small — 3 records per project per arm, 3 healthsheet records total — so this is
a signal to follow, not a result.

**Core records fail less than their full counterparts in every arm**, consistent
with `CoreDataset` being the smaller target: 79 slots against 94.

By cause, 20 of 23 failures are temporal format (11) or enum values (9), both
fixed forward. The nine enum failures split into 6 DataCite spellings — the
model reaching for a vocabulary it knew because the digest never showed it the
declared one — and 2 outright inventions, which no alignment repairs.

## Falsifiable

If the forward fixes work, a rerun under the current schema and digest should
land near 3 remaining failures rather than 23. If it does not, they did not
land, and this note is the baseline that says so.

`scripts/validation_profile.py` regenerates the whole thing, no API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)