### PR TITLE
Pin the semantic agents' grounding, and audit what the records were scored under (#162)

### DIFF
--- a/notes/semantic_evaluation_corpus_2026-08-03.md
+++ b/notes/semantic_evaluation_corpus_2026-08-03.md
@@ -1,0 +1,71 @@
+# The recorded semantic evaluations cannot go in the manuscript as they stand
+
+The semantic rubric agents are cited in `publication_summary_2026-07-22_fable-5.md`
+and `three_way_comparison_2026-07-22.md`. Auditing what is actually on disk
+turned up three independent problems, and every recorded evaluation has at least
+one of them.
+
+## What is on disk
+
+| set | files | recorded dates |
+|---|---|---|
+| `rubric10_semantic` | 36 | 2025-12-10 (12), 2026-05-13/14 (8), 2026-07-22 (16) |
+| `rubric20_semantic` | 24 | 2026-05-13/14 (8), 2026-07-22 (16) |
+
+## Problem 1 — ungrounded scoring (#162)
+
+Both agents were asked whether a description suits "the claimed dataset type
+**and program of origin**". No `program` or `project` slot exists anywhere in
+the D4D schema, so the inference falls back to the filename, the invocation
+context or prior knowledge — and the agents promise temperature 0.0 with
+"same file → same score".
+
+**Fixed in the prompts on 2026-07-22** (`0e19e85f`), which restricted the
+inference to quoted values in `keywords`, `publisher` or `funders` and forbade
+the filename explicitly. `tests/test_evaluation/test_semantic_agent_grounding.py`
+now pins that, including the premise — if the schema ever gains a `program`
+slot the test fails and the workaround can go.
+
+**The records predate or straddle the fix.** 8 rubric20 records and 20 rubric10
+records are from before it. The 16 dated 2026-07-22 fall on the same day as the
+commit and cannot be placed either side of it from the data alone.
+
+## Problem 2 — wrong denominator
+
+All 24 `rubric20_semantic` records carry `max_points: 84`. The rubric's own
+questions define 88 — 17 numeric at 5 plus 3 pass/fail — and the presence path
+has always used 88. So every semantic percentage is computed against a maximum
+the rubric does not have, and is roughly 4.8% high.
+
+`rubric10_semantic` is unaffected: 50 throughout, which is what rubric10 defines.
+
+## Problem 3 — a split project name
+
+Three `rubric10_semantic` records carry `project: "AI"` and
+`method: "READI_claudecode"`. `AI_READI` was split on its underscore.
+
+The parsing bug was fixed in `69aa303d` on **2025-12-08**; these records are
+dated **2025-12-10**, two days later. So the fix did not cover the path that
+produced them, or they were generated from a stale copy. Either way three
+records attribute their scores to a project and a method that do not exist.
+
+## What follows
+
+**Every recorded semantic evaluation is affected by at least one of the three.**
+Nothing here is recoverable by rescaling: the denominator could be corrected
+arithmetically, but a score produced under an ungrounded prompt is not a score
+of the record, it is a score of the record plus its filename.
+
+So if semantic results appear in the manuscript, **they need re-running** under
+the corrected prompts, against 88, with project names parsed correctly. That is
+60 evaluations across the two rubrics.
+
+The alternative is to drop the semantic path from reported results and say why.
+That is a decision about the paper rather than the code, and it is cheaper.
+
+## What is safe to keep
+
+The **presence** and **fitness** paths are untouched by all three problems:
+presence has always scored rubric20 against 88, fitness has its own rubric and
+cache keyed on `(axis, model, rubric, corpus, schema)`, and neither reads a
+`program` field. The agreement and form-defect measurements likewise.

