### PR TITLE
Guard what enters history: CI size check (#262) and cache budgets (#258)

### DIFF
--- a/.github/workflows/large-files.yaml
+++ b/.github/workflows/large-files.yaml
@@ -1,0 +1,38 @@
+# Stop a large file before it reaches shared history.
+#
+# On the pull request rather than in a pre-commit hook, because the boundary
+# worth defending is what enters the shared repository: a stray large object is
+# recoverable locally, and permanent once pushed. See scripts/check_large_files.py
+# and issue #262.
+---
+name: Check for large files
+
+on: [pull_request]
+
+jobs:
+  large-files:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          # The check diffs against the merge base, which needs real history.
+          # The default shallow clone has none and the check would compare
+          # against nothing.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      # No dependencies: the script is stdlib and git only, so this job stays
+      # fast and cannot be blocked by an unrelated install failure.
+      - name: Check added and modified files
+        run: |
+          python scripts/check_large_files.py \
+            --base "origin/${{ github.base_ref }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/scripts/check_large_files.py
+++ b/scripts/check_large_files.py
@@ -44,16 +44,55 @@ def _git(*args: str) -> str:
                           check=True).stdout
 
 
+class BaseRefMissing(RuntimeError):
+    """The branch being merged into is not in this clone."""
+
+
 def changed_files(base: str, head: str = "HEAD") -> list[str]:
     """Paths added or modified between the merge base and `head`.
 
     Merge base rather than the base tip: a long-running branch should be judged
     on what it adds, not on files someone else committed to main meanwhile.
     Deletions are excluded — removing a large file is the fix, not the problem.
+
+    Renames need `--raw` rather than `--diff-filter=AM`. A true rename adds no
+    bytes to history, so skipping it is right; but git *detects* renames by
+    similarity, so deleting `old.zip` and adding a 60%-similar `new.zip` is
+    reported as R and would slip past unweighed even though the destination is
+    a genuinely new blob (#267). Comparing the two blob hashes tells the cases
+    apart: identical means the object already exists, different means it does
+    not.
     """
-    merge_base = _git("merge-base", base, head).strip()
-    out = _git("diff", "--name-only", "--diff-filter=AM", "-z", merge_base, head)
-    return [p for p in out.split("\0") if p]
+    try:
+        merge_base = _git("merge-base", base, head).strip()
+    except subprocess.CalledProcessError:
+        raise BaseRefMissing(base) from None
+
+    out = _git("diff", "--raw", "-z", "--find-renames", merge_base, head)
+    fields = out.split("\0")
+    paths: list[str] = []
+    i = 0
+    while i < len(fields):
+        meta = fields[i]
+        if not meta.startswith(":"):
+            i += 1
+            continue
+        # :<srcmode> <dstmode> <srcsha> <dstsha> <status>
+        parts = meta.split()
+        src_sha, dst_sha, status = parts[2], parts[3], parts[4]
+        code = status[0]
+        if code in ("R", "C"):
+            # Rename/copy: two paths follow, source then destination.
+            dst = fields[i + 2] if i + 2 < len(fields) else None
+            if dst and src_sha != dst_sha:
+                paths.append(dst)
+            i += 3
+            continue
+        dst = fields[i + 1] if i + 1 < len(fields) else None
+        if code in ("A", "M") and dst:
+            paths.append(dst)
+        i += 2
+    return paths
 
 
 def blob_size(path: str, ref: str = "HEAD") -> int:
@@ -94,7 +133,19 @@ def main(argv: list[str] | None = None) -> int:
                    help=f"bytes (default: {MAX_BYTES})")
     a = p.parse_args(argv)
 
-    paths = changed_files(a.base, a.head)
+    try:
+        paths = changed_files(a.base, a.head)
+    except BaseRefMissing as missing:
+        # Fails closed, but say why. Reading a traceback to discover that a ref
+        # was never fetched is a bad way to spend a CI cycle (#266).
+        print(f"base ref {str(missing)!r} not found in this clone.\n"
+              "The check diffs against the merge base, so the base branch has "
+              "to be present:\n"
+              "  - in CI, give actions/checkout `fetch-depth: 0`\n"
+              "  - locally, `git fetch origin <branch>` first",
+              file=sys.stderr)
+        return 1
+
     if not paths:
         print("no files added or modified; nothing to check")
         return 0

