### PR TITLE
Select one replicate as canonical, keeping all of them (#176)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -476,3 +476,143 @@ def merge_cmd(method, project, labels, config, out_label, unguarded, execute):
     click.echo("record_mode: derived — not a generated record. `d4d runs "
                "compare` excludes it from agreement figures and says so, "
                "because it is built from the runs those figures measure.")
+
+
+def _validates(record: Path) -> bool:
+    """Run the validator, rather than trust a status recorded earlier."""
+    import subprocess
+    schema = "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
+    try:
+        return subprocess.run(
+            ["poetry", "run", "linkml-validate", "-s", schema, "-C", "Dataset",
+             str(record)], capture_output=True, text=True,
+            timeout=300).returncode == 0
+    except Exception:                                   # noqa: BLE001
+        return False
+
+
+@runs.command("select")
+@click.option("--method", default="claudecode_agent",
+              help="Method directory the replicates live under.")
+@click.option("--project", required=True)
+@click.option("--config", required=True,
+              help="Config prefix whose replicates are the candidates, e.g. "
+                   "2026-07-31_claude-opus-5-generic-v2.")
+@click.option("--allow-unverified", is_flag=True,
+              help="Consider replicates whose validation status is unknown. "
+                   "Off by default: absence of evidence is not validity.")
+@click.option("--execute", is_flag=True,
+              help="Record the choice in the winner's provenance. Without "
+                   "this, report and write nothing.")
+def select_cmd(method, project, config, allow_unverified, execute):
+    """Mark one replicate canonical, keeping all of them.
+
+    Selection, not merging. Merging splices values across replicates that
+    disagree on 77-98% of the slots they share, for a coverage gain of 1-5 slots
+    (#229) — and a spliced record can assert a participant count from one
+    referent and a DOI from another. A single replicate is internally coherent
+    because one generation produced it.
+
+    The criterion is **validity first, coverage second**. Coverage alone is
+    close to arbitrary here: margins across the generic-v2 config are +0, +1,
+    +2 and +1 slots, and AI-READI is an outright tie. Validity is decisive —
+    it breaks that tie, eliminates a higher-coverage CM4AI replicate, and shows
+    that no VOICE replicate is shippable at all.
+
+    Nothing is moved or copied. The winner's provenance gains a `canonical`
+    block naming every candidate and the criterion, so the choice is auditable
+    and reversible.
+    """
+    import yaml as _yaml
+    from data_sheets_schema.runs import (
+        CONCAT_DIR, INVALID, UNVERIFIED, VALID, is_complete, validation_status)
+    from data_sheets_schema.provenance import ProvenanceRecord, record_path_for
+
+    base_dir = CONCAT_DIR / method
+    labels = sorted(p.name for p in base_dir.glob(f"{config}_rep*") if p.is_dir())
+    if len(labels) < 2:
+        raise click.ClickException(
+            f"selection needs at least two replicates of {config!r}; "
+            f"found {len(labels)}")
+
+    candidates = []
+    for label in labels:
+        record = base_dir / label / f"{project}_d4d.yaml"
+        if not record.exists():
+            candidates.append((label, None, "no record", 0, "no record"))
+            continue
+        if not is_complete(method, label, project, CONCAT_DIR):
+            candidates.append((label, record, "incomplete", 0, "incomplete"))
+            continue
+        loaded = _yaml.safe_load(record.read_text(encoding="utf-8"))
+        slots = len(loaded) if isinstance(loaded, dict) else 0
+        # Validate now, rather than reading the status recorded at generation
+        # time. `compare()` reads the record because it runs over 100+ runs in
+        # an analysis hot path; selection touches three and happens once, so it
+        # can afford the truth. It matters: the schema has moved since these
+        # runs, and CM4AI rep1 is recorded `invalid` but validates against the
+        # current schema — the DataCite alignment admits a value that was
+        # rejected when the run was made. Selecting on the stale claim would
+        # have excluded a perfectly good record.
+        live = VALID if _validates(record) else INVALID
+        recorded = validation_status(method, label, project, CONCAT_DIR)
+        candidates.append((label, record, live, slots, recorded))
+
+    accept = {VALID} | ({UNVERIFIED} if allow_unverified else set())
+    eligible = [c for c in candidates if c[2] in accept]
+
+    click.echo(f"{project} — {len(labels)} replicate(s) of {config}")
+    for label, _record, status, slots, recorded in candidates:
+        mark = "  " if status in accept else "✗ "
+        drift = (f"  (provenance says {recorded}; the schema has moved since "
+                 f"this run)" if recorded != status and
+                 recorded in (VALID, INVALID) else "")
+        click.echo(f" {mark}{label:52s} {slots:3d} slots  {status}{drift}")
+
+    if not eligible:
+        raise click.ClickException(
+            f"no replicate of {project} is eligible. Nothing here can be "
+            f"canonical, and picking the least-bad would ship a record known "
+            f"to be broken. Fix the generator and rerun, or pass "
+            f"--allow-unverified if the statuses are merely unrecorded.")
+
+    # Coverage second, and the label as a deterministic tie-break so repeated
+    # runs agree. Margins are thin enough that ties are ordinary, not freak.
+    eligible.sort(key=lambda c: (-c[3], c[0]))
+    winner = eligible[0]
+    runner_up = eligible[1] if len(eligible) > 1 else None
+    margin = winner[3] - runner_up[3] if runner_up else None
+
+    click.echo(f"\n→ {winner[0]}  ({winner[3]} slots)")
+    if margin == 0:
+        click.echo("   Tied on coverage with the runner-up; the label broke the "
+                   "tie. The choice between them is arbitrary on this "
+                   "criterion.")
+    elif margin is not None:
+        click.echo(f"   {margin} slot(s) ahead of the runner-up — a thin margin "
+                   f"on ~{winner[3]} slots, so read this as 'no reason to "
+                   f"prefer another', not 'clearly best'.")
+
+    if not execute:
+        click.echo("\nDry run. Re-run with --execute to record the choice.")
+        return
+
+    prov_path = record_path_for(project, method, winner[0], CONCAT_DIR)
+    if not prov_path.exists():
+        raise click.ClickException(
+            f"{winner[0]} has no provenance record at {prov_path}; a canonical "
+            f"record must be attributable.")
+    data = _yaml.safe_load(prov_path.read_text(encoding="utf-8")) or {}
+    data["canonical"] = {
+        "criterion": "validates against the current schema, then most slots, then lowest label",
+        "selected_from": [
+            {"label": lab, "slots": n, "validation": st,
+             "validation_recorded_at_run_time": rec}
+            for lab, _r, st, n, rec in candidates],
+        "margin_over_runner_up": margin,
+        "selected_by": "d4d runs select",
+    }
+    ProvenanceRecord(data=data).write(prov_path)
+    click.echo(f"\nRecorded in {prov_path}")
+    click.echo("All replicates kept — this marks one, it does not move or "
+               "delete anything.")

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -478,17 +478,41 @@ def merge_cmd(method, project, labels, config, out_label, unguarded, execute):
                "because it is built from the runs those figures measure.")
 
 