--- a/tests/test_evaluation/test_semantic_agent_grounding.py
+++ b/tests/test_evaluation/test_semantic_agent_grounding.py
@@ -1,0 +1,95 @@
+"""The semantic agents must score only what the datasheet contains (#162).
+
+Both agents promise temperature 0.0 and "same file → same score". PR #154 added
+a check asking whether a description suits "the claimed dataset type **and
+program of origin**" — and there is no `program` or `project` field anywhere in
+the D4D schema to read that from. With no field to ground on, an evaluator
+infers program from the filename, the invocation context, or prior knowledge,
+and the same datasheet scores differently depending on who asks.
+
+The prompts were corrected on 2026-07-22 to name the exact fields the inference
+may use. Nothing pins that correction, and it is one careless edit from
+returning — so this does.
+
+These tests read the agent definitions rather than running them. That is the
+right level here: the defect is a sentence in a prompt, and what must not
+regress is the sentence.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+AGENTS = Path(__file__).resolve().parents[2] / ".claude" / "agents"
+SEMANTIC = ("d4d-rubric10-semantic.md", "d4d-rubric20-semantic.md")
+
+#: The only datasheet fields a program inference may rest on. Named here rather
+#: than in prose so the test and the prompts cannot drift apart quietly.
+GROUNDING_FIELDS = ("keywords", "publisher", "funders")
+
+
+class TestSemanticAgentsGroundProgramInference(unittest.TestCase):
+
+    def _text(self, name):
+        path = AGENTS / name
+        self.assertTrue(path.exists(), f"{name} is missing")
+        return path.read_text(encoding="utf-8")
+
+    def test_both_agents_exist(self):
+        for name in SEMANTIC:
+            with self.subTest(agent=name):
+                self.assertTrue((AGENTS / name).exists())
+
+    def test_program_inference_is_restricted_to_named_fields(self):
+        for name in SEMANTIC:
+            with self.subTest(agent=name):
+                text = self._text(name)
+                if "program" not in text.lower():
+                    continue  # dropped entirely — also an acceptable fix
+                for field in GROUNDING_FIELDS:
+                    self.assertIn(
+                        field, text,
+                        f"{name} mentions program context but does not name "
+                        f"`{field}` as a permitted source")
+
+    def test_the_ungrounded_sources_are_explicitly_forbidden(self):
+        """Naming what may be used is not enough on its own.
+
+        A model told "infer from keywords" and left free to consult a filename
+        will still consult the filename. The prompt has to rule it out.
+        """
+        for name in SEMANTIC:
+            with self.subTest(agent=name):
+                text = self._text(name).lower()
+                if "program" not in text:
+                    continue
+                self.assertIn("never from the filename", text,
+                              f"{name} must forbid filename inference")
+                for forbidden in ("invocation context", "prior knowledge"):
+                    self.assertIn(forbidden, text,
+                                  f"{name} must forbid {forbidden}")
+
+    def test_the_original_ungrounded_phrasing_is_gone(self):
+        """`dataset type and program of origin` is the exact wording of #162."""
+        pattern = re.compile(r"dataset type\s+and\s+program of origin", re.I)
+        for name in SEMANTIC:
+            with self.subTest(agent=name):
+                self.assertIsNone(pattern.search(self._text(name)))
+
+    def test_no_program_or_project_slot_exists_to_ground_on(self):
+        """The premise. If the schema ever gains one, this test should fail and
+        the prompts can stop working around its absence."""
+        schema = (Path(__file__).resolve().parents[2] / "src"
+                  / "data_sheets_schema" / "schema" / "D4D_Core.yaml")
+        if not schema.exists():
+            self.skipTest("D4D_Core.yaml not present")
+        text = schema.read_text(encoding="utf-8")
+        for slot in ("\n  program:", "\n  project:"):
+            self.assertNotIn(
+                slot, text,
+                "D4D_Core now declares a program/project slot — the semantic "
+                "agents can ground on it directly and this workaround should go")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation/test_semantic_agent_grounding.py
+++ b/tests/test_evaluation/test_semantic_agent_grounding.py
@@ -76,19 +76,44 @@ class TestSemanticAgentsGroundProgramInference(unittest.TestCase):
             with self.subTest(agent=name):
                 self.assertIsNone(pattern.search(self._text(name)))
 
