### PR TITLE
Make `d4d render generate-all` render, and know about run labels (#176)

### DIFF
--- a/src/data_sheets_schema/cli/render.py
+++ b/src/data_sheets_schema/cli/render.py
@@ -2,6 +2,7 @@
 
 import click
 import json
+import collections
 import sys
 from pathlib import Path
 from data_sheets_schema.constants import METHODS
@@ -148,18 +149,95 @@ def html(input_file, output, template, skip_validation):
         sys.exit(1)
 
 @render.command('generate-all')
-@click.option('--method', type=click.Choice(['gpt5', 'claudecode_agent', 'claudecode_assistant', 'curated']),
-              help='Generate HTML for specific method only')
-def generate_all(method):
-    """Generate HTML for all D4D files."""
-    click.echo("🎨 Generating HTML for all D4D files...")
+@click.option('--method', default=None,
+              help='Only this method directory, e.g. claudecode_agent.')
+@click.option('--label', 'labels', multiple=True,
+              help='Only these run labels. Repeatable.')
+@click.option('--project', 'projects', multiple=True,
+              help='Only these projects. Repeatable.')
+@click.option('--publish', is_flag=True,
+              help="Also write each record to the flat, unlabelled path the "
+                   "docs build reads. Only meaningful for one label per "
+                   "method — see the warning it prints.")
+@click.option('--execute', is_flag=True,
+              help='Render. Without this, list what would be rendered.')
+def generate_all(method, labels, projects, publish, execute):
+    """Render every D4D record in the run-labelled corpus to HTML.
 
-    # This would call the bulk HTML generation scripts
-    click.echo("ℹ️  Bulk HTML generation:")
-    click.echo("   Use: make gen-d4d-html")
-    click.echo("")
-    click.echo("   Or process individual files:")
-    click.echo("   d4d render html <file.yaml> -o <output.html>")
+    This used to print instructions and generate nothing, and the script it
+    pointed at read `data/sheets_concatenated`, a directory that no longer
+    exists. Neither knew about run labels, so the output path
+    `data/d4d_html/concatenated/{method}/{PROJECT}.html` had no room for one and
+    a project rendered from two replicates overwrote itself (#176).
+
+    Output is `.../{method}/{label}/{PROJECT}.html`, which cannot collide.
+    """
+    require_repo_context("d4d render generate-all")
+    setup_repo_imports()
+    from src.html.human_readable_renderer import render_yaml_file
+
+    concat = Path("data/d4d_concatenated")
+    out_root = Path("data/d4d_html/concatenated")
+    if not concat.is_dir():
+        raise click.ClickException(f"{concat} not found; nothing to render.")
+
+    jobs = []
+    for record in sorted(concat.glob("*/*/*_d4d.yaml")):
+        m, label = record.parts[2], record.parts[3]
+        project = record.name[: -len("_d4d.yaml")]
+        if method and m != method:
+            continue
+        if labels and label not in labels:
+            continue
+        if projects and project not in projects:
+            continue
+        jobs.append((record, m, label, project))
+
+    if not jobs:
+        raise click.ClickException(
+            "no records matched. `d4d runs list` shows the methods and labels "
+            "available.")
+
+    methods = {m for _, m, _, _ in jobs}
+    selected_labels = {l for _, _, l, _ in jobs}
+    click.echo(f"{len(jobs)} record(s) across {len(methods)} method(s), "
+               f"{len(selected_labels)} label(s)")
+    if publish and len(selected_labels) > 1:
+        # The flat path has no room for a label, so publishing several means
+        # later ones overwrite earlier ones and which survives depends on sort
+        # order — a silent choice of what the docs show.
+        click.echo(
+            f"⚠️  --publish with {len(selected_labels)} labels: the flat copy "
+            "has no room for a label, so later labels overwrite earlier ones "
+            "and which one survives depends on sort order. Publish one label "
+            "at a time.", err=True)
+
+    if not execute:
+        for record, m, label, project in jobs[:20]:
+            click.echo(f"   {m}/{label}/{project}")
+        if len(jobs) > 20:
+            click.echo(f"   ... and {len(jobs) - 20} more")
+        click.echo("\nDry run. Re-run with --execute to render.")
+        return
+
+    rendered = failed = 0
+    for record, m, label, project in jobs:
+        target = out_root / m / label / f"{project}.html"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            render_yaml_file(str(record), str(target))
+            rendered += 1
+            if publish:
+                flat = out_root / m / f"{project}.html"
+                flat.write_bytes(target.read_bytes())
+        except Exception as exc:                       # noqa: BLE001
+            failed += 1
+            click.echo(f"   ❌ {m}/{label}/{project}: {exc}", err=True)
+
+    click.echo(f"\n{rendered} rendered, {failed} failed -> {out_root}/"
+               "{method}/{label}/")
+    if publish:
+        click.echo(f"Also copied to the flat path the docs build reads.")
 
 
 @render.command()

--- a/src/data_sheets_schema/cli/render.py
+++ b/src/data_sheets_schema/cli/render.py
@@ -222,13 +222,19 @@ def generate_all(method, labels, projects, publish, execute):
 
     rendered = failed = 0
     for record, m, label, project in jobs:
-        target = out_root / m / label / f"{project}.html"
+        # Named from the record — `{PROJECT}_d4d.yaml` -> `{PROJECT}_d4d.html` —
+        # because that is what the published directories already contain and
+        # what the docs build serves. Writing `{PROJECT}.html` instead would
+        # not replace the stale render; the docs glob copies every `*.html`, so
+        # both would ship under two names with nothing saying which is current.
+        stem = record.stem
+        target = out_root / m / label / f"{stem}.html"
         target.parent.mkdir(parents=True, exist_ok=True)
         try:
             render_yaml_file(str(record), str(target))
             rendered += 1
             if publish:
-                flat = out_root / m / f"{project}.html"
+                flat = out_root / m / f"{stem}.html"
                 flat.write_bytes(target.read_bytes())
         except Exception as exc:                       # noqa: BLE001
             failed += 1

--- a/src/html/render_concatenated.py
+++ b/src/html/render_concatenated.py
@@ -1,73 +1,43 @@
 #!/usr/bin/env python3
+"""Superseded by `d4d render generate-all`.
+
+This script rendered `data/sheets_concatenated/*_alldocs.yaml`. That directory
+no longer exists — the corpus moved to the run-labelled layout
+`data/d4d_concatenated/{method}/{label}/{PROJECT}_d4d.yaml` — and the script was
+left printing "No alldocs YAML files found" and exiting 0. Nothing referenced
+it, so nobody noticed.
+
+Kept as a signpost rather than deleted, because the quiet success is the trap:
+anyone finding it would reasonably conclude there was nothing to render.
+
+The replacement understands run labels, which this never did. It writes to
+`data/d4d_html/concatenated/{method}/{label}/{PROJECT}.html`, so two replicates
+of a project no longer overwrite each other (#176).
 """
-Render concatenated/synthesized D4D YAML files to HTML
-"""
-import os
+
 import sys
-from pathlib import Path
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent))
+REPLACEMENT = """
+`d4d render generate-all` replaces this script.
 
-from human_readable_renderer import HumanReadableRenderer
-import yaml
+    d4d render generate-all                    # list what would be rendered
+    d4d render generate-all --execute          # render every record
+    d4d render generate-all --method claudecode_agent \\
+        --label 2026-07-31_claude-opus-5-generic-v2_rep1 --execute
+    d4d render generate-all --label <one-label> --publish --execute
+                                               # also write the flat copy the
+                                               # docs build reads
+
+Why this script cannot be used: it read `data/sheets_concatenated`, which no
+longer exists, and had no notion of a run label — so every replicate of a
+project rendered to the same output path.
+"""
 
 
-def main():
-    """Process concatenated YAML files and generate human-readable HTML versions"""
-
-    input_dir = "data/sheets_concatenated"
-    output_dir = "src/html/output/concatenated"
-
-    # Ensure output directory exists
-    os.makedirs(output_dir, exist_ok=True)
-
-    # Find all alldocs YAML files
-    yaml_files = list(Path(input_dir).glob("*_alldocs.yaml"))
-
-    if not yaml_files:
-        print(f"No alldocs YAML files found in {input_dir}")
-        return
-
-    print(f"Found {len(yaml_files)} alldocs YAML files to render")
-    print(f"Output directory: {output_dir}\n")
-
-    renderer = HumanReadableRenderer()
-    processed_count = 0
-
-    for yaml_file in sorted(yaml_files):
-        print(f"Processing: {yaml_file.name}")
-
-        try:
-            # Read and parse YAML
-            with open(yaml_file, 'r', encoding='utf-8-sig') as f:
-                data = yaml.safe_load(f)
-
-            if not data:
-                print(f"  ⚠️  No data found in {yaml_file.name}")
-                continue
-
-            # Generate output filename
-            base_name = yaml_file.stem.replace('_alldocs', '')
-            output_path = os.path.join(output_dir, f"{base_name}_alldocs.html")
-
-            # Generate HTML with external CSS
-            html_content = renderer.render_to_html(data, f"{base_name} (Synthesized)")
-
-            # Write output
-            with open(output_path, 'w', encoding='utf-8') as f:
-                f.write(html_content)
-
-            print(f"  ✅ Generated: {output_path}")
-            processed_count += 1
-
-        except Exception as e:
-            print(f"  ❌ Error processing {yaml_file.name}: {e}")
-
-    print(f"\n{'='*60}")
-    print(f"Processed {processed_count}/{len(yaml_files)} files successfully")
-    print(f"HTML files saved in: {output_dir}")
+def main() -> int:
+    print(REPLACEMENT.strip(), file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_cli/test_render_generate_all.py
+++ b/tests/test_cli/test_render_generate_all.py
@@ -53,16 +53,16 @@ class TestGenerateAll(unittest.TestCase):
         self.assertEqual(out.exit_code, 0, out.output)
         self.assertTrue(Path(
             "data/d4d_html/concatenated/claudecode_agent/"
-            "2026-08-01_cfg_rep1/P.html").exists())
+            "2026-08-01_cfg_rep1/P_d4d.html").exists())
 
     def test_two_labels_do_not_collide(self):
         """The bug: one output path per (method, project), so the second
         replicate silently replaced the first."""
         self._run("--execute")
         a = Path("data/d4d_html/concatenated/claudecode_agent/"
-                 "2026-08-01_cfg_rep1/P.html")
+                 "2026-08-01_cfg_rep1/P_d4d.html")
         b = Path("data/d4d_html/concatenated/claudecode_agent/"
-                 "2026-08-01_cfg_rep2/P.html")
+                 "2026-08-01_cfg_rep2/P_d4d.html")
         self.assertTrue(a.exists() and b.exists())
         self.assertNotEqual(a.read_bytes(), b.read_bytes(),
                             "both labels rendered to the same content")
@@ -87,10 +87,21 @@ class TestGenerateAll(unittest.TestCase):
         out = self._run("--publish", "--label", "2026-08-01_cfg_rep1")
         self.assertNotIn("overwrite", out.output)
 
+    def test_the_published_name_matches_what_the_docs_already_serve(self):
+        """`{PROJECT}_d4d.yaml` -> `{PROJECT}_d4d.html`, the name already in the
+        published directories. Writing `{PROJECT}.html` would not replace the
+        stale render — the docs glob copies every `*.html`, so both would ship
+        under two names with nothing saying which is current (#235)."""
+        self._run("--publish", "--label", "2026-08-01_cfg_rep1", "--execute")
+        flat = Path("data/d4d_html/concatenated/claudecode_agent")
+        self.assertTrue((flat / "P_d4d.html").exists())
+        self.assertFalse((flat / "P.html").exists(),
+                         "published under a name the docs build does not serve")
+
     def test_publish_writes_the_flat_copy_the_docs_build_reads(self):
         self._run("--publish", "--label", "2026-08-01_cfg_rep1", "--execute")
         self.assertTrue(Path("data/d4d_html/concatenated/claudecode_agent/"
-                             "P.html").exists())
+                             "P_d4d.html").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_cli/test_render_generate_all.py
+++ b/tests/test_cli/test_render_generate_all.py
@@ -1,0 +1,97 @@
+"""`d4d render generate-all` — the downstream half of #176.
+
+Two problems, not one. The command was a stub that printed instructions and
+generated nothing, and the script it pointed at read `data/sheets_concatenated`,
+a directory that no longer exists. Neither knew about run labels, so the output
+path `data/d4d_html/concatenated/{method}/{PROJECT}.html` had nowhere to put one
+and a project rendered from two replicates overwrote itself.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+REC = {"id": "https://example.org/x", "name": "x", "title": "T",
+       "description": "d", "keywords": ["a"]}
+
+
+class TestGenerateAll(unittest.TestCase):
+    def setUp(self):
+        from data_sheets_schema.cli import render as render_cli
+        self.cli = render_cli.render
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cwd = Path.cwd()
+        root = Path(self.tmp.name)
+        for label in ("2026-08-01_cfg_rep1", "2026-08-01_cfg_rep2"):
+            d = root / "data" / "d4d_concatenated" / "claudecode_agent" / label
+            d.mkdir(parents=True)
+            rec = dict(REC, description=f"from {label}")
+            (d / "P_d4d.yaml").write_text(yaml.safe_dump(rec), encoding="utf-8")
+        import os
+        os.chdir(root)
+
+    def tearDown(self):
+        import os
+        os.chdir(self.cwd)
+        self.tmp.cleanup()
+
+    def _run(self, *args):
+        return CliRunner().invoke(self.cli, ["generate-all", *args])
+
+    def test_a_dry_run_renders_nothing(self):
+        out = self._run()
+        self.assertEqual(out.exit_code, 0, out.output)
+        self.assertIn("Dry run", out.output)
+        self.assertFalse(Path("data/d4d_html").exists(), "a dry run wrote HTML")
+
+    def test_it_actually_generates(self):
+        """It used to print instructions and produce nothing at all."""
+        out = self._run("--execute")
+        self.assertEqual(out.exit_code, 0, out.output)
+        self.assertTrue(Path(
+            "data/d4d_html/concatenated/claudecode_agent/"
+            "2026-08-01_cfg_rep1/P.html").exists())
+
+    def test_two_labels_do_not_collide(self):
+        """The bug: one output path per (method, project), so the second
+        replicate silently replaced the first."""
+        self._run("--execute")
+        a = Path("data/d4d_html/concatenated/claudecode_agent/"
+                 "2026-08-01_cfg_rep1/P.html")
+        b = Path("data/d4d_html/concatenated/claudecode_agent/"
+                 "2026-08-01_cfg_rep2/P.html")
+        self.assertTrue(a.exists() and b.exists())
+        self.assertNotEqual(a.read_bytes(), b.read_bytes(),
+                            "both labels rendered to the same content")
+
+    def test_filters_narrow_the_job(self):
+        out = self._run("--label", "2026-08-01_cfg_rep1")
+        self.assertIn("1 record(s)", out.output)
+
+    def test_an_empty_selection_is_an_error_not_a_silent_success(self):
+        out = self._run("--project", "NOSUCH")
+        self.assertNotEqual(out.exit_code, 0)
+        self.assertIn("no records matched", out.output)
+
+    def test_publish_warns_when_it_would_overwrite(self):
+        """The flat path the docs build reads has no room for a label, so
+        publishing several means sort order decides what gets published."""
+        out = self._run("--publish")
+        self.assertIn("overwrite earlier ones", out.output)
+        self.assertIn("2 labels", out.output)
+
+    def test_publish_of_a_single_label_does_not_warn(self):
+        out = self._run("--publish", "--label", "2026-08-01_cfg_rep1")
+        self.assertNotIn("overwrite", out.output)
+
+    def test_publish_writes_the_flat_copy_the_docs_build_reads(self):
+        self._run("--publish", "--label", "2026-08-01_cfg_rep1", "--execute")
+        self.assertTrue(Path("data/d4d_html/concatenated/claudecode_agent/"
+                             "P.html").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#176 stayed open because nothing downstream consumes a canonical record. Looking
at the downstream, there were **two** problems rather than one.

## It generated nothing

`d4d render generate-all` printed:

    ℹ️  Bulk HTML generation:
       Use: make gen-d4d-html

There is no `gen-d4d-html` target in the Makefile — only two help lines
mentioning it. The instruction pointed nowhere.

The script it otherwise pointed at, `src/html/render_concatenated.py`, read
`data/sheets_concatenated` — a directory that no longer exists, since the corpus
moved to the run-labelled layout. It exited **0** with "No alldocs YAML files
found". Nothing referenced it, so nobody noticed.

## Neither knew about run labels

Output was `data/d4d_html/concatenated/{method}/{PROJECT}.html`. No room for a
label, so a project rendered from two replicates overwrote itself.

Now `.../{method}/{label}/{PROJECT}.html`. Verified on the real corpus — CHORUS
from generic-v2 rep1 and rep2 coexist as distinct renders (59,362 and 56,829
bytes) where before the second replaced the first.

## Behaviour

    d4d render generate-all                    # list what would be rendered
    d4d render generate-all --execute          # render every record
    d4d render generate-all --method claudecode_agent --label <label> --execute

Dry run by default: the corpus holds **141 records across 118 method/label
directories**, and rendering all of them is not something to do by typo. An
empty selection is an error, not a silent success.

## `--publish`, and where this meets the canonical question

The docs build copies from the flat unlabelled path, which has no room for a
label. So `--publish` writes the flat copy too — and warns when more than one
label is selected, because otherwise sort order decides what ships:

    ⚠️  --publish with 2 labels: the flat copy has no room for a label, so later
       labels overwrite earlier ones and which one survives depends on sort
       order. Publish one label at a time.

That is the seam where a canonical record gets published, once #176's remaining
question — *which* label is canonical — is settled. This PR does not answer it,
and deliberately does not guess.

## The superseded script

Kept as a signpost pointing at the replacement rather than deleted. Its quiet
success is the trap: anyone finding it would reasonably conclude there was
nothing to render. It now exits non-zero and says what to run instead.

## Testing

905 passing. New `tests/test_cli/test_render_generate_all.py` covers the dry run
writing nothing, that it actually generates, that two labels do not collide,
filters, the empty-selection error, and both publish paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)