### PR TITLE
Draft the companion rule for v2's rule 1 (generic-v3) — staged, not run

### DIFF
--- a/notes/generic_v3_analysis_plan.md
+++ b/notes/generic_v3_analysis_plan.md
@@ -1,0 +1,77 @@
+# generic-v3 analysis plan
+
+Registered before any v3 generation run. The prediction is here rather than in
+the prompt because writing it there would instruct the model to produce the
+result the run is meant to test.
+
+## What v3 changes
+
+One rule, added to v2's three:
+
+> When a slot's declared range is a class, populate the fields that class
+> declares. Placing the content in a free-text field such as `description` while
+> the declared fields — a name, an identifier, dates, affiliations — stay empty
+> produces an object of the correct shape holding none of the structure it
+> exists to carry. Where the evidence answers a declared field, populate that
+> field rather than restating it in prose.
+
+## Why
+
+v2's rule 1 worked and traded one defect for another. Splitting the fitness
+`form` class (`notes/form_defect_split_2026-08-03.md`) measured, over the 106
+form failures already judged:
+
+| defect | v1 → v2 |
+|---|---|
+| collapsed cardinality | 42 → 7 |
+| hollow object | 8 → 50 |
+
+The reported `form` total moved 50 → 56 and hid both.
+
+## The comparison
+
+**v2 against v3**, not v1 against v3. The two differ on one axis (`base`), and
+only that pairing isolates the companion rule. v1 against v3 would measure four
+rules at once.
+
+Same four projects, three replicates, same model and settings as the v1 and v2
+series. The label carries `generic-v3`.
+
+## Prediction, registered
+
+1. **Hollow objects fall.** This is the rule's own target and the only outcome
+   that would make it worth promoting.
+2. **Collapsed cardinality does not return.** v2's rule 1 is still present and
+   unchanged, so its effect should persist. If collapsed cardinality rises again
+   the two rules interact, and the companion is not additive.
+3. **The `form` total falls**, because it is now the sum of two things both
+   predicted to be low. This is the outcome the unsplit axis could not show for
+   v2 and is the reason the split had to come first.
+4. **Substance and target stay flat** against v2. Nothing in the new rule
+   addresses either. Movement there is a signal that adding any fourth rule
+   changes behaviour diffusely rather than at the point it names — which would
+   itself be worth knowing, and would weaken the case that these rules compose.
+
+## What would count as failure
+
+- Hollow objects flat or up: the rule is not doing what it says.
+- Collapsed cardinality returning: the rules are not additive, and rule 1 plus
+  the companion needs rewriting as a single instruction rather than two.
+- A new form sub-type appearing in `other`: the same exchange happening again
+  one level down. `other` is now measured, so this is visible rather than
+  inferred — it was 8 → 4 across v1 → v2.
+
+## How it will be measured
+
+Fitness scoring as before, then `python -m data_sheets_schema.form_defects` for
+the sub-type breakdown. The fitness rubric is **not** edited, so the v1 and v2
+judgements stay valid and the three arms remain comparable; the sub-type
+classifier's rubric is likewise unchanged, so its cached labels stay valid too.
+Both caches are keyed on their rubric, so an edit to either invalidates rather
+than silently mixes.
+
+## Cost
+
+Twelve generations (four projects x three replicates), then fitness scoring of
+the new records and sub-type classification of whatever form failures they
+produce. Not yet run, and not to be run without a decision to spend it.

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -54,8 +54,16 @@ GENERIC_PROMPT = PROMPTS / "d4d_generic_arm_prompt.md"
 # edit: v1 produced the 2026-07-28 series and is the baseline v2 is measured
 # against, so editing it in place would silently redefine that baseline.
 GENERIC_PROMPT_V2 = PROMPTS / "d4d_generic_arm_prompt_v2.md"
