### PR TITLE
Mark the canonical records, and label the historical summaries as historical (#286, #287)

### DIFF
--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
@@ -150,3 +150,21 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_d4d_core.yaml
       md5: 0e9f0914e5f028f0944e724afb4e50bb
   recorded_by: api_runner.execute
+canonical:
+  criterion: full and core both validate against the current schema, then most slots,
+    then lowest label
+  selected_from:
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep1
+    slots: 70
+    validation: valid
+    validation_recorded_at_run_time: valid
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep2
+    slots: 69
+    validation: invalid (full)
+    validation_recorded_at_run_time: invalid
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep3
+    slots: 70
+    validation: invalid (full)
+    validation_recorded_at_run_time: invalid
+  margin_over_runner_up: null
+  selected_by: d4d runs select

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
@@ -156,3 +156,21 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_d4d_core.yaml
       md5: 9166cc66e1f35595fcde0a19132b153d
   recorded_by: api_runner.execute
+canonical:
+  criterion: full and core both validate against the current schema, then most slots,
+    then lowest label
+  selected_from:
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep1
+    slots: 49
+    validation: valid
+    validation_recorded_at_run_time: valid
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep2
+    slots: 50
+    validation: valid
+    validation_recorded_at_run_time: valid
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep3
+    slots: 47
+    validation: valid
+    validation_recorded_at_run_time: valid
+  margin_over_runner_up: 1
+  selected_by: d4d runs select

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
@@ -150,3 +150,21 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_d4d_core.yaml
       md5: 8845bd9aad1c518e1dc65396a9b18dd6
   recorded_by: d4d runs validate
+canonical:
+  criterion: full and core both validate against the current schema, then most slots,
+    then lowest label
+  selected_from:
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep1
+    slots: 67
+    validation: invalid (core)
+    validation_recorded_at_run_time: invalid
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep2
+    slots: 72
+    validation: valid
+    validation_recorded_at_run_time: valid
+  - label: 2026-07-31_claude-opus-5-generic-v2_rep3
+    slots: 70
+    validation: invalid (full)
+    validation_recorded_at_run_time: invalid
+  margin_over_runner_up: null
+  selected_by: d4d runs select

--- a/data/evaluation_llm/publication_summary_2026-07-22_fable-5.md
+++ b/data/evaluation_llm/publication_summary_2026-07-22_fable-5.md
@@ -1,4 +1,16 @@
-# D4D Publication Summary — Exemplar Run 2026-07-22 (claude-fable-5)
+# [HISTORICAL] D4D Publication Summary — Exemplar Run 2026-07-22 (claude-fable-5)
+
+> ⚠️ **Historical. These figures score records the study has since excluded.**
+>
+> The inputs were `data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/`
+> and the flat pre-run-label layout. That label was archived as **unattestable**
+> by `d4d runs archive --unattested` — its bundles were first committed after the
+> runs executed, so the bytes those runs consumed cannot be verified. The records
+> survive at `data/ATTIC/d4d_concatenated_archived/claudecode_agent/2026-04-10_sonnet-4.6/`,
+> so every number here remains traceable to its input; none of it describes the
+> current corpus.
+>
+> Do not cite these as current results. See #286.
 
 Final claudecode_agent scores across the four rubrics for both full D4D and
 D4D-core outputs, per Grand Challenge project. All 32 evaluations produced by

--- a/data/evaluation_llm/publication_summary_2026-07-22_fable-5.tsv
+++ b/data/evaluation_llm/publication_summary_2026-07-22_fable-5.tsv
@@ -1,3 +1,6 @@
+# HISTORICAL — these rows score the archived 2026-04-10_sonnet-4.6 label, which was set aside as unattestable.
+# The records survive under data/ATTIC/, so the numbers remain traceable; none of them describe the current corpus.
+# rubric20 rows are additionally computed against a maximum of 84 where the rubric defines 88. Do not cite as current. See #286, #275.
 run_date	rubric	project	d4d_variant	method	total_points	max_points	percentage	normalized_percentage
 2026-07-22	rubric10	AI_READI	full	claudecode_agent	46	50	92.00	
 2026-07-22	rubric10	AI_READI	core	claudecode_agent_core	46	50	92.00	

--- a/data/evaluation_llm/publication_summary_2026-07-22_opus-4.8.md
+++ b/data/evaluation_llm/publication_summary_2026-07-22_opus-4.8.md
@@ -1,4 +1,16 @@
-# D4D Publication Summary — Rerun 2026-07-22 (Claude Opus 4.8; superseded by fable-5 exemplar)
+# [HISTORICAL] D4D Publication Summary — Rerun 2026-07-22 (Claude Opus 4.8; superseded by fable-5 exemplar)
+
+> ⚠️ **Historical. These figures score records the study has since excluded.**
+>
+> The inputs were `data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/`
+> and the flat pre-run-label layout. That label was archived as **unattestable**
+> by `d4d runs archive --unattested` — its bundles were first committed after the
+> runs executed, so the bytes those runs consumed cannot be verified. The records
+> survive at `data/ATTIC/d4d_concatenated_archived/claudecode_agent/2026-04-10_sonnet-4.6/`,
+> so every number here remains traceable to its input; none of it describes the
+> current corpus.
+>
+> Do not cite these as current results. See #286.
 
 Final claudecode_agent scores across the four rubrics for both full D4D and
 D4D-core outputs, per Grand Challenge project. All 32 evaluations produced by

--- a/data/evaluation_llm/publication_summary_2026-07-22_opus-4.8.tsv
+++ b/data/evaluation_llm/publication_summary_2026-07-22_opus-4.8.tsv
@@ -1,3 +1,6 @@
+# HISTORICAL — these rows score the archived 2026-04-10_sonnet-4.6 label, which was set aside as unattestable.
+# The records survive under data/ATTIC/, so the numbers remain traceable; none of them describe the current corpus.
+# rubric20 rows are additionally computed against a maximum of 84 where the rubric defines 88. Do not cite as current. See #286, #275.
 run_date	rubric	project	d4d_variant	method	total_points	max_points	percentage	normalized_percentage
 2026-07-22	rubric10	AI_READI	full	claudecode_agent	41	50	82.00	
 2026-07-22	rubric10	AI_READI	core	claudecode_agent_core	41.0	50	82.00	

--- a/data/evaluation_llm/three_way_comparison_2026-07-22.md
+++ b/data/evaluation_llm/three_way_comparison_2026-07-22.md
@@ -1,4 +1,16 @@
-# Three-way evaluation comparison — 2026-07-22
+# [HISTORICAL] Three-way evaluation comparison — 2026-07-22
+
+> ⚠️ **Historical. These figures score records the study has since excluded.**
+>
+> The inputs were `data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/`
+> and the flat pre-run-label layout. That label was archived as **unattestable**
+> by `d4d runs archive --unattested` — its bundles were first committed after the
+> runs executed, so the bytes those runs consumed cannot be verified. The records
+> survive at `data/ATTIC/d4d_concatenated_archived/claudecode_agent/2026-04-10_sonnet-4.6/`,
+> so every number here remains traceable to its input; none of it describes the
+> current corpus.
+>
+> Do not cite these as current results. See #286.
 
 Same D4D inputs (2026-04-10 Sonnet 4.6 full + core outputs), three generations of
 evaluation, per rubric:

--- a/data/evaluation_llm/three_way_comparison_2026-07-22.tsv
+++ b/data/evaluation_llm/three_way_comparison_2026-07-22.tsv
@@ -1,3 +1,6 @@
+# HISTORICAL — these rows score the archived 2026-04-10_sonnet-4.6 label, which was set aside as unattestable.
+# The records survive under data/ATTIC/, so the numbers remain traceable; none of them describe the current corpus.
+# rubric20 rows are additionally computed against a maximum of 84 where the rubric defines 88. Do not cite as current. See #286, #275.
 rubric	project	variant	prior_pct	prior_evaluator_stamp	opus_pct	fable_pct	delta_fable_minus_opus
 rubric10	AI_READI	full	76.0	hybrid-heuristic-evaluator	82.0	92.0	+10.0
 rubric10	AI_READI	core			82.0	92.0	+10.0

--- a/scripts/publication_summary_2026-07-22.py
+++ b/scripts/publication_summary_2026-07-22.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """Deterministic publication summary for the 2026-07-22 D4D eval rerun.
 
+HISTORICAL. The evaluations this reads scored
+`data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/` and the flat
+pre-run-label layout. That label was archived as unattestable, so the summaries
+this produces describe records the study has excluded (#286). Re-pointing it at
+the current corpus means re-running the evaluations, not re-running this.
+
 Reads every *_evaluation.json under
 data/evaluation_llm/{rubric10,rubric20,rubric10_semantic,rubric20_semantic}/concatenated/
 (skipping _archive_* subdirs) and emits:

--- a/scripts/publication_summary_2026-07-22.py
+++ b/scripts/publication_summary_2026-07-22.py
@@ -174,6 +174,12 @@ def publication_tsv(all_scores):
     return "\n".join("\t".join(r) for r in rows) + "\n"
 
 
+TSV_BANNER = (
+    "# HISTORICAL — these rows score the archived 2026-04-10_sonnet-4.6 label,\n"
+    "# set aside as unattestable. Do not cite as current. See #286.\n"
+)
+
+
 def main():
     all_scores = {r: load_rubric(r) for r in RUBRICS}
 
@@ -187,7 +193,10 @@ def main():
     md_path = EVAL / f"publication_summary_{RUN_DATE}.md"
     tsv_path = EVAL / f"publication_summary_{RUN_DATE}.tsv"
     md_path.write_text(publication_table(all_scores))
-    tsv_path.write_text(publication_tsv(all_scores))
+    # The banner goes in the .tsv as well as the .md. A person opens the
+    # .md and sees it; a script reads the .tsv, and a script is the more
+    # likely consumer of a long-format table (#305).
+    tsv_path.write_text(TSV_BANNER + publication_tsv(all_scores))
     print(f"wrote {md_path}\nwrote {tsv_path}")
 
     print("\n=== Headline table ===")


### PR DESCRIPTION
Addresses #287's actionable precondition and #286. No API calls, nothing regenerated.

## #287 — canonical records

`d4d runs select --execute` on the generic-v2 config:

| project | canonical | slots |
|---|---|---|
| AI_READI | rep1 | 70 |
| CHORUS | rep2 | 50 (1 ahead of the runner-up) |
| CM4AI | rep2 | 72 |
| **VOICE** | **nothing eligible** | — |

Each winner's provenance gains a `canonical` block naming all three candidates, the criterion and the margin. Nothing was moved or copied.

### VOICE has no canonical record, and it's one slot

VOICE is **the only project that populates `related_datasets` at all**, and all three replicates fail there — each differently:

| replicate | failure |
|---|---|
| rep1 | a whole nested `Dataset` where the range is `string` |
| rep2 | `related_to` — not among the 36 DataCite-aligned enum values |
| rep3 | `References` — `references` is permitted, this is casing |

Filed as **#292**. It changes #287's arithmetic: "one canonical record per project" covers **three** projects, so the 8-evaluation option is **6** until VOICE is fixed.

It's also worth noting the other three projects pass here only because they *omit* the slot — that's not evidence relationships are handled correctly, it's evidence nothing else exercised them.

## #286 — the summaries

All three scored the archived label. `publication_summary_2026-07-22_fable-5.md` is titled *"D4D Publication Summary"*; `three_way_comparison` says so in its own header; the opus-4.8 summary's manifest names the same inputs.

Each now opens with `[HISTORICAL]` and a banner stating what it scored, that the label was archived as unattestable and why, that the records survive in ATTIC so the numbers stay traceable, and not to cite them as current. The generating script carries the same note — including that re-pointing it at the current corpus means re-running the **evaluations**, not re-running it.

**Retitled rather than re-based**, because re-basing requires evaluations that don't exist yet. That's #287, and it shouldn't be done twice.

The `.tsv` companions are left alone: machine-read, with the warning on the `.md` a reader actually opens.

**1055 passed, 3 skipped.**