### PR TITLE
Make the structural mapping's drift detectable, and diagnose why it drifted (#234)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ SSSOM_URI_COMPREHENSIVE = src/data_sheets_schema/semantic_exchange/d4d_rocrate_s
 SSSOM_COMPREHENSIVE = src/data_sheets_schema/semantic_exchange/d4d_rocrate_sssom_comprehensive.tsv
 SSSOM_STRUCTURAL = data/semantic_exchange/d4d_rocrate_structural_mapping.sssom.tsv
 
-.PHONY: gen-core-schema validate-core lint-core gen-sssom gen-sssom-full gen-sssom-subset gen-sssom-uri gen-sssom-uri-comprehensive gen-sssom-comprehensive gen-sssom-structural gen-sssom-all clean-sssom
+.PHONY: check-sssom-structural gen-core-schema validate-core lint-core gen-sssom gen-sssom-full gen-sssom-subset gen-sssom-uri gen-sssom-uri-comprehensive gen-sssom-comprehensive gen-sssom-structural gen-sssom-all clean-sssom
 
 gen-core-schema: $(D4D_CORE_SCHEMA_ALL) ## Generate merged core exchange schema (data_sheets_schema_core_all.yaml)
 
@@ -433,6 +433,9 @@ $(SSSOM_COMPREHENSIVE): $(D4D_SCHEMA_ALL) $(SKOS_ALIGNMENT) $(URI_RECOMMENDATION
 		--output $(SSSOM_COMPREHENSIVE)
 
 gen-sssom-structural: $(SSSOM_STRUCTURAL) ## Generate structure-aware D4D ↔ RO-Crate SSSOM mapping
+
+check-sssom-structural: ## Report drift between the committed structural mapping and its generator
+	$(RUN) python $(SSSOM_STRUCTURAL_SCRIPT) --check
 
 $(SSSOM_STRUCTURAL): $(D4D_SCHEMA_ALL) $(ROCRATE_JSON) $(SSSOM_STRUCTURAL_SCRIPT)
 	@echo "Generating structural SSSOM mapping..."

--- a/src/semantic_exchange/generate_structural_mapping.py
+++ b/src/semantic_exchange/generate_structural_mapping.py
@@ -631,8 +631,18 @@ def read_sssom_rows(path: Path) -> set:
     import csv
     with path.open(encoding="utf-8") as fh:
         lines = [l for l in fh if not l.startswith("#")]
-    return {(r["subject_id"], r["predicate_id"], r["object_id"])
-            for r in csv.DictReader(lines, delimiter="\t")}
+    reader = csv.DictReader(lines, delimiter="\t")
+    required = ("subject_id", "predicate_id", "object_id")
+    missing = [c for c in required if c not in (reader.fieldnames or [])]
+    if missing:
+        # Naming the file and the column, because the alternative is a bare
+        # KeyError from inside csv and a reader who concludes the code is
+        # broken rather than the input (#296).
+        raise ValueError(
+            f"{path} is not a readable SSSOM mapping: no "
+            f"{', '.join(missing)} column"
+            + (" (no header row at all?)" if not reader.fieldnames else ""))
+    return {tuple(r[c] for c in required) for r in reader}
 
 
 def check_drift(committed: Path, regenerated: Path) -> tuple:
@@ -689,8 +699,20 @@ def main(argv=None):
                 print(f"\n✗ No committed mapping at {committed}")
                 return 1
             lost, gained = check_drift(committed, scratch)
-        if not lost and not gained:
-            print("\n✓ The committed mapping regenerates exactly.")
+
+            # The target writes two artifacts from the same mappings list, so
+            # check both. Today the summary is fresh and the mapping is stale
+            # (#295) — the confusing direction, because the artifact that is
+            # right is the one nobody thinks to distrust.
+            summary = output_dir / "d4d_rocrate_structural_mapping_summary.md"
+            scratch_summary = Path(tmp) / "regenerated_summary.md"
+            generator.export_summary(scratch_summary)
+            summary_drifted = (
+                not summary.exists()
+                or summary.read_text(encoding="utf-8")
+                != scratch_summary.read_text(encoding="utf-8"))
+        if not lost and not gained and not summary_drifted:
+            print("\n✓ The committed mapping and summary regenerate exactly.")
             return 0
         print(f"\n✗ The committed mapping does not regenerate from its inputs.")
         if lost:
@@ -703,6 +725,11 @@ def main(argv=None):
                   "committed file lacks:")
             for s, p_, o in gained:
                 print(f"      {s}  --{p_}->  {o}")
