### PR TITLE
Rubric20 scores out of 88 everywhere, including where the judge is told

### DIFF
--- a/scripts/batch_evaluate_rubric20_hybrid.py
+++ b/scripts/batch_evaluate_rubric20_hybrid.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from typing import Dict, List, Any, Optional, Tuple
 import hashlib
 import re
+from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
 
 # Base directory
 BASE_DIR = Path(__file__).parent.parent
@@ -703,7 +704,7 @@ def evaluate_d4d_file(file_path: Path, project: str, method: str, eval_type: str
     }
 
     total_score = 0
-    max_total = 84  # 16 numeric questions × 5 + 4 pass/fail × 1
+    max_total = RUBRIC20_MAX_SCORE  # 17 numeric x 5 + 3 pass/fail x 1
 
     # Group by category
     categories = {}
@@ -815,7 +816,7 @@ def main():
             json.dump(result, f, indent=2)
 
         score = result["overall_score"]
-        print(f"   ✅ Score: {score['total_points']}/84 ({score['percentage']}%)")
+        print(f"   ✅ Score: {score['total_points']}/{RUBRIC20_MAX_SCORE} ({score['percentage']}%)")
 
         concat_count += 1
 
@@ -862,7 +863,7 @@ def main():
                 json.dump(result, f, indent=2)
 
             score = result["overall_score"]
-            print(f"   ✅ Score: {score['total_points']}/84 ({score['percentage']}%)")
+            print(f"   ✅ Score: {score['total_points']}/{RUBRIC20_MAX_SCORE} ({score['percentage']}%)")
 
             individual_count += 1
 

--- a/scripts/generate_gc_approach_comparison.py
+++ b/scripts/generate_gc_approach_comparison.py
@@ -8,6 +8,7 @@ import json
 import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
+from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
 
 # Project root
 BASE_DIR = Path(__file__).parent.parent
@@ -64,7 +65,7 @@ def generate_comparison_table():
                 row = [
                     f"{gc} - {method}",
                     f"{r10['total_points']}/50",
-                    f"{r20['total_points']}/84",
+                    f"{r20['total_points']}/{RUBRIC20_MAX_SCORE}",
                     f"{r10['percentage']}%",
                     f"{r20['percentage']}%"
                 ]
@@ -79,12 +80,12 @@ def generate_comparison_table():
             gc_r10_avg = gc_r10_total / gc_count
             gc_r20_avg = gc_r20_total / gc_count
             gc_r10_pct = (gc_r10_avg / 50) * 100
-            gc_r20_pct = (gc_r20_avg / 84) * 100
+            gc_r20_pct = (gc_r20_avg / RUBRIC20_MAX_SCORE) * 100
             
             avg_row = [
                 f"{gc} Average",
                 f"{gc_r10_avg:.1f}/50",
-                f"{gc_r20_avg:.1f}/84",
+                f"{gc_r20_avg:.1f}/{RUBRIC20_MAX_SCORE}",
                 f"{gc_r10_pct:.1f}%",
                 f"{gc_r20_pct:.1f}%"
             ]
@@ -108,12 +109,12 @@ def generate_comparison_table():
             method_r10_avg = method_r10_total / method_count
             method_r20_avg = method_r20_total / method_count
             method_r10_pct = (method_r10_avg / 50) * 100
-            method_r20_pct = (method_r20_avg / 84) * 100
+            method_r20_pct = (method_r20_avg / RUBRIC20_MAX_SCORE) * 100
             
             method_row = [
                 f"Overall - {method}",
                 f"{method_r10_avg:.1f}/50",
-                f"{method_r20_avg:.1f}/84",
+                f"{method_r20_avg:.1f}/{RUBRIC20_MAX_SCORE}",
                 f"{method_r10_pct:.1f}%",
                 f"{method_r20_pct:.1f}%"
             ]
@@ -128,12 +129,12 @@ def generate_comparison_table():
         grand_r10_avg = grand_r10_total / grand_count
         grand_r20_avg = grand_r20_total / grand_count
         grand_r10_pct = (grand_r10_avg / 50) * 100
