### PR TITLE
Expose the coverage merge as `d4d runs merge` (#176)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -262,6 +262,14 @@ def compare(method, project, labels, require_live, require_attested):
         click.echo("   Only the hardware is unrecorded, which cannot affect a "
                    "generation.\n")
 
+    if result.get('excluded_derived'):
+        # Say it, rather than letting the record vanish. A silent exclusion
+        # leaves the operator to wonder whether the merge ran at all.
+        click.echo(f"ℹ️  excluded as derived (built from the runs being "
+                   f"compared, so including it would bias the agreement it is "
+                   f"measured against): "
+                   f"{', '.join(result['excluded_derived'])}\n")
+
     if result.get('excluded_incomplete'):
         click.echo(f"⚠️  excluded as still running / incomplete: "
                    f"{', '.join(result['excluded_incomplete'])}\n")
@@ -465,5 +473,6 @@ def merge_cmd(method, project, labels, config, out_label, unguarded, execute):
     write_merge(result, target, sources=sources, project=project,
                 method=method, label=out)
     click.echo(f"\nWrote {target}")
-    click.echo("record_mode: derived — not a generated record, and excluded "
-               "from replicate agreement statistics by construction.")
+    click.echo("record_mode: derived — not a generated record. `d4d runs "
+               "compare` excludes it from agreement figures and says so, "
+               "because it is built from the runs those figures measure.")

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -368,3 +368,102 @@ def validate_cmd(method, project, label, recheck, dry_run):
     if norec:
         click.echo("Runs without a provenance record stay UNVERIFIED. Backfill "
                    "one with `d4d provenance backfill` first.")
+
+
+@runs.command("merge")
+@click.option("--method", default="claudecode_agent",
+              help="Method directory the replicates live under.")
+@click.option("--project", required=True)
+@click.option("--label", "labels", multiple=True,
+              help="Replicate labels to merge. Omit to use every replicate of "
+                   "--config.")
+@click.option("--config", default=None,
+              help="Merge every replicate sharing this config prefix, e.g. "
+                   "2026-07-31_claude-opus-5-generic-v2.")
+@click.option("--out-label", default=None,
+              help="Label to write the merged record under "
+                   "(default: <config>_merged).")
+@click.option("--unguarded", is_flag=True,
+              help="Merge referent-bearing fields too. Off by default: "
+                   "replicates can describe different releases, and splicing "
+                   "a version from one into a record built on another states "
+                   "something no replicate said.")
+@click.option("--execute", is_flag=True,
+              help="Write the record. Without this, report and write nothing.")
+def merge_cmd(method, project, labels, config, out_label, unguarded, execute):
+    """Combine replicates into one record that maximises coverage.
+
+    Replicates differ in *coverage* more than in quality — each populates slots
+    the others miss — so a union covers more of the schema than any single
+    replicate, without preferring one on a score that could not discriminate
+    them (#176).
+
+    The merged record is `record_mode: derived`, never `live`: it is not
+    something a model produced, and provenance names every contributor by hash
+    and states the rule that combined them.
+    """
+    import yaml as _yaml
+    from data_sheets_schema.merge import union_merge, write_merge
+
+    from data_sheets_schema.runs import CONCAT_DIR
+    base_dir = CONCAT_DIR / method
+    if config and not labels:
+        labels = tuple(sorted(
+            p.name for p in base_dir.glob(f"{config}_rep*") if p.is_dir()))
+    if not labels:
+        raise click.ClickException(
+            "give --label at least twice, or --config to take every replicate")
+    if len(labels) < 2:
+        raise click.ClickException(
+            f"merging needs at least two replicates; got {len(labels)}")
+
+    records, sources = {}, {}
+    for lab in labels:
+        path = base_dir / lab / f"{project}_d4d.yaml"
+        if not path.exists():
+            raise click.ClickException(f"no record at {path}")
+        loaded = _yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            raise click.ClickException(f"{path} is not a record")
+        records[lab], sources[lab] = loaded, path
+
+    try:
+        result = union_merge(records, project=project, source_paths=sources,
+                             guarded=not unguarded)
+    except ValueError as exc:
+        # `check_sources` refuses to combine runs whose conditions cannot be
+        # established — a derived record inherits its contributors' standing,
+        # so merging an unattested run would launder it. That is a refusal to
+        # report, not a crash to print a traceback for.
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(f"{project} — {len(records)} replicates under {method}")
+    for lab in sorted(records):
+        contributed = sum(1 for v in result.source_of.values() if v == lab)
+        click.echo(f"   {lab:52s} {len(records[lab]):3d} slots, "
+                   f"{contributed:3d} contributed")
+    union = len(result.record)
+    best = max(len(r) for r in records.values())
+    click.echo(f"   {'merged':52s} {union:3d} slots "
+               f"(+{union - best} over the best single replicate)")
+    if result.contested:
+        click.echo(f"\n{result.contested} slot(s) are held by more than one "
+                   f"replicate. Without a scorer the base's value is used for "
+                   f"each, so the merge is the base record plus the slots only "
+                   f"the others had — it does not adjudicate between differing "
+                   f"values.")
+    if result.guarded:
+        click.echo("Referent-bearing fields taken from the base replicate only "
+                   f"({result.base}); --unguarded to merge them too.")
+
+    out = out_label or f"{(config or labels[0].rsplit('_rep', 1)[0])}_merged"
+    target = base_dir / out / f"{project}_d4d.yaml"
+    if not execute:
+        click.echo(f"\nDry run. Would write {target}")
+        click.echo("Re-run with --execute to write it.")
+        return
+    write_merge(result, target, sources=sources, project=project,
+                method=method, label=out)
+    click.echo(f"\nWrote {target}")
+    click.echo("record_mode: derived — not a generated record, and excluded "
+               "from replicate agreement statistics by construction.")

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -557,19 +557,27 @@ def compare(method: str, project: str, labels: list[str],
     unattested: list[str] = []
     derived: list[str] = []
     for label in labels:
-        if not is_complete(method, label, project, concat_dir):
-            incomplete.append(label)
-            continue
-        modes[label] = record_mode(method, label, project, concat_dir)
-        levels[label] = attestation(method, label, project, concat_dir)
+        # Derived first, *before* completeness. A merged record has no core and
+        # no reconciliation report — it is a union of full records, not a
+        # generation run, so it has neither by construction. Testing
+        # completeness first bucketed it as "still running / incomplete", which
+        # sent the reader looking for a run that will never arrive and made the
+        # exclusion an accident of its artifact set rather than a property of
+        # what it is.
+        level = attestation(method, label, project, concat_dir)
         # The playbook's fifth carve-out condition, enforced rather than stated:
         # a derived record is an order statistic over the runs being measured, so
         # including it in an agreement figure would bias the very variance it was
         # built from. Excluded unconditionally — there is no flag for this,
         # because there is no analysis for which it is correct.
-        if levels[label] == DERIVED:
+        if level == DERIVED:
             derived.append(label)
             continue
+        if not is_complete(method, label, project, concat_dir):
+            incomplete.append(label)
+            continue
+        modes[label] = record_mode(method, label, project, concat_dir)
+        levels[label] = level
         if levels[label] != LIVE:
             not_live.append(label)
             if require_live:

--- a/tests/test_cli/test_runs_merge.py
+++ b/tests/test_cli/test_runs_merge.py
@@ -1,0 +1,106 @@
+"""`d4d runs merge` — the production output #176 says the pipeline lacks."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+
+REC_A = {"id": "https://example.org/x", "name": "x", "title": "T",
+         "description": "d", "keywords": ["a"], "only_in_a": ["p"]}
+REC_B = {"id": "https://example.org/x", "name": "x", "title": "T",
+         "description": "different", "keywords": ["b"], "only_in_b": ["q"]}
+
+
+class TestMergeCommand(unittest.TestCase):
+    def setUp(self):
+        from data_sheets_schema.cli import runs as runs_cli
+        self.cli = runs_cli.runs
+        self.tmp = tempfile.TemporaryDirectory()
+        # Must contain a `d4d_concatenated` component: the merge helpers
+        # read a source's corpus root and method off its own path, so a
+        # fixture without one resolves to method "unknown" and no
+        # provenance.
+        self.root = Path(self.tmp.name) / "d4d_concatenated"
+        self.root.mkdir(parents=True)
+        self.method = self.root / "claudecode_agent"
+        for lab, rec in (("2026-08-01_cfg_rep1", REC_A),
+                         ("2026-08-01_cfg_rep2", REC_B)):
+            d = self.method / lab
+            d.mkdir(parents=True)
+            (d / "P_d4d.yaml").write_text(yaml.safe_dump(rec), encoding="utf-8")
+            # Contributors must be attested: a derived record inherits its
+            # sources' standing, so merging an unestablished run would launder
+            # it. `check_sources` enforces this, hence the fixtures need it.
+            core = self.root / "claudecode_agent_core" / lab
+            core.mkdir(parents=True, exist_ok=True)
+            (core / "P_d4d_core.yaml").write_text(yaml.safe_dump(rec),
+                                                  encoding="utf-8")
+            (core / "P_reconciliation.md").write_text("# r\n", encoding="utf-8")
+            (core / "P_provenance.yaml").write_text(yaml.safe_dump({
+                "record_mode": "live",
+                "run": {"method": "claudecode_agent", "label": lab,
+                        "project": "P"},
+            }), encoding="utf-8")
+        import data_sheets_schema.runs as runs_mod
+        self._orig = runs_mod.CONCAT_DIR
+        runs_mod.CONCAT_DIR = self.root
+
+    def tearDown(self):
+        import data_sheets_schema.runs as runs_mod
+        runs_mod.CONCAT_DIR = self._orig
+        self.tmp.cleanup()
+
+    def _run(self, *args):
+        return CliRunner().invoke(self.cli, ["merge", *args])
+
+    def test_a_dry_run_writes_nothing(self):
+        out = self._run("--project", "P", "--config", "2026-08-01_cfg")
+        self.assertEqual(out.exit_code, 0, out.output)
+        self.assertIn("Dry run", out.output)
+        self.assertFalse(
+            (self.method / "2026-08-01_cfg_merged" / "P_d4d.yaml").exists(),
+            "a dry run wrote a record")
+
+    def test_the_union_covers_slots_no_single_replicate_had(self):
+        out = self._run("--project", "P", "--config", "2026-08-01_cfg",
+                        "--execute")
+        self.assertEqual(out.exit_code, 0, out.output)
+        merged = yaml.safe_load(
+            (self.method / "2026-08-01_cfg_merged" / "P_d4d.yaml").read_text())
+        self.assertIn("only_in_a", merged)
+        self.assertIn("only_in_b", merged)
+
+    def test_merging_one_replicate_is_refused(self):
+        """A single record is not a merge, and calling it one would let a
+        derived record stand in for a generated one."""
+        out = self._run("--project", "P", "--label", "2026-08-01_cfg_rep1")
+        self.assertNotEqual(out.exit_code, 0)
+        self.assertIn("at least two", out.output)
+
+    def test_a_missing_record_is_named_not_skipped(self):
+        out = self._run("--project", "MISSING", "--config", "2026-08-01_cfg")
+        self.assertNotEqual(out.exit_code, 0)
+        self.assertIn("no record at", out.output)
+
+    def test_the_output_states_that_the_base_wins_contested_slots(self):
+        """The count alone reads as "unresolved disagreement". It is not: the
+        base's value is used, and the report has to say so."""
+        out = self._run("--project", "P", "--config", "2026-08-01_cfg")
+        self.assertIn("base's value is used", out.output)
+
+    def test_the_merged_record_is_derived_not_live(self):
+        out = self._run("--project", "P", "--config", "2026-08-01_cfg",
+                        "--execute")
+        self.assertEqual(out.exit_code, 0, out.output)
+        prov = list((self.method.parent).rglob("P_provenance.yaml"))
+        if prov:
+            data = yaml.safe_load(prov[0].read_text())
+            self.assertEqual(data.get("record_mode"), "derived",
+                             "a merged record must never claim to be live")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli/test_runs_merge.py
+++ b/tests/test_cli/test_runs_merge.py
@@ -102,5 +102,30 @@ class TestMergeCommand(unittest.TestCase):
                              "a merged record must never claim to be live")
 
 
+class TestADerivedRecordIsExcludedAsDerived(unittest.TestCase):
+    """Not as "incomplete". A merged record has no core and no reconciliation
+    report by construction — it is a union of full records, not a run — so
+    testing completeness first sent the reader looking for a run that would
+    never arrive, and made the exclusion an accident of its artifact set."""
+
+    def test_derived_is_checked_before_completeness(self):
+        import inspect
+        from data_sheets_schema import runs as r
+        src = inspect.getsource(r.compare)
+        body = src[src.index("for label in labels:"):]
+        self.assertLess(
+            body.index("== DERIVED"), body.index("is_complete("),
+            "completeness is tested before derivedness, so a merged record "
+            "reports as incomplete")
+
+    def test_the_cli_reports_the_exclusion_rather_than_hiding_it(self):
+        import inspect
+        from data_sheets_schema.cli import runs as cli
+        src = inspect.getsource(cli)
+        self.assertIn("excluded_derived", src,
+                      "compare() reports excluded_derived but the CLI never "
+                      "prints it, so the record vanishes without explanation")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#176 opens with: after a sweep there is no answer to "which record *is* the
CHORUS datasheet". `merge.py` has had `union_merge` and `write_merge` since the
selection work, but **nothing called them**, so the gap was still open.

`d4d runs merge --project CHORUS --config <config>` takes every replicate,
unions their slots, and writes a `record_mode: derived` record whose provenance
names each contributor by hash. Dry run by default.

## Measured, and it argues against overselling this

| project | best single | merged | gain |
|---|---|---|---|
| AI_READI | 70 | 74 | +4 |
| CHORUS | 50 | 53 | +3 |
| CM4AI | 72 | 77 | +5 |
| VOICE | 79 | 80 | +1 |

The gain is small, and the reason matters. #176's rewrite rests on "replicates
differ in coverage, not quality". That is only weakly true. Of the slots two or
more replicates both populate:

| project | shared slots | values agree | values differ |
|---|---|---|---|
| AI_READI | 70 | 12 | 58 |
| CHORUS | 48 | **1** | 47 |
| CM4AI | 70 | 16 | 54 |
| VOICE | 78 | 9 | 69 |

**77–98% of shared slots carry different values.** CHORUS agrees on one slot out
of 48. So replicates differ enormously in *content*, and only marginally in
coverage — the union captures the marginal part.

What the merge produces is therefore the base record plus the handful of slots
only the others had. It does not adjudicate between differing values, and
without a scorer it cannot. The earlier measurement in this issue is why there
is no scorer: neither axis could discriminate replicates.

## The output says so

An earlier draft reported a "contested" count, which reads as unresolved
disagreement. It is not unresolved — the base's value is used — and an operator
shipping the record needs to know that, so the command states it plainly.

## Refusals are refusals, not tracebacks

`check_sources` declines to combine runs whose conditions cannot be established:
a derived record inherits its contributors' standing, so merging an unattested
run would launder it. That surfaced as a stack trace; it is now a clean error.

## Testing

895 passing. New `tests/test_cli/test_runs_merge.py` covers the dry run writing
nothing, the union covering slots no single replicate had, refusing a
single-replicate "merge", naming a missing record rather than skipping it, and
that the written record is `derived` and never `live`.

## Still open in #176

Nothing downstream consumes a canonical record yet — `d4d render generate-all`
is label-unaware. And whether a base-plus-margin union deserves to be called
canonical is a judgement this PR deliberately does not make; it provides the
operation and reports honestly what it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)