+class TestThePremise(unittest.TestCase):
+    """Both halves of it, from the schema rather than from a file path.
+
+    An earlier version read `D4D_Core.yaml` for the absence of `program`. That
+    is the wrong scope — records are evaluated as `Dataset`, which draws from
+    the whole schema, and the fields the prompt *may* use are declared
+    elsewhere: `publisher` and `keywords` in `D4D_Base_import.yaml`, `funders`
+    as an attribute rather than a top-level slot. A `program` slot added to any
+    other module would have left it green (#285).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from data_sheets_schema import schema_digest
+        cls.slots = {s.name for s in schema_digest.build("Dataset").slots}
+
     def test_no_program_or_project_slot_exists_to_ground_on(self):
-        """The premise. If the schema ever gains one, this test should fail and
-        the prompts can stop working around its absence."""
-        schema = (Path(__file__).resolve().parents[2] / "src"
-                  / "data_sheets_schema" / "schema" / "D4D_Core.yaml")
-        if not schema.exists():
-            self.skipTest("D4D_Core.yaml not present")
-        text = schema.read_text(encoding="utf-8")
-        for slot in ("\n  program:", "\n  project:"):
-            self.assertNotIn(
-                slot, text,
-                "D4D_Core now declares a program/project slot — the semantic "
-                "agents can ground on it directly and this workaround should go")
+        """If the schema gains one, this fails and the workaround can go."""
+        for name in ("program", "project", "program_of_origin"):
+            with self.subTest(slot=name):
+                self.assertNotIn(
+                    name, self.slots,
+                    f"Dataset now declares `{name}` — the semantic agents can "
+                    "ground on it directly and this workaround should go")
+
+    def test_the_fields_the_prompt_may_use_actually_exist(self):
+        """The other half, and #162 in miniature.
+
+        A test that stops a prompt grounding on nothing should check that what
+        it grounds on is something. `funders` is an attribute, so a naive grep
+        for a top-level slot reports it missing when it is not.
+        """
+        for name in GROUNDING_FIELDS:
+            with self.subTest(slot=name):
+                self.assertIn(
+                    name, self.slots,
+                    f"the prompts tell the agent to infer from `{name}`, which "
+                    "is not a Dataset slot — the same defect as #162")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #162's code half and establishes what the data half costs.

## The prompt fix was already in

Both agents were corrected on **2026-07-22** (`0e19e85f`): program inference is restricted to quoted values in `keywords`, `publisher` or `funders`, and the filename, invocation context and prior knowledge are forbidden by name — exactly recommendation (a) from the issue.

Nothing pinned it, and it is one careless edit from returning. Five tests now do, including the premise: if the schema ever gains a `program` slot the test fails and the workaround can go.

## The audit is the bigger half

Since semantic scores are going in the manuscript, I audited what's actually on disk. **Three independent defects, and every recorded evaluation has at least one.**

| set | files | recorded dates |
|---|---|---|
| `rubric10_semantic` | 36 | 2025-12-10 (12), 2026-05-13/14 (8), 2026-07-22 (16) |
| `rubric20_semantic` | 24 | 2026-05-13/14 (8), 2026-07-22 (16) |

**1. Ungrounded scoring.** 8 rubric20 and 20 rubric10 records predate the fix. The 16 dated 2026-07-22 fall on the same day as the commit and **cannot be placed either side of it** from the data alone.

**2. Wrong denominator.** All 24 `rubric20_semantic` records carry `max_points: 84` against the 88 the rubric's questions define — every semantic percentage ~4.8% high. `rubric10_semantic` is unaffected at 50 throughout.

**3. A split project name.** Three records carry `project: "AI"` and `method: "READI_claudecode"` — `AI_READI` split on its underscore. The parsing bug was fixed in `69aa303d` on **2025-12-08**; these records are dated **2025-12-10**, two days later, so the fix didn't cover the path that produced them.

## Why rescaling won't do

The denominator could be corrected arithmetically. **A score produced under an ungrounded prompt cannot** — it is not a score of the record, it is a score of the record plus its filename.

So the semantic path needs **re-running (60 evaluations across both rubrics)**, or dropping from reported results with the reason stated. That's a decision about the paper rather than the code, and I'm not making it here.

## What is safe

Presence and fitness are untouched by all three: presence has always scored rubric20 against 88, fitness has its own rubric and a cache keyed on `(axis, model, rubric, corpus, schema)`, and neither reads a `program` field. The agreement and form-defect measurements likewise.

Full write-up in `notes/semantic_evaluation_corpus_2026-08-03.md`.

**1054 passed, 3 skipped** (+5).