-        grand_r20_pct = (grand_r20_avg / 84) * 100
+        grand_r20_pct = (grand_r20_avg / RUBRIC20_MAX_SCORE) * 100
         
         grand_row = [
             "Grand Average",
             f"{grand_r10_avg:.1f}/50",
-            f"{grand_r20_avg:.1f}/84",
+            f"{grand_r20_avg:.1f}/{RUBRIC20_MAX_SCORE}",
             f"{grand_r10_pct:.1f}%",
             f"{grand_r20_pct:.1f}%"
         ]

--- a/scripts/render_evaluation_html_rubric20_semantic.py
+++ b/scripts/render_evaluation_html_rubric20_semantic.py
@@ -16,6 +16,7 @@ To validate evaluations against the schema, run:
 import json
 from pathlib import Path
 from datetime import datetime
+from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
 
 
 def generate_evaluation_html(eval_data, output_path):
@@ -32,7 +33,7 @@ def generate_evaluation_html(eval_data, output_path):
     # Extract overall score
     overall = eval_data.get("overall_score", {})
     total_score = overall.get("total_points", 0)
-    max_score = overall.get("max_points", 84)
+    max_score = overall.get("max_points", RUBRIC20_MAX_SCORE)
     percentage = overall.get("percentage", 0)
 
     # Calculate grade

--- a/scripts/render_interleaved_evaluation.py
+++ b/scripts/render_interleaved_evaluation.py
@@ -26,6 +26,7 @@ import sys
 from pathlib import Path
 
 import yaml
+from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
 
 
 SEVERITY_COLOR = {
@@ -346,7 +347,7 @@ def render_html(yaml_data: dict, r10: dict, r20: dict, source_paths: dict) -> st
     r20_total = (r20.get("overall_score") or {}).get("total_points") or \
                 (r20.get("summary_scores") or {}).get("total_score")
     r20_max = (r20.get("overall_score") or {}).get("max_points") or \
-              (r20.get("summary_scores") or {}).get("total_max_score") or 84
+              (r20.get("summary_scores") or {}).get("total_max_score") or RUBRIC20_MAX_SCORE
     r20_pct = (r20.get("overall_score") or {}).get("percentage") or \
               (r20.get("summary_scores") or {}).get("overall_percentage")
 

--- a/scripts/summarize_rubric20_results.py
+++ b/scripts/summarize_rubric20_results.py
@@ -182,12 +182,24 @@ def create_markdown_table(results: List[Dict]):
                 avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in results_list) / file_count
                 avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in results_list) / file_count
 
+                # The records carry their own denominator, and 167 committed
+                # rubric20 evaluations were scored against 84 (#275). Printing a
+                # constant beside an average of those is confidently wrong where
+                # printing the record's own value is merely stale. Pooling
+                # records with different denominators is not meaningful at all,
+                # so say so rather than average across them (#274).
+                maxima = {r.get('overall_score', {}).get('max_points',
+                                                         RUBRIC20_MAX_SCORE)
+                          for r in results_list}
+                denom = (str(maxima.pop()) if len(maxima) == 1
+                         else "MIXED(" + "/".join(str(m) for m in sorted(maxima)) + ")")
+
                 avg_cat1 = sum(r.get('categories', {}).get('Structural Completeness', {}).get('category_score', 0) for r in results_list) / file_count
                 avg_cat2 = sum(r.get('categories', {}).get('Metadata Quality & Content', {}).get('category_score', 0) for r in results_list) / file_count
                 avg_cat3 = sum(r.get('categories', {}).get('Technical Documentation', {}).get('category_score', 0) for r in results_list) / file_count
                 avg_cat4 = sum(r.get('categories', {}).get('FAIRness & Accessibility', {}).get('category_score', 0) for r in results_list) / file_count
 
-                md += f"| {project} | {method} | {avg_score:.1f}/{RUBRIC20_MAX_SCORE} | {file_count} | {avg_pct:.1f}% | {avg_cat1:.1f} | {avg_cat2:.1f} | {avg_cat3:.1f} | {avg_cat4:.1f} |\n"
+                md += f"| {project} | {method} | {avg_score:.1f}/{denom} | {file_count} | {avg_pct:.1f}% | {avg_cat1:.1f} | {avg_cat2:.1f} | {avg_cat3:.1f} | {avg_cat4:.1f} |\n"
 
     # Top performers
     md += "\n## Top Performing D4Ds (Score >= 80%)\n\n"
