### PR TITLE
Keep the vectors, guard the growth (#247)

### DIFF
--- a/notes/replicate_agreement_2026-08-02.md
+++ b/notes/replicate_agreement_2026-08-02.md
@@ -243,9 +243,18 @@ Filed rather than fixed, so they are on the record either way:
 - **#243** — those same records do not carry the judge model. It is recovered
   above from the run configuration, not from the cache. The 30 re-judged records
   do carry it, along with the cap they were judged under.
-- **#247** — `embeddings.jsonl` is 1.4 MB of vectors for a proxy this note
-  concludes does not work. Kept, because it is what makes `--offline --embed`
-  reproduce the 0.923 / 0.914 table rather than print nulls.
+- **#247 — kept, and the reasons first given for both keeping and worrying
+  about it were wrong.** The file is 1.4 MB in the working tree but 587 KB
+  packed, which is 0.017% of this repository's 3.25 GiB of objects and does not
+  appear in its fifteen largest blobs. It is also already in history, so
+  deleting it from HEAD would reclaim exactly nothing — only a history rewrite
+  would, which is not a thing to do to a shared `main` over half a megabyte.
+  And it is *not* what makes the negative result reproducible: the 0.923 /
+  0.914 table recomputes from the 24 KB `CHORUS_v2_rows.json`, with no vectors
+  involved. That table is now asserted by the test suite rather than left to be
+  re-derived. What remains real is growth — embedding the whole corpus would be
+  1439 vectors rather than 136, about 14 MB, tracked permanently — so a test
+  bounds the count and makes that a decision instead of a side effect.
 - **#251 — fixed.** Vectors are keyed on the text sent rather than the value it
   came from, mirroring #244, and the client now reads `usage.prompt_tokens` back
   and refuses to build a cosine on a prefix. Nothing was orphaned: no cached

--- a/tests/test_agreement.py
+++ b/tests/test_agreement.py
@@ -464,7 +464,14 @@ class TestJudgeCache(unittest.TestCase):
             self.assertEqual(judge.legacy_hits, 1)
 
 
-@unittest.skipUnless((CACHE / "matrix.json").exists(), "agreement cache not present")
+#: Every file this class reads. Guarding on one of them and reading three meant
+#: a partial cache errored instead of skipping, so "the cache is not here" and
+#: "the cache is here and wrong" arrived as the same red result (#260).
+CACHE_FILES = ("matrix.json", "CHORUS_v2_rows.json", "embeddings.jsonl")
+
+
+@unittest.skipUnless(all((CACHE / f).exists() for f in CACHE_FILES),
+                     "agreement cache not present")
 class TestPublishedMatrixReproduces(unittest.TestCase):
     """The note's tables must come back out of the committed cache.
 
@@ -552,9 +559,15 @@ class TestPublishedMatrixReproduces(unittest.TestCase):
         mean_eq, mean_df = sum(eq) / len(eq), sum(df) / len(df)
         self.assertAlmostEqual(mean_eq, 0.92272, places=4)
         self.assertAlmostEqual(mean_df, 0.91442, places=4)
-        self.assertLess(mean_eq - mean_df, 0.01,
-                        "if the gap ever exceeds a point, the proxy is worth "
-                        "revisiting and this test should be the thing that says so")
+        # abs(), because the claim is that the classes do not *separate*, and
+        # separation is a magnitude. A signed test would pass on mean_eq=0.40
+        # against mean_df=0.92 — the proxy discriminating strongly, merely
+        # inverted — which is the single most interesting result this test
+        # could meet and the one it would otherwise be blind to (#259).
+        self.assertLess(abs(mean_eq - mean_df), 0.01,
+                        "if the gap ever exceeds a point in either direction, "
+                        "the proxy is worth revisiting and this test should be "
+                        "the thing that says so")
 
     def test_the_tracked_vector_cache_stays_small(self):
         """#247: growth here is permanent, so it should be a decision.

--- a/tests/test_agreement.py
+++ b/tests/test_agreement.py
@@ -523,6 +523,48 @@ class TestPublishedMatrixReproduces(unittest.TestCase):
             self.assertEqual(cell["unjudged"], 0, key)
             self.assertIsNotNone(cell["rate"], key)
 
+    def test_the_embedding_proxy_still_fails_to_discriminate(self):
+        """The negative result, asserted rather than merely reproducible (#247).
+
+        This is the finding that closes off the cheap route: cosine similarity
+        cannot separate slots the judge called equivalent from slots it called
+        different, because every value is schema-shaped prose about the same
+        dataset and the embedding measures topic. Recomputed here from the
+        committed per-slot rows — no vectors needed, which is the point.
+
+        It is pinned because it is the kind of result someone will want to
+        re-litigate when the judge's cost comes up, and a number in a note is
+        easier to wave away than a red test.
+        """
+        rows = json.loads((CACHE / "CHORUS_v2_rows.json").read_text())
+        eq = [r["similarity"] for r in rows if r["equivalent"]]
+        df = [r["similarity"] for r in rows if not r["equivalent"]]
+        self.assertEqual((len(eq), len(df)), (18, 30))
+        mean_eq, mean_df = sum(eq) / len(eq), sum(df) / len(df)
+        self.assertAlmostEqual(mean_eq, 0.92272, places=4)
+        self.assertAlmostEqual(mean_df, 0.91442, places=4)
+        self.assertLess(mean_eq - mean_df, 0.01,
+                        "if the gap ever exceeds a point, the proxy is worth "
+                        "revisiting and this test should be the thing that says so")
+
+    def test_the_tracked_vector_cache_stays_small(self):
+        """#247: growth here is permanent, so it should be a decision.
+
+        Nothing in git can be un-committed — this blob is already in history at
+        587 KB packed, so deleting it from HEAD would reclaim exactly nothing.
+        What *is* still available is refusing to add ten times more of it. The
+        cache holds 136 vectors, one per distinct CHORUS v2 value; embedding
+        the whole corpus would be 1439 vectors, about 14 MB, tracked forever.
+
+        If you meant to do that, raise this bound in the same commit and say
+        why. The number existing is the point; its exact value is not.
+        """
+        path = CACHE / "embeddings.jsonl"
+        vectors = sum(1 for line in path.read_text().splitlines() if line.strip())
+        self.assertLessEqual(vectors, 200,
+                             f"{vectors} vectors tracked; a full-corpus sweep "
+                             "is ~1439 and adds ~14 MB to history permanently")
+
     def test_missing_similarity_is_counted_rather_than_left_to_be_inferred(self):
         """#253 — only CHORUS v2 was ever embedded; the rest must say so."""
         published = json.loads((CACHE / "matrix.json").read_text())

--- a/tests/test_agreement.py
+++ b/tests/test_agreement.py
@@ -537,8 +537,17 @@ class TestPublishedMatrixReproduces(unittest.TestCase):
         easier to wave away than a red test.
         """
         rows = json.loads((CACHE / "CHORUS_v2_rows.json").read_text())
-        eq = [r["similarity"] for r in rows if r["equivalent"]]
-        df = [r["similarity"] for r in rows if not r["equivalent"]]
+        # `is True` / `is False`, not truthiness: `equivalent` is tri-state and
+        # an unjudged row is None. Splitting on truthiness would file it under
+        # "judged, and they differed" — the #250 bug, which this very test
+        # would otherwise reintroduce while pinning the finding it protects.
+        self.assertTrue(all(r["equivalent"] is not None for r in rows),
+                        "every row must carry a verdict for the means to mean anything")
+        self.assertTrue(all(r["similarity"] is not None for r in rows),
+                        "and a similarity, or the sample is not what it claims")
+        eq = [r["similarity"] for r in rows if r["equivalent"] is True]
+        df = [r["similarity"] for r in rows if r["equivalent"] is False]
+        self.assertEqual(len(eq) + len(df), len(rows), "no row may be dropped")
         self.assertEqual((len(eq), len(df)), (18, 30))
         mean_eq, mean_df = sum(eq) / len(eq), sum(df) / len(df)
         self.assertAlmostEqual(mean_eq, 0.92272, places=4)


### PR DESCRIPTION
Closes #247.

I filed #247 worrying about 1.4 MB, then kept the file for a reason that was also wrong. Both are worth correcting.

## The size concern was off by three orders of magnitude

| | |
|---|---|
| working tree | 1.4 MB |
| **packed in git** | **587 KB** |
| share of this repo's 3.25 GiB of objects | **0.017%** |
| rank among largest blobs in history | not in the top 15 (largest is a 3.3 MB source text) |

And the blob has been in history since `a1b3f5ae`, so **deleting it from HEAD reclaims exactly zero bytes**. Only a history rewrite would, and rewriting a shared `main` over half a megabyte is not a trade worth taking.

## The reason for keeping it was wrong too

I wrote that the file is "what makes the negative result reproducible". It isn't. The 0.923 / 0.914 table recomputes from the 24 KB `CHORUS_v2_rows.json` with no vectors involved:

```
from CHORUS_v2_rows.json alone (24 KB):
  equivalent n=18 mean=0.92272
  different  n=30 mean=0.91442
  gap=0.00831   <- the whole finding
```

I had already run exactly this during the #251 review without noticing it refuted my own justification. The vectors let you re-derive the cosines; the rows already carry them.

## What this PR does instead

**Pins the negative result in the suite.** It is the finding someone will want to re-litigate the first time the judge's cost comes up, and a number in a note is easier to wave away than a red test. The assertion also has a direction: if the gap ever exceeds one point, the proxy is worth another look and the test is what says so.

**Bounds the growth, which is the part that was actually unguarded.** The cache holds 136 vectors — one per distinct CHORUS v2 value. Embedding the whole corpus is 1439, about **14 MB at 10,343 bytes a vector**, tracked permanently, and `--embed --embed-online` would do it in a single command. A test caps the count at 200 so crossing it is a decision made in a commit rather than a side effect discovered later.

**Corrects the record** in the note's known-limits section.

## Unrelated, and much bigger than any of this

`.git/objects` is **3.25 GiB across 42 packs**, with 18 prune-packable objects. That smells like it would repack considerably smaller. I have not touched it — flagging rather than acting, since it affects the whole repository and is not mine to decide.

**976 passed, 3 skipped.**