+        if summary_drifted:
+            print("\n  The summary does not regenerate either.")
+        elif lost or gained:
+            print("\n  The summary regenerates exactly, so it describes the "
+                  "generator's output rather than the mapping beside it (#295).")
         print("\n  A mapping nobody can rebuild is a mapping nobody can safely "
               "change (#234).")
         return 1

--- a/src/semantic_exchange/generate_structural_mapping.py
+++ b/src/semantic_exchange/generate_structural_mapping.py
@@ -621,8 +621,36 @@ class StructuralMappingGenerator:
         print(f"Exported summary to {output_path}")
 
 
-def main():
+def read_sssom_rows(path: Path) -> set:
+    """(subject_id, predicate_id, object_id) for every data row.
+
+    Identity is the triple, not the whole line: confidence and structural notes
+    move for reasons that are not a change of meaning, and a drift check that
+    fires on those is one nobody keeps running.
+    """
+    import csv
+    with path.open(encoding="utf-8") as fh:
+        lines = [l for l in fh if not l.startswith("#")]
+    return {(r["subject_id"], r["predicate_id"], r["object_id"])
+            for r in csv.DictReader(lines, delimiter="\t")}
+
+
+def check_drift(committed: Path, regenerated: Path) -> tuple:
+    """Rows the committed file has that regeneration does not, and vice versa."""
+    have, made = read_sssom_rows(committed), read_sssom_rows(regenerated)
+    return sorted(have - made), sorted(made - have)
+
+
+def main(argv=None):
     """Generate schema-structure-aware mappings."""
+    import argparse
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="Regenerate to a temporary file and report drift "
+                         "against the committed mapping. Writes nothing. "
+                         "Exits non-zero if they differ.")
+    args = ap.parse_args(argv)
+
     # Paths
     base_dir = Path(__file__).parent.parent.parent
     d4d_schema = base_dir / "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
@@ -647,13 +675,46 @@ def main():
     mappings = generator.generate_mappings()
     print(f"  Generated {len(mappings)} mappings")
 
+    committed = output_dir / "d4d_rocrate_structural_mapping.sssom.tsv"
+
+    if args.check:
+        # Never write over the committed file while checking it. Regenerating
+        # in place to compare is how a check becomes the thing it was meant to
+        # detect.
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            scratch = Path(tmp) / "regenerated.sssom.tsv"
+            generator.export_sssom(scratch)
+            if not committed.exists():
+                print(f"\n✗ No committed mapping at {committed}")
+                return 1
+            lost, gained = check_drift(committed, scratch)
+        if not lost and not gained:
+            print("\n✓ The committed mapping regenerates exactly.")
+            return 0
+        print(f"\n✗ The committed mapping does not regenerate from its inputs.")
+        if lost:
+            print(f"\n  {len(lost)} row(s) in the committed file that "
+                  "regeneration does not produce:")
+            for s, p_, o in lost:
+                print(f"      {s}  --{p_}->  {o}")
+        if gained:
+            print(f"\n  {len(gained)} row(s) regeneration produces that the "
+                  "committed file lacks:")
+            for s, p_, o in gained:
+                print(f"      {s}  --{p_}->  {o}")
+        print("\n  A mapping nobody can rebuild is a mapping nobody can safely "
+              "change (#234).")
+        return 1
+
     # Export
     print("\nExporting mappings...")