@@ -246,7 +258,7 @@ def create_detailed_report(results: List[Dict]):
             avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in method_results) / len(method_results)
             report += f"### {method}\n"
             report += f"- Files evaluated: {len(method_results)}\n"
-            report += f"- Average score: {avg_score:.1f}/{RUBRIC20_MAX_SCORE} ({avg_pct:.1f}%)\n\n"
+            report += f"- Average score: {avg_score:.1f}/{denom} ({avg_pct:.1f}%)\n\n"
 
     # Project comparison
     report += "\n## Project Comparison\n\n"
@@ -258,7 +270,7 @@ def create_detailed_report(results: List[Dict]):
             avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in project_results) / len(project_results)
             report += f"### {project}\n"
             report += f"- Files evaluated: {len(project_results)}\n"
-            report += f"- Average score: {avg_score:.1f}/{RUBRIC20_MAX_SCORE} ({avg_pct:.1f}%)\n\n"
+            report += f"- Average score: {avg_score:.1f}/{denom} ({avg_pct:.1f}%)\n\n"
 
     # Category analysis
     report += "\n## Category Performance\n\n"

--- a/scripts/summarize_rubric20_results.py
+++ b/scripts/summarize_rubric20_results.py
@@ -19,6 +19,10 @@ from pathlib import Path
 from typing import List, Dict
 from datetime import datetime
 
+# The denominator lives with the rubric, not as a literal in a report.
+# It was 84 here while the questions defined 88 (#270 thread).
+from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
+
 # Base directory
 BASE_DIR = Path(__file__).parent.parent
 EVAL_DIR = BASE_DIR / "data" / "evaluation_llm" / "rubric20"
@@ -74,7 +78,7 @@ def create_csv_summary(results: List[Dict]):
 
             overall = result.get('overall_score', {})
             total_score = overall.get('total_points', 0)
-            max_score = overall.get('max_points', 84)
+            max_score = overall.get('max_points', RUBRIC20_MAX_SCORE)
             percentage = overall.get('percentage', 0)
 
             # Category scores
@@ -139,7 +143,7 @@ def create_markdown_table(results: List[Dict]):
                 result = table_data[key][0]  # Should only be one per key
                 overall = result.get('overall_score', {})
                 total = overall.get('total_points', 0)
-                max_pts = overall.get('max_points', 84)
+                max_pts = overall.get('max_points', RUBRIC20_MAX_SCORE)
                 pct = overall.get('percentage', 0)
 
                 # Category scores
@@ -183,7 +187,7 @@ def create_markdown_table(results: List[Dict]):
                 avg_cat3 = sum(r.get('categories', {}).get('Technical Documentation', {}).get('category_score', 0) for r in results_list) / file_count
                 avg_cat4 = sum(r.get('categories', {}).get('FAIRness & Accessibility', {}).get('category_score', 0) for r in results_list) / file_count
 
-                md += f"| {project} | {method} | {avg_score:.1f}/84 | {file_count} | {avg_pct:.1f}% | {avg_cat1:.1f} | {avg_cat2:.1f} | {avg_cat3:.1f} | {avg_cat4:.1f} |\n"
+                md += f"| {project} | {method} | {avg_score:.1f}/{RUBRIC20_MAX_SCORE} | {file_count} | {avg_pct:.1f}% | {avg_cat1:.1f} | {avg_cat2:.1f} | {avg_cat3:.1f} | {avg_cat4:.1f} |\n"
 
     # Top performers
     md += "\n## Top Performing D4Ds (Score >= 80%)\n\n"
@@ -198,7 +202,7 @@ def create_markdown_table(results: List[Dict]):
         method = result.get('method', 'unknown')
         eval_type = result.get('evaluation_type', 'unknown')
         overall = result.get('overall_score', {})
-        score_str = f"{overall.get('total_points', 0)}/{overall.get('max_points', 84)} ({overall.get('percentage', 0):.1f}%)"
+        score_str = f"{overall.get('total_points', 0)}/{overall.get('max_points', RUBRIC20_MAX_SCORE)} ({overall.get('percentage', 0):.1f}%)"
         file_name = Path(result.get('d4d_file', '')).name
 
         md += f"| {project} | {method} | {eval_type} | {score_str} | {file_name} |\n"
@@ -225,10 +229,10 @@ def create_detailed_report(results: List[Dict]):
 
     # Calculate overall statistics
     total_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in results)
