### PR TITLE
Honour the enum aliases the schema declares; the range union is not expressible (#292)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -283,6 +283,38 @@ a budget on every tracked cache under `agreement_cache/`.
 
 ---
 
+## 9. Split VOICE into two datasets — registered, not generated
+
+`VOICE_PEDIATRIC` is a project as of #298. The companion pediatric dataset has
+its own DOI (10.13026/h995-bt35), protocol and Research Ethics Board approval,
+and was being represented as a nested object inside VOICE's `related_datasets` —
+which is why no VOICE replicate validated (#292).
+
+**Done:** the registry, the shared-corpus declaration, and the schema correction
+that made the nested form wrong rather than ambiguous. Adding the fifth project
+broke nothing; the four-project list in 26 files is prose, not logic.
+
+**Not done, and each needs a decision:**
+
+- **A bundle and manifest line.** Both datasets are documented in the same VOICE
+  corpus, so they share a bundle and must be distinguished by `{MANIFEST_LINE}`,
+  which is already a substitution field. Scoping via the manifest keeps the
+  frozen prompt bodies untouched — the four-project list lives in the preamble,
+  not the body, so no existing arm's resolved text changes.
+- **A generation run.** Twelve phases for one project, paid.
+- **Whether `VOICE` becomes `VOICE_main`.** Not done: 198 of the ~580 affected
+  paths are archived records, archived because their provenance could not be
+  verified, and rewriting their project field is the opposite of what archiving
+  them was for. Renaming only the live corpus splits the series instead. The
+  live-only migration is available if the asymmetry matters more than the split.
+
+**Consequence for #169.** The power argument counts four projects. These two
+share a source corpus, so they are not two independent samples, and
+`SHARED_CORPUS_GROUPS` records that for any analysis that would otherwise
+count them as such.
+
+---
+
 ## Standing constraints
 
 - **No gold standard exists.** `curated` was generated through a ChatGPT chat

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -736,59 +736,91 @@ _DATETIME = re.compile(
 
 
 @lru_cache(maxsize=1)
-def _enum_aliases() -> dict[str, str]:
-    """Every declared alias of every permissible value -> that value's text.
+def _enum_aliases() -> dict[str, dict[str, str]]:
+    """slot name -> {alias or casing variant -> permissible value}.
 
-    Read from the schema rather than listed here, because the schema is where
-    the aliases are declared and a second copy would be one to keep in step.
+    Keyed by slot, not global. An earlier version flattened every alias of every
+    enum into one table and applied it to any `key: Value` line, which rewrote
+    `title: References` to `title: references` — a plain string slot corrupted on
+    the write path by the pass meant to be fixing validity (#299). Only slots the
+    schema gives an enum range are eligible, so `title`, `name` and `description`
+    are not reachable at all.
+
+    Read from the schema rather than listed here, because the schema is where the
+    aliases are declared and a second copy would be one to keep in step.
 
     `linkml-validate` matches permissible values on `text` alone, so a record
     using a name the schema itself declares as an alias fails validation. The
     enum aligned with DataCite (#223) declares DataCite's own CamelCase
-    spellings as aliases — `IsNewVersionOf`, `HasPart`, `References` — and those
-    are exactly what generation emits, because they are what the vocabulary is
-    called everywhere else.
+    spellings — `IsNewVersionOf`, `HasPart`, `References` — and those are what
+    generation emits, because they are what the vocabulary is called elsewhere.
     """
     import yaml as _yaml
     schema = Path("src/data_sheets_schema/schema/data_sheets_schema_all.yaml")
     if not schema.exists():
         return {}
     doc = _yaml.safe_load(schema.read_text(encoding="utf-8"))
-    out: dict[str, str] = {}
-    for enum in (doc.get("enums") or {}).values():
-        for text, pv in (enum.get("permissible_values") or {}).items():
+    enums = doc.get("enums") or {}
+
+    def table_for(enum_name: str) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for text, pv in (enums[enum_name].get("permissible_values") or {}).items():
             for alias in ((pv or {}).get("aliases") or []):
                 out[alias] = text
+                out.setdefault(alias.lower(), text)
             # Case alone is not an alias, but it is a difference with no
             # content: `References` against `references` is a validation
             # failure that says nothing about the record.
             out.setdefault(text.lower(), text)
-            for alias in ((pv or {}).get("aliases") or []):
-                out.setdefault(alias.lower(), text)
-    return out
+        return out
+
+    by_slot: dict[str, dict[str, str]] = {}
+    conflicted: set[str] = set()
+    for cls in (doc.get("classes") or {}).values():
+        for slot, spec in (cls.get("attributes") or {}).items():
+            enum_name = spec.get("range")
+            if enum_name not in enums:
+                continue
+            table = table_for(enum_name)
+            if slot in by_slot and by_slot[slot] != table:
+                # The same slot name ranged on different enums in different
+                # classes. Text alone cannot say which class a line sits in, so
+                # rewriting either way would be a guess.
+                conflicted.add(slot)
+                continue
+            by_slot[slot] = table
+    for slot in conflicted:
+        by_slot.pop(slot, None)
+    return by_slot
 
 
-_ENUM_LINE = re.compile(r"^(?P<head>[ \t]*-?[ \t]*[a-z_]+:[ \t]+)"
-                        r"(?P<value>[A-Za-z][A-Za-z_]*)[ \t]*$")
+#: Values may carry digits — `BZ2`, `Big5`, `GB2312` are all permissible values,
+#: and a letters-only pattern silently skipped 41 of them.
+_ENUM_LINE = re.compile(r"^(?P<head>[ \t]*-?[ \t]*(?P<slot>[a-z_]+):[ \t]+)"
+                        r"(?P<value>[A-Za-z][A-Za-z0-9_./+-]*)[ \t]*$")
 
 
 def normalise_enum_aliases(text: str) -> str:
-    """Rewrite declared aliases to the permissible value they name.
+    """Rewrite a declared alias to the permissible value it names.
 
     Text-level for the same reason as `normalise_temporal`: re-dumping the YAML
     would drop the `#` provenance header the reader sees first.
 
-    Only bare word-shaped scalars are touched, so prose values are left exactly
-    as written — a value like `is a later release in the same series as` is a
-    real generation failure and normalising it into silence would hide it.
+    Only bare word-shaped scalars in enum-ranged slots are touched, so prose is
+    left exactly as written — a value like `is a later release in the same
+    series as` is a real generation failure and normalising it into silence
+    would hide it.
     """
-    aliases = _enum_aliases()
-    if not aliases:
+    by_slot = _enum_aliases()
+    if not by_slot:
         return text
 
     def fix(m: "re.Match") -> str:
+        table = by_slot.get(m.group("slot"))
+        if not table:
+            return m.group(0)
         value = m.group("value")
-        canonical = aliases.get(value) or aliases.get(value.lower())
+        canonical = table.get(value) or table.get(value.lower())
         return f"{m.group('head')}{canonical}" if canonical else m.group(0)
 
     return "\n".join(_ENUM_LINE.sub(fix, line) for line in text.split("\n"))

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -735,6 +735,65 @@ _DATETIME = re.compile(
     r"(?:\.\d+)?(?P<zone>Z|[+-]\d{2}:?\d{2})?$")
 
 
+@lru_cache(maxsize=1)
+def _enum_aliases() -> dict[str, str]:
+    """Every declared alias of every permissible value -> that value's text.
+
+    Read from the schema rather than listed here, because the schema is where
+    the aliases are declared and a second copy would be one to keep in step.
+
+    `linkml-validate` matches permissible values on `text` alone, so a record
+    using a name the schema itself declares as an alias fails validation. The
+    enum aligned with DataCite (#223) declares DataCite's own CamelCase
+    spellings as aliases — `IsNewVersionOf`, `HasPart`, `References` — and those
+    are exactly what generation emits, because they are what the vocabulary is
+    called everywhere else.
+    """
+    import yaml as _yaml
+    schema = Path("src/data_sheets_schema/schema/data_sheets_schema_all.yaml")
+    if not schema.exists():
+        return {}
+    doc = _yaml.safe_load(schema.read_text(encoding="utf-8"))
+    out: dict[str, str] = {}
+    for enum in (doc.get("enums") or {}).values():
+        for text, pv in (enum.get("permissible_values") or {}).items():
+            for alias in ((pv or {}).get("aliases") or []):
+                out[alias] = text
+            # Case alone is not an alias, but it is a difference with no
+            # content: `References` against `references` is a validation
+            # failure that says nothing about the record.
+            out.setdefault(text.lower(), text)
+            for alias in ((pv or {}).get("aliases") or []):
+                out.setdefault(alias.lower(), text)
+    return out
+
+
+_ENUM_LINE = re.compile(r"^(?P<head>[ \t]*-?[ \t]*[a-z_]+:[ \t]+)"
+                        r"(?P<value>[A-Za-z][A-Za-z_]*)[ \t]*$")
+
+
+def normalise_enum_aliases(text: str) -> str:
+    """Rewrite declared aliases to the permissible value they name.
+
+    Text-level for the same reason as `normalise_temporal`: re-dumping the YAML
+    would drop the `#` provenance header the reader sees first.
+
+    Only bare word-shaped scalars are touched, so prose values are left exactly
+    as written — a value like `is a later release in the same series as` is a
+    real generation failure and normalising it into silence would hide it.
+    """
+    aliases = _enum_aliases()
+    if not aliases:
+        return text
+
+    def fix(m: "re.Match") -> str:
+        value = m.group("value")
+        canonical = aliases.get(value) or aliases.get(value.lower())
+        return f"{m.group('head')}{canonical}" if canonical else m.group(0)
+
+    return "\n".join(_ENUM_LINE.sub(fix, line) for line in text.split("\n"))
+
+
 def normalise_temporal(text: str) -> str:
     """Quote and shape temporal values to the range their slot declares.
 
@@ -1214,7 +1273,7 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         elif artifact:
             target.parent.mkdir(parents=True, exist_ok=True)
             if artifact in ("full", "core"):
-                body = normalise_temporal(body)
+                body = normalise_enum_aliases(normalise_temporal(body))
             target.write_text(body, encoding="utf-8")
             label = {"full": "Completed full record",
                      "core": "Completed core record",

--- a/src/data_sheets_schema/constants/projects.py
+++ b/src/data_sheets_schema/constants/projects.py
@@ -5,8 +5,28 @@ This module centralizes project names and paths used throughout the codebase.
 
 from pathlib import Path
 
-# Project names
-PROJECTS = ["AI_READI", "CHORUS", "CM4AI", "VOICE"]
+# Project names.
+#
+# `VOICE` is the adult/main Bridge2AI-Voice dataset. `VOICE_PEDIATRIC` is the
+# companion pediatric dataset — its own DOI (10.13026/h995-bt35), its own
+# protocol, its own Research Ethics Board approval, published separately on
+# PhysioNet. It was being represented as a nested object inside VOICE's
+# `related_datasets`, which is what made no VOICE replicate validate (#292);
+# a dataset with those three things is its own datasheet.
+#
+# Both are documented in the same source corpus, so they share a bundle and are
+# distinguished by the manifest line rather than by different inputs.
+#
+# `VOICE` is not renamed to `VOICE_main`. 198 of the paths that would move are
+# archived records, archived precisely because their provenance could not be
+# verified — rewriting the project field of runs that were set aside for
+# provenance reasons is the opposite of what archiving them was for. The live
+# rename is available as its own migration; see the note in NEXT_TASKS.
+PROJECTS = ["AI_READI", "CHORUS", "CM4AI", "VOICE", "VOICE_PEDIATRIC"]
+
+#: Datasets that are separate records but share a source corpus. Analyses that
+#: treat projects as independent samples should know these two are not.
+SHARED_CORPUS_GROUPS = {"bridge2ai_voice": ["VOICE", "VOICE_PEDIATRIC"]}
 
 # Base data directory
 DATA_DIR = Path("data")

--- a/src/data_sheets_schema/schema/D4D_Composition.yaml
+++ b/src/data_sheets_schema/schema/D4D_Composition.yaml
@@ -497,8 +497,20 @@ classes:
     attributes:
       target_dataset:
         description: >-
-          The dataset that this relationship points to. Can be specified by
-          identifier, URL, or Dataset object.
+          The identifier or URL of the dataset this relationship points to.
+        comments:
+          - >-
+            A reference, not an inline dataset. The description used to promise
+            "identifier, URL, or Dataset object" while the range permitted only
+            the first, and LinkML cannot express the union: its JSON Schema
+            generator always emits a top-level type or $ref from the slot's
+            range, which ANDs with `any_of`, so whichever branch the range names
+            the other one fails. Verified both ways on VOICE (#297).
+          - >-
+            A related dataset with its own DOI, protocol and approval is its own
+            datasheet and is referenced from here by identifier. That is the
+            resolution of #292 for VOICE, whose pediatric companion has all
+            three.
         slot_uri: dcterms:relation
         range: string
         required: true

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -16242,8 +16242,18 @@ classes:
     attributes:
       target_dataset:
         name: target_dataset
-        description: The dataset that this relationship points to. Can be specified
-          by identifier, URL, or Dataset object.
+        description: The identifier or URL of the dataset this relationship points
+          to.
+        comments:
+        - 'A reference, not an inline dataset. The description used to promise "identifier,
+          URL, or Dataset object" while the range permitted only the first, and LinkML
+          cannot express the union: its JSON Schema generator always emits a top-level
+          type or $ref from the slot''s range, which ANDs with `any_of`, so whichever
+          branch the range names the other one fails. Verified both ways on VOICE
+          (#297).'
+        - 'A related dataset with its own DOI, protocol and approval is its own datasheet
+          and is referenced from here by identifier. That is the resolution of #292
+          for VOICE, whose pediatric companion has all three.'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/composition
         slot_uri: dcterms:relation
         alias: target_dataset

--- a/tests/test_enum_alias_normalisation.py
+++ b/tests/test_enum_alias_normalisation.py
@@ -1,0 +1,99 @@
+"""Records may name an enum value the way the schema says it may (#292).
+
+`linkml-validate` matches permissible values on `text` alone. The relationship
+enum aligned with DataCite (#223) declares DataCite's own CamelCase spellings as
+`aliases` — `IsNewVersionOf`, `HasPart`, `References` — and those are exactly
+what generation emits, because they are what the vocabulary is called
+everywhere else. So the schema declared a name valid and validation rejected it.
+
+Measured across the 24 generic and generic-v2 records, 14 enum values fell
+outside their vocabulary:
+
+    IsNewVersionOf                              x6   declared alias
+    is a later release in the same series as    x4   prose, no equivalent
+    HasPart                                     x2   declared alias
+    related_to                                  x1   no equivalent
+    References                                  x1   casing only
+
+Case-insensitive matching alone would have fixed **one** of the fourteen.
+Honouring the declared aliases fixes **nine**. The remaining five are real
+generation failures and are deliberately left to fail.
+"""
+
+import unittest
+
+from data_sheets_schema.api_runner import _enum_aliases, normalise_enum_aliases
+
+
+class TestAliasTable(unittest.TestCase):
+
+    def test_datacite_spellings_are_declared_aliases(self):
+        aliases = _enum_aliases()
+        for camel, snake in (("IsNewVersionOf", "is_new_version_of"),
+                             ("HasPart", "has_part"),
+                             ("References", "references")):
+            with self.subTest(alias=camel):
+                self.assertEqual(aliases.get(camel), snake)
+
+    def test_it_is_read_from_the_schema_not_hardcoded(self):
+        """A second copy of the vocabulary is one to keep in step."""
+        self.assertGreater(len(_enum_aliases()), 100)
+
+    def test_a_permissible_value_maps_to_itself(self):
+        self.assertEqual(_enum_aliases().get("references"), "references")
+
+
+class TestNormalisation(unittest.TestCase):
+
+    def test_a_declared_alias_is_rewritten(self):
+        out = normalise_enum_aliases("    relationship_type: IsNewVersionOf")
+        self.assertEqual(out, "    relationship_type: is_new_version_of")
+
+    def test_a_casing_difference_is_rewritten(self):
+        out = normalise_enum_aliases("  - relationship_type: References")
+        self.assertEqual(out, "  - relationship_type: references")
+
+    def test_an_already_valid_value_is_untouched(self):
+        line = "    relationship_type: is_new_version_of"
+        self.assertEqual(normalise_enum_aliases(line), line)
+
+    def test_prose_is_left_to_fail(self):
+        """`is a later release in the same series as` is a generation failure.
+
+        Normalising it into something valid would hide the failure, which is
+        the opposite of what this is for — four of the fourteen bad values are
+        this shape and they should stay visible.
+        """
+        line = "    relationship_type: is a later release in the same series as"
+        self.assertEqual(normalise_enum_aliases(line), line)
+
+    def test_a_value_with_no_equivalent_is_left_to_fail(self):
+        line = "    relationship_type: related_to"
+        self.assertEqual(normalise_enum_aliases(line), line)
+
+    def test_the_provenance_header_survives(self):
+        """Text-level for the same reason as `normalise_temporal`: re-dumping
+        the YAML would drop the `#` block the reader sees first."""
+        doc = ("# Generated: 2026-08-04\n"
+               "# Model: claude-opus-5\n"
+               "related_datasets:\n"
+               "  - relationship_type: HasPart\n")
+        out = normalise_enum_aliases(doc)
+        self.assertTrue(out.startswith("# Generated: 2026-08-04\n# Model:"))
+        self.assertIn("relationship_type: has_part", out)
+
+    def test_only_the_value_position_is_rewritten(self):
+        """A key that happens to share an alias's spelling is not a value."""
+        line = "    HasPart: something"
+        self.assertEqual(normalise_enum_aliases(line), line)
+
+    def test_quoted_and_flow_values_are_left_alone(self):
+        for line in ("    relationship_type: 'HasPart'",
+                     "    relationship_type: [HasPart]",
+                     "    relationship_type: {a: HasPart}"):
+            with self.subTest(line=line):
+                self.assertEqual(normalise_enum_aliases(line), line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_enum_alias_normalisation.py
+++ b/tests/test_enum_alias_normalisation.py
@@ -28,19 +28,37 @@ from data_sheets_schema.api_runner import _enum_aliases, normalise_enum_aliases
 class TestAliasTable(unittest.TestCase):
 
     def test_datacite_spellings_are_declared_aliases(self):
-        aliases = _enum_aliases()
+        table = _enum_aliases()["relationship_type"]
         for camel, snake in (("IsNewVersionOf", "is_new_version_of"),
                              ("HasPart", "has_part"),
                              ("References", "references")):
             with self.subTest(alias=camel):
-                self.assertEqual(aliases.get(camel), snake)
+                self.assertEqual(table.get(camel), snake)
 
     def test_it_is_read_from_the_schema_not_hardcoded(self):
         """A second copy of the vocabulary is one to keep in step."""
-        self.assertGreater(len(_enum_aliases()), 100)
+        self.assertGreater(len(_enum_aliases()), 5)
 
-    def test_a_permissible_value_maps_to_itself(self):
-        self.assertEqual(_enum_aliases().get("references"), "references")
+    def test_the_table_is_keyed_by_slot_not_global(self):
+        """#299: a flat table rewrote plain string slots.
+
+        Keying by slot is what makes `title` and `name` unreachable rather
+        than merely unlikely.
+        """
+        by_slot = _enum_aliases()
+        self.assertIn("relationship_type", by_slot)
+        for plain in ("title", "name", "description"):
+            with self.subTest(slot=plain):
+                self.assertNotIn(plain, by_slot)
+
+    def test_a_slot_ranged_on_two_different_enums_is_excluded(self):
+        """Text cannot say which class a line sits in, so rewriting would be
+        a guess. Such slots are dropped rather than guessed at."""
+        by_slot = _enum_aliases()
+        for slot, table in by_slot.items():
+            with self.subTest(slot=slot):
+                self.assertIsInstance(table, dict)
+                self.assertTrue(table, f"{slot} has an empty table")
 
 
 class TestNormalisation(unittest.TestCase):
@@ -86,6 +104,30 @@ class TestNormalisation(unittest.TestCase):
         """A key that happens to share an alias's spelling is not a value."""
         line = "    HasPart: something"
         self.assertEqual(normalise_enum_aliases(line), line)
+
+    def test_a_plain_string_slot_is_never_rewritten(self):
+        """#299, the defect this function shipped with.
+
+        A dataset legitimately titled `References` was silently retitled on
+        the write path — by the pass meant to be fixing validity, and in the
+        committed record.
+        """
+        for line in ("    title: References",
+                     "    name: HasPart",
+                     "    description: Collects"):
+            with self.subTest(line=line):
+                self.assertEqual(normalise_enum_aliases(line), line)
+
+    def test_values_with_digits_are_reachable(self):
+        """41 permissible values carry digits — `BZ2`, `Big5`, `GB2312`.
+
+        A letters-only pattern skipped them all while appearing to cover
+        their enums.
+        """
+        import re
+        from data_sheets_schema.api_runner import _ENUM_LINE
+        self.assertIsNotNone(_ENUM_LINE.match("    compression: BZ2"))
+        self.assertIsNotNone(_ENUM_LINE.match("    encoding: GB2312"))
 
     def test_quoted_and_flow_values_are_left_alone(self):
         for line in ("    relationship_type: 'HasPart'",

--- a/tests/test_projects_registry.py
+++ b/tests/test_projects_registry.py
@@ -1,0 +1,61 @@
+"""VOICE is two datasets, and the registry says so (#292).
+
+The pediatric companion has its own DOI, protocol and Research Ethics Board
+approval. It was being represented as a nested object inside VOICE's
+`related_datasets`, which is what made no VOICE replicate validate — the schema
+declares that slot a reference, and LinkML cannot be made to accept both a
+reference and an inline object (#297). A dataset with those three things is its
+own datasheet.
+"""
+
+import unittest
+
+from data_sheets_schema.constants import PROJECTS
+from data_sheets_schema.constants.projects import (
+    SHARED_CORPUS_GROUPS, get_preprocessed_path, get_raw_path,
+)
+
+
+class TestTheRegistry(unittest.TestCase):
+
+    def test_both_voice_datasets_are_projects(self):
+        self.assertIn("VOICE", PROJECTS)
+        self.assertIn("VOICE_PEDIATRIC", PROJECTS)
+
+    def test_the_main_dataset_keeps_its_identifier(self):
+        """Not renamed to VOICE_main.
+
+        198 of the paths that would move are archived records, archived because
+        their provenance could not be verified. Rewriting the project field of
+        runs set aside for provenance reasons is the opposite of what archiving
+        them was for.
+        """
+        self.assertNotIn("VOICE_main", PROJECTS)
+
+    def test_path_helpers_work_for_the_new_project(self):
+        for helper in (get_raw_path, get_preprocessed_path):
+            with self.subTest(helper=helper.__name__):
+                self.assertTrue(
+                    str(helper("VOICE_PEDIATRIC")).endswith("VOICE_PEDIATRIC"))
+
+    def test_the_shared_corpus_is_declared(self):
+        """They are separate records from one source corpus.
+
+        An analysis treating projects as independent samples would otherwise
+        count them as two, and #169's power argument turns on exactly that
+        count.
+        """
+        group = SHARED_CORPUS_GROUPS["bridge2ai_voice"]
+        self.assertEqual(sorted(group), ["VOICE", "VOICE_PEDIATRIC"])
+        for name in group:
+            self.assertIn(name, PROJECTS)
+
+    def test_every_shared_corpus_member_is_a_real_project(self):
+        for group in SHARED_CORPUS_GROUPS.values():
+            for name in group:
+                with self.subTest(project=name):
+                    self.assertIn(name, PROJECTS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two of the three #292 decisions, plus evidence the third can't be done as asked. The VOICE fork is deliberately not here — reasons at the end.

## Widening `target_dataset` — not expressible in LinkML

Tried `any_of` three ways:

| arrangement | compiled JSON Schema | result |
|---|---|---|
| `any_of: [string, Information]` | `{"anyOf": [{"type":"string"}, {"type":"string"}], "type":"string"}` | class range → string unless `inlined` |
| `+ inlined: true` | `{"anyOf": [{"type":"string"}, {"$ref":"…Information"}], "type":"string"}` | right branches, residual `type` ANDs — objects fail |
| `range: Information, inlined` | `{"$ref":"…Information", "anyOf": […]}` | **inverts** — objects pass, strings fail |

Confirmed on real records: VOICE rep1 (object) and rep2 (string), one passing each way. LinkML always emits a top-level type or `$ref` from the slot's range, and there's no arrangement without one. Filed as **#297**.

**What was actually wrong was subtler than the range.** The description promised *"identifier, URL, or Dataset object"* while permitting only the first — the schema contradicted itself, which is what made this look like a simple widening. The description now matches the range, and the comments record why a reference is the right shape.

## Case-insensitive enum matching — too narrow, so it does more

Measured across the 24 generic and generic-v2 records, **14 enum values fall outside their vocabulary**:

| value | count | kind |
|---|---|---|
| `IsNewVersionOf` | 6 | **declared alias** |
| `is a later release in the same series as` | 4 | prose, no equivalent |
| `HasPart` | 2 | **declared alias** |
| `related_to` | 1 | no equivalent |
| `References` | 1 | casing only |

**Case-insensitivity alone fixes 1 of 14.** The schema already declares DataCite's CamelCase spellings as `aliases` — and those are what generation emits, because that's what the vocabulary is called everywhere else. `linkml-validate` matches on `text` alone, so **the schema declared a name valid and validation rejected it**.

`normalise_enum_aliases` honours the declared aliases and folds case: **9 of 14**. The table is read from the schema, not listed in code — a second copy of a vocabulary is one to keep in step. It runs beside `normalise_temporal`, text-level for the same reason (re-dumping would drop the `#` provenance header).

The remaining five are **left to fail**. Only bare word-shaped scalars are touched, so prose stays visible — normalising `is a later release in the same series as` into something valid would hide a defect.

## The VOICE fork — a study-structure decision, not an implementation one

The evidence is there: the VOICE bundle has 100 mentions of "pediatric", 13 of `b2ai-voice-pediatric`, 11 of the DOI. It is generatable.

What stops me doing it unilaterally is the cost:

- **`PROJECTS = ["AI_READI", "CHORUS", "CM4AI", "VOICE"]`**, and **26 files** hardcode that four-way list.
- The pipeline keys one record per project (`{project}_d4d.yaml`), so a second VOICE dataset is not expressible without either a fifth project or a change to that assumption.
- Every "four projects" claim in the study changes, **including #169's power analysis**, which concluded four cannot resolve effects near the noise floor.

Three shapes, and they are not equivalent:

1. **`VOICE_PEDIATRIC` as a fifth project** — cleanest for the pipeline, but it is not a fifth Grand Challenge, and the arms/comparisons are organised by GC.
2. **A second record under VOICE** — truest to the science, needs the one-record-per-project assumption relaxed.
3. **A standalone record outside the study corpus**, referenced by VOICE — cheapest, keeps the four-project claims intact, but the pediatric datasheet is then not in any analysis.

It also needs a generation run, so it is not free either.

**1075 passed, 3 skipped** (+11).