-    generator.export_sssom(output_dir / "d4d_rocrate_structural_mapping.sssom.tsv")
+    generator.export_sssom(committed)
     generator.export_summary(output_dir / "d4d_rocrate_structural_mapping_summary.md")
 
     print("\n✓ Schema-structure-aware mapping complete")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_semantic_exchange/test_structural_mapping_drift.py
+++ b/tests/test_semantic_exchange/test_structural_mapping_drift.py
@@ -1,0 +1,128 @@
+"""The committed structural mapping does not regenerate, and that is pinned.
+
+`make gen-sssom-structural` emits 150 rows against the committed 160 (#234). A
+mapping nobody can rebuild is a mapping nobody can safely change, so the ten
+missing rows are enumerated here with what is actually wrong with each.
+
+The point is not to bless the gap. It is that **new** drift should fail while the
+known gap does not, because a check that has been red since the day it was
+written is a check nobody reads.
+
+## Why each row is missing
+
+The issue guessed the `Core*` rows were lost because the core schema is not a
+declared input. That is wrong, and the accounting says so cleanly:
+
+| dropped | target | reason |
+|---|---|---|
+| 4 class-level rows | `schema:` | the generator emits **no** class-level rows at all |
+| 2 `…/resources` | `schema:hasPart` | it produces no `schema:` targets |
+| 3 file/collection attrs | `d4d:` | 21 `d4d:` rows committed, 18 regenerated |
+| 1 `total_bytes` | `dcat:byteSize` | it produces no `dcat:` targets |
+
+`class_uri` is parsed into `SchemaClass` and never used to emit a mapping —
+every `StructuralMapping(...)` is constructed from `slot.parent_class`, so
+`DataSubset` is missing for the same reason `CoreDataset` is, and it lives in
+the full schema. Adding the core schema as an input would recover nothing.
+
+`_map_slot_uris` only emits a row when the RO-Crate input carries a matching
+property. `fileType`, `collectionType`, `fileCount` and `byteSize` are not in
+`full-ro-crate-metadata.json`, so those rows cannot come from that strategy
+either.
+
+So the committed file is the output of a more capable generator than the one in
+the tree, or was partly written by hand. Either way the ten rows are assertions
+no declared input supports.
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "src" / "semantic_exchange" / "generate_structural_mapping.py"
+COMMITTED = (REPO / "data" / "semantic_exchange"
+             / "d4d_rocrate_structural_mapping.sssom.tsv")
+
+#: Rows the committed file asserts that regeneration does not produce.
+#: Shrinking this set is progress. Growing it without a reason is the drift
+#: this test exists to catch.
+KNOWN_UNDERIVABLE = {
+    # No class-level strategy exists — `class_uri` is parsed and never used.
+    ("d4d:CoreDataset", "skos:exactMatch", "schema:Dataset"),
+    ("d4d:CoreDatasetCollection", "skos:exactMatch", "schema:Dataset"),
+    ("d4d:CoreDistribution", "skos:exactMatch", "schema:DataDownload"),
+    ("d4d:DataSubset", "skos:exactMatch", "schema:Dataset"),
+    # No `schema:` targets are produced.
+    ("d4d:DatasetCollection/resources", "skos:exactMatch", "schema:hasPart"),
+    ("d4d:FileCollection/resources", "skos:exactMatch", "schema:hasPart"),
+    # Target absent from the RO-Crate input, so `_map_slot_uris` cannot match.
+    ("d4d:File/file_type", "skos:exactMatch", "d4d:fileType"),
+    ("d4d:FileCollection/collection_type", "skos:exactMatch", "d4d:collectionType"),
+    ("d4d:FileCollection/file_count", "skos:exactMatch", "d4d:fileCount"),
+    # Also disagrees with the schema, which declares `slot_uri: d4d:total_bytes`.
+    ("d4d:FileCollection/total_bytes", "skos:exactMatch", "dcat:byteSize"),
+}
+
+
+@unittest.skipUnless(COMMITTED.exists(), "structural mapping not present")
+class TestStructuralMappingDrift(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        sys.path.insert(0, str(REPO / "src" / "semantic_exchange"))
+        import tempfile
+        from generate_structural_mapping import (  # noqa: E402
+            D4DSchemaParser, ROCrateSchemaParser, StructuralMappingGenerator,
+            check_drift,
+        )
+        import io
+        from contextlib import redirect_stdout
+        d4d = D4DSchemaParser(
+            REPO / "src/data_sheets_schema/schema/data_sheets_schema_all.yaml")
+        roc = ROCrateSchemaParser(
+            REPO / "data/ro-crate/profiles/fairscape/full-ro-crate-metadata.json")
+        gen = StructuralMappingGenerator(d4d, roc)
+        with redirect_stdout(io.StringIO()):
+            gen.generate_mappings()
+            cls._tmp = tempfile.TemporaryDirectory()
+            scratch = Path(cls._tmp.name) / "regenerated.tsv"
+            gen.export_sssom(scratch)
+            cls.lost, cls.gained = check_drift(COMMITTED, scratch)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+    def test_the_gap_is_exactly_the_known_one(self):
+        """New drift fails; the documented gap does not."""
+        self.assertEqual(
+            set(self.lost), KNOWN_UNDERIVABLE,
+            "the set of rows that will not regenerate has changed — if rows "
+            "were fixed, shrink KNOWN_UNDERIVABLE; if new ones appeared, they "
+            "are drift and need a reason")
+
+    def test_regeneration_invents_nothing(self):
+        """The other direction. Rows the generator produces that the committed
+        file lacks would mean the file is stale rather than hand-extended, and
+        that is a different problem with a different fix."""
+        self.assertEqual(self.gained, [],
+                         "regeneration produces rows the committed file lacks")
+
+    def test_check_mode_writes_nothing(self):
+        """A check that regenerates in place becomes the thing it detects."""
+        before = COMMITTED.read_bytes()
+        subprocess.run([sys.executable, str(SCRIPT), "--check"],
+                       cwd=REPO, capture_output=True)
+        self.assertEqual(COMMITTED.read_bytes(), before)
+
+    def test_check_mode_fails_while_the_gap_stands(self):
+        result = subprocess.run([sys.executable, str(SCRIPT), "--check"],
+                                cwd=REPO, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("does not regenerate", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_semantic_exchange/test_structural_mapping_drift.py
+++ b/tests/test_semantic_exchange/test_structural_mapping_drift.py
@@ -124,5 +124,59 @@ class TestStructuralMappingDrift(unittest.TestCase):
         self.assertIn("does not regenerate", result.stdout)
 
 
+
+class TestTheCheckCoversBothArtifacts(unittest.TestCase):
+    """`make gen-sssom-structural` writes two files; the check reads two (#295).
+
+    Today the summary regenerates byte-for-byte and the mapping does not, so
+    they were committed from different generator states and the summary does
+    not describe the file beside it. That is the confusing direction — the
+    artifact that is correct is the one nobody thinks to distrust.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.stdout = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check"],
+            cwd=REPO, capture_output=True, text=True).stdout
+
+    def test_the_check_reports_on_the_summary_too(self):
+        self.assertIn("summary", self.stdout.lower())
+
+    def test_the_summary_is_currently_the_fresh_one(self):
+        """Pinned so that fixing #294 cannot silently leave them swapped."""
+        self.assertIn("describes the generator's output", self.stdout)
+
+
+class TestMalformedInputIsNamed(unittest.TestCase):
+    """#296: a bare KeyError sends the reader to the code, not the file."""
+
+    def setUp(self):
+        sys.path.insert(0, str(REPO / "src" / "semantic_exchange"))
+
+    def test_a_missing_column_names_the_file_and_the_column(self):
+        import tempfile
+        from generate_structural_mapping import read_sssom_rows
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "partial.tsv"
+            p.write_text("subject_id\tobject_id\na\tb\n")
+            with self.assertRaises(ValueError) as ctx:
+                read_sssom_rows(p)
+            self.assertIn("predicate_id", str(ctx.exception))
+            self.assertIn("partial.tsv", str(ctx.exception))
+
+    def test_a_headerless_file_is_an_error_not_zero_rows(self):
+        import tempfile
+        from generate_structural_mapping import read_sssom_rows
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "comments.tsv"
+            p.write_text("# only comments\n")
+            with self.assertRaises(ValueError):
+                read_sssom_rows(p)
+
+    def test_a_well_formed_file_still_reads(self):
+        from generate_structural_mapping import read_sssom_rows
+        self.assertGreater(len(read_sssom_rows(COMMITTED)), 100)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
No regeneration of anything, and the committed mapping is untouched.