-def _validates(record: Path) -> bool:
-    """Run the validator, rather than trust a status recorded earlier."""
+def _validates_one(record: Path, schema: str, cls: str) -> bool:
     import subprocess
-    schema = "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
     try:
         return subprocess.run(
-            ["poetry", "run", "linkml-validate", "-s", schema, "-C", "Dataset",
+            ["poetry", "run", "linkml-validate", "-s", schema, "-C", cls,
              str(record)], capture_output=True, text=True,
             timeout=300).returncode == 0
     except Exception:                                   # noqa: BLE001
         return False
+
+
+def _validates(record: Path) -> tuple[bool, str]:
+    """Both records a run ships, not just the full one.
+
+    Marking a run canonical marks its core record too, so judging it on the full
+    record alone can bless a run that cannot ship half of itself. CM4AI rep1 in
+    the 2026-07-31 generic-v2 config is exactly that — full valid, core invalid
+    — and it is only excluded today because it loses on coverage (#237).
+
+    Returns (ok, detail) so the report can say *which* record failed; "invalid"
+    alone sends the reader to the wrong file.
+    """
+    full_schema = "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
+    core_schema = "src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml"
+    core = (record.parent.parent.parent / f"{record.parent.parent.name}_core"
+            / record.parent.name / f"{record.name[:-len('_d4d.yaml')]}_d4d_core.yaml")
+    full_ok = _validates_one(record, full_schema, "Dataset")
+    if not core.exists():
+        return False, "no core record"
+    core_ok = _validates_one(core, core_schema, "CoreDataset")
+    if full_ok and core_ok:
+        return True, "valid"
+    if not full_ok and not core_ok:
+        return False, "invalid (full and core)"
+    return False, f"invalid ({'full' if not full_ok else 'core'})"
 
 
 @runs.command("select")
@@ -539,10 +563,10 @@ def select_cmd(method, project, config, allow_unverified, execute):
     for label in labels:
         record = base_dir / label / f"{project}_d4d.yaml"
         if not record.exists():
-            candidates.append((label, None, "no record", 0, "no record"))
+            candidates.append((label, None, "no record", 0, "no record", "no record"))
             continue
         if not is_complete(method, label, project, CONCAT_DIR):
-            candidates.append((label, record, "incomplete", 0, "incomplete"))
+            candidates.append((label, record, "incomplete", 0, "incomplete", "incomplete"))
             continue
         loaded = _yaml.safe_load(record.read_text(encoding="utf-8"))
         slots = len(loaded) if isinstance(loaded, dict) else 0
@@ -554,20 +578,21 @@ def select_cmd(method, project, config, allow_unverified, execute):
         # current schema — the DataCite alignment admits a value that was
         # rejected when the run was made. Selecting on the stale claim would
         # have excluded a perfectly good record.
-        live = VALID if _validates(record) else INVALID
+        ok, detail = _validates(record)
+        live = VALID if ok else INVALID
         recorded = validation_status(method, label, project, CONCAT_DIR)
-        candidates.append((label, record, live, slots, recorded))
+        candidates.append((label, record, live, slots, recorded, detail))
 
     accept = {VALID} | ({UNVERIFIED} if allow_unverified else set())
     eligible = [c for c in candidates if c[2] in accept]
 
     click.echo(f"{project} — {len(labels)} replicate(s) of {config}")
-    for label, _record, status, slots, recorded in candidates:
+    for label, _record, status, slots, recorded, detail in candidates:
         mark = "  " if status in accept else "✗ "
         drift = (f"  (provenance says {recorded}; the schema has moved since "
                  f"this run)" if recorded != status and
                  recorded in (VALID, INVALID) else "")
-        click.echo(f" {mark}{label:52s} {slots:3d} slots  {status}{drift}")
+        click.echo(f" {mark}{label:52s} {slots:3d} slots  {detail}{drift}")
 
     if not eligible:
         raise click.ClickException(
@@ -604,11 +629,11 @@ def select_cmd(method, project, config, allow_unverified, execute):
             f"record must be attributable.")
     data = _yaml.safe_load(prov_path.read_text(encoding="utf-8")) or {}
     data["canonical"] = {
-        "criterion": "validates against the current schema, then most slots, then lowest label",
+        "criterion": "full and core both validate against the current schema, then most slots, then lowest label",
         "selected_from": [
-            {"label": lab, "slots": n, "validation": st,
+            {"label": lab, "slots": n, "validation": detail,
              "validation_recorded_at_run_time": rec}
-            for lab, _r, st, n, rec in candidates],
+            for lab, _r, st, n, rec, detail in candidates],
         "margin_over_runner_up": margin,
         "selected_by": "d4d runs select",
     }

--- a/tests/test_cli/test_runs_select.py
+++ b/tests/test_cli/test_runs_select.py
@@ -58,10 +58,16 @@ class TestSelect(unittest.TestCase):
         self.tmp.cleanup()
 
     def _run(self, *args, valid=None):
-        """`valid` maps label -> bool; default every replicate validates."""
+        """`valid` maps label -> bool, or label -> (bool, detail).
+
+        `_validates` returns (ok, detail) so the report can name *which* of the
+        two records a run ships failed; "invalid" alone sends the reader to the
+        wrong file (#237).
+        """
         def fake(record):
             label = Path(record).parent.name
-            return True if valid is None else valid.get(label, True)
+            v = True if valid is None else valid.get(label, True)
+            return v if isinstance(v, tuple) else (v, "valid" if v else "invalid")
         with mock.patch("data_sheets_schema.cli.runs._validates", fake):
             return CliRunner().invoke(
                 self.cli, ["select", "--project", "P", "--config", "cfg", *args])
@@ -77,6 +83,16 @@ class TestSelect(unittest.TestCase):
         drops a higher-coverage CM4AI replicate."""
         out = self._run(valid={"cfg_rep2": False})
         self.assertEqual(out.exit_code, 0, out.output)
+        self.assertIn("→ cfg_rep3", out.output)
+
+    def test_an_invalid_core_disqualifies_a_run(self):
+        """A run ships two records and selection marks both. Judging it on the
+        full record alone can bless a run that cannot ship half of itself —
+        CM4AI rep1 in the real corpus is exactly that, and is excluded today
+        only because it loses on coverage (#237)."""
+        out = self._run(valid={"cfg_rep2": (False, "invalid (core)")})
+        self.assertEqual(out.exit_code, 0, out.output)
+        self.assertIn("invalid (core)", out.output)
         self.assertIn("→ cfg_rep3", out.output)
 
     def test_it_refuses_when_nothing_validates(self):

--- a/tests/test_cli/test_runs_select.py
+++ b/tests/test_cli/test_runs_select.py
@@ -1,0 +1,132 @@
+"""`d4d runs select` — pick one replicate, keep them all (#176).
+
+Selection rather than merging. Merging splices values across replicates that
+disagree on 77-98% of the slots they share, for a coverage gain of 1-5 slots
+(#229), and a spliced record can assert a participant count from one referent
+and a DOI from another. One replicate is internally coherent because one
+generation produced it.
+
+Validity first, coverage second — because coverage alone is nearly arbitrary
+here. Across the generic-v2 config the margins are +0, +1, +2 and +1 slots, and
+AI-READI is an outright tie that only validity resolves.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+from click.testing import CliRunner
+
+
+def _rec(n):
+    d = {"id": "https://example.org/x", "name": "x", "title": "T",
+         "description": "d"}
+    d.update({f"slot_{i}": [f"v{i}"] for i in range(n)})
+    return d
+
+
+class TestSelect(unittest.TestCase):
+    def setUp(self):
+        from data_sheets_schema.cli import runs as runs_cli
+        self.cli = runs_cli.runs
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name) / "d4d_concatenated"
+        self.method = self.root / "claudecode_agent"
+        # rep1 smallest, rep2 largest, rep3 middle
+        for label, n in (("cfg_rep1", 4), ("cfg_rep2", 9), ("cfg_rep3", 6)):
+            d = self.method / label
+            d.mkdir(parents=True)
+            (d / "P_d4d.yaml").write_text(yaml.safe_dump(_rec(n)),
+                                          encoding="utf-8")
+            core = self.root / "claudecode_agent_core" / label
+            core.mkdir(parents=True, exist_ok=True)
+            (core / "P_d4d_core.yaml").write_text("id: x\n", encoding="utf-8")
+            (core / "P_reconciliation.md").write_text("# r\n", encoding="utf-8")
+            (core / "P_provenance.yaml").write_text(yaml.safe_dump({
+                "record_mode": "live",
+                "run": {"method": "claudecode_agent", "label": label,
+                        "project": "P"}}), encoding="utf-8")
+        import data_sheets_schema.runs as runs_mod
+        self._orig = runs_mod.CONCAT_DIR
+        runs_mod.CONCAT_DIR = self.root
+
+    def tearDown(self):
+        import data_sheets_schema.runs as runs_mod
+        runs_mod.CONCAT_DIR = self._orig
+        self.tmp.cleanup()
+
+    def _run(self, *args, valid=None):
+        """`valid` maps label -> bool; default every replicate validates."""
+        def fake(record):
+            label = Path(record).parent.name
+            return True if valid is None else valid.get(label, True)
+        with mock.patch("data_sheets_schema.cli.runs._validates", fake):
+            return CliRunner().invoke(
+                self.cli, ["select", "--project", "P", "--config", "cfg", *args])
+
+    def test_the_largest_valid_replicate_wins(self):
+        out = self._run()
+        self.assertEqual(out.exit_code, 0, out.output)
+        self.assertIn("→ cfg_rep2", out.output)
+
+    def test_validity_outranks_coverage(self):
+        """The whole point: the biggest record is not canonical if it is
+        broken. On the real corpus this is what resolves AI-READI's tie and
+        drops a higher-coverage CM4AI replicate."""
+        out = self._run(valid={"cfg_rep2": False})
+        self.assertEqual(out.exit_code, 0, out.output)
+        self.assertIn("→ cfg_rep3", out.output)
+
+    def test_it_refuses_when_nothing_validates(self):
+        """No VOICE replicate validates. Picking the least-bad would ship a
+        record known to be broken, so the command declines."""
+        out = self._run(valid={"cfg_rep1": False, "cfg_rep2": False,
+                               "cfg_rep3": False})
+        self.assertNotEqual(out.exit_code, 0)
+        self.assertIn("Nothing here can be canonical", out.output)
+
+    def test_a_thin_margin_is_reported_as_thin(self):
+        out = self._run(valid={"cfg_rep2": False})   # rep3 (6) over rep1 (4)
+        self.assertIn("ahead of the runner-up", out.output)
+
+    def test_a_dry_run_records_nothing(self):
+        before = (self.root / "claudecode_agent_core" / "cfg_rep2" /
+                  "P_provenance.yaml").read_text()
+        self._run()
+        after = (self.root / "claudecode_agent_core" / "cfg_rep2" /
+                 "P_provenance.yaml").read_text()
+        self.assertEqual(before, after)
+
+    def test_execute_records_the_choice_and_its_candidates(self):
+        out = self._run("--execute")
+        self.assertEqual(out.exit_code, 0, out.output)
+        prov = yaml.safe_load((self.root / "claudecode_agent_core" /
+                               "cfg_rep2" / "P_provenance.yaml").read_text())
+        canon = prov.get("canonical")
+        self.assertIsNotNone(canon, "no canonical block written")
+        self.assertEqual(len(canon["selected_from"]), 3,
+                         "the losers must be named, or the choice is not "
+                         "auditable")
+        self.assertIn("criterion", canon)
+
+    def test_nothing_is_moved_or_deleted(self):
+        """Replicates are a measurement device; selection marks one, it does
+        not collapse the set."""
+        self._run("--execute")
+        for label in ("cfg_rep1", "cfg_rep2", "cfg_rep3"):
+            self.assertTrue((self.method / label / "P_d4d.yaml").exists(),
+                            f"{label} disappeared")
+
+    def test_one_replicate_is_not_a_selection(self):
+        import shutil
+        for label in ("cfg_rep2", "cfg_rep3"):
+            shutil.rmtree(self.method / label)
+        out = self._run()
+        self.assertNotEqual(out.exit_code, 0)
+        self.assertIn("at least two", out.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Selection, not merging — reversing the direction #176 took on 2026-07-29.

## Why the reversal

That rewrite was right that **scored** selection is not worth building: fitness
and grounding both rank replicates identically to counting slots, so paying 78
judgements to reproduce `len(record)` buys nothing. It was explicit about this:

> Selecting by score reduces to selecting by coverage, which needs no API calls.

But it made a coverage-maximising **merge** the primary line, and the merge has
since been measured (#229):

| project | merge gain | shared slots | values agree |
|---|---|---|---|
| AI_READI | +4 | 70 | 12 |
| CHORUS | +3 | 48 | **1** |
| CM4AI | +5 | 70 | 16 |
| VOICE | +1 | 78 | 9 |

**77–98% of shared slots carry different values.** So a merge mostly reproduces
its base record while splicing values from records that disagree — and a spliced
record can assert a participant count from one referent and a DOI from another,
which is the risk #176 flagged from the start. One replicate is internally
coherent because one generation produced it.

## Validity first, coverage second

Coverage alone is nearly arbitrary here. Margins across generic-v2 are **+0, +1,
+2, +1**, and AI-READI is an outright tie. Validity is what discriminates:

    AI_READI  rep1 valid, rep2/rep3 invalid   -> resolves the tie
    CHORUS    all three valid                 -> coverage, +1, flagged as thin
    CM4AI     rep3 invalid                    -> drops a 70-slot candidate
    VOICE     nothing validates               -> refuses to select

VOICE is why the ordering matters. A coverage rule would have confidently made
an invalid record canonical. This declines — picking the least-bad ships
something known to be broken.

## Validates live, not from the record

`compare()` reads validation status from provenance because it runs over 100+
runs in a hot path. Selection touches three, once, so it can afford the truth.

It matters: **CM4AI rep1 is recorded `invalid` but validates against the current
schema** — the DataCite alignment (#219) admits a value rejected when the run
was made. Selecting on the stale claim would have excluded a good record. Where
live and recorded disagree the command says so, because that disagreement means
the schema moved under the corpus.

## Nothing is moved

The winner's provenance gains a `canonical` block naming every candidate, its
slot count and both verdicts. Auditable, reversible, and replicates stay a
measurement device rather than being collapsed into one.

## Also fixed

`is_complete`, `validation_status` and `record_path_for` bind `concat_dir` as an
import-time default, so they answered about the default corpus regardless of
where the replicates were. Latent until something used a different one.

## Testing

922 passing. New `tests/test_cli/test_runs_select.py` covers validity
outranking coverage, the refusal when nothing validates, thin-margin reporting,
dry run writing nothing, the canonical block naming the losers, that nothing is
moved, and that one replicate is not a selection.

## Note on `d4d runs merge`

Left in place. It is honest about what it does and useful for asking "what would
full coverage look like", but it is no longer the answer to "which record *is*
the CHORUS datasheet".

🤖 Generated with [Claude Code](https://claude.com/claude-code)