-    max_possible = len(results) * 84
+    max_possible = len(results) * RUBRIC20_MAX_SCORE
     avg_percentage = sum(r.get('overall_score', {}).get('percentage', 0) for r in results) / len(results) if results else 0
 
-    report += f"- **Average Score:** {total_score / len(results):.1f}/84 ({avg_percentage:.1f}%)\n"
+    report += f"- **Average Score:** {total_score / len(results):.1f}/{RUBRIC20_MAX_SCORE} ({avg_percentage:.1f}%)\n"
     report += f"- **Best Score:** {max(results, key=lambda x: x.get('overall_score', {}).get('percentage', 0)).get('overall_score', {}).get('percentage', 0):.1f}%\n" if results else ""
     report += f"- **Worst Score:** {min(results, key=lambda x: x.get('overall_score', {}).get('percentage', 0)).get('overall_score', {}).get('percentage', 0):.1f}%\n" if results else ""
 
@@ -242,7 +246,7 @@ def create_detailed_report(results: List[Dict]):
             avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in method_results) / len(method_results)
             report += f"### {method}\n"
             report += f"- Files evaluated: {len(method_results)}\n"
-            report += f"- Average score: {avg_score:.1f}/84 ({avg_pct:.1f}%)\n\n"
+            report += f"- Average score: {avg_score:.1f}/{RUBRIC20_MAX_SCORE} ({avg_pct:.1f}%)\n\n"
 
     # Project comparison
     report += "\n## Project Comparison\n\n"
@@ -254,7 +258,7 @@ def create_detailed_report(results: List[Dict]):
             avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in project_results) / len(project_results)
             report += f"### {project}\n"
             report += f"- Files evaluated: {len(project_results)}\n"
-            report += f"- Average score: {avg_score:.1f}/84 ({avg_pct:.1f}%)\n\n"
+            report += f"- Average score: {avg_score:.1f}/{RUBRIC20_MAX_SCORE} ({avg_pct:.1f}%)\n\n"
 
     # Category analysis
     report += "\n## Category Performance\n\n"

--- a/src/data_sheets_schema/constants/evaluation.py
+++ b/src/data_sheets_schema/constants/evaluation.py
@@ -19,8 +19,20 @@ RUBRIC10_SUBELEMENTS_PER_ELEMENT = 5
 RUBRIC10_MAX_SCORE = RUBRIC10_MAX_ELEMENTS * RUBRIC10_SUBELEMENTS_PER_ELEMENT  # 50
 
 # Rubric20 scoring
-RUBRIC20_MAX_QUESTIONS = 20
-RUBRIC20_MAX_SCORE = 84  # Mixed scoring: some 0-5, some pass/fail
+#
+# 88, not 84. The 84 was written when the rubric's prose said 84 and its
+# questions defined 88; the questions are what get scored, so the prose was
+# stale and the constant inherited the staleness. Spelled out as its parts, the
+# way RUBRIC10_MAX_SCORE is, so the arithmetic is visible rather than asserted —
+# a bare 84 gave nothing to check it against, which is how it survived.
+# `tests/test_evaluation/test_rubric20_scoring.py` fails if this stops matching
+# the rubric file.
+RUBRIC20_NUMERIC_QUESTIONS = 17
+RUBRIC20_PASS_FAIL_QUESTIONS = 3
+RUBRIC20_POINTS_PER_NUMERIC = 5
+RUBRIC20_MAX_QUESTIONS = RUBRIC20_NUMERIC_QUESTIONS + RUBRIC20_PASS_FAIL_QUESTIONS
+RUBRIC20_MAX_SCORE = (RUBRIC20_NUMERIC_QUESTIONS * RUBRIC20_POINTS_PER_NUMERIC
+                      + RUBRIC20_PASS_FAIL_QUESTIONS)  # 88
 
 # Evaluation types
 EVALUATION_TYPES = ["presence", "llm", "semantic"]