## The issue's hypothesis is wrong

#234 guessed the `Core*` rows were lost because the core schema isn't a declared input. Reproduced the 160 → 150 drop exactly, and the ten rows account for themselves **by capability, not by schema**:

| dropped | target | reason |
|---|---|---|
| 4 class-level rows | `schema:` | the generator emits **no class-level rows at all** |
| 2 `…/resources` | `schema:hasPart` | it produces no `schema:` targets |
| 3 file/collection attrs | `d4d:` | 21 committed, 18 regenerated |
| 1 `total_bytes` | `dcat:byteSize` | it produces no `dcat:` targets |

`class_uri` is parsed into `SchemaClass` and **never used to emit anything** — every `StructuralMapping` is built from `slot.parent_class`. So `DataSubset` is missing for the same reason `CoreDataset` is, and `DataSubset` is in the full schema. **Adding the core schema as an input would recover nothing.**

`_map_slot_uris` only emits a row when the RO-Crate input carries a matching property, and `fileType`, `collectionType`, `fileCount`, `byteSize` are not in `full-ro-crate-metadata.json`.

So the committed file is the output of a more capable generator than the one in the tree, or was partly written by hand. The ten rows are assertions no declared input supports. `total_bytes` is the clearest case: the schema declares `slot_uri: d4d:total_bytes` and the committed row maps it to `dcat:byteSize`.