+# v3 is v2 plus one rule. v2's first rule stopped the model collapsing several
+# entities into one object and left objects of the right cardinality whose
+# declared fields are empty because the content sits in `description`
+# (notes/form_defect_split_2026-08-03.md). A third file for the same reason v2
+# was one: v2 produced the 2026-07-31 series and is the baseline v3 is measured
+# against. The comparison that isolates the companion rule is v2 against v3.
+GENERIC_PROMPT_V3 = PROMPTS / "d4d_generic_arm_prompt_v3.md"
 CONDITION_PROMPTS = {"generic": GENERIC_PROMPT,
                      "generic_v2": GENERIC_PROMPT_V2,
+                     "generic_v3": GENERIC_PROMPT_V3,
                      "tuned": GENERIC_PROMPT}
 
 # Which generic base each condition is built on. The generic/tuned comparison
@@ -71,6 +79,7 @@ CONDITION_PROMPTS = {"generic": GENERIC_PROMPT,
 CONDITION_AXES = {
     "generic":    {"base": "v1", "tuned": False},
     "generic_v2": {"base": "v2", "tuned": False},
+    "generic_v3": {"base": "v3", "tuned": False},
     "tuned":      {"base": "v1", "tuned": True},
 }
 

--- a/src/download/prompts/d4d_generic_arm_prompt_v3.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v3.md
@@ -1,0 +1,163 @@
+# D4D generic-arm generation prompt — v3
+
+**This is v2 plus one uniform decision rule, and nothing else.** The
+substitution fields, outputs, header block, constraints, the four original rules
+and v2's three additions are byte-identical to
+`src/download/prompts/d4d_generic_arm_prompt_v2.md`; a test asserts that the only
+difference is the block marked `ADDED IN v3`.
+
+## Why v3 exists
+
+v2's first rule — one object per distinct entity for a multivalued slot — did
+what it was written to do. Splitting the fitness `form` class into its two
+component defects (`notes/form_defect_split_2026-08-03.md`) measured
+collapsed cardinality falling by more than four fifths, while a second defect
+rose to take its place: objects of the correct cardinality whose declared
+structured fields are empty because the content sits in a free-text
+`description`.
+
+One class covering both defects reported that exchange as a net regression. It
+was not one. But the exchange is real, and a rule that trades one form failure
+for another is not finished.
+
+The companion rule addresses the second defect on the same terms as the first:
+it concerns how the schema is used, states no fact about any dataset, and can
+therefore be said without naming a project.
+
+## Why this addition is generic and not priming
+
+Measured against the taxonomy in `.claude/commands/d4d-full-core.md`:
+
+- it applies identically to every project, naming no project, dataset or input
+  set;
+- it states no target count, no expected density, and no expected relationship
+  to any other arm — it is a decision rule, not an outcome expectation;
+- it concerns the schema, which every arm shares.
+
+## What is NOT in this file, deliberately
+
+The prediction that this rule reduces hollow objects without returning
+collapsed cardinality. Writing it here would instruct the model to produce the
+result the run is meant to test. It lives in
+`notes/generic_v3_analysis_plan.md`, registered before any generation run.
+
+## Relationship to v1 and v2
+
+Neither is superseded and neither may be edited. The 2026-07-28 generic series
+was produced under v1 and the 2026-07-31 generic-v2 series under v2; both remain
+baselines this version is measured against. The comparison that isolates this
+rule is v2 against v3.
+
+## Prompt body
+
+Generate paired full and core D4D records for the {PROJECT} project.
+
+READ FIRST, IN THIS ORDER, AND FOLLOW EXACTLY:
+
+1. `.claude/agents/d4d-provenance-guard.md` — the factual evidence boundary.
+   Enforce it in every phase.
+2. `.claude/commands/d4d-full-core.md` — the four-phase playbook.
+
+Execution mode: four-phase project agent. Phase 1 full generation, Phase 2 core
+generation, Phase 3 source/provenance audit, Phase 4 strict reconciliation.
+Phase 2 must wait for a validated Phase 1 file.
+
+VERSION LABEL — use verbatim in every output path: {LABEL}
+
+ARM: {ARM}
+
+DECLARED INPUT BUNDLE — your only source of dataset facts:
+    {BUNDLE}
+
+Full schema: `src/data_sheets_schema/schema/data_sheets_schema_all.yaml` (class
+`Dataset`)
+Core schema: `src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml`
+(class `CoreDataset`)
+
+OUTPUTS — do not write outside these three:
+
+- Full:   `data/d4d_concatenated/{METHOD}/{LABEL}/{PROJECT}_d4d.yaml`
+- Core:   `data/d4d_concatenated/{METHOD}_core/{LABEL}/{PROJECT}_d4d_core.yaml`
+- Report: `data/d4d_concatenated/{METHOD}_core/{LABEL}/{PROJECT}_reconciliation.md`
+
+HEADER BLOCK — use exactly:
+
+    # D4D Datasheet for {PROJECT} Dataset
+    # Generation Method: schema-grounded agentic, phase 1
+    # Agent runtime: {RUNTIME}
+    # Provider: {PROVIDER}
+    # Model: {MODEL}
+    # Mode: four-phase project agent, generic-v2 prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v2.md (identical for all projects)
+    # Arm: {ARM}
+    # Source bundle: {BUNDLE}
+    {MANIFEST_LINE}
+    # Schema: src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+    # Prior D4D factual reuse: prohibited
+    # Temperature: 0.0
+    # Generated: {DATE}
+
+The core file uses "phase 2" and the core schema path in the corresponding lines.
+
+AFTER Phase 4, write a LIVE provenance record:
+
+    poetry run d4d provenance record --project {PROJECT} --method {METHOD} --label {LABEL} --input-bundle {BUNDLE}
+
+VALIDATE both files before finishing:
+
+    poetry run linkml-validate -s src/data_sheets_schema/schema/data_sheets_schema_all.yaml -C Dataset <full>
+    poetry run linkml-validate -s src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml -C CoreDataset <core>
+
+ABSOLUTE CONSTRAINT — do not read, open, grep, or consult any previously
+generated D4D record, from any arm, any label, or any date. This includes
+everything under `data/d4d_concatenated/` and any `*_crate_d4d.yaml` or
+`*_crate_mapped_d4d.yaml` under `data/ro-crate_packages/`. Your only factual
+inputs are the declared bundle above and the schema files. Prior-D4D reuse is a
+defect under the provenance guard.
+
+UNIFORM DECISION RULES — these apply identically to every project and every arm:
+
+- Populate a slot only where the declared bundle supports it. Prefer omission
+  over inference: an absent slot is a correct answer when the evidence is
+  absent, and a plausible guess is not.
+- Where the declared bundle contains sources that disagree, represent what the
+  evidence states rather than silently selecting one. Do not merge distinct
+  entities into a single claim.
+- `Dataset` admits one referent. Choose the one the declared bundle best
+  supports, state that choice in the reconciliation report, and hold to it
+  consistently across both records.
+- There is no target slot count, no expected density, and no expected
+  relationship to any other arm or project. Apply your own judgment about what
+  the evidence supports.
+
+--- ADDED IN v2 ---
+
+- When a slot's declared range is multivalued, emit one object per distinct
+  entity. Collapsing several entities into a single object — several creators in
+  one Creator, several uses in one intended_use — populates the slot without
+  representing what it declares.
+- Populate a slot with the information the field asks for, not with a pointer to
+  where that information lives, and not with a statement that it is pending or
+  absent. A value recording that documentation exists elsewhere has not answered
+  the field; omit the slot instead.
+- Read the slot's description before populating it. Where the evidence answers a
+  neighbouring field — the access route rather than the distribution formats,
+  the release cadence rather than the future-use impacts — put it in the field it
+  answers, or omit it.
+
+--- END ADDED IN v2 ---
+
+--- ADDED IN v3 ---
+
+- When a slot's declared range is a class, populate the fields that class
+  declares. Placing the content in a free-text field such as `description` while
+  the declared fields — a name, an identifier, dates, affiliations — stay empty
+  produces an object of the correct shape holding none of the structure it
+  exists to carry. Where the evidence answers a declared field, populate that
+  field rather than restating it in prose.
+
+--- END ADDED IN v3 ---
+
+
+RETURN: full slot count, core slot count, whether both validated, and the
+reconciliation outcome. Return data, not prose.

--- a/tests/test_download/test_generic_v3_prompt.py
+++ b/tests/test_download/test_generic_v3_prompt.py
@@ -1,0 +1,134 @@
+"""generic-v3 must stay generic, and must be v2 plus one rule.
+
+Mirrors `test_generic_v2_prompt.py`. The arm's value is that every project
+receives identical text and that exactly one thing changed since the baseline it
+is measured against — v2, not v1.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from data_sheets_schema.api_runner import (
+    CONDITION_AXES,
+    CONDITION_PROMPTS,
+    GENERIC_PROMPT,
+    GENERIC_PROMPT_V2,
+    GENERIC_PROMPT_V3,
+    comparable_conditions,
+    condition_delta,
+    prompt_body,
+)
+
+PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
+MARK_START = "--- ADDED IN v3 ---"
+MARK_END = "--- END ADDED IN v3 ---"
+
+
+def _added_block(text):
+    return text.split(MARK_START, 1)[1].split(MARK_END, 1)[0]
+
+
+def _norm(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+class TestV3IsV2PlusTheAddedBlock(unittest.TestCase):
+
+    def test_body_differs_from_v2_only_by_the_marked_block(self):
+        v2 = prompt_body(GENERIC_PROMPT_V2)
+        v3 = prompt_body(GENERIC_PROMPT_V3)
+        stripped = (v3.split(MARK_START, 1)[0]
+                    + v3.split(MARK_END, 1)[1]).strip()
+        self.assertEqual(_norm(stripped), _norm(v2),
+                         "v3 must be v2 plus the marked block and nothing else")
+
+    def test_v2s_three_rules_survive_intact(self):
+        """The companion supplements rule 1; it does not replace it.
+
+        If v2's rules were dropped, a v2-vs-v3 difference would measure their
+        removal as well as the addition.
+        """
+        v3 = prompt_body(GENERIC_PROMPT_V3)
+        v2_block = v3.split("--- ADDED IN v2 ---", 1)[1] \
+                     .split("--- END ADDED IN v2 ---", 1)[0]
+        self.assertEqual(len([l for l in v2_block.splitlines()
+                              if l.startswith("- ")]), 3)
+
+    def test_the_added_block_holds_exactly_one_rule(self):
+        rules = [l for l in _added_block(GENERIC_PROMPT_V3.read_text()).splitlines()
+                 if l.startswith("- ")]
+        self.assertEqual(len(rules), 1)
+
+    def test_v1_and_v2_are_untouched_by_v3(self):
+        for path in (GENERIC_PROMPT, GENERIC_PROMPT_V2):
+            with self.subTest(path=path.name):
+                self.assertNotIn(MARK_START, path.read_text(),
+                                 "an earlier version produced a baseline and "
+                                 "must not acquire v3's rule")
+
+
+class TestTheAddedRuleIsGeneric(unittest.TestCase):
+
+    def setUp(self):
+        self.block = _added_block(GENERIC_PROMPT_V3.read_text())
+
+    def test_no_project_is_named(self):
+        for project in PROJECTS:
+            with self.subTest(project=project):
+                self.assertNotIn(project, self.block)
+
+    def test_no_dataset_identifiers(self):
+        for token in ("fairhub", "physionet", "dataverse", "10.18130",
+                      "cm4ai.org", "HIGT4C", "B35XWX"):
+            with self.subTest(token=token):
+                self.assertNotIn(token.lower(), self.block.lower())
+
+    def test_no_expected_quantities(self):
+        numbers = re.findall(r"\b\d+\b", self.block)
+        self.assertEqual(numbers, [],
+                         f"the rule must state no quantities, found {numbers}")
+        for phrase in ("expect", "should yield", "typically", "at least",
+                       "roughly", "approximately"):
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, self.block.lower())
+
+    def test_no_reference_to_prior_runs(self):
+        """The defect it corrects was found in a prior run; saying so would
+        turn a decision rule into a quality warning."""
+        for phrase in ("earlier run", "previous run", "prior run", "last time",
+                       "has been observed", "tends to", "hollow"):
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, self.block.lower())
+
+    def test_the_prediction_lives_outside_the_prompt(self):
+        text = GENERIC_PROMPT_V3.read_text().lower()
+        self.assertNotIn("we expect", text)
+        self.assertTrue(Path("notes/generic_v3_analysis_plan.md").exists(),
+                        "the prediction must be registered before running")
+
+
+class TestTheConditionIsWiredComparably(unittest.TestCase):
+
+    def test_v3_resolves_to_its_own_prompt(self):
+        self.assertEqual(CONDITION_PROMPTS["generic_v3"], GENERIC_PROMPT_V3)
+
+    def test_v2_against_v3_is_the_isolating_comparison(self):
+        self.assertTrue(comparable_conditions("generic_v2", "generic_v3"))
+        self.assertEqual(condition_delta("generic_v2", "generic_v3"), ["base"])
+
+    def test_v3_against_tuned_is_confounded(self):
+        """Same trap v2 had: tuned is pinned to the v1 base."""
+        self.assertFalse(comparable_conditions("generic_v3", "tuned"))
+        self.assertEqual(sorted(condition_delta("generic_v3", "tuned")),
+                         ["base", "tuned"])
+
+    def test_each_generic_base_is_distinct(self):
+        bases = [CONDITION_AXES[c]["base"]
+                 for c in ("generic", "generic_v2", "generic_v3")]
+        self.assertEqual(len(set(bases)), 3,
+                         "two conditions sharing a base would be indistinguishable")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-on from #271. The form-defect split showed v2's rule 1 doing exactly what it says and handing the failure to a neighbour:

| defect | v1 → v2 |
|---|---|
| collapsed cardinality | 42 → 7 |
| hollow object | 8 → 50 |

The rule is a success on its own terms and is not finished. This drafts the companion. **Nothing is run.**

## The rule

> When a slot's declared range is a class, populate the fields that class declares. Placing the content in a free-text field such as `description` while the declared fields — a name, an identifier, dates, affiliations — stay empty produces an object of the correct shape holding none of the structure it exists to carry. Where the evidence answers a declared field, populate that field rather than restating it in prose.

Stated on the same terms as v2's three: how the schema is used, no fact about any dataset, so it can be said without naming a project.

## v3 is a third file, not an edit

Same reason v2 was one — v2 produced the 2026-07-31 series and is the baseline v3 is measured against. v3's body is **generated from v2's**, so everything outside the marked block is provably identical, and a test asserts it. A second test asserts v2's three rules survive intact, since dropping them would make a v2-vs-v3 difference measure their removal as well as the addition.

## Comparability

`CONDITION_AXES` gains base `v3`, so:

| pairing | differs on | interpretable? |
|---|---|---|
| `generic_v2` vs `generic_v3` | base | ✅ isolates the companion rule |
| `generic_v3` vs `tuned` | base **and** tuned | ❌ flagged confounded |

Same trap v2 had — `tuned` is pinned to the v1 base. A test asserts all three generic bases are distinct, because two conditions sharing one would be silently indistinguishable.

## Genericness

The block carries no digits, no project, no dataset identifier, no expectation phrasing, and no reference to prior runs. That last one is worth naming: the defect it corrects *was* found in a prior run, and saying so would turn a decision rule into a quality warning. The test also bans the word **"hollow"** from the block, so the prompt cannot name the failure class it is about to be measured on.

## The prediction is registered, not in the prompt

`notes/generic_v3_analysis_plan.md`, written before any run, including what would count as failure:

- hollow objects flat or up — the rule is not doing what it says
- collapsed cardinality returning — the rules are not additive, and rule 1 plus the companion needs rewriting as one instruction
- a new sub-type appearing in `other` — the same exchange one level down, now **visible** because `other` is measured rather than inferred (8 → 4 across v1 → v2)

Neither the fitness rubric nor the sub-type classifier's rubric is edited, so the v1/v2 judgements and cached sub-type labels stay valid and all three arms remain comparable.

## Cost, if you decide to run it

Twelve generations (4 projects × 3 replicates) plus fitness scoring and sub-type classification of whatever form failures result.

**1005 passed, 3 skipped** (+13).