### PR TITLE
The embedding endpoint truncates at 2048 tokens and returns 200 (#251)

### DIFF
--- a/data/evaluation_llm/agreement_cache/matrix.json
+++ b/data/evaluation_llm/agreement_cache/matrix.json
@@ -7,6 +7,7 @@
   "truncated": 0,
   "truncated_at_legacy_cap": 6,
   "rate": 0.5822784810126582,
+  "similarity_absent": 69,
   "judge_model": "google/claude-opus-5-high",
   "judge_chars": 100000,
   "replicates": [
@@ -23,6 +24,7 @@
   "truncated": 0,
   "truncated_at_legacy_cap": 1,
   "rate": 0.5454545454545454,
+  "similarity_absent": 51,
   "judge_model": "google/claude-opus-5-high",
   "judge_chars": 100000,
   "replicates": [
@@ -39,6 +41,7 @@
   "truncated": 0,
   "truncated_at_legacy_cap": 5,
   "rate": 0.4838709677419355,
+  "similarity_absent": 59,
   "judge_model": "google/claude-opus-5-high",
   "judge_chars": 100000,
   "replicates": [
@@ -55,6 +58,7 @@
   "truncated": 0,
   "truncated_at_legacy_cap": 9,
   "rate": 0.3717948717948718,
+  "similarity_absent": 74,
   "judge_model": "google/claude-opus-5-high",
   "judge_chars": 100000,
   "replicates": [
@@ -71,6 +75,7 @@
   "truncated": 0,
   "truncated_at_legacy_cap": 4,
   "rate": 0.5285714285714286,
+  "similarity_absent": 58,
   "judge_model": "google/claude-opus-5-high",
   "judge_chars": 100000,
   "replicates": [
@@ -87,6 +92,7 @@
   "truncated": 0,
   "truncated_at_legacy_cap": 0,
   "rate": 0.375,
+  "similarity_absent": 0,
   "judge_model": "google/claude-opus-5-high",
   "judge_chars": 100000,
   "replicates": [
@@ -103,6 +109,7 @@
   "truncated": 0,
   "truncated_at_legacy_cap": 3,
   "rate": 0.5142857142857142,
+  "similarity_absent": 54,
   "judge_model": "google/claude-opus-5-high",
   "judge_chars": 100000,
   "replicates": [
@@ -119,6 +126,7 @@
   "truncated": 0,
   "truncated_at_legacy_cap": 2,
   "rate": 0.44871794871794873,
+  "similarity_absent": 69,
   "judge_model": "google/claude-opus-5-high",
   "judge_chars": 100000,
   "replicates": [

--- a/notes/replicate_agreement_2026-08-02.md
+++ b/notes/replicate_agreement_2026-08-02.md
@@ -72,6 +72,38 @@ Sanity check that the embeddings themselves are fine: on a hand-built pair they
 score 0.865 for a paraphrase against 0.564 for unrelated text. The failure is
 specific to this population, not the model.
 
+### The endpoint also truncates at 2048 tokens, and does not say so
+
+Found while fixing #251, and independent of the topic-collapse result above.
+
+`lbl/nomic-embed-text` through CBORG accepts a 30,000-character input, returns
+**HTTP 200**, and reports `prompt_tokens: 2048`. Everything past that is
+discarded silently. nomic-embed-text is documented at 8192 tokens; this endpoint
+is not that, which is why the number here is measured rather than cited.
+
+The consequence is not a slightly worse number, it is a maximally wrong one:
+
+| | cosine |
+|---|---|
+| two values contradicting each other **past** the ceiling | **1.000000** (byte-identical vectors) |
+| the same contradiction, short enough to fit | 0.843 |
+
+So the endpoint will report perfect agreement between two values that contradict
+each other, provided the contradiction is late enough.
+
+**The published table is unaffected.** The only cell ever embedded is CHORUS v2,
+whose longest value is 2,876 characters — roughly 719 tokens, about a third of
+the ceiling. Verified live: at the 8000-character client cap the endpoint
+returns a genuine vector for the corpus's longest value; raised to 40,000 it
+truncates and the client now refuses.
+
+Across the whole corpus 17 of 1619 values would exceed the ceiling. None are
+cached, because none are in CHORUS v2 — so this is a trap for reviving the
+measure, not a defect in the result reported here. A character cap cannot fix
+it, since characters per token vary with the text; what the client can do is
+read `usage.prompt_tokens` back and refuse to build a cosine on a prefix, which
+is what it now does.
+
 ## Cost
 
 44 judge calls and 127 embeddings for one project's three replicates. One call
@@ -214,5 +246,12 @@ Filed rather than fixed, so they are on the record either way:
 - **#247** — `embeddings.jsonl` is 1.4 MB of vectors for a proxy this note
   concludes does not work. Kept, because it is what makes `--offline --embed`
   reproduce the 0.923 / 0.914 table rather than print nulls.
+- **#251 — fixed.** Vectors are keyed on the text sent rather than the value it
+  came from, mirroring #244, and the client now reads `usage.prompt_tokens` back
+  and refuses to build a cosine on a prefix. Nothing was orphaned: no cached
+  vector was ever truncated, so every key was already the key of what was sent.
+  The reason originally given for deferring this — that fixing it would orphan
+  the cache — was simply wrong, and checking cost less than the sentence
+  asserting it.
 - **Not filed, but true**: the judge is the same model family that wrote the
   records. See the provenance section.

--- a/src/data_sheets_schema/agreement.py
+++ b/src/data_sheets_schema/agreement.py
@@ -92,6 +92,13 @@ LEGACY_JUDGE_VALUE_CHARS = 4000
 # is roughly 2000 tokens of English prose, just under the ceiling, so ordinary
 # values never reach the server's silent cut in the first place.
 EMBED_VALUE_CHARS = 8000
+
+# Hitting this exactly is inference, not observation: a complete 2048-token
+# value and a cut one report the same `prompt_tokens`, so both are refused
+# (#255). That is the right way round to be wrong — refusing a good vector
+# costs a null, accepting a cut one costs a cosine of 1.0 between values that
+# contradict each other. On this corpus it cannot arise; the 17 values over the
+# ceiling all clear it comfortably.
 EMBED_MAX_TOKENS = 2048
 
 EQUIVALENCE_SYSTEM = """\
@@ -279,8 +286,9 @@ class Embedder:
         self._save(key, vec, tokens, prefix_only)
         if prefix_only:
             raise PrefixOnlyEmbedding(
-                f"endpoint kept only {tokens} tokens of a "
-                f"{len(sent)}-character value; the rest was discarded")
+                f"{len(sent)}-character value came back at the "
+                f"{EMBED_MAX_TOKENS}-token ceiling, so the tail was almost "
+                "certainly discarded; refusing to build a cosine on it")
         return vec
 
     def similarity(self, texts: list[str]) -> float:
@@ -481,6 +489,17 @@ def _parse_verdict(text: str) -> tuple[bool, str]:
     raise ValueError(f"no verdict in response: {text.strip()[:160]!r}")
 
 
+def _bump(obj: Any, name: str) -> None:
+    """Increment a counter on an object we do not own.
+
+    `embedder` is an injection point, so it may be any object with
+    `.similarity()`. Requiring it to pre-declare bookkeeping attributes would
+    mean the failure paths — the ones that only run when something has already
+    gone wrong — demand more of the caller than the happy path does (#254).
+    """
+    setattr(obj, name, getattr(obj, name, 0) + 1)
+
+
 def compare_records(records: dict[str, dict[str, Any]], *,
                     embedder: Embedder | None = None,
                     judge: EquivalenceJudge | None = None,
@@ -508,13 +527,13 @@ def compare_records(records: dict[str, dict[str, Any]], *,
                 # leave it null and count it. Refusing to pay is the point of
                 # offline mode; refusing to report the judgement too would not
                 # be. Only the CHORUS v2 embeddings were ever computed.
-                embedder.offline_misses += 1
+                _bump(embedder, "offline_misses")
             except PrefixOnlyEmbedding:
                 # The endpoint kept only the head of a value here, so any
                 # cosine would describe prefixes rather than values. Null is
                 # the honest entry; the judge's verdict for this slot stands
                 # on its own and is unaffected.
-                embedder.prefix_only_skips += 1
+                _bump(embedder, "prefix_only_skips")
         if judge is not None:
             row.equivalent, row.reason = judge(slot, values)
         out.append(row)
@@ -599,6 +618,11 @@ def build_matrix(*, root: Path = DEFAULT_ROOT, method: str = DEFAULT_METHOD,
                                                for r in result),
                 "rate": (n_equiv / len(result)
                          if result and len(judged) == len(result) else None),
+                # A null similarity has three quite different causes — never
+                # asked, not cached offline, or refused as prefix-only — and
+                # an artifact that shows none of them reads as full coverage
+                # when it is not (#253).
+                "similarity_absent": sum(r.similarity is None for r in result),
                 "judge_model": judge.model,
                 "judge_chars": JUDGE_VALUE_CHARS,
                 "replicates": sorted(records),
@@ -641,6 +665,11 @@ def main(argv: list[str] | None = None) -> int:
               f"= {rate}  (exact {cell['exact']}, "
               f"truncated {cell['truncated']}, "
               f"would-have-been {cell['truncated_at_legacy_cap']})")
+    absent = sum(c["similarity_absent"] for c in matrix.values())
+    if a.embed and absent:
+        print(f"similarity absent for {absent} slots "
+              f"(offline or refused as prefix-only); see rows files",
+              file=sys.stderr)
     if a.write:
         a.cache_dir.mkdir(parents=True, exist_ok=True)
         (a.cache_dir / "matrix.json").write_text(

--- a/src/data_sheets_schema/agreement.py
+++ b/src/data_sheets_schema/agreement.py
@@ -74,11 +74,25 @@ EMBED_MODEL = "lbl/nomic-embed-text"
 JUDGE_VALUE_CHARS = 100_000
 LEGACY_JUDGE_VALUE_CHARS = 4000
 
-# The embedder's cap is a property of the model, not a choice: nomic-embed-text
-# takes 8192 tokens, and 8000 characters is comfortably inside that. Raising it
-# would not buy a better proxy — the proxy was shown not to discriminate at all
-# here (0.923 against 0.914), so the ceiling on its input is not what limits it.
+# The embedding endpoint truncates at 2048 tokens and does not say so. Measured,
+# not read off a datasheet — nomic-embed-text is documented at 8192 tokens, and
+# this endpoint is not that. A 30,000-character input returns HTTP 200 with
+# `prompt_tokens: 2048`, and two values differing only past that point come back
+# byte-identical, cosine 1.000000. The same contradiction scores 0.843 when it
+# fits. So the endpoint will quietly report perfect agreement between two values
+# that contradict each other, if the contradiction is late enough.
+#
+# A character cap cannot prevent this: characters per token vary with the text,
+# so no fixed number is safe for all input. What is reliable is the response
+# itself — `usage.prompt_tokens` hitting the ceiling means the tail was
+# discarded, and that is recorded per vector and refuses to produce a
+# similarity. See `notes/replicate_agreement_2026-08-02.md` and issue #251.
+#
+# 8000 characters remains as a client-side bound, now with an honest reason: it
+# is roughly 2000 tokens of English prose, just under the ceiling, so ordinary
+# values never reach the server's silent cut in the first place.
 EMBED_VALUE_CHARS = 8000
+EMBED_MAX_TOKENS = 2048
 
 EQUIVALENCE_SYSTEM = """\
 You judge whether two or more values placed in the SAME field of a dataset
@@ -172,8 +186,17 @@ class OfflineCacheMiss(RuntimeError):
     """
 
 
+class PrefixOnlyEmbedding(RuntimeError):
+    """The endpoint kept only the start of this value.
+
+    Raised rather than returned because the failure mode is not a degraded
+    number, it is a maximally wrong one: two values agreeing on their prefix and
+    contradicting each other afterwards score exactly 1.0.
+    """
+
+
 class Embedder:
-    """Cosine similarity between rendered values, memoised on the text."""
+    """Cosine similarity between rendered values, memoised on the text sent."""
 
     def __init__(self, model: str = EMBED_MODEL, cache_path: Path | None = None,
                  offline: bool = False):
@@ -181,8 +204,10 @@ class Embedder:
         self.cache_path = Path(cache_path) if cache_path else None
         self.offline = offline
         self._vecs: dict[str, list[float]] = {}
+        self._prefix_only: set[str] = set()
         self.calls = 0
         self.offline_misses = 0
+        self.prefix_only_skips = 0
         self._load()
 
     def _load(self) -> None:
@@ -192,25 +217,44 @@ class Embedder:
             if not line.strip():
                 continue
             e = json.loads(line)
-            if e.get("model") == self.model:
-                self._vecs[e["key"]] = e["vector"]
+            if e.get("model") != self.model:
+                continue
+            self._vecs[e["key"]] = e["vector"]
+            # Records written before the ceiling was known carry no token count.
+            # Treating unknown as "not truncated" is safe here and only here:
+            # every cached vector is a CHORUS v2 value, the longest of which is
+            # 2,876 characters — roughly 719 tokens, a third of the ceiling.
+            if e.get("prefix_only"):
+                self._prefix_only.add(e["key"])
 
-    def _save(self, key: str, vector: list[float]) -> None:
+    def _save(self, key: str, vector: list[float], tokens: int | None,
+              prefix_only: bool) -> None:
         if not self.cache_path:
             return
         self.cache_path.parent.mkdir(parents=True, exist_ok=True)
         with self.cache_path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps({"model": self.model, "key": key,
+                                 "chars": EMBED_VALUE_CHARS, "tokens": tokens,
+                                 "prefix_only": prefix_only,
                                  "vector": vector}) + "\n")
 
     def vector(self, text: str) -> list[float]:
-        key = _digest(text)
+        """The vector for `text`, keyed on the text actually sent.
+
+        Keyed on what is sent rather than on the value it came from, for the
+        same reason as the judge (#244): otherwise changing the cap re-serves
+        every vector computed under the old one. Nothing in the current cache
+        moves, because no cached value is anywhere near the cap.
+        """
+        sent = text[:EMBED_VALUE_CHARS]
+        key = _digest(sent)
         if key in self._vecs:
+            if key in self._prefix_only:
+                raise PrefixOnlyEmbedding(f"cached vector for {key} is a prefix")
             return self._vecs[key]
         if self.offline:
             raise OfflineCacheMiss(f"no cached embedding for {key}")
-        body = json.dumps({"model": self.model,
-                           "input": [text[:EMBED_VALUE_CHARS]]}).encode()
+        body = json.dumps({"model": self.model, "input": [sent]}).encode()
         try:
             token = os.environ["CBORG_API_KEY"]
         except KeyError:
@@ -222,14 +266,30 @@ class Embedder:
             headers={"Authorization": f"Bearer {token}",
                      "Content-Type": "application/json"})
         with urllib.request.urlopen(req, timeout=120) as resp:
-            vec = json.load(resp)["data"][0]["embedding"]
+            payload = json.load(resp)
+        vec = payload["data"][0]["embedding"]
+        tokens = (payload.get("usage") or {}).get("prompt_tokens")
+        # The endpoint's own count is the only honest signal that the tail was
+        # dropped: it answers 200 either way and says nothing about the cut.
+        prefix_only = tokens is not None and tokens >= EMBED_MAX_TOKENS
         self.calls += 1
         self._vecs[key] = vec
-        self._save(key, vec)
+        if prefix_only:
+            self._prefix_only.add(key)
+        self._save(key, vec, tokens, prefix_only)
+        if prefix_only:
+            raise PrefixOnlyEmbedding(
+                f"endpoint kept only {tokens} tokens of a "
+                f"{len(sent)}-character value; the rest was discarded")
         return vec
 
     def similarity(self, texts: list[str]) -> float:
-        """Mean pairwise cosine. 1.0 for a single distinct text."""
+        """Mean pairwise cosine. 1.0 for a single distinct text.
+
+        Raises `PrefixOnlyEmbedding` if any input was cut by the endpoint, since
+        the resulting cosine would be a statement about prefixes wearing the
+        costume of a statement about values.
+        """
         distinct = list(dict.fromkeys(texts))
         if len(distinct) < 2:
             return 1.0
@@ -449,6 +509,12 @@ def compare_records(records: dict[str, dict[str, Any]], *,
                 # offline mode; refusing to report the judgement too would not
                 # be. Only the CHORUS v2 embeddings were ever computed.
                 embedder.offline_misses += 1
+            except PrefixOnlyEmbedding:
+                # The endpoint kept only the head of a value here, so any
+                # cosine would describe prefixes rather than values. Null is
+                # the honest entry; the judge's verdict for this slot stands
+                # on its own and is unaffected.
+                embedder.prefix_only_skips += 1
         if judge is not None:
             row.equivalent, row.reason = judge(slot, values)
         out.append(row)

--- a/tests/test_agreement.py
+++ b/tests/test_agreement.py
@@ -317,6 +317,32 @@ class TestPrefixOnlyEmbedding(unittest.TestCase):
         self.assertIsNone(rows[0].similarity)
         self.assertEqual(emb.prefix_only_skips, 1)
 
+    def test_a_bare_embedder_needs_no_bookkeeping_attributes(self):
+        """#254: the failure path must not demand more than the happy path.
+
+        `embedder` is an injection point. Requiring it to pre-declare counters
+        meant the only code that touched them — the error handlers — raised
+        AttributeError on any object that had not anticipated them.
+        """
+        class Bare:
+            def similarity(self, texts):
+                raise PrefixOnlyEmbedding("kept only the head")
+
+        emb = Bare()
+        rows = compare_records({"r1": {"a": "x"}, "r2": {"a": "y"}}, embedder=emb)
+        self.assertIsNone(rows[0].similarity)
+        self.assertEqual(emb.prefix_only_skips, 1)
+
+    def test_a_bare_embedder_survives_an_offline_miss_too(self):
+        class Bare:
+            def similarity(self, texts):
+                raise OfflineCacheMiss("not cached")
+
+        emb = Bare()
+        rows = compare_records({"r1": {"a": "x"}, "r2": {"a": "y"}}, embedder=emb)
+        self.assertIsNone(rows[0].similarity)
+        self.assertEqual(emb.offline_misses, 1)
+
 
 class TestJudgeCache(unittest.TestCase):
     def test_identical_values_never_reach_the_judge(self):
@@ -496,6 +522,20 @@ class TestPublishedMatrixReproduces(unittest.TestCase):
         for key, cell in published.items():
             self.assertEqual(cell["unjudged"], 0, key)
             self.assertIsNotNone(cell["rate"], key)
+
+    def test_missing_similarity_is_counted_rather_than_left_to_be_inferred(self):
+        """#253 — only CHORUS v2 was ever embedded; the rest must say so."""
+        published = json.loads((CACHE / "matrix.json").read_text())
+        for key, cell in published.items():
+            self.assertIn("similarity_absent", cell)
+        chorus_v2 = next(c for k, c in published.items()
+                         if k.startswith("v2") and k.endswith("CHORUS"))
+        self.assertEqual(chorus_v2["similarity_absent"], 0,
+                         "CHORUS v2 is the one cell with a full similarity column")
+        others = [c["similarity_absent"] for k, c in published.items()
+                  if not (k.startswith("v2") and k.endswith("CHORUS"))]
+        self.assertTrue(all(n > 0 for n in others),
+                        "every other cell is missing similarity and must record it")
 
 
 class TestUnjudgedSlotsAreNotCountedAsDisagreement(unittest.TestCase):

--- a/tests/test_agreement.py
+++ b/tests/test_agreement.py
@@ -6,18 +6,21 @@ where a miss raises instead of billing.
 """
 
 import json
+import os
 import tempfile
 import unittest
 import unittest.mock
 from pathlib import Path
 
 from data_sheets_schema.agreement import (
+    EMBED_MAX_TOKENS,
     EQUIVALENCE_SYSTEM,
     JUDGE_VALUE_CHARS,
     LEGACY_JUDGE_VALUE_CHARS,
     Embedder,
     EquivalenceJudge,
     OfflineCacheMiss,
+    PrefixOnlyEmbedding,
     SlotAgreement,
     _digest,
     _judge_key,
@@ -234,6 +237,85 @@ class TestEmbedderSimilarity(unittest.TestCase):
     def test_offline_miss_raises_rather_than_billing(self):
         with self.assertRaises(OfflineCacheMiss):
             Embedder(cache_path=None, offline=True).similarity(["a", "b"])
+
+    def test_vectors_are_keyed_on_the_text_actually_sent(self):
+        """#251, mirroring #244: the cap must be part of the cache identity."""
+        long_a = "x" * 200
+        long_b = "x" * 190 + "y" * 10
+        with unittest.mock.patch("data_sheets_schema.agreement.EMBED_VALUE_CHARS", 100):
+            k_a, k_b = _digest(long_a[:100]), _digest(long_b[:100])
+        self.assertEqual(k_a, k_b, "identical prefixes collapse under a narrow cap")
+        with unittest.mock.patch("data_sheets_schema.agreement.EMBED_VALUE_CHARS", 500):
+            self.assertNotEqual(_digest(long_a[:500]), _digest(long_b[:500]))
+
+
+class TestPrefixOnlyEmbedding(unittest.TestCase):
+    """The endpoint truncates at 2048 tokens and answers 200 (#251).
+
+    Measured against the live endpoint: a 30,000-character input returns
+    `prompt_tokens: 2048`, and two values differing only past that point come
+    back byte-identical at cosine 1.000000, where the same contradiction scores
+    0.843 when it fits. These tests pin the client's response to that, without
+    calling it.
+    """
+
+    def _embedder_returning(self, tokens):
+        emb = Embedder(cache_path=None)
+        payload = {"data": [{"embedding": [1.0, 0.0]}],
+                   "usage": {"prompt_tokens": tokens}}
+
+        class FakeResp:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *a):
+                return False
+
+            def read(self_inner):
+                return json.dumps(payload).encode()
+
+        return emb, FakeResp
+
+    def test_a_truncated_vector_refuses_to_be_used(self):
+        emb, resp = self._embedder_returning(EMBED_MAX_TOKENS)
+        with unittest.mock.patch.dict(os.environ, {"CBORG_API_KEY": "x"}), \
+             unittest.mock.patch("urllib.request.urlopen", return_value=resp()), \
+             unittest.mock.patch("json.load",
+                                 lambda f: json.loads(f.read().decode())):
+            with self.assertRaises(PrefixOnlyEmbedding):
+                emb.vector("a very long value")
+
+    def test_a_vector_inside_the_ceiling_is_returned(self):
+        emb, resp = self._embedder_returning(EMBED_MAX_TOKENS - 1)
+        with unittest.mock.patch.dict(os.environ, {"CBORG_API_KEY": "x"}), \
+             unittest.mock.patch("urllib.request.urlopen", return_value=resp()), \
+             unittest.mock.patch("json.load",
+                                 lambda f: json.loads(f.read().decode())):
+            self.assertEqual(emb.vector("short value"), [1.0, 0.0])
+
+    def test_a_cached_prefix_only_vector_still_refuses(self):
+        """The refusal must survive a round trip through the cache file."""
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "e.jsonl"
+            emb = Embedder(cache_path=path)
+            emb._save(_digest("sent"), [1.0, 0.0], EMBED_MAX_TOKENS, True)
+            reloaded = Embedder(cache_path=path, offline=True)
+            with self.assertRaises(PrefixOnlyEmbedding):
+                reloaded.vector("sent")
+
+    def test_compare_records_records_null_rather_than_a_prefix_cosine(self):
+        """A cosine over prefixes must not be filed as a cosine over values."""
+        class PrefixEmbedder:
+            offline_misses = 0
+            prefix_only_skips = 0
+
+            def similarity(self, texts):
+                raise PrefixOnlyEmbedding("kept only the head")
+
+        emb = PrefixEmbedder()
+        rows = compare_records({"r1": {"a": "x"}, "r2": {"a": "y"}}, embedder=emb)
+        self.assertIsNone(rows[0].similarity)
+        self.assertEqual(emb.prefix_only_skips, 1)
 
 
 class TestJudgeCache(unittest.TestCase):


### PR DESCRIPTION
Fixes #251. Stacked on #248 — base is `fix-244-judge-truncation`, so this diff shows only the embedder work. It will retarget to `main` when #248 merges.

## I deferred this for a wrong reason

#251 was filed with the note that fixing it "would orphan the 1.4 MB of vectors that make the negative result reproducible." One query settled it: **of the 136 cached vectors, zero were ever truncated.** They are all CHORUS v2, whose longest value is 2,876 characters. Keying on the text sent rather than the value it came from moves no existing key at all.

The second reason was also wrong, and this one matters more. I wrote that the 8000-character cap was "nomic-embed-text's 8192-token input limit, not an arbitrary choice." The endpoint is not that model's documented limit.

## What the endpoint actually does

| input | response | `prompt_tokens` |
|---|---|---|
| 8,000 chars | 200 | 1602 |
| 30,000 chars | 200 | **2048** |
| 40,000 chars | 200 | **2048** |

It truncates at 2048 tokens and says nothing — no error, no field, no warning.

The failure mode is not a degraded number, it is a maximally wrong one:

| | cosine |
|---|---|
| two values contradicting each other **past** the ceiling | **1.000000** — byte-identical vectors |
| the same contradiction, short enough to fit | 0.843 |

**The endpoint reports perfect agreement between two values that contradict each other, provided the contradiction is late enough.** For a module whose entire purpose is detecting whether two values state the same fact, that is the exact inversion of the measurement.

## The fix

A character cap cannot fix this — characters per token vary with the text, so no fixed number is safe for all input. What is reliable is the endpoint's own report: the client reads `usage.prompt_tokens` back and refuses to build a cosine on a prefix.

`PrefixOnlyEmbedding` is raised rather than returned, on the same reasoning as #249 and `_parse_verdict`: never quietly return the answer that flatters the measure. The refusal survives a round trip through the cache, so a stored prefix-vector cannot be reused later either.

Vectors are also now keyed on the text sent (mirroring #244), and cache records carry `chars`, `tokens` and `prefix_only` so a future cap change is auditable.

## The published table is untouched

CHORUS v2's longest value is 2,876 chars ≈ 719 tokens, about a third of the ceiling. Offline reproduction is byte-identical: **48/48 rows still carry similarity, 0.92272 against 0.91442.**

Across the whole corpus 17 of 1619 values would exceed the ceiling, none of them cached — a trap for reviving the measure, not a defect in what is reported.

## Verification

Live, both branches, on the corpus's longest real value (20,335 chars):

- at the 8000-char client cap → endpoint returns a genuine vector
- cap raised to 40,000 → `endpoint kept only 2048 tokens of a 20335-character value; the rest was discarded`

Five new tests pin the client's behaviour without calling the endpoint. **971 passed, 3 skipped.**