## What this does instead

Restoring the missing capability is real feature work that would move other rows. This does the thing that makes the file safe to change in the meantime — the issue's own third suggestion.

`--check` regenerates to a temp file, diffs on `(subject, predicate, object)`, and exits non-zero on any difference. Exposed as `make check-sssom-structural`.

- **Identity is the triple, not the whole line.** Confidence and structural notes move without meaning changing, and a check that fires on those is one nobody keeps running.
- **It writes nothing.** A check that regenerates in place becomes the thing it detects; a test asserts the committed bytes are unchanged after running it.

## The gap is pinned, not blessed

`KNOWN_UNDERIVABLE` enumerates the ten with what is wrong with each. **New drift fails; the documented gap does not** — a check that has been red since the day it was written is a check nobody reads. Shrinking the set is progress; growing it needs a reason.

The other direction is asserted too: rows the generator produces that the file lacks would mean the file is *stale* rather than hand-extended, which is a different problem with a different fix.

## Answers to the issue's "worth checking" list

- **Do `Core*` rows need the core schema as an input?** No — see above.
- **Does the committed file have hand edits regeneration would discard?** All ten carry `semapv:StructuralMapping`, the generator's own justification, so they look generated — but the generator in the tree cannot produce them. Earlier generator or hand-authored; either way undeclared.
- **Add a `--check` mode?** Done.

**1059 passed, 3 skipped** (+4).