--- a/src/download/prompts/rubric20_system_prompt.md
+++ b/src/download/prompts/rubric20_system_prompt.md
@@ -60,8 +60,8 @@ Return your evaluation as a **JSON object** with this EXACT structure:
   },
   "overall_score": {
     "total_points": 72.5,
-    "max_points": 84,
-    "percentage": 86.3
+    "max_points": 88,
+    "percentage": 82.4
   },
   "categories": [
     {
@@ -112,11 +112,21 @@ Return your evaluation as a **JSON object** with this EXACT structure:
 
 ## Scoring Summary
 
-**Maximum Possible Score:** 84 points
-- **Structural Completeness (5 questions):** 24 points max (4 numeric @5 each + 1 pass/fail)
-- **Metadata Quality & Content (5 questions):** 22 points max (4 numeric @5 each + 1 pass/fail)
-- **Technical Documentation (5 questions):** 25 points max (5 numeric @5 each)
-- **FAIRness & Accessibility (5 questions):** 13 points max (3 numeric @5 each + 2 pass/fail)
+**Maximum Possible Score:** 88 points
+- **17 numeric questions** @ 5 points each = 85
+- **3 pass/fail questions** @ 1 point each = 3
+
+This is the total the rubric's own questions define, and it is what the presence
+path scores against. It read 84 here for a long time, decomposed as 16 numeric +
+4 pass/fail — one question counted as pass/fail that the rubric defines as
+numeric — so the LLM path reported every record out of 84 while the presence
+path used 88, and the two were never comparable.
+
+The four category names below are this prompt's grouping. The rubric file does
+not declare categories, so no per-category maximum can be derived from it; each
+category's maximum is whatever its questions sum to. Earlier versions of this
+section stated per-category totals that summed to 84, which is how the wrong
+total survived being read.
 
 ## Key Principles
 

--- a/src/download/prompts/rubric20_system_prompt.md
+++ b/src/download/prompts/rubric20_system_prompt.md
@@ -81,7 +81,7 @@ Return your evaluation as a **JSON object** with this EXACT structure:
         ...
       ],
       "category_score": 23,
-      "category_max": 24
+      "category_max": "<sum of this category's question maxima>"
     },
     ...
   ],

--- a/tests/test_evaluation/test_rubric20_scoring.py
+++ b/tests/test_evaluation/test_rubric20_scoring.py
@@ -156,6 +156,34 @@ class TestDeclaredMaximumMatchesTheQuestions(unittest.TestCase):
                     offenders.append(f"{path}:{n}: {line.strip()[:70]}")
         self.assertEqual(offenders, [])
 
+    def test_the_judge_template_carries_no_literal_category_max(self):
+        """#276: the example is what the model imitates.
+
+        `"category_max": 24` was Structural Completeness's maximum under the
+        old 16-numeric-plus-4-pass/fail decomposition — the arithmetic that
+        produced 84. Removing it from the prose while leaving it in the
+        template is the weaker half of the fix.
+        """
+        from pathlib import Path
+        text = Path("src/download/prompts/rubric20_system_prompt.md").read_text()
+        import re
+        literals = re.findall(r'"category_max"\s*:\s*(\d+)', text)
+        self.assertEqual(literals, [])
+
+    def test_the_summary_table_reads_each_records_own_denominator(self):
+        """#274: 167 committed records were scored against 84.
+
+        A constant printed beside an average of those is confidently wrong
+        where the record's own value is merely stale, and pooling records with
+        different denominators is not meaningful at all.
+        """
+        from pathlib import Path
+        script = Path("scripts/summarize_rubric20_results.py").read_text()
+        self.assertIn("MIXED(", script,
+                      "a set spanning two denominators must say so")
+        self.assertNotIn("{avg_score:.1f}/{RUBRIC20_MAX_SCORE}", script,
+                         "the table must not hardcode a denominator")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_evaluation/test_rubric20_scoring.py
+++ b/tests/test_evaluation/test_rubric20_scoring.py
@@ -111,6 +111,51 @@ class TestDeclaredMaximumMatchesTheQuestions(unittest.TestCase):
         self.assertIsNotNone(m, "the rubric should declare its total")
         self.assertEqual(int(m.group(1)), computed)
 
