### PR TITLE
Correct the number `d4d runs select` argues from (#176)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -412,7 +412,7 @@ def merge_cmd(method, project, labels, config, out_label, unguarded, execute):
 
     **`d4d runs select` is the recommended way to get a shippable record, and
     it argues against this command.** Replicates state different facts on
-    47-62% of the slots they share, so a union splices across referents — one
+    47-63% of the slots they share, so a union splices across referents — one
     replicate's participant count beside another's DOI — to gain 1-5 slots.
     That objection is about coherence and this command's case is about
     coverage; both are true, and the two commands existing without naming each
@@ -540,7 +540,7 @@ def _validates(record: Path) -> tuple[bool, str]:
 def select_cmd(method, project, config, allow_unverified, execute):
     """Mark one replicate canonical, keeping all of them.
 
-    Selection, not merging. Replicates state different facts on **47-62% of the
+    Selection, not merging. Replicates state different facts on **47-63% of the
     slots they share** (generic-v2, judged equivalence), for a coverage gain
     from merging of 1-5 slots (#229) — and a spliced record can assert a
     participant count from one referent and a DOI from another. A single
@@ -550,7 +550,7 @@ def select_cmd(method, project, config, allow_unverified, execute):
     over values that are mostly nested objects of free text, and on these same
     runs it still gives 77-98% — but two records describing one collection
     method in different words are not two facts. Judged on whether the values
-    state the same fact, it is 47-62%.
+    state the same fact, it is 47-63%.
 
     The decision survives the correction because it never rested on the
     magnitude. Splicing mixes referents whether half the shared slots differ or

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -409,6 +409,15 @@ def merge_cmd(method, project, labels, config, out_label, unguarded, execute):
     The merged record is `record_mode: derived`, never `live`: it is not
     something a model produced, and provenance names every contributor by hash
     and states the rule that combined them.
+
+    **`d4d runs select` is the recommended way to get a shippable record, and
+    it argues against this command.** Replicates state different facts on
+    47-62% of the slots they share, so a union splices across referents — one
+    replicate's participant count beside another's DOI — to gain 1-5 slots.
+    That objection is about coherence and this command's case is about
+    coverage; both are true, and the two commands existing without naming each
+    other is how a reader ends up believing whichever help text they opened.
+    Use this when a union is what you want and you can defend the splice.
     """
     import yaml as _yaml
     from data_sheets_schema.merge import union_merge, write_merge
@@ -531,11 +540,23 @@ def _validates(record: Path) -> tuple[bool, str]:
 def select_cmd(method, project, config, allow_unverified, execute):
     """Mark one replicate canonical, keeping all of them.
 
-    Selection, not merging. Merging splices values across replicates that
-    disagree on 77-98% of the slots they share, for a coverage gain of 1-5 slots
-    (#229) — and a spliced record can assert a participant count from one
-    referent and a DOI from another. A single replicate is internally coherent
-    because one generation produced it.
+    Selection, not merging. Replicates state different facts on **47-62% of the
+    slots they share** (generic-v2, judged equivalence), for a coverage gain
+    from merging of 1-5 slots (#229) — and a spliced record can assert a
+    participant count from one referent and a DOI from another. A single
+    replicate is internally coherent because one generation produced it.
+
+    That figure read 77-98% here until #169 was settled. It was byte equality
+    over values that are mostly nested objects of free text, and on these same
+    runs it still gives 77-98% — but two records describing one collection
+    method in different words are not two facts. Judged on whether the values
+    state the same fact, it is 47-62%.
+
+    The decision survives the correction because it never rested on the
+    magnitude. Splicing mixes referents whether half the shared slots differ or
+    nearly all of them, and the coverage it buys is 1-5 slots either way. What
+    the old number did was make the case look stronger than the evidence for
+    it, which is worth not repeating.
 
     The criterion is **validity first, coverage second**. Coverage alone is
     close to arbitrary here: margins across the generic-v2 config are +0, +1,

--- a/tests/test_cli/test_runs_select.py
+++ b/tests/test_cli/test_runs_select.py
@@ -1,6 +1,6 @@
 """`d4d runs select` — pick one replicate, keep them all (#176).
 
-Selection rather than merging. Replicates state different facts on 47-62% of
+Selection rather than merging. Replicates state different facts on 47-63% of
 the slots they share (generic-v2, judged equivalence), for a coverage gain from
 merging of 1-5 slots (#229), and a spliced record can assert a participant count
 from one referent and a DOI from another. One replicate is internally coherent
@@ -181,14 +181,24 @@ class TestTheRationaleMatchesTheMeasurement(unittest.TestCase):
 
     @unittest.skipUnless(CACHE.exists(), "agreement matrix not present")
     def test_the_quoted_range_is_the_measured_one(self):
+        import math
         published = json.loads(self.CACHE.read_text())
-        differ = sorted(round(100 * (1 - c["rate"]))
+        differ = sorted(100 * (1 - c["rate"])
                         for k, c in published.items() if k.startswith("v2"))
-        expected = f"{differ[0]}-{differ[-1]}%"
+        # Floor the low end and ceil the high end so the quoted range provably
+        # contains every project. `round()` put CHORUS's exact 62.5 outside the
+        # range that claimed to span it, because Python rounds half to even
+        # (#283) — no rounding rule should be load-bearing in a figure whose
+        # whole point is that the previous one was wrong.
+        expected = f"{math.floor(differ[0])}-{math.ceil(differ[-1])}%"
         for command in ("select", "merge"):
             with self.subTest(command=command):
-                self.assertIn(expected, self._help(command),
-                              f"help should quote the measured {expected}")
+                self.assertIn(
+                    expected, self._help(command),
+                    f"`d4d runs {command} --help` must quote {expected}, the "
+                    f"measured range (per-project: "
+                    f"{[f'{d:.1f}' for d in differ]}). If the corpus changed, "
+                    f"update the prose in cli/runs.py to match.")
 
     def test_each_command_names_the_other(self):
         """Two commands recommending opposite things must acknowledge it.

--- a/tests/test_cli/test_runs_select.py
+++ b/tests/test_cli/test_runs_select.py
@@ -1,16 +1,24 @@
 """`d4d runs select` — pick one replicate, keep them all (#176).
 
-Selection rather than merging. Merging splices values across replicates that
-disagree on 77-98% of the slots they share, for a coverage gain of 1-5 slots
-(#229), and a spliced record can assert a participant count from one referent
-and a DOI from another. One replicate is internally coherent because one
-generation produced it.
+Selection rather than merging. Replicates state different facts on 47-62% of
+the slots they share (generic-v2, judged equivalence), for a coverage gain from
+merging of 1-5 slots (#229), and a spliced record can assert a participant count
+from one referent and a DOI from another. One replicate is internally coherent
+because one generation produced it.
+
+That figure said 77-98% until #169 was settled — byte equality over nested free
+text, which counts two wordings of one fact as two facts. The decision is
+unchanged: splicing mixes referents at either rate, and the coverage bought is
+1-5 slots either way. The old number only made the case look better supported
+than it was.
 
 Validity first, coverage second — because coverage alone is nearly arbitrary
 here. Across the generic-v2 config the margins are +0, +1, +2 and +1 slots, and
 AI-READI is an outright tie that only validity resolves.
 """
 
+import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -142,6 +150,53 @@ class TestSelect(unittest.TestCase):
         out = self._run()
         self.assertNotEqual(out.exit_code, 0)
         self.assertIn("at least two", out.output)
+
+
+
+class TestTheRationaleMatchesTheMeasurement(unittest.TestCase):
+    """The figure in the help text must be the one that was measured (#176).
+
+    `select` justified itself with "replicates disagree on 77-98% of the slots
+    they share" for months. That was byte equality over nested free text — the
+    measure #169 showed returns the same answer regardless of input. A command
+    whose stated reason rests on a disproved number is worse than one that
+    states no reason, because the number invites belief.
+    """
+
+    CACHE = Path("data/evaluation_llm/agreement_cache/matrix.json")
+
+    def _help(self, command):
+        from click.testing import CliRunner
+        from data_sheets_schema.cli.runs import runs
+        return CliRunner().invoke(runs, [command, "--help"]).output
+
+    def test_the_disproved_figure_is_not_offered_as_the_reason(self):
+        for command in ("select", "merge"):
+            with self.subTest(command=command):
+                text = self._help(command)
+                claim = re.search(r"disagree on 77-98%", text)
+                self.assertIsNone(
+                    claim, "77-98% is byte equality; it cannot be the stated "
+                           "disagreement rate")
+
+    @unittest.skipUnless(CACHE.exists(), "agreement matrix not present")
+    def test_the_quoted_range_is_the_measured_one(self):
+        published = json.loads(self.CACHE.read_text())
+        differ = sorted(round(100 * (1 - c["rate"]))
+                        for k, c in published.items() if k.startswith("v2"))
+        expected = f"{differ[0]}-{differ[-1]}%"
+        for command in ("select", "merge"):
+            with self.subTest(command=command):
+                self.assertIn(expected, self._help(command),
+                              f"help should quote the measured {expected}")
+
+    def test_each_command_names_the_other(self):
+        """Two commands recommending opposite things must acknowledge it.
+
+        Otherwise a reader believes whichever help text they happened to open.
+        """
+        self.assertIn("merging", self._help("select"))
+        self.assertIn("select", self._help("merge"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`d4d runs select` justified itself with *"replicates disagree on 77-98% of the slots they share"* — byte equality over values that are mostly nested objects of free text, which is the measure #169 showed returns the same answer regardless of input.

## The two measures, on the same generic-v2 runs

| project | byte equality | judged equivalence |
|---|---|---|
| AI_READI | 83% | **47%** |
| CHORUS | 98% | **62%** |
| CM4AI | 77% | **49%** |
| VOICE | 88% | **55%** |

The 77–98% was real — it is exactly what byte equality gives on these runs. It just doesn't mean what the sentence claimed, because two records describing one collection method in different words are not two facts. The honest figure is **47–62%**.

Both help texts now say so, and a test derives the range from `matrix.json` rather than restating it, so they can't drift apart again.

## The decision is unchanged

It never rested on the magnitude. Splicing mixes referents whether half the shared slots differ in fact or nearly all of them, and the coverage merging buys is 1–5 slots either way.

What the old number did was make the case look **better supported than the evidence for it**. That matters most given where this reasoning is headed — a rationale resting on a disproved figure does not survive review, even when the conclusion happens to be right.

## A gap the correction exposed

`select` and `merge` recommend opposite things and **neither named the other**, so a reader believed whichever help text they opened. `merge` now carries the coherence objection and points to `select` as the recommended route to a shippable record.

Both cases are true — one is about coverage, one about coherence. Stating only one of them per command was the actual problem.

Tests assert each command names the other, and that neither offers 77–98% as a disagreement rate again.

**1049 passed, 3 skipped** (+3).