--- a/scripts/check_large_files.py
+++ b/scripts/check_large_files.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Refuse to let a large file into shared history.
+
+A stray large object is cheap to fix locally and impossible to fix once pushed.
+This repository learned that the expensive way: a 3.19 GB ZIP of CM4AI images
+was staged and unstaged, leaving an unreferenced blob that sat in .git/objects
+for months — invisible to log, status and every other ordinary command, and 96%
+of the local repository (#261). That one was recoverable precisely because it
+never reached GitHub. Had it been committed and pushed, no later `git rm` would
+have got it back out; the only remedy is rewriting shared history.
+
+So the check runs on the pull request, where the damage has not happened yet.
+
+`.gitignore` cannot express "no file over N megabytes" — it matches names, and
+the next oversized file will not be named like the last one (#262). A pre-commit
+hook could express it but only protects contributors who install one, which is
+the wrong side of the boundary: the thing worth defending is what enters the
+shared repository, not what enters a working tree.
+
+The limit is deliberately not overridable at runtime. Committing something this
+large should be a decision someone makes in a diff, with the number and the
+reason visible to a reviewer, rather than an environment variable set once in a
+workflow and never read again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+#: Bytes. The largest file tracked when this was written was 3.94 MB and
+#: nothing exceeded 5 MB, so this is roughly 2.5x the real ceiling: large
+#: enough that ordinary source PDFs and concatenated corpora pass untouched,
+#: small enough that anything of a different kind entirely gets stopped.
+#:
+#: Raising it is allowed. Raise it in the same commit as the file that needs it
+#: and say why, the way `test_the_tracked_vector_cache_stays_small` asks.
+MAX_BYTES = 10 * 1024 * 1024
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(("git",) + args, capture_output=True, text=True,
+                          check=True).stdout
+
+
+def changed_files(base: str, head: str = "HEAD") -> list[str]:
+    """Paths added or modified between the merge base and `head`.
+
+    Merge base rather than the base tip: a long-running branch should be judged
+    on what it adds, not on files someone else committed to main meanwhile.
+    Deletions are excluded — removing a large file is the fix, not the problem.
+    """
+    merge_base = _git("merge-base", base, head).strip()
+    out = _git("diff", "--name-only", "--diff-filter=AM", "-z", merge_base, head)
+    return [p for p in out.split("\0") if p]
+
+
+def blob_size(path: str, ref: str = "HEAD") -> int:
+    """Size in bytes of `path` as it exists at `ref`."""
+    return int(_git("cat-file", "-s", f"{ref}:{path}").strip())
+
+
+def oversized(sizes: dict[str, int], limit: int = MAX_BYTES) -> list[tuple[str, int]]:
+    """Every offender, largest first.
+
+    Every one, not the first: a PR that adds three large files should learn
+    that in one run rather than three, and a check that reports a subset reads
+    as "this is all of it" when it is not.
+    """
+    return sorted(((p, n) for p, n in sizes.items() if n > limit),
+                  key=lambda kv: kv[1], reverse=True)
+
+
+def human(n: int) -> str:
+    """A size someone can read.
+
+    Fixed MB reported every offender under a megabyte as "0.00 MB", which is
+    both useless and slightly insulting when the whole message is asking the
+    reader to judge whether a file is too big.
+    """
+    for unit, scale in (("GB", 1 << 30), ("MB", 1 << 20), ("KB", 1 << 10)):
+        if n >= scale:
+            return f"{n / scale:.2f} {unit}"
+    return f"{n} B"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--base", default="origin/main",
+                   help="branch this PR targets (default: origin/main)")
+    p.add_argument("--head", default="HEAD")
+    p.add_argument("--limit", type=int, default=MAX_BYTES,
+                   help=f"bytes (default: {MAX_BYTES})")
+    a = p.parse_args(argv)
+
+    paths = changed_files(a.base, a.head)
+    if not paths:
+        print("no files added or modified; nothing to check")
+        return 0
+
+    sizes = {}
+    for path in paths:
+        try:
+            sizes[path] = blob_size(path, a.head)
+        except (subprocess.CalledProcessError, ValueError):
+            # A submodule entry or a path git cannot size as a blob. Skipping is
+            # safe here: neither can carry file content into history.
+            continue
+
+    bad = oversized(sizes, a.limit)
+    total = sum(sizes.values())
+    print(f"checked {len(sizes)} added/modified file(s), "
+          f"{human(total)} total, limit {human(a.limit)} each")
+
+    if not bad:
+        if sizes:
+            biggest, n = max(sizes.items(), key=lambda kv: kv[1])
+            print(f"largest: {human(n)}  {biggest}")
+        return 0
+
+    # Flush before writing to stderr: the two streams buffer independently, so
+    # without this the summary lands *after* the failure it is meant to precede
+    # and the CI log reads back-to-front.
+    sys.stdout.flush()
+    print(f"\n{len(bad)} file(s) over the limit:", file=sys.stderr)
+    for path, n in bad:
+        print(f"  {human(n):>12}  {path}", file=sys.stderr)
+    print(
+        "\nA large file is cheap to remove now and permanent once merged —"
+        "\nrewriting shared history is the only way back."
+        "\n\nIf it does not belong in git, add it to .gitignore."
+        f"\nIf it does, raise MAX_BYTES in {__file__.split('/')[-1]} in this"
+        "\nsame PR and say why in the commit message.",
+        file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agreement.py
+++ b/tests/test_agreement.py
@@ -569,24 +569,6 @@ class TestPublishedMatrixReproduces(unittest.TestCase):
                         "the proxy is worth revisiting and this test should be "
                         "the thing that says so")
 
-    def test_the_tracked_vector_cache_stays_small(self):
-        """#247: growth here is permanent, so it should be a decision.
-
-        Nothing in git can be un-committed — this blob is already in history at
-        587 KB packed, so deleting it from HEAD would reclaim exactly nothing.
-        What *is* still available is refusing to add ten times more of it. The
-        cache holds 136 vectors, one per distinct CHORUS v2 value; embedding
-        the whole corpus would be 1439 vectors, about 14 MB, tracked forever.
-
-        If you meant to do that, raise this bound in the same commit and say
-        why. The number existing is the point; its exact value is not.
-        """
-        path = CACHE / "embeddings.jsonl"
-        vectors = sum(1 for line in path.read_text().splitlines() if line.strip())
-        self.assertLessEqual(vectors, 200,
-                             f"{vectors} vectors tracked; a full-corpus sweep "
-                             "is ~1439 and adds ~14 MB to history permanently")
-
     def test_missing_similarity_is_counted_rather_than_left_to_be_inferred(self):
         """#253 — only CHORUS v2 was ever embedded; the rest must say so."""
         published = json.loads((CACHE / "matrix.json").read_text())
@@ -621,6 +603,74 @@ class TestUnjudgedSlotsAreNotCountedAsDisagreement(unittest.TestCase):
         # The bug: bool() folds the unjudged row into the disagreements.
         self.assertEqual(sum(bool(r.equivalent) for r in rows), 1)
         self.assertEqual(len(rows) - sum(bool(r.equivalent) for r in rows), 2)
+
+
+#: Records allowed in each tracked cache, and why that number.
+#:
+#: Every cache, not just the expensive one. #247 bounded `embeddings.jsonl`
+#: because a vector is 10 KB; #258 pointed out that leaving the other four
+#: unbounded made the guard look like an oversight rather than a judgement.
+#: A verdict is ~395 bytes, so the caches differ in cost per record by 26x —
+#: which is a reason for different *numbers*, not for guarding one and not the
+#: others.
+#:
+#: Raising a bound is fine. Raise it in the same commit as the growth and say
+#: why. The bound existing is the point; its exact value is not.
+CACHE_BUDGET = {
+    # 136 today, one vector per distinct CHORUS v2 value. A full-corpus sweep
+    # is 1439 vectors and ~14 MB, permanently, in one command.
+    "embeddings.jsonl": 200,
+    # 99-154 today. A full re-judge of one project across both configs, plus
+    # the retained legacy-keyed verdicts, lands around 300.
+    "AI_READI_equivalence.jsonl": 400,
+    "CHORUS_equivalence.jsonl": 400,
+    "CM4AI_equivalence.jsonl": 400,
+    "VOICE_equivalence.jsonl": 400,
+}
+
+#: Bytes for the whole directory, which is what actually enters history. Record
+#: counts alone would miss a cache that grew by getting fatter rather than
+#: longer — a larger embedding dimension, or a judge that started returning
+#: paragraphs. 1.78 MB today.
+CACHE_TOTAL_BYTES = 4 * 1024 * 1024
+
+
+@unittest.skipUnless(CACHE.exists(), "agreement cache not present")
+class TestCacheGrowthIsBounded(unittest.TestCase):
+    """These files are committed, so growth in them is permanent (#247, #258).
+
+    Not a style rule. A 3.19 GB archive reached this repository's object store
+    once already, and the only reason it was recoverable is that it never got
+    as far as a commit.
+    """
+
+    def test_every_jsonl_cache_is_within_its_budget(self):
+        for name, budget in CACHE_BUDGET.items():
+            path = CACHE / name
+            if not path.exists():
+                continue
+            n = sum(1 for line in path.read_text().splitlines() if line.strip())
+            self.assertLessEqual(
+                n, budget,
+                f"{name}: {n} records against a budget of {budget}")
+
+    def test_no_jsonl_cache_is_unbudgeted(self):
+        """The gap #258 was actually about.
+
+        A new cache file appearing with no entry here would be unguarded, and
+        nothing would say so — which is how the verdict caches ended up outside
+        the first version of this guard.
+        """
+        found = {p.name for p in CACHE.glob("*.jsonl")}
+        self.assertEqual(found - set(CACHE_BUDGET), set(),
+                         "a tracked cache exists with no budget; add one")
+
+    def test_the_directory_as_a_whole_stays_bounded(self):
+        total = sum(p.stat().st_size for p in CACHE.iterdir() if p.is_file())
+        self.assertLessEqual(
+            total, CACHE_TOTAL_BYTES,
+            f"agreement_cache is {total / 1048576:.2f} MB against a "
+            f"{CACHE_TOTAL_BYTES / 1048576:.0f} MB budget")
 
 
 if __name__ == "__main__":

--- a/tests/test_check_large_files.py
+++ b/tests/test_check_large_files.py
@@ -1,0 +1,161 @@
+"""Tests for the large-file guard.
+
+The pure part is tested directly; the git-facing part is exercised against a
+real throwaway repository rather than a mock, because what this check has to get
+right is exactly the thing a mock would paper over — which commits `git diff`
+considers, and whether a merge base is used.
+"""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from check_large_files import (  # noqa: E402
+    MAX_BYTES,
+    blob_size,
+    changed_files,
+    human,
+    main,
+    oversized,
+)
+
+
+class TestHumanSize(unittest.TestCase):
+    """Fixed MB printed every sub-megabyte offender as "0.00 MB"."""
+
+    def test_scales_to_the_magnitude(self):
+        self.assertEqual(human(512), "512 B")
+        self.assertEqual(human(5 * 1024), "5.00 KB")
+        self.assertEqual(human(5 * 1024 ** 2), "5.00 MB")
+        self.assertEqual(human(3 * 1024 ** 3), "3.00 GB")
+
+    def test_no_size_renders_as_zero_of_a_larger_unit(self):
+        for n in (1, 999, 5000, 1048575):
+            self.assertNotIn("0.00 MB", human(n))
+
+
+class TestOversized(unittest.TestCase):
+    def test_nothing_over_the_limit(self):
+        self.assertEqual(oversized({"a": 10, "b": 20}, limit=100), [])
+
+    def test_boundary_is_exclusive(self):
+        """Exactly at the limit passes; one byte over does not."""
+        self.assertEqual(oversized({"a": 100}, limit=100), [])
+        self.assertEqual(oversized({"a": 101}, limit=100), [("a", 101)])
+
+    def test_every_offender_is_reported_largest_first(self):
+        """Not just the first.
+
+        A PR adding three large files should learn that in one run, and a
+        report that shows a subset reads as "this is all of it".
+        """
+        found = oversized({"small": 1, "big": 300, "mid": 200, "huge": 900}, limit=100)
+        self.assertEqual([p for p, _ in found], ["huge", "big", "mid"])
+
+    def test_the_default_limit_is_the_documented_one(self):
+        self.assertEqual(MAX_BYTES, 10 * 1024 * 1024)
+
+
+class TestAgainstARealRepository(unittest.TestCase):
+    """Against real git, because the mock-able parts are not the risky parts."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.email", "t@example.invalid")
+        self._git("config", "user.name", "T")
+        (self.repo / "base.txt").write_text("base")
+        self._git("add", "-A")
+        self._git("commit", "-qm", "base")
+        self._git("checkout", "-q", "-b", "feature")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _git(self, *args):
+        return subprocess.run(("git",) + args, cwd=self.repo,
+                              capture_output=True, text=True, check=True).stdout
+
+    def _commit(self, name, content):
+        (self.repo / name).write_text(content)
+        self._git("add", "-A")
+        self._git("commit", "-qm", f"add {name}")
+
+    def test_added_file_is_seen_and_sized(self):
+        self._commit("new.txt", "x" * 5000)
+        import os
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            self.assertIn("new.txt", changed_files("main"))
+            self.assertEqual(blob_size("new.txt"), 5000)
+        finally:
+            os.chdir(cwd)
+
+    def test_a_deletion_is_not_an_offence(self):
+        """Removing a large file is the fix, not the problem."""
+        import os
+        (self.repo / "gone.txt").write_text("y" * 5000)
+        self._git("add", "-A")
+        self._git("commit", "-qm", "add gone")
+        self._git("rm", "-q", "gone.txt")
+        self._git("commit", "-qm", "remove gone")
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            self.assertNotIn("gone.txt", changed_files("main"))
+        finally:
+            os.chdir(cwd)
+
+    def test_files_landing_on_the_base_afterwards_are_not_blamed(self):
+        """Merge base, not base tip.
+
+        A long-running branch must be judged on what it adds. Diffing against
+        the moving tip of main would blame it for a large file somebody else
+        committed in the meantime, and the author could do nothing about it.
+        """
+        import os
+        self._commit("mine.txt", "small")
+        self._git("checkout", "-q", "main")
+        (self.repo / "theirs.txt").write_text("z" * 9000)
+        self._git("add", "-A")
+        self._git("commit", "-qm", "someone else adds a big file")
+        self._git("checkout", "-q", "feature")
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            changed = changed_files("main")
+            self.assertIn("mine.txt", changed)
+            self.assertNotIn("theirs.txt", changed,
+                             "the branch must not be blamed for main's files")
+        finally:
+            os.chdir(cwd)
+
+    def test_main_fails_on_an_oversized_file_and_passes_otherwise(self):
+        import os
+        self._commit("big.bin", "q" * 4096)
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            self.assertEqual(main(["--base", "main", "--limit", "10000"]), 0)
+            self.assertEqual(main(["--base", "main", "--limit", "1000"]), 1)
+        finally:
+            os.chdir(cwd)
+
+    def test_no_changes_is_a_pass_not_a_crash(self):
+        import os
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            self.assertEqual(main(["--base", "main"]), 0)
+        finally:
+            os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_large_files.py
+++ b/tests/test_check_large_files.py
@@ -156,6 +156,68 @@ class TestAgainstARealRepository(unittest.TestCase):
         finally:
             os.chdir(cwd)
 
+    def test_a_true_rename_adds_no_bytes_and_is_ignored(self):
+        """The blob already exists in history; moving it costs nothing (#267).
+
+        The file has to pre-exist on `main` for this to be a rename at all. A
+        file created on the branch and then moved is, relative to the merge
+        base, simply a new file at its final path — and flagging that is right,
+        because its blob is new to history either way.
+        """
+        import os
+        self._git("checkout", "-q", "main")
+        (self.repo / "big.bin").write_text("x" * 9000)
+        self._git("add", "-A")
+        self._git("commit", "-qm", "big.bin lands on main")
+        self._git("checkout", "-q", "feature")
+        self._git("merge", "-q", "main", "-m", "merge")
+        self._git("mv", "big.bin", "moved.bin")
+        self._git("commit", "-qm", "rename")
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            self.assertNotIn("moved.bin", changed_files("main"),
+                             "moving an existing blob adds nothing to history")
+        finally:
+            os.chdir(cwd)
+
+    def test_a_rename_detected_new_blob_is_still_weighed(self):
+        """Similar-but-not-identical is a new object wearing a rename's clothes.
+
+        git reports >50%-similar delete+add as R. The destination is a blob
+        that does not exist in history yet, so it has to be sized.
+        """
+        import os
+        self._commit("orig.bin", "y" * 9000)
+        (self.repo / "orig.bin").unlink()
+        (self.repo / "copy.bin").write_text("y" * 8000 + "DIFFERENT" * 100)
+        self._git("add", "-A")
+        self._git("commit", "-qm", "delete one, add a similar one")
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            self.assertIn("copy.bin", changed_files("main"),
+                          "a rename-detected new blob must not slip past")
+        finally:
+            os.chdir(cwd)
+
+    def test_a_missing_base_ref_fails_closed_with_a_readable_message(self):
+        """#266: exit non-zero, and say what to do about it."""
+        import io
+        import os
+        from contextlib import redirect_stderr
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        try:
+            err = io.StringIO()
+            with redirect_stderr(err):
+                code = main(["--base", "origin/does-not-exist"])
+            self.assertEqual(code, 1, "must fail closed, never wave the PR through")
+            self.assertIn("not found", err.getvalue())
+            self.assertIn("fetch-depth", err.getvalue())
+        finally:
+            os.chdir(cwd)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #262 and #258. Both are the same shape — bound what can enter shared history — so they share a branch, one commit each.

## #262 — a CI check on the PR diff

A stray large object is cheap to fix locally and impossible to fix once pushed. The 3.19 GB CM4AI archive in #261 was recoverable **because it never reached GitHub**; committed and pushed, rewriting shared history would have been the only remedy.

`.gitignore` can't express "no file over N megabytes" — it matches names, and #263 and #264 were both cases of the next file not being named like the last. A pre-commit hook could express the rule but protects only contributors who install one, which is the wrong side of the boundary. So: CI, on the pull request.

**The limit is 10 MB, chosen against the repository rather than picked round:**

| | |
|---|---|
| largest file tracked at HEAD | 3.94 MB |
| files over 5 MB | 0 (of 3,669) |
| files 1–5 MB | 20 |

That's ~2.5× the real ceiling — source PDFs and concatenated corpora pass untouched.

Two details that are why this is a script and not one line of bash:

- **It diffs against the merge base, not the base tip.** A long-running branch must be judged on what *it* adds; diffing the moving tip of `main` would fail someone's PR for a large file a different PR merged yesterday. There's a test for exactly that.
- **It reports every offender, not the first.** A PR adding three large files should learn that once, and a check showing a subset reads as "this is all of it".

Deletions are excluded — removing a large file is the fix, not the offence. The limit isn't overridable by environment variable: committing something this big should be a decision visible in a diff, not a workflow setting nobody reads.

Canaried against its own PR (passes at 10 MB, fails at a 3 KB limit with the full offender list). The canary also caught two defects in my own output — every sub-MB file printed as `0.00 MB`, and stdout/stderr interleaving so the summary landed *after* the failure it introduces. Both fixed, both tested.

## #258 — budget every cache, not just the expensive one

#247 bounded `embeddings.jsonl` because a vector costs ~10 KB. The four verdict caches had no bound, which made the guard read as an oversight. A verdict is ~395 bytes — a 26× difference in cost per record, which is a reason for different *numbers*, not for guarding one and ignoring the others.

```
embeddings.jsonl              136 -> 200   full-corpus sweep is 1439, ~14 MB
{PROJECT}_equivalence.jsonl 99-154 -> 400  full re-judge of one project ~300
```

Plus two things per-file counts don't give:

- **A total-bytes bound** (1.78 MB today against 4 MB), because a cache can grow by getting *fatter* rather than longer — a larger embedding dimension, or a judge that starts returning paragraphs, sails past a record count.
- **A test that every `*.jsonl` has a budget entry.** That's the gap #258 was actually about: the verdict caches were unguarded and nothing said so. Verified it fires on a hypothetical new cache file.

**989 passed, 3 skipped** (was 976; +11 for the new script, +2 net for the cache guards).