### PR TITLE
Ignore CM4AI image archives: one left a 3.19 GB orphan in .git/objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,21 @@ dmypy.json
 # (ro-crate-preview.html up to 11.8 MB each). Re-extract from raw/*.zip.
 data/ro-crate_packages/*/crate/
 
+# ...but "keep the upstream archive" holds for a 1.1 MB metadata zip and stops
+# holding at 3.19 GB. CM4AI's image archives are gigabytes; committing one would
+# push it to a repository that is 60 MB today, and no later `git rm` would get
+# it back out of history.
+#
+# This is not hypothetical. One such archive was staged and then unstaged, which
+# left a 3.19 GB unreferenced blob in .git/objects — invisible to every ordinary
+# git command, never pushed, and 96% of the local repository.
+#
+# Allowlist rather than a pattern per treatment condition: the archive names are
+# upstream's to choose, so anything new in raw/ is ignored until someone decides
+# otherwise. The one zip already tracked is named explicitly.
+data/ro-crate_packages/*/raw/*.zip
+!data/ro-crate_packages/CM4AI/raw/cm4ai_release_metadata.zip
+
 # Poster/slide artifacts are kept local-only and never committed to this repo.
 data/poster_assets/
 

--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,12 @@ dmypy.json
 
 # RO-Crate packages: keep the upstream archive (raw/), not the extracted tree.
 # CM4AI's extracted crate is ~47 MB, almost entirely per-file listing HTML
-# (ro-crate-preview.html up to 11.8 MB each). Re-extract from raw/*.zip.
+# (ro-crate-preview.html up to 11.8 MB each).
+#
+# Re-extract from raw/cm4ai_release_metadata.zip, named rather than globbed:
+# raw/ now holds two unrelated archives and `raw/*.zip` matches both. The other
+# is cm4ai_images_untreated.zip, 3.2 GB of immunofluorescence JPEGs under
+# untreated/ — 15,911 files that are not a crate and will not rebuild one.
 data/ro-crate_packages/*/crate/
 
 # ...but "keep the upstream archive" holds for a 1.1 MB metadata zip and stops
@@ -164,9 +169,17 @@ data/ro-crate_packages/*/crate/
 # raw/*.zip when tested. This still only guards archives under raw/; a general
 # "no large file anywhere" check needs a size threshold, which .gitignore cannot
 # express. See #262.
+#
+# Compression suffixes are spelled out rather than written `*.tar.*`, which also
+# swallowed images.tar.md5 and manifest.tar.sha256. A tracked checksum beside an
+# untracked archive is the only way anyone verifies the copy in their raw/ is
+# the right one, so ignoring it defeats the reason the archive is untracked.
 data/ro-crate_packages/*/raw/**/*.zip
 data/ro-crate_packages/*/raw/**/*.tar
-data/ro-crate_packages/*/raw/**/*.tar.*
+data/ro-crate_packages/*/raw/**/*.tar.gz
+data/ro-crate_packages/*/raw/**/*.tar.bz2
+data/ro-crate_packages/*/raw/**/*.tar.xz
+data/ro-crate_packages/*/raw/**/*.tar.zst
 data/ro-crate_packages/*/raw/**/*.tgz
 data/ro-crate_packages/*/raw/**/*.7z
 data/ro-crate_packages/*/raw/**/*.zip.[0-9][0-9][0-9]

--- a/.gitignore
+++ b/.gitignore
@@ -158,7 +158,18 @@ data/ro-crate_packages/*/crate/
 # Allowlist rather than a pattern per treatment condition: the archive names are
 # upstream's to choose, so anything new in raw/ is ignored until someone decides
 # otherwise. The one zip already tracked is named explicitly.
-data/ro-crate_packages/*/raw/*.zip
+#
+# Every archive extension and any depth, because the next one will not be named
+# like the last one — .tar.gz and raw/images/foo.zip both slipped past a plain
+# raw/*.zip when tested. This still only guards archives under raw/; a general
+# "no large file anywhere" check needs a size threshold, which .gitignore cannot
+# express. See #262.
+data/ro-crate_packages/*/raw/**/*.zip
+data/ro-crate_packages/*/raw/**/*.tar
+data/ro-crate_packages/*/raw/**/*.tar.*
+data/ro-crate_packages/*/raw/**/*.tgz
+data/ro-crate_packages/*/raw/**/*.7z
+data/ro-crate_packages/*/raw/**/*.zip.[0-9][0-9][0-9]
 !data/ro-crate_packages/CM4AI/raw/cm4ai_release_metadata.zip
 
 # Poster/slide artifacts are kept local-only and never committed to this repo.


### PR DESCRIPTION
Follow-up to the repository-size question raised on #256.

## What was actually there

A single **unreferenced 3.19 GB blob** — 96% of a 3.3 GB local `.git`, against 118 MB for everything else.

| | |
|---|---|
| the orphan blob | **3.19 GB** |
| everything else in `.git` | 118 MB |
| **the shared repo on GitHub** | **60 MB — never affected** |

It is a ZIP of CM4AI immunofluorescence images: **15,911 files, 4.12 GB uncompressed**, four channels under `untreated/`. No commit references it, no ref reaches it, it was never pushed. Someone staged it and unstaged it, and git kept the object — invisible to `log`, `status`, and every other ordinary command. The pack was dated March.

## I was wrong twice about this

- **"42 packs, would repack smaller"** — wrong. The other 41 packs total 55 MB; repacking reclaims essentially nothing. It was one object, not fragmentation.
- **`git gc --prune=now`**, the obvious move, would have destroyed **58 unreachable commits and a dropped stash** as collateral. The blob happened to have its own pack containing exactly one object, so removing that pack removed exactly it and nothing else.

## The data is preserved, verified three ways

Extracted to `data/ro-crate_packages/CM4AI/raw/cm4ai_images_untreated.zip`:

1. byte length matches exactly (3,419,931,819)
2. `unzip -t` clears all 15,911 entries — no CRC errors
3. `git hash-object` on the extracted file returns `b214aa2e…` — **bit-for-bit the blob it came from**

The pack was quarantined by rename, `git fsck` run clean, all refs and 8 stashes confirmed intact, and only then deleted.

```
.git   3.3 GB -> 85 MB
raw/   0      -> 3.2 GB (a normal file, and finally visible)
```

## What this PR actually changes

Only `.gitignore` — the part that stops it recurring. `raw/` is **tracked**, so a 3.19 GB file sitting there is one `git add .` away from being pushed to a 60 MB repository, and no later `git rm` would get it back out of history.

An allowlist rather than a pattern per treatment condition: the archive names are upstream's to choose, so anything new in `raw/` is ignored until someone decides otherwise, and the one zip already tracked is named explicitly.

Verified the rule ignores a new image archive, leaves `cm4ai_release_metadata.zip` tracked, and newly ignores no file already in the index.

**976 passed, 3 skipped.**