### PR TITLE
Refuse to average scores measured against different maxima (#275)

### DIFF
--- a/scripts/generate_gc_approach_comparison.py
+++ b/scripts/generate_gc_approach_comparison.py
@@ -9,6 +9,23 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
+from data_sheets_schema.rubric_pooling import MixedDenominators, common_denominator
+
+
+def _r20_cells(records, avg_points):
+    """Score and percentage cells for a set of rubric20 records.
+
+    Refuses rather than dividing by a constant: this table compares Grand
+    Challenge approaches, and if one approach's evaluations predate the
+    denominator correction and another's do not, a pooled average compares an
+    approach against a measurement change (#281). `common_denominator` raises
+    on a mixed set; the cells say so instead of printing a number.
+    """
+    try:
+        denom = common_denominator(records)
+    except MixedDenominators as mixed:
+        return (f"{avg_points:.1f}/MIXED{tuple(mixed.seen)}", "n/a (mixed maxima)")
+    return f"{avg_points:.1f}/{denom}", f"{(avg_points / denom) * 100:.1f}%"
 
 # Project root
 BASE_DIR = Path(__file__).parent.parent
@@ -53,6 +70,7 @@ def generate_comparison_table():
     for gc in GRAND_CHALLENGES:
         gc_r10_total = 0
         gc_r20_total = 0
+        gc_r20_records = []
         gc_count = 0
         
         for method in METHODS:
@@ -65,7 +83,7 @@ def generate_comparison_table():
                 row = [
                     f"{gc} - {method}",
                     f"{r10['total_points']}/50",
-                    f"{r20['total_points']}/{RUBRIC20_MAX_SCORE}",
+                    f"{r20['total_points']}/{r20.get('max_points', RUBRIC20_MAX_SCORE)}",
                     f"{r10['percentage']}%",
                     f"{r20['percentage']}%"
                 ]
@@ -73,6 +91,7 @@ def generate_comparison_table():
                 
                 gc_r10_total += r10['total_points']
                 gc_r20_total += r20['total_points']
+                gc_r20_records.append({'overall_score': r20})
                 gc_count += 1
         
         # GC average row
@@ -80,14 +99,14 @@ def generate_comparison_table():
             gc_r10_avg = gc_r10_total / gc_count
             gc_r20_avg = gc_r20_total / gc_count
             gc_r10_pct = (gc_r10_avg / 50) * 100
-            gc_r20_pct = (gc_r20_avg / RUBRIC20_MAX_SCORE) * 100
+            gc_r20_score_cell, gc_r20_pct_cell = _r20_cells(gc_r20_records, gc_r20_avg)
             
             avg_row = [
                 f"{gc} Average",
                 f"{gc_r10_avg:.1f}/50",
-                f"{gc_r20_avg:.1f}/{RUBRIC20_MAX_SCORE}",
+                gc_r20_score_cell,
                 f"{gc_r10_pct:.1f}%",
-                f"{gc_r20_pct:.1f}%"
+                gc_r20_pct_cell
             ]
             rows.append(avg_row)
             rows.append(["", "", "", "", ""])  # Blank separator
@@ -96,6 +115,7 @@ def generate_comparison_table():
     for method in METHODS:
         method_r10_total = 0
         method_r20_total = 0
+        method_r20_records = []
         method_count = 0
         
         for gc in GRAND_CHALLENGES:
@@ -103,40 +123,42 @@ def generate_comparison_table():
             if key in r10_scores and key in r20_scores:
                 method_r10_total += r10_scores[key]['total_points']
                 method_r20_total += r20_scores[key]['total_points']
+                method_r20_records.append({'overall_score': r20_scores[key]})
                 method_count += 1
         
         if method_count > 0:
             method_r10_avg = method_r10_total / method_count
             method_r20_avg = method_r20_total / method_count
             method_r10_pct = (method_r10_avg / 50) * 100
-            method_r20_pct = (method_r20_avg / RUBRIC20_MAX_SCORE) * 100
+            method_r20_score_cell, method_r20_pct_cell = _r20_cells(method_r20_records, method_r20_avg)
             
             method_row = [
                 f"Overall - {method}",
                 f"{method_r10_avg:.1f}/50",
-                f"{method_r20_avg:.1f}/{RUBRIC20_MAX_SCORE}",
+                method_r20_score_cell,
                 f"{method_r10_pct:.1f}%",
-                f"{method_r20_pct:.1f}%"
+                method_r20_pct_cell
             ]
             rows.append(method_row)
     
     # Grand average
     grand_r10_total = sum(s['total_points'] for s in r10_scores.values())
     grand_r20_total = sum(s['total_points'] for s in r20_scores.values())
+    grand_r20_records = [{'overall_score': s} for s in r20_scores.values()]
     grand_count = len(r10_scores)
     
     if grand_count > 0:
         grand_r10_avg = grand_r10_total / grand_count
         grand_r20_avg = grand_r20_total / grand_count
         grand_r10_pct = (grand_r10_avg / 50) * 100
-        grand_r20_pct = (grand_r20_avg / RUBRIC20_MAX_SCORE) * 100
+        grand_r20_score_cell, grand_r20_pct_cell = _r20_cells(grand_r20_records, grand_r20_avg)
         
         grand_row = [
             "Grand Average",
             f"{grand_r10_avg:.1f}/50",
-            f"{grand_r20_avg:.1f}/{RUBRIC20_MAX_SCORE}",
+            grand_r20_score_cell,
             f"{grand_r10_pct:.1f}%",
-            f"{grand_r20_pct:.1f}%"
+            grand_r20_pct_cell
         ]
         rows.append(grand_row)
     

--- a/scripts/summarize_rubric20_results.py
+++ b/scripts/summarize_rubric20_results.py
@@ -22,6 +22,8 @@ from datetime import datetime
 # The denominator lives with the rubric, not as a literal in a report.
 # It was 84 here while the questions defined 88 (#270 thread).
 from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
+from data_sheets_schema.rubric_pooling import (
+    denominator_label, group_by_denominator, pooling_warning)
 
 # Base directory
 BASE_DIR = Path(__file__).parent.parent
@@ -188,11 +190,7 @@ def create_markdown_table(results: List[Dict]):
                 # printing the record's own value is merely stale. Pooling
                 # records with different denominators is not meaningful at all,
                 # so say so rather than average across them (#274).
-                maxima = {r.get('overall_score', {}).get('max_points',
-                                                         RUBRIC20_MAX_SCORE)
-                          for r in results_list}
-                denom = (str(maxima.pop()) if len(maxima) == 1
-                         else "MIXED(" + "/".join(str(m) for m in sorted(maxima)) + ")")
+                denom = denominator_label(results_list)
 
                 avg_cat1 = sum(r.get('categories', {}).get('Structural Completeness', {}).get('category_score', 0) for r in results_list) / file_count
                 avg_cat2 = sum(r.get('categories', {}).get('Metadata Quality & Content', {}).get('category_score', 0) for r in results_list) / file_count
@@ -239,14 +237,21 @@ def create_detailed_report(results: List[Dict]):
 
 """
 
-    # Calculate overall statistics
-    total_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in results)
-    max_possible = len(results) * RUBRIC20_MAX_SCORE
-    avg_percentage = sum(r.get('overall_score', {}).get('percentage', 0) for r in results) / len(results) if results else 0
-
-    report += f"- **Average Score:** {total_score / len(results):.1f}/{RUBRIC20_MAX_SCORE} ({avg_percentage:.1f}%)\n"
-    report += f"- **Best Score:** {max(results, key=lambda x: x.get('overall_score', {}).get('percentage', 0)).get('overall_score', {}).get('percentage', 0):.1f}%\n" if results else ""
-    report += f"- **Worst Score:** {min(results, key=lambda x: x.get('overall_score', {}).get('percentage', 0)).get('overall_score', {}).get('percentage', 0):.1f}%\n" if results else ""
+    # One block per denominator, never one number across both (#275). A mean of
+    # 84-scored and 88-scored records lands somewhere plausible and reads as a
+    # result, which is exactly the failure worth refusing.
+    report += pooling_warning(results)
+    for denom, group in group_by_denominator(results).items():
+        if not group:
+            continue
+        total_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in group)
+        avg_percentage = sum(r.get('overall_score', {}).get('percentage', 0) for r in group) / len(group)
+        best = max(group, key=lambda x: x.get('overall_score', {}).get('percentage', 0))
+        worst = min(group, key=lambda x: x.get('overall_score', {}).get('percentage', 0))
+        report += f"### Scored out of {denom} ({len(group)} evaluation(s))\n\n"
+        report += f"- **Average Score:** {total_score / len(group):.1f}/{denom} ({avg_percentage:.1f}%)\n"
+        report += f"- **Best Score:** {best.get('overall_score', {}).get('percentage', 0):.1f}%\n"
+        report += f"- **Worst Score:** {worst.get('overall_score', {}).get('percentage', 0):.1f}%\n\n"
 
     # Method comparison
     report += "\n## Method Comparison\n\n"
@@ -254,11 +259,16 @@ def create_detailed_report(results: List[Dict]):
     for method in ['curated', 'gpt5', 'claudecode', 'claudecode_agent', 'claudecode_assistant']:
         method_results = [r for r in results if r.get('method') == method]
         if method_results:
-            avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in method_results) / len(method_results)
-            avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in method_results) / len(method_results)
             report += f"### {method}\n"
             report += f"- Files evaluated: {len(method_results)}\n"
-            report += f"- Average score: {avg_score:.1f}/{denom} ({avg_pct:.1f}%)\n\n"
+            # One line per denominator. Averaging a method across two maxima
+            # would rank it against itself measured two different ways (#275).
+            for denom, group in group_by_denominator(method_results).items():
+                avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in group) / len(group)
+                avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in group) / len(group)
+                report += (f"- Average score: {avg_score:.1f}/{denom} "
+                           f"({avg_pct:.1f}%) over {len(group)} evaluation(s)\n")
+            report += "\n"
 
     # Project comparison
     report += "\n## Project Comparison\n\n"
@@ -266,11 +276,16 @@ def create_detailed_report(results: List[Dict]):
     for project in ['AI_READI', 'CHORUS', 'CM4AI', 'VOICE']:
         project_results = [r for r in results if r.get('project') == project]
         if project_results:
-            avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in project_results) / len(project_results)
-            avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in project_results) / len(project_results)
             report += f"### {project}\n"
             report += f"- Files evaluated: {len(project_results)}\n"
-            report += f"- Average score: {avg_score:.1f}/{denom} ({avg_pct:.1f}%)\n\n"
+            # One line per denominator. Averaging a method across two maxima
+            # would rank it against itself measured two different ways (#275).
+            for denom, group in group_by_denominator(project_results).items():
+                avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in group) / len(group)
+                avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in group) / len(group)
+                report += (f"- Average score: {avg_score:.1f}/{denom} "
+                           f"({avg_pct:.1f}%) over {len(group)} evaluation(s)\n")
+            report += "\n"
 
     # Category analysis
     report += "\n## Category Performance\n\n"

--- a/scripts/summarize_rubric20_results.py
+++ b/scripts/summarize_rubric20_results.py
@@ -200,22 +200,33 @@ def create_markdown_table(results: List[Dict]):
                 md += f"| {project} | {method} | {avg_score:.1f}/{denom} | {file_count} | {avg_pct:.1f}% | {avg_cat1:.1f} | {avg_cat2:.1f} | {avg_cat3:.1f} | {avg_cat4:.1f} |\n"
 
     # Top performers
-    md += "\n## Top Performing D4Ds (Score >= 80%)\n\n"
-    md += "| Project | Method | Type | Score | File |\n"
-    md += "|---------|--------|------|-------|------|\n"
+    md += "\n## Top Performing D4Ds (Score >= 80%)\n"
 
-    top_performers = [r for r in results if r.get('overall_score', {}).get('percentage', 0) >= 80]
-    top_performers.sort(key=lambda x: x.get('overall_score', {}).get('percentage', 0), reverse=True)
-
-    for result in top_performers[:20]:  # Top 20
-        project = result.get('project', 'unknown')
-        method = result.get('method', 'unknown')
-        eval_type = result.get('evaluation_type', 'unknown')
-        overall = result.get('overall_score', {})
-        score_str = f"{overall.get('total_points', 0)}/{overall.get('max_points', RUBRIC20_MAX_SCORE)} ({overall.get('percentage', 0):.1f}%)"
-        file_name = Path(result.get('d4d_file', '')).name
-
-        md += f"| {project} | {method} | {eval_type} | {score_str} | {file_name} |\n"
+    # One table per denominator. A >=80% cut and a sort applied across two
+    # maxima rank on the maximum rather than the record: 71/84 is 84.5% and
+    # 71/88 is 80.7%, so identical raw scores separate purely by which
+    # instrument measured them, and the 167 records scored out of 84 win
+    # systematically (#280). A table titled "Top Performing" that is not a
+    # valid ranking is worse than two shorter ones that are.
+    for denom, group in group_by_denominator(results).items():
+        ranked = [r for r in group
+                  if r.get('overall_score', {}).get('percentage', 0) >= 80]
+        ranked.sort(key=lambda x: x.get('overall_score', {}).get('percentage', 0),
+                    reverse=True)
+        if not ranked:
+            continue
+        md += f"\n### Scored out of {denom}\n\n"
+        md += "| Project | Method | Type | Score | File |\n"
+        md += "|---------|--------|------|-------|------|\n"
+        for result in ranked[:20]:  # Top 20 within this denominator
+            project = result.get('project', 'unknown')
+            method = result.get('method', 'unknown')
+            eval_type = result.get('evaluation_type', 'unknown')
+            overall = result.get('overall_score', {})
+            score_str = (f"{overall.get('total_points', 0)}/{denom} "
+                         f"({overall.get('percentage', 0):.1f}%)")
+            file_name = Path(result.get('d4d_file', '')).name
+            md += f"| {project} | {method} | {eval_type} | {score_str} | {file_name} |\n"
 
     # Save markdown
     md_path = EVAL_DIR / "summary_table.md"

--- a/src/data_sheets_schema/rubric_pooling.py
+++ b/src/data_sheets_schema/rubric_pooling.py
@@ -1,0 +1,107 @@
+"""Refuse to average scores that were measured against different maxima.
+
+Rubric20's total was 84 in the LLM path and 88 in the presence path for a long
+time (#273). The judge's own prompt handed the model a `"max_points": 84`
+template, so **167 committed evaluations record 84** while everything generated
+after the correction records 88.
+
+Those records are not wrong — each states the denominator it used, which is what
+separates them from the bug that produced them, where every layer agreed on 84
+and nothing recorded a dissent. What is wrong is *pooling* them. An average
+score over a mix of 84-scored and 88-scored records is not a score, and an
+average percentage is worse, because percentages look comparable while being
+computed against different maxima.
+
+The failure this guards against is quiet: a mean of the two populations lands
+somewhere plausible and reads as a result. So the default here is to refuse —
+`common_denominator` raises rather than picking one — and callers that must
+produce a report group by denominator and say so.
+
+`RUBRIC20_MAX_SCORE` remains the right **fallback for a record that omits
+`max_points`**. It is not a substitute for reading one that has it (#274).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
+
+
+class MixedDenominators(ValueError):
+    """Results measured against more than one maximum were pooled."""
+
+    def __init__(self, seen: Iterable[int]):
+        self.seen = sorted(seen)
+        super().__init__(
+            f"results span {len(self.seen)} denominators: {self.seen}. "
+            "These were measured against different maxima and cannot be "
+            "averaged; group by denominator, or re-run the older set.")
+
+
+def denominator_of(result: dict[str, Any],
+                   default: int = RUBRIC20_MAX_SCORE) -> int:
+    """The maximum this single record was scored against."""
+    return (result.get("overall_score") or {}).get("max_points") or default
+
+
+def denominators(results: Iterable[dict[str, Any]],
+                 default: int = RUBRIC20_MAX_SCORE) -> set[int]:
+    return {denominator_of(r, default) for r in results}
+
+
+def common_denominator(results: Iterable[dict[str, Any]],
+                       default: int = RUBRIC20_MAX_SCORE) -> int:
+    """The one maximum shared by every record, or raise.
+
+    Raising is the point. Returning a default, a max, or the most common value
+    would let an aggregate over two instruments look like an aggregate over one.
+    """
+    results = list(results)
+    if not results:
+        return default
+    seen = denominators(results, default)
+    if len(seen) > 1:
+        raise MixedDenominators(seen)
+    return seen.pop()
+
+
+def group_by_denominator(results: Iterable[dict[str, Any]],
+                         default: int = RUBRIC20_MAX_SCORE
+                         ) -> dict[int, list[dict[str, Any]]]:
+    """Partition results so each group *can* be pooled.
+
+    For report generators, which should still produce a report when the corpus
+    spans two instruments — just not a single number spanning both.
+    """
+    groups: dict[int, list[dict[str, Any]]] = {}
+    for result in results:
+        groups.setdefault(denominator_of(result, default), []).append(result)
+    return dict(sorted(groups.items()))
+
+
+def denominator_label(results: Iterable[dict[str, Any]],
+                      default: int = RUBRIC20_MAX_SCORE) -> str:
+    """A denominator to print, marked when it is not one denominator.
+
+    `MIXED(84/88)` rather than a number, so a reader of the rendered table sees
+    the same thing the code saw instead of a figure that looks authoritative.
+    """
+    seen = sorted(denominators(list(results), default))
+    if len(seen) == 1:
+        return str(seen[0])
+    return "MIXED(" + "/".join(str(n) for n in seen) + ")"
+
+
+def pooling_warning(results: Iterable[dict[str, Any]],
+                    default: int = RUBRIC20_MAX_SCORE) -> str:
+    """A note to put at the top of a report, or "" when there is nothing to say."""
+    groups = group_by_denominator(results, default)
+    if len(groups) <= 1:
+        return ""
+    counts = ", ".join(f"{len(v)} scored out of {k}" for k, v in groups.items())
+    return (
+        f"> ⚠️ **These results span {len(groups)} different maxima** ({counts}).\n"
+        "> Scores and percentages are reported per group and never pooled "
+        "across them: an average over records measured against different\n"
+        "> maxima is not a score. See issue #275.\n\n")

--- a/tests/test_evaluation/test_rubric20_scoring.py
+++ b/tests/test_evaluation/test_rubric20_scoring.py
@@ -173,16 +173,20 @@ class TestDeclaredMaximumMatchesTheQuestions(unittest.TestCase):
     def test_the_summary_table_reads_each_records_own_denominator(self):
         """#274: 167 committed records were scored against 84.
 
-        A constant printed beside an average of those is confidently wrong
-        where the record's own value is merely stale, and pooling records with
-        different denominators is not meaningful at all.
+        This asserted on the script's source text, which is how #278 shipped —
+        a grep cannot see an unbound name. The behaviour is now covered by
+        `test_rubric_pooling.py`, which runs the report generators; what is
+        left here is the one thing a source check is actually good for.
         """
         from pathlib import Path
         script = Path("scripts/summarize_rubric20_results.py").read_text()
-        self.assertIn("MIXED(", script,
-                      "a set spanning two denominators must say so")
         self.assertNotIn("{avg_score:.1f}/{RUBRIC20_MAX_SCORE}", script,
                          "the table must not hardcode a denominator")
+        from data_sheets_schema.rubric_pooling import denominator_label
+        self.assertEqual(
+            denominator_label([{"overall_score": {"max_points": 84}},
+                               {"overall_score": {"max_points": 88}}]),
+            "MIXED(84/88)")
 
 
 if __name__ == "__main__":

--- a/tests/test_evaluation/test_rubric_pooling.py
+++ b/tests/test_evaluation/test_rubric_pooling.py
@@ -1,0 +1,156 @@
+"""Scores measured against different maxima must never be averaged together.
+
+167 committed rubric20 evaluations record `max_points: 84`; everything written
+after the correction records 88 (#275). A mean over both lands somewhere
+plausible and reads as a result, which is why the default here is to refuse.
+
+These tests **run** the report generators rather than inspecting their source.
+The previous round asserted on the text of the file, and a grep cannot see an
+unbound name — which is how `create_detailed_report` shipped raising NameError
+with a green suite and three green CI runs behind it (#278).
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from data_sheets_schema.rubric_pooling import (  # noqa: E402
+    MixedDenominators,
+    common_denominator,
+    denominator_label,
+    denominator_of,
+    group_by_denominator,
+    pooling_warning,
+)
+
+
+def _result(points, maximum, method="claudecode_agent", project="CHORUS"):
+    return {"project": project, "method": method,
+            "overall_score": {"total_points": points, "max_points": maximum,
+                              "percentage": 100.0 * points / maximum}}
+
+
+class TestCommonDenominator(unittest.TestCase):
+    def test_one_maximum_is_returned(self):
+        self.assertEqual(common_denominator([_result(70, 88), _result(60, 88)]), 88)
+
+    def test_two_maxima_raise(self):
+        with self.assertRaises(MixedDenominators) as ctx:
+            common_denominator([_result(70, 88), _result(70, 84)])
+        self.assertIn("84", str(ctx.exception))
+        self.assertIn("88", str(ctx.exception))
+
+    def test_it_does_not_quietly_pick_one(self):
+        """Returning the max, the mode, or a default would let an aggregate
+        over two instruments look like an aggregate over one."""
+        for picker in (max, min):
+            with self.assertRaises(MixedDenominators):
+                common_denominator([_result(70, 88), _result(70, 84)])
+
+    def test_a_record_without_max_points_falls_back(self):
+        self.assertEqual(denominator_of({"overall_score": {}}, default=88), 88)
+        self.assertEqual(denominator_of({}, default=88), 88)
+
+    def test_empty_is_the_default_not_an_error(self):
+        self.assertEqual(common_denominator([], default=88), 88)
+
+
+class TestGrouping(unittest.TestCase):
+    def test_groups_are_poolable(self):
+        groups = group_by_denominator(
+            [_result(70, 88), _result(60, 84), _result(50, 88)])
+        self.assertEqual(sorted(groups), [84, 88])
+        self.assertEqual(len(groups[88]), 2)
+        for denom, group in groups.items():
+            self.assertEqual(common_denominator(group), denom,
+                             "every group must itself be poolable")
+
+    def test_label_marks_a_mixed_set(self):
+        self.assertEqual(denominator_label([_result(70, 88)]), "88")
+        self.assertEqual(denominator_label([_result(70, 88), _result(70, 84)]),
+                         "MIXED(84/88)")
+
+    def test_warning_is_empty_when_there_is_nothing_to_warn_about(self):
+        self.assertEqual(pooling_warning([_result(70, 88)]), "")
+
+    def test_warning_names_both_populations(self):
+        text = pooling_warning([_result(70, 88), _result(70, 84), _result(60, 84)])
+        self.assertIn("2 scored out of 84", text)
+        self.assertIn("1 scored out of 88", text)
+
+
+class TestTheReportGeneratorsActuallyRun(unittest.TestCase):
+    """#278: the bug a source-text assertion could not see.
+
+    `create_detailed_report` referenced a name bound in a different function.
+    Every existing assertion passed because they read the file instead of
+    calling it.
+    """
+
+    def setUp(self):
+        """Redirect output to a temp dir.
+
+        These functions write into `data/evaluation_llm/rubric20/`. An earlier
+        version of this file called them without redirecting and overwrote two
+        committed artifacts with fixture data — a test that damages the corpus
+        it is meant to protect.
+        """
+        import tempfile
+        import summarize_rubric20_results as mod
+        self.mod = mod
+        self._tmp = tempfile.TemporaryDirectory()
+        self._real_dir = mod.EVAL_DIR
+        mod.EVAL_DIR = Path(self._tmp.name)
+        self.mixed = [_result(70, 88, method="claudecode_agent"),
+                      _result(66, 84, method="gpt5"),
+                      _result(60, 84, method="curated", project="VOICE")]
+
+    def tearDown(self):
+        self.mod.EVAL_DIR = self._real_dir
+        self._tmp.cleanup()
+
+    def _report(self, results):
+        import io
+        from contextlib import redirect_stdout
+        with redirect_stdout(io.StringIO()):
+            self.mod.create_detailed_report(results)
+        written = Path(self._tmp.name) / "summary_report.md"
+        self.assertTrue(written.exists(), "the report must actually be written")
+        return written.read_text()
+
+    def test_detailed_report_runs_on_a_mixed_corpus(self):
+        """The call itself is the assertion — an unbound name raises here."""
+        self.assertIn("Rubric20", self._report(self.mixed))
+
+    def test_detailed_report_reports_each_maximum_separately(self):
+        text = self._report(self.mixed)
+        self.assertIn("Scored out of 84", text)
+        self.assertIn("Scored out of 88", text)
+
+    def test_detailed_report_warns_that_the_corpus_is_mixed(self):
+        self.assertIn("different maxima", self._report(self.mixed))
+
+    def test_no_single_average_spans_both_maxima(self):
+        """The whole point: one number over two instruments must not appear."""
+        text = self._report(self.mixed)
+        self.assertNotIn("/MIXED", text,
+                         "an average must belong to one denominator, not a label")
+
+    def test_a_single_denominator_corpus_gets_no_warning(self):
+        text = self._report([_result(70, 88), _result(60, 88)])
+        self.assertNotIn("different maxima", text)
+        self.assertIn("Scored out of 88", text)
+
+    def test_markdown_table_runs_and_marks_mixed_rows(self):
+        import io
+        from contextlib import redirect_stdout
+        with redirect_stdout(io.StringIO()):
+            self.mod.create_markdown_table(self.mixed)
+        written = Path(self._tmp.name) / "summary_table.md"
+        self.assertTrue(written.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation/test_rubric_pooling.py
+++ b/tests/test_evaluation/test_rubric_pooling.py
@@ -151,6 +151,47 @@ class TestTheReportGeneratorsActuallyRun(unittest.TestCase):
         written = Path(self._tmp.name) / "summary_table.md"
         self.assertTrue(written.exists())
 
+    def test_top_performers_ranks_within_a_denominator(self):
+        """#280: a >=80% cut and a sort across two maxima rank on the maximum.
+
+        71/84 is 84.5% and 71/88 is 80.7% — identical raw scores separating
+        purely by which instrument measured them, with the 167 older records
+        winning systematically in a table whose purpose is ranking.
+        """
+        import io
+        from contextlib import redirect_stdout
+        both = [_result(71, 84, method="gpt5"),
+                _result(71, 88, method="claudecode_agent")]
+        with redirect_stdout(io.StringIO()):
+            self.mod.create_markdown_table(both)
+        text = (Path(self._tmp.name) / "summary_table.md").read_text()
+        top = text.split("Top Performing")[1]
+        self.assertIn("Scored out of 84", top)
+        self.assertIn("Scored out of 88", top)
+
+
+class TestTheGCComparisonRefuses(unittest.TestCase):
+    """#281: the table compares approaches, so a mixed average compares an
+    approach against a measurement change."""
+
+    def setUp(self):
+        import generate_gc_approach_comparison as mod
+        self.mod = mod
+
+    def test_a_single_denominator_set_is_averaged_normally(self):
+        score, pct = self.mod._r20_cells(
+            [{"overall_score": {"max_points": 88}}], 70.0)
+        self.assertEqual(score, "70.0/88")
+        self.assertEqual(pct, "79.5%")
+
+    def test_a_mixed_set_yields_no_percentage(self):
+        score, pct = self.mod._r20_cells(
+            [{"overall_score": {"max_points": 88}},
+             {"overall_score": {"max_points": 84}}], 70.0)
+        self.assertIn("MIXED", score)
+        self.assertEqual(pct, "n/a (mixed maxima)")
+        self.assertNotIn("%", pct.replace("n/a (mixed maxima)", ""))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #275 and #278.

## The problem

167 committed rubric20 evaluations record `max_points: 84`; everything after the correction records 88. Those records aren't *wrong* — each states the denominator it used, which is exactly what separates them from the bug that produced them, where every layer agreed on 84 and nothing recorded a dissent.

What's wrong is **pooling** them. A mean over both lands somewhere plausible and reads as a result.

## The fix: refusing is the default

`src/data_sheets_schema/rubric_pooling.py`. `common_denominator()` **raises** rather than picking the max, the mode, or a fallback — any of which would let an aggregate over two instruments look like an aggregate over one. Report generators, which should still produce a report, use `group_by_denominator()` and report per group under a warning naming both populations.

The executive summary was the worst offender — one Average Score over every record regardless of maximum. So were the method and project comparisons: averaging a method across two maxima ranks it against itself measured two different ways.

## It also fixes a bug I shipped in #273

`create_detailed_report` referenced `denom`, a local of a *different* function. **Calling it raised `NameError`** — merged, with 1028 tests and three green CI runs behind it.

Nothing caught it because the test I wrote for #274 asserted on the script's **source text**:

```python
self.assertIn("MIXED(", script)
```

A grep cannot see an unbound name, and no test in the suite had ever *called* these functions.

## So the new tests run them

**Mutation-checked**: reintroducing the exact shipped bug turns 5 of them red; restoring the fix turns them green.

Writing them surfaced a second problem — the first version called the generators without redirecting output and **overwrote two committed artifacts with fixture data**, a test damaging the corpus it exists to protect. They now patch `EVAL_DIR` to a temp directory, and the artifacts were restored with `git checkout`.

The source-text assertion in `test_rubric20_scoring` is replaced by a behavioural one; its coverage moved to `test_rubric_pooling`, which calls the code.

**1043 passed, 3 skipped** (+15).