+    def test_the_constant_matches_the_questions_too(self):
+        """The third place the total lived, and the one nothing checked.
+
+        `RUBRIC20_MAX_SCORE` said 84 while the questions defined 88. It was
+        exported and imported by nothing, so no test and no caller ever
+        contradicted it — dead and wrong, which is the combination the next
+        person needing a denominator picks up.
+        """
+        from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
+        ev = D4DEvaluator(str(RUBRIC10_PATH), str(RUBRIC20_PATH))
+        qs = ev.rubric20["d4d_evaluation_rubric"]["rubric"]
+        computed = (sum(5 for q in qs if q.get("score_type") != "pass_fail")
+                    + sum(1 for q in qs if q.get("score_type") == "pass_fail"))
+        self.assertEqual(RUBRIC20_MAX_SCORE, computed)
+
+    def test_the_question_count_matches_too(self):
+        from data_sheets_schema.constants import RUBRIC20_MAX_QUESTIONS
+        ev = D4DEvaluator(str(RUBRIC10_PATH), str(RUBRIC20_PATH))
+        qs = ev.rubric20["d4d_evaluation_rubric"]["rubric"]
+        self.assertEqual(RUBRIC20_MAX_QUESTIONS, len(qs))
+
+    def test_no_rubric20_path_hardcodes_a_denominator(self):
+        """A literal denominator is one nothing can keep in sync.
+
+        The total lived in seven places. Fixing the two obvious ones left the
+        LLM path — including the judge's own prompt, which handed the model a
+        `"max_points": 84` template to copy — still reporting out of 84 while
+        the presence path used 88, so the two were never comparable.
+
+        Unrelated 84s exist (an 84-question healthsheet, a percentage), so this
+        matches the shapes a denominator takes rather than the digits.
+        """
+        from pathlib import Path
+        patterns = ("/84", "* 84", ", 84)", "or 84", "= 84", '"max_points": 84')
+        offenders = []
+        for path in (list(Path("scripts").glob("*rubric20*.py"))
+                     + list(Path("scripts").glob("*evaluation*.py"))
+                     + [Path("src/download/prompts/rubric20_system_prompt.md")]):
+            for n, line in enumerate(path.read_text().splitlines(), 1):
+                if line.lstrip().startswith("#"):
+                    continue
+                if any(p in line for p in patterns):
+                    offenders.append(f"{path}:{n}: {line.strip()[:70]}")
+        self.assertEqual(offenders, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes the §4 residual in NEXT_TASKS.

## My earlier diagnosis was incomplete

I reported two places carrying 84. There were **seven** — and the two I found were the two that didn't matter.

| location | effect |
|---|---|
| `constants/evaluation.py` | exported, imported by nothing — dead |
| `summarize_rubric20_results.py` | 3 fallbacks + a hardcoded table denominator |
| **`rubric20_system_prompt.md`** | **the judge's own prompt — the one that actually bit** |
| `batch_evaluate_rubric20_hybrid.py` | `max_total = 84` |
| `render_evaluation_html_rubric20_semantic.py` | fallback |
| `generate_gc_approach_comparison.py` | 3 divisions + 3 display sites |
| `render_interleaved_evaluation.py` | fallback |

## Why fixing the fallbacks alone would have changed nothing

The system prompt handed the model a `"max_points": 84` template to copy, and told it to compute `percentage` as `total_points / max_points`. So **every LLM-path result carried `max_points: 84` in its data**, every downstream `overall.get('max_points', 84)` agreed with it, and the fallbacks never fired. The data itself was wrong.

Its Scoring Summary also decomposed 84 as *16 numeric + 4 pass/fail*. The rubric defines **17 numeric + 3 pass/fail = 88** — one question counted as pass/fail that the rubric defines as numeric. The presence path used 88, the LLM path used 84, and the two were never comparable.

## Per-category maxima removed, not corrected

They summed to 84, and the rubric file **declares no categories at all** — the four-way grouping is the prompt's own, so nothing can derive a per-category maximum from it. Writing four numbers I can't check is how the wrong total survived being read this long.

## The constant is now derived

```python
RUBRIC20_MAX_SCORE = 17 * 5 + 3   # 88
```

Spelled out as its parts, the way `RUBRIC10_MAX_SCORE` already is. A bare `84` gave nothing to check it against.

Tests tie the constant *and* the question count to the rubric file, and sweep every rubric20/evaluation script plus the judge prompt for a hardcoded denominator — matching the shapes a denominator takes rather than the digits, since unrelated 84s exist (an 84-question healthsheet, a percentage).

## Consequence worth stating plainly

**LLM-path rubric20 percentages recorded before this were computed against 84 and are ~4.8% high.** They are not comparable with presence-path scores, and re-running them is the only way to make them so.

**995 passed, 3 skipped.**