### PR TITLE
Scope VOICE_PEDIATRIC by its bundle (NEXT_TASKS §9)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -296,17 +296,31 @@ broke nothing; the four-project list in 26 files is prose, not logic.
 
 **Not done, and each needs a decision:**
 
-- **A bundle and manifest line.** Both datasets are documented in the same VOICE
-  corpus, so they share a bundle and must be distinguished by `{MANIFEST_LINE}`,
-  which is already a substitution field. Scoping via the manifest keeps the
-  frozen prompt bodies untouched — the four-project list lives in the preamble,
-  not the body, so no existing arm's resolved text changes.
+- **A scoped bundle — done.** `{MANIFEST_LINE}` was the wrong mechanism and the
+  claim here was wrong: it is substituted into the *output record's* header
+  block as a provenance comment, not into the instruction. The frozen body says
+  "DECLARED INPUT BUNDLE — your only source of dataset facts: {BUNDLE}", so the
+  bundle is the scope. `VOICE_PEDIATRIC` now has a manifest selection of six
+  sources — the pediatric PhysioNet record plus the programme documents that
+  cover it — and its own 204 KB bundle. The three adult version pages and the
+  two adult-cohort papers are excluded: they carry no pediatric content, and
+  including them would import adult facts into a pediatric datasheet, which is
+  the failure the fitness axis calls `target`.
+
+  The VOICE bundle is byte-identical (md5 `e637eb75`, what 49 runs attest), and
+  a test pins it.
 - **A generation run.** Twelve phases for one project, paid.
-- **Whether `VOICE` becomes `VOICE_main`.** Not done: 198 of the ~580 affected
-  paths are archived records, archived because their provenance could not be
-  verified, and rewriting their project field is the opposite of what archiving
-  them was for. Renaming only the live corpus splits the series instead. The
-  live-only migration is available if the asymmetry matters more than the split.
+- **Whether `VOICE` becomes `VOICE_main` — decided: no.** Attempted and reverted.
+  The path moves were clean (567 files, no clashes), but the content rewrite
+  broke attestation two ways that no amount of care avoids: record bodies carry
+  `VOICE` in titles and prose and their byte counts are recorded in provenance,
+  so rewriting them failed 33 runs outright; and `source_manifest.yaml` is keyed
+  by project and its md5 is recorded by **115 runs**, so renaming the project
+  necessarily changes a file those runs attest.
+
+  Renaming would convert attested runs into reconstructed ones — the same
+  property that got the 2026-04-10 series archived. `VOICE` therefore keeps its
+  identifier and `VOICE_PEDIATRIC` carries the distinction.
 
 **Consequence for #169.** The power argument counts four projects. These two
 share a source corpus, so they are not two independent samples, and

--- a/data/preprocessed/concatenated/VOICE_PEDIATRIC_preprocessed.txt
+++ b/data/preprocessed/concatenated/VOICE_PEDIATRIC_preprocessed.txt
@@ -1,0 +1,2872 @@
+================================================================================
+CONCATENATED DOCUMENT
+================================================================================
+Input Directory: data/preprocessed/individual/VOICE
+Total Files: 6
+Extensions: ['.txt']
+Recursive: False
+Selection Manifest: data/preprocessed/source_manifest.yaml
+================================================================================
+
+TABLE OF CONTENTS
+--------------------------------------------------------------------------------
+  1. physionet_b2ai-voice-pediatric_1.1.0_2026-07-24.txt
+  2. gdrive_1gTFzAM-FoYlM_X9qF0s7fXoswmaz8IqN_row13.txt
+  3. docs_b2ai-voice_org_row10.txt
+  4. reporter_nih_gov_project-details-11376382_row7.txt
+  5. gdrive_1z4zZ_Z_Jb017IoVZn5btJnSLKdEOHZPA_row14.txt
+  6. github_eipm_bridge2ai-docs_README_row22.txt
+================================================================================
+
+FILE: physionet_b2ai-voice-pediatric_1.1.0_2026-07-24.txt
+PATH: data/preprocessed/individual/VOICE/physionet_b2ai-voice-pediatric_1.1.0_2026-07-24.txt
+SIZE: 31586 bytes
+--------------------------------------------------------------------------------
+
+SOURCE METADATA
+Project: VOICE
+Source ID: physionet_pediatric_1_1_0
+Source type: data resource
+Source URL: https://physionet.org/content/b2ai-voice-pediatric/1.1.0/
+Raw file: data/raw/VOICE/physionet_b2ai-voice-pediatric_1.1.0_2026-07-24.html
+Curation note: Current Bridge2AI-Voice pediatric release, published 2026-05-01, 300 participants aged 2-18, 23,533 derived recordings, credentialed access. This is a separate PhysioNet project from the adult b2ai-voice dataset, not a version of it; the two releases are distinct cohorts collected under a separate pediatric protocol, with pediatric participants recruited at the Hospital for Sick Children (SickKids). Raw pediatric audio is distributed via Synapse (syn73617068) rather than PhysioNet. Added because the current VOICE documentation advertises pediatric v1.1.0 alongside adult v3.1.0 while the input sheet lists no pediatric source at all. Pediatric v1.0.0 exists upstream but is superseded and was not captured.
+Verification URL: https://physionet.org/content/b2ai-voice-pediatric/
+--------------------------------------------------------------------------------
+Bridge2AI-Voice Pediatric Dataset v1.1.0
+Menu
+Share
+About
+FAQs
+Explore
+Data
+View datasets
+Software
+View software
+Challenges
+View challenges
+Tutorials
+View tutorials
+Cancel
+Search
+Search PhysioNet
+Log in
+Share
+About
+FAQs
+Data
+View datasets
+Software
+View software
+Challenges
+View challenges
+Tutorials
+View tutorials
+Database
+Credentialed Access
+Bridge2AI-Voice Pediatric Dataset
+Yael Bensoussan
+,
+Alexandros Sigaras
+,
+Anais Rameau
+,
+Olivier Elemento
+,
+Maria Powell
+,
+David Dorr
+,
+Philip Payne
+,
+Vardit Ravitsky
+,
+Jean-Christophe Bélisle-Pipon
+,
+Ruth Bahr
+,
+Stephanie Watts
+,
+Donald Bolser
+,
+Jennifer Siu
+,
+Jordan Lerner-Ellis
+,
+Frank Rudzicz
+,
+Micah Boyer
+,
+Yassmeen Abdel-Aty
+,
+Toufeeq Ahmed Syed
+,
+Dona Amraei
+,
+James Anibal
+,
+Stephen Aradi
+,
+Kirollos Armosh
+,
+Ana Sophia Martinez
+,
+Shaheen Awan
+,
+Steven Bedrick
+,
+Helena Beltran
+,
+Alexander Bernier
+,
+Moroni Berrios
+,
+Isaac Bevers
+,
+Alden Blatter
+,
+Rahul Brito
+,
+Amy Brown
+,
+Johnathan Brown
+,
+Léo Cadillac
+,
+Selina Casalino
+,
+John Costello
+,
+Abhijeet Dalal
+,
+Iris De Santiago
+,
+Enrique Diaz-Ocampo
+,
+Amanda Doherty-Kirby
+,
+Mohamed Ebraheem
+,
+Ellie Eiseman
+,
+Mahmoud Elmahdy
+,
+Renee English
+,
+Emily Evangelista
+,
+Kenneth Fletcher
+,
+Hortense Gallois
+,
+Gaelyn Garrett
+,
+Alexander Gelbard
+,
+Omar Ghaffar
+,
+Anna Goldenberg
+,
+Karim Hanna
+,
+William Hersh
+,
+Jennifer Jain
+,
+Lochana Jayachandran
+,
+Kaley Jenney
+,
+Kathy Jenkins
+,
+Stacy Jo
+,
+Alistair Johnson
+,
+Ayush Kalia
+,
+Megha Kalia
+,
+Zoha Khawa
+,
+Kenji Kobayashi
+,
+Cindy Kostelnik
+,
+Alisa Krause
+,
+Andrea Krussel
+,
+Elisa Lapadula
+,
+Genelle Leo
+,
+Justin Levinsky
+,
+Chloe Loewith
+,
+Radhika Mahajan
+,
+Vrishni Maharaj
+,
+Siyu Miao
+,
+LeAnn Michaels
+,
+Matthew Mifsud
+,
+Marian Mikhael
+,
+Elijah Moothedan
+,
+Yosef Nafii
+,
+Tempestt Neal
+,
+Karlee Newberry
+,
+Evan Ng
+,
+Christopher Nickel
+,
+Amanda Peltier
+,
+Trevor Pharr
+,
+Michaela Pnacekova
+,
+Matthew Pontell
+,
+Jaiden Potter
+,
+Claire Premi-Bortolotto
+,
+Parnaz Rafatjou
+,
+JM Rahman
+,
+Gayathiri Rajkumar
+,
+John Ramos
+,
+Michael de Riesthal
+,
+Sarah Rohde
+,
+Jillian Rossi
+,
+Laurie Russell
+,
+Samantha Salvi Cruz
+,
+Joyce Samuel
+,
+Suketu Shah
+,
+Ahmed Shawkat
+,
+Elizabeth Silberholz
+,
+John Stark
+,
+Lala Su
+,
+Shrramana Ganesh Sudhakar
+,
+Duncan Sutherland
+,
+Venkata Swarna Mukhi
+,
+Jeffrey Tang
+,
+Luka Taylor
+,
+Jamie Toghranegar
+,
+Julie Tu
+,
+Megan Urbano
+,
+Gavin Victor
+,
+Kimberly Vinson
+,
+Jordan Wilke
+,
+Claire Wilson
+,
+Madeleine Zanin
+,
+Xijie Zeng
+,
+Theresa Zesiewicz
+,
+Robin Zhao
+,
+Pantelis Zisimopoulos
+,
+Satrajit Ghosh
+Published: May 1, 2026. Version:
+1.1.0
+Raw Audio Data Access for Bridge2AI Voice Pediatric Cohort is via Synapse
+(March 9, 2026, 10:07 a.m.)
+The published Bridge2AI-Voice Pediatric Dataset contains derived features from the audio waveforms. This PhysioNet project does not contain raw audios.
+Accessing raw audio is a more involved process and requires institutional sign off. Please reach out to the access committee if you are interested in access: DACO@b2ai-voice.org
+Data will be made available via Synapse
+:
+https://www.synapse.org/Synapse:syn73617068
+For questions regarding the dataset itself, please contact the corresponding author, listed on the sidebar.
+Note that the Bridge2AI-Voice Adult Dataset is also available on PhysioNet:
+https://physionet.org/content/b2ai-voice/
+When using this resource, please cite:
+Cite
+Copy BibTeX
+Bensoussan, Y., Sigaras, A., Rameau, A., Elemento, O., Powell, M., Dorr, D., Payne, P., Ravitsky, V., Bélisle-Pipon, J., Bahr, R., Watts, S., Bolser, D., Siu, J., Lerner-Ellis, J., Rudzicz, F., Boyer, M., Abdel-Aty, Y., Ahmed Syed, T., Amraei, D., ... Ghosh, S. (2026). Bridge2AI-Voice Pediatric Dataset (version 1.1.0).
+PhysioNet
+. RRID:SCR_007345.
+https://doi.org/10.13026/h995-bt35
+@article{PhysioNet-b2ai-voice-pediatric-1.1.0,
+author = {Bensoussan, Yael and Sigaras, Alexandros and Rameau, Anais and Elemento, Olivier and Powell, Maria and Dorr, David and Payne, Philip and Ravitsky, Vardit and Bélisle-Pipon, Jean-Christophe and Bahr, Ruth and Watts, Stephanie and Bolser, Donald and Siu, Jennifer and Lerner-Ellis, Jordan and Rudzicz, Frank and Boyer, Micah and Abdel-Aty, Yassmeen and {Ahmed Syed}, Toufeeq and Amraei, Dona and Anibal, James and Aradi, Stephen and Armosh, Kirollos and Martinez, Ana Sophia and Awan, Shaheen and Bedrick, Steven and Beltran, Helena and Bernier, Alexander and Berrios, Moroni and Bevers, Isaac and Blatter, Alden and Brito, Rahul and Brown, Amy and Brown, Johnathan and Cadillac, Léo and Casalino, Selina and Costello, John and Dalal, Abhijeet and {De Santiago}, Iris and Diaz-Ocampo, Enrique and Doherty-Kirby, Amanda and Ebraheem, Mohamed and Eiseman, Ellie and Elmahdy, Mahmoud and English, Renee and Evangelista, Emily and Fletcher, Kenneth and Gallois, Hortense and Garrett, Gaelyn and Gelbard, Alexander and Ghaffar, Omar and Goldenberg, Anna and Hanna, Karim and Hersh, William and Jain, Jennifer and Jayachandran, Lochana and Jenney, Kaley and Jenkins, Kathy and Jo, Stacy and Johnson, Alistair and Kalia, Ayush and Kalia, Megha and Khawa, Zoha and Kobayashi, Kenji and Kostelnik, Cindy and Krause, Alisa and Krussel, Andrea and Lapadula, Elisa and Leo, Genelle and Levinsky, Justin and Loewith, Chloe and Mahajan, Radhika and Maharaj, Vrishni and Miao, Siyu and Michaels, LeAnn and Mifsud, Matthew and Mikhael, Marian and Moothedan, Elijah and Nafii, Yosef and Neal, Tempestt and Newberry, Karlee and Ng, Evan and Nickel, Christopher and Peltier, Amanda and Pharr, Trevor and Pnacekova, Michaela and Pontell, Matthew and Potter, Jaiden and Premi-Bortolotto, Claire and Rafatjou, Parnaz and Rahman, JM and Rajkumar, Gayathiri and Ramos, John and {de Riesthal}, Michael and Rohde, Sarah and Rossi, Jillian and Russell, Laurie and {Salvi Cruz}, Samantha and Samuel, Joyce and Shah, Suketu and Shawkat, Ahmed and Silberholz, Elizabeth and Stark, John and Su, Lala and Sudhakar, Shrramana Ganesh and Sutherland, Duncan and {Swarna Mukhi}, Venkata and Tang, Jeffrey and Taylor, Luka and Toghranegar, Jamie and Tu, Julie and Urbano, Megan and Victor, Gavin and Vinson, Kimberly and Wilke, Jordan and Wilson, Claire and Zanin, Madeleine and Zeng, Xijie and Zesiewicz, Theresa and Zhao, Robin and Zisimopoulos, Pantelis and Ghosh, Satrajit},
+title = {{Bridge2AI-Voice Pediatric Dataset}},
+journal = {{PhysioNet}},
+year = {2026},
+month = may,
+note = {Version 1.1.0},
+doi = {10.13026/h995-bt35},
+url = {https://doi.org/10.13026/h995-bt35}
+}
+Cite
+×
+MLA
+Bensoussan, Yael, et al. "Bridge2AI-Voice Pediatric Dataset" (version 1.1.0).
+PhysioNet
+(2026). RRID:SCR_007345.
+https://doi.org/10.13026/h995-bt35
+APA
+Bensoussan, Y., Sigaras, A., Rameau, A., Elemento, O., Powell, M., Dorr, D., Payne, P., Ravitsky, V., Bélisle-Pipon, J., Bahr, R., Watts, S., Bolser, D., Siu, J., Lerner-Ellis, J., Rudzicz, F., Boyer, M., Abdel-Aty, Y., Ahmed Syed, T., Amraei, D., ... Ghosh, S. (2026). Bridge2AI-Voice Pediatric Dataset (version 1.1.0).
+PhysioNet
+. RRID:SCR_007345.
+https://doi.org/10.13026/h995-bt35
+Chicago
+Bensoussan, Yael, Sigaras, Alexandros, Rameau, Anais, Elemento, Olivier, Powell, Maria, Dorr, David, Payne, Philip, Ravitsky, Vardit, Bélisle-Pipon, Jean-Christophe, Bahr, Ruth, Watts, Stephanie, Bolser, Donald, Siu, Jennifer, Lerner-Ellis, Jordan, Rudzicz, Frank, Boyer, Micah, Abdel-Aty, Yassmeen, Ahmed Syed, Toufeeq, Amraei, Dona, Anibal, James, Aradi, Stephen, Armosh, Kirollos, Martinez, Ana Sophia, Awan, Shaheen, Bedrick, Steven, Beltran, Helena, Bernier, Alexander, Berrios, Moroni, Bevers, Isaac, Blatter, Alden, Brito, Rahul, Brown, Amy, Brown, Johnathan, Cadillac, Léo, Casalino, Selina, Costello, John, Dalal, Abhijeet, De Santiago, Iris, Diaz-Ocampo, Enrique, Doherty-Kirby, Amanda, Ebraheem, Mohamed, Eiseman, Ellie, Elmahdy, Mahmoud, English, Renee, Evangelista, Emily, Fletcher, Kenneth, Gallois, Hortense, Garrett, Gaelyn, Gelbard, Alexander, Ghaffar, Omar, Goldenberg, Anna, Hanna, Karim, Hersh, William, Jain, Jennifer, Jayachandran, Lochana, Jenney, Kaley, Jenkins, Kathy, Jo, Stacy, Johnson, Alistair, Kalia, Ayush, Kalia, Megha, Khawa, Zoha, Kobayashi, Kenji, Kostelnik, Cindy, Krause, Alisa, Krussel, Andrea, Lapadula, Elisa, Leo, Genelle, Levinsky, Justin, Loewith, Chloe, Mahajan, Radhika, Maharaj, Vrishni, Miao, Siyu, Michaels, LeAnn, Mifsud, Matthew, Mikhael, Marian, Moothedan, Elijah, Nafii, Yosef, Neal, Tempestt, Newberry, Karlee, Ng, Evan, Nickel, Christopher, Peltier, Amanda, Pharr, Trevor, Pnacekova, Michaela, Pontell, Matthew, Potter, Jaiden, Premi-Bortolotto, Claire, Rafatjou, Parnaz, Rahman, JM, Rajkumar, Gayathiri, Ramos, John, de Riesthal, Michael, Rohde, Sarah, Rossi, Jillian, Russell, Laurie, Salvi Cruz, Samantha, Samuel, Joyce, Shah, Suketu, Shawkat, Ahmed, Silberholz, Elizabeth, Stark, John, Su, Lala, Sudhakar, Shrramana Ganesh, Sutherland, Duncan, Swarna Mukhi, Venkata, Tang, Jeffrey, Taylor, Luka, Toghranegar, Jamie, Tu, Julie, Urbano, Megan, Victor, Gavin, Vinson, Kimberly, Wilke, Jordan, Wilson, Claire, Zanin, Madeleine, Zeng, Xijie, Zesiewicz, Theresa, Zhao, Robin, Zisimopoulos, Pantelis, and Satrajit Ghosh. "Bridge2AI-Voice Pediatric Dataset" (version 1.1.0).
+PhysioNet
+(2026). RRID:SCR_007345.
+https://doi.org/10.13026/h995-bt35
+Harvard
+Bensoussan, Y., Sigaras, A., Rameau, A., Elemento, O., Powell, M., Dorr, D., Payne, P., Ravitsky, V., Bélisle-Pipon, J., Bahr, R., Watts, S., Bolser, D., Siu, J., Lerner-Ellis, J., Rudzicz, F., Boyer, M., Abdel-Aty, Y., Ahmed Syed, T., Amraei, D., Anibal, J., Aradi, S., Armosh, K., Martinez, A. S., Awan, S., Bedrick, S., Beltran, H., Bernier, A., Berrios, M., Bevers, I., Blatter, A., Brito, R., Brown, A., Brown, J., Cadillac, L., Casalino, S., Costello, J., Dalal, A., De Santiago, I., Diaz-Ocampo, E., Doherty-Kirby, A., Ebraheem, M., Eiseman, E., Elmahdy, M., English, R., Evangelista, E., Fletcher, K., Gallois, H., Garrett, G., Gelbard, A., Ghaffar, O., Goldenberg, A., Hanna, K., Hersh, W., Jain, J., Jayachandran, L., Jenney, K., Jenkins, K., Jo, S., Johnson, A., Kalia, A., Kalia, M., Khawa, Z., Kobayashi, K., Kostelnik, C., Krause, A., Krussel, A., Lapadula, E., Leo, G., Levinsky, J., Loewith, C., Mahajan, R., Maharaj, V., Miao, S., Michaels, L., Mifsud, M., Mikhael, M., Moothedan, E., Nafii, Y., Neal, T., Newberry, K., Ng, E., Nickel, C., Peltier, A., Pharr, T., Pnacekova, M., Pontell, M., Potter, J., Premi-Bortolotto, C., Rafatjou, P., Rahman, J., Rajkumar, G., Ramos, J., de Riesthal, M., Rohde, S., Rossi, J., Russell, L., Salvi Cruz, S., Samuel, J., Shah, S., Shawkat, A., Silberholz, E., Stark, J., Su, L., Sudhakar, S. G., Sutherland, D., Swarna Mukhi, V., Tang, J., Taylor, L., Toghranegar, J., Tu, J., Urbano, M., Victor, G., Vinson, K., Wilke, J., Wilson, C., Zanin, M., Zeng, X., Zesiewicz, T., Zhao, R., Zisimopoulos, P., and Ghosh, S. (2026) 'Bridge2AI-Voice Pediatric Dataset' (version 1.1.0),
+PhysioNet
+. RRID:SCR_007345. Available at:
+https://doi.org/10.13026/h995-bt35
+Vancouver
+Bensoussan Y, Sigaras A, Rameau A, Elemento O, Powell M, Dorr D, Payne P, Ravitsky V, Bélisle-Pipon J, Bahr R, Watts S, Bolser D, Siu J, Lerner-Ellis J, Rudzicz F, Boyer M, Abdel-Aty Y, Ahmed Syed T, Amraei D, Anibal J, Aradi S, Armosh K, Martinez A S, Awan S, Bedrick S, Beltran H, Bernier A, Berrios M, Bevers I, Blatter A, Brito R, Brown A, Brown J, Cadillac L, Casalino S, Costello J, Dalal A, De Santiago I, Diaz-Ocampo E, Doherty-Kirby A, Ebraheem M, Eiseman E, Elmahdy M, English R, Evangelista E, Fletcher K, Gallois H, Garrett G, Gelbard A, Ghaffar O, Goldenberg A, Hanna K, Hersh W, Jain J, Jayachandran L, Jenney K, Jenkins K, Jo S, Johnson A, Kalia A, Kalia M, Khawa Z, Kobayashi K, Kostelnik C, Krause A, Krussel A, Lapadula E, Leo G, Levinsky J, Loewith C, Mahajan R, Maharaj V, Miao S, Michaels L, Mifsud M, Mikhael M, Moothedan E, Nafii Y, Neal T, Newberry K, Ng E, Nickel C, Peltier A, Pharr T, Pnacekova M, Pontell M, Potter J, Premi-Bortolotto C, Rafatjou P, Rahman J, Rajkumar G, Ramos J, de Riesthal M, Rohde S, Rossi J, Russell L, Salvi Cruz S, Samuel J, Shah S, Shawkat A, Silberholz E, Stark J, Su L, Sudhakar S G, Sutherland D, Swarna Mukhi V, Tang J, Taylor L, Toghranegar J, Tu J, Urbano M, Victor G, Vinson K, Wilke J, Wilson C, Zanin M, Zeng X, Zesiewicz T, Zhao R, Zisimopoulos P, Ghosh S. Bridge2AI-Voice Pediatric Dataset (version 1.1.0). PhysioNet. 2026. RRID:SCR_007345. Available from:
+https://doi.org/10.13026/h995-bt35
+BibTeX
+Copy
+@article{PhysioNet-b2ai-voice-pediatric-1.1.0,
+author = {Bensoussan, Yael and Sigaras, Alexandros and Rameau, Anais and Elemento, Olivier and Powell, Maria and Dorr, David and Payne, Philip and Ravitsky, Vardit and Bélisle-Pipon, Jean-Christophe and Bahr, Ruth and Watts, Stephanie and Bolser, Donald and Siu, Jennifer and Lerner-Ellis, Jordan and Rudzicz, Frank and Boyer, Micah and Abdel-Aty, Yassmeen and {Ahmed Syed}, Toufeeq and Amraei, Dona and Anibal, James and Aradi, Stephen and Armosh, Kirollos and Martinez, Ana Sophia and Awan, Shaheen and Bedrick, Steven and Beltran, Helena and Bernier, Alexander and Berrios, Moroni and Bevers, Isaac and Blatter, Alden and Brito, Rahul and Brown, Amy and Brown, Johnathan and Cadillac, Léo and Casalino, Selina and Costello, John and Dalal, Abhijeet and {De Santiago}, Iris and Diaz-Ocampo, Enrique and Doherty-Kirby, Amanda and Ebraheem, Mohamed and Eiseman, Ellie and Elmahdy, Mahmoud and English, Renee and Evangelista, Emily and Fletcher, Kenneth and Gallois, Hortense and Garrett, Gaelyn and Gelbard, Alexander and Ghaffar, Omar and Goldenberg, Anna and Hanna, Karim and Hersh, William and Jain, Jennifer and Jayachandran, Lochana and Jenney, Kaley and Jenkins, Kathy and Jo, Stacy and Johnson, Alistair and Kalia, Ayush and Kalia, Megha and Khawa, Zoha and Kobayashi, Kenji and Kostelnik, Cindy and Krause, Alisa and Krussel, Andrea and Lapadula, Elisa and Leo, Genelle and Levinsky, Justin and Loewith, Chloe and Mahajan, Radhika and Maharaj, Vrishni and Miao, Siyu and Michaels, LeAnn and Mifsud, Matthew and Mikhael, Marian and Moothedan, Elijah and Nafii, Yosef and Neal, Tempestt and Newberry, Karlee and Ng, Evan and Nickel, Christopher and Peltier, Amanda and Pharr, Trevor and Pnacekova, Michaela and Pontell, Matthew and Potter, Jaiden and Premi-Bortolotto, Claire and Rafatjou, Parnaz and Rahman, JM and Rajkumar, Gayathiri and Ramos, John and {de Riesthal}, Michael and Rohde, Sarah and Rossi, Jillian and Russell, Laurie and {Salvi Cruz}, Samantha and Samuel, Joyce and Shah, Suketu and Shawkat, Ahmed and Silberholz, Elizabeth and Stark, John and Su, Lala and Sudhakar, Shrramana Ganesh and Sutherland, Duncan and {Swarna Mukhi}, Venkata and Tang, Jeffrey and Taylor, Luka and Toghranegar, Jamie and Tu, Julie and Urbano, Megan and Victor, Gavin and Vinson, Kimberly and Wilke, Jordan and Wilson, Claire and Zanin, Madeleine and Zeng, Xijie and Zesiewicz, Theresa and Zhao, Robin and Zisimopoulos, Pantelis and Ghosh, Satrajit},
+title = {{Bridge2AI-Voice Pediatric Dataset}},
+journal = {{PhysioNet}},
+year = {2026},
+month = may,
+note = {Version 1.1.0},
+doi = {10.13026/h995-bt35},
+url = {https://doi.org/10.13026/h995-bt35}
+}
+Close
+Please include the standard citation for PhysioNet:
+(show more options)
+Pollard, T., Moody, B. E., Lehman, L., Gow, B., Fernandes, C., Xie, C., Johnson, A., Mark, R. G., & Heldt, T. (2026). PhysioNet as a global platform for biomedical research. Nature Health. https://doi.org/10.1038/s44360-026-00096-z. Available from: https://rdcu.be/faatM
+Cite
+×
+APA
+Pollard, T., Moody, B. E., Lehman, L., Gow, B., Fernandes, C., Xie, C., Johnson, A., Mark, R. G., & Heldt, T. (2026). PhysioNet as a global platform for biomedical research. Nature Health. https://doi.org/10.1038/s44360-026-00096-z. Available from: https://rdcu.be/faatM
+MLA
+Pollard, Tom, et al. “PhysioNet as a Global Platform for Biomedical Research.” Nature Health, 2026, https://doi.org/10.1038/s44360-026-00096-z. Available from: https://rdcu.be/faatM
+CHICAGO
+Pollard, Tom, Benjamin E. Moody, Li-wei Lehman, Brian Gow, Chrystinne Fernandes, Chen Xie, Alistair Johnson, Roger G. Mark, and Thomas Heldt. “PhysioNet as a Global Platform for Biomedical Research.” Nature Health (2026). https://doi.org/10.1038/s44360-026-00096-z.i Available from: https://rdcu.be/faatM
+HARVARD
+Pollard, T., Moody, B.E., Lehman, L., Gow, B., Fernandes, C., Xie, C., Johnson, A., Mark, R.G. and Heldt, T., 2026. PhysioNet as a global platform for biomedical research. Nature Health. Available at: https://doi.org/10.1038/s44360-026-00096-z. Available from: https://rdcu.be/faatM
+VANCOUVER
+Pollard T, Moody BE, Lehman L, Gow B, Fernandes C, Xie C, et al. PhysioNet as a global platform for biomedical research. Nature Health. 2026. doi:10.1038/s44360-026-00096-z. Available from: https://rdcu.be/faatM
+Close
+Abstract
+The human voice contains complex acoustic markers which have been linked to important health conditions including dementia, mood disorders, and cancer. When viewed as a biomarker, voice is a promising characteristic to measure as it is simple to collect, cost-effective, and has broad clinical utility. Recent advances in artificial intelligence have provided techniques to extract previously unknown prognostically useful information from dense data elements such as images. The Bridge2AI-Voice project seeks to create an ethically sourced flagship dataset to enable future research in artificial intelligence and support critical insights into the use of voice as a biomarker of health. Here we present Bridge2AI-Voice, a comprehensive collection of data derived from voice recordings with corresponding clinical information.
+Bridge2AI-Voice Pediatric Dataset v1.1.0 contains derived audio features for 23,533 recordings collected from 300 participants aged 2-18. The release contains data considered low risk, including derivations such as spectrograms but not the original voice recordings. Detailed demographic, clinical, and validated questionnaire data are also made available.
+Background
+Understanding voice and speech development in children is essential for identifying communication or speech disorders early in life, and for supporting timely intervention [1]. Pediatric and adult voice/speech production are fundamentally different because the respiratory system and larynx undergo rapid functional maturation/development throughout childhood [2, 3]. These developmental changes can influence acoustic features such as fundamental frequency (F₀) [2]. As a result, evidence/normative data that we have in adults cannot be generalized to pediatric populations.
+Despite the clinical importance of detecting pediatric communication disorders such as autism spectrum disorder and speech delays, the availability of large-scale pediatric databases/datasets remains/is limited. Data collection in pediatric populations introduces/poses unique challenges such as privacy issues, consent processes, the need for developmentally appropriate tasks. These factors have contributed to the lack of publicly/open access/ available pediatric data sets that enable machine learning for pediatric voice analysis [3].
+Establishing a robust multi-institutional dataset that integrates pediatric voice data with demographic information would advance the understanding of voice and disease as well as early detection and intervention. Resources such as this project are intended to enable study of developmental norms, create AI-driven tools for early screening, and support clinical insight.
+Methods
+Patients/healthy volunteers at the Hospital for Sick Children were considered for enrollment in the study. Patients were considered eligible for the study if they fulfilled the inclusion criteria of 2 to 18 years of age, and English proficiency. Exclusion criteria included participants over 18 years of age, and individuals who were non-verbal. Non-patients, recruited through research postings, were evaluated for eligibility based on the study’s inclusion and exclusion criteria. Following confirmation of eligibility, parental or participant consent was obtained prior to data collection and data sharing. Once consented, patients were assigned a unique study identification number and a standardized age-appropriate protocol for data collection was adopted. The protocol included the collection of demographic information, voice and speech related questionnaires, and questionnaires inquiring about medical history.
+All data was collected through customized software –
+reproschema-ui –
+on tablets. A headset was used to record for most participants, while the remaining recordings utilized the built-in tablet microphone due to low tolerance of wearing headphones or existing complex medical conditions. All participants completed the recording and demographic data collection in one session. For participants without adequate comprehension and familiarity with their past medical history, parents or decision-makers completed the survey during the recording on a separate tablet. The simultaneous completion of the recording and survey improved efficiency and minimized participant burden and fatigue. Data were exported and converted to tab delimited values using an open source library developed by our team [4].
+Data Description
+The dataset contains both derived audio data features (under features) and phenotypic information acquired during data collection (under phenotype), as well as metadata information for the recordings (available under metadata). Binary files are made available as Parquet, an open-source column-oriented data file format. Each of the parquet files is formatted similarly. Each element of the parquet formatted dataset contains a unique identifier for the participant (participant_id), a unique identifier for the recording session (session_id), the task performed (task_name), the number of time frames associated with that feature (n_frames), and the tensor data for the feature.
+torchaudio_spectrograms.parquet (n=23533) contains spectrograms of dimension 201xT generated using the short-time Fast Fourier Transform (FFT) with a 25ms window size, 10ms hop length, and a 400-point FFT.
+torchaudio_mel_spectrograms.parquet (n=23533) contains Mel spectrograms of dimension 60xT generated with a 25ms window size, 10ms hop length, a 400-point FFT and 60 Mel bins.
+torchaudio_mfcc.parquet (n=23533) contains Mel-frequency cepstrum coefficients of dimension 60xT using the same parameters as the mel spectrograms.
+torchaudio_pitch.parquet (n=23533) contains the detected pitch (fundamental frequency) over time and is of dimension T with a min and max pitch of 80 and 500 respectively.
+sparc_ema.parquet (n=23532) contains the estimated electromagnetic articulography (EMA) using a deep learning model with dimensions Tx12 where the 12 correspond to X/Y positions of six articulators: tongue dorsum (TD), tongue body (TB), tongue tip (TT), lower incisor (LI), upper lip (UL), lower lip (LL), respectively.
+sparc_loudness.parquet (n=23532) contains the estimated loudness based on the average absolute amplitude of the audio waveform of size T, using 20ms windows.
+sparc_periodicity.parquet (n=23532) contains the estimated periodicity (confidence of pitch presence) derived from the audio using 20ms windows of dimension T.
+sparc_pitch.parquet (n=23532) contains the estimated fundamental frequency (F0) of the audio signal using a different algorithm than before with a range of 50-550Hz and dimension T.
+ppgs.parquet (n=23533) contains the phonetic posteriorgram probabilities across 40 phoneme categories giving a dimension of 40xT with a frame rate of 100Hz.
+Spectrograms, Mel Spectrograms, MFC coefficients, PPGs, and EMAs for sensitive records and audio checks have been removed from v1.1. Additionally, some files, whether due to length or other issues, could not generate certain features and so are not included in the bundled data.
+In addition to the parquet files, the features folder contains the following plain-text file, features derived from the open-source Speech and Music Interpretation by Large-space Extraction (openSMILE [5]), Praat [6], parselmouth [7], and torchaudio [8, 9] are provided. Each feature is present in the static_features.tsv file. There is also metrics related to audio quality derived from the recordings present in the audio_quality_metrics.tsv file.
+All of the above files are associated with a data dictionary file which has the same file stem and a JSON suffixes (e.g. torch_spectrogram.json). The above data dictionaries have the same overall structure: a dictionary where keys are the column names matching the associated data file, and values are dictionaries with further detail. The description value in the data dictionary provides a one sentence summary of the respective column.
+The code used to preprocess the raw audio waveforms into the parquet file and to merge the source data into the phenotype files has been made open source in the
+b2aiprep library
+[4].
+Usage Notes
+If using Python, the parquet dataset can be loaded in with the HuggingFace datasets library as follows:
+from datasets import Dataset
+ds = Dataset.from_parquet("torchaudio_spectrogram.parquet")
+A spectrogram can be plotted in decibels by converting it from its original power representation:
+from datasets import Dataset
+import pandas as pd
+import matplotlib.pyplot as plt
+import librosa
+import numpy as np
+ds = Dataset.from_parquet("torchaudio_mel_spectrogram.parquet")
+spectrogram = librosa.power_to_db(np.asarray(ds[0]['mel_spectrogram']))
+plt.figure(figsize=(10, 4))
+plt.imshow(spectrogram, aspect='auto', origin='lower')
+plt.title('Spectrogram')
+plt.xlabel('Time Step')
+plt.ylabel('Frequency')
+plt.colorbar()
+plt.show()
+A phenotype file can be loaded with any statistical analysis tool. For example, the pandas library in Python can read the data:
+import pandas as pd
+df = pd.read_csv("demographics.tsv", sep="\t", header=0)
+Release Notes
+b2ai-voice-pediatric v1.1: No new participants released in this minor update, but releasing audio features for all free speech tasks that were manually checked for presence of unconsented speakers and PII. Additionally, releases new metrics related to the audio quality of the recordings and per recording metadata information.
+b2ai-voice-pediatric v1.0: This was the first release of the Bridge2AI-Voice Pediatric dataset.
+Ethics
+Data collection and sharing was approved by the Research Ethics Board at the Hospital for Sick Children.
+Acknowledgements
+This release would not be possible without the graceful contribution of data from all the participants of the study.
+This project was funded by NIH project number 3OT2OD032720-01S1: Bridge2AI: Voice as a Biomarker of Health - Building an ethically sourced, bioaccoustic database to understand disease like never before. We would also like to thank the NIH for their continued support of the project.
+Conflicts of Interest
+None to declare.
+References
+Kelchner, L. N., Brehm, S. B., de Alarcon, A., & Weinrich, B. (2012). Update on pediatric voice and airway disorders: assessment and care. Current opinion in otolaryngology & head and neck surgery, 20(3), 160–164.
+https://doi.org/10.1097/MOO.0b013e3283530ecb
+Tavares, E. L., Labio, R. B., & Martins, R. H. (2010). Normative study of vocal acoustic parameters from children from 4 to 12 years of age without vocal symptoms: a pilot study. Brazilian journal of otorhinolaryngology, 76(4), 485–490.
+https://doi.org/10.1590/S1808-86942010000400013
+Fujiki RB, Venkatraman A, Heller Murray ES. The Pediatric Vocal Mechanism: Structure and Function. J Voice. 2025 Apr 4:S0892-1997(25)00118-3. doi: 10.1016/j.jvoice.2025.03.025. Epub ahead of print. PMID: 40187973; PMCID: PMC12353639.
+Johnson, A., Bevers, I., Ng, E., Wilke, J., Brito, R., Bedrick, S., Catania, F. & Ghosh, S. (2025). Bridge2AI Data Processing Library (Version 3.0.0) [Computer software].
+https://github.com/sensein/b2aiprep
+Florian Eyben, Martin Wöllmer, Björn Schuller: "openSMILE - The Munich Versatile and Fast Open-Source Audio Feature Extractor", Proc. ACM Multimedia (MM), ACM, Florence, Italy, ISBN 978-1-60558-933-6, pp. 1459-1462, 25.-29.10.2010.
+Boersma P, Van Heuven V. Speak and unSpeak with PRAAT. Glot International. 2001 Nov;5(9/10):341-7.
+Jadoul Y, Thompson B, De Boer B. Introducing parselmouth: A python interface to praat. Journal of Phonetics. 2018 Nov 1;71:1-5.
+Hwang, J., Hira, M., Chen, C., Zhang, X., Ni, Z., Sun, G., Ma, P., Huang, R., Pratap, V., Zhang, Y., Kumar, A., Yu, C.-Y., Zhu, C., Liu, C., Kahn, J., Ravanelli, M., Sun, P., Watanabe, S., Shi, Y., Tao, T., Scheibler, R., Cornell, S., Kim, S., & Petridis, S. (2023). TorchAudio 2.1: Advancing speech recognition, self-supervised learning, and audio processing components for PyTorch. arXiv preprint arXiv:2310.17864
+Yang, Y.-Y., Hira, M., Ni, Z., Chourdia, A., Astafurov, A., Chen, C., Yeh, C.-F., Puhrsch, C., Pollack, D., Genzel, D., Greenberg, D., Yang, E. Z., Lian, J., Mahadeokar, J., Hwang, J., Chen, J., Goldsborough, P., Roy, P., Narenthiran, S., Watanabe, S., Chintala, S., Quenneville-Bélair, V, & Shi, Y. (2021). TorchAudio: Building Blocks for Audio and Speech Processing. arXiv preprint arXiv:2110.15018.
+Contents
+Abstract
+Background
+Methods
+Data Description
+Usage Notes
+Release Notes
+Ethics
+Acknowledgements
+Conflicts of Interest
+References
+Files
+Share
+Access
+Access Policy:
+Only credentialed users who sign the DUA can access the files.
+License (for files):
+Bridge2AI Voice Registered Access License
+Data Use Agreement:
+Bridge2AI Voice Registered Access Agreement
+Required training:
+No training required
+Discovery
+DOI (version 1.1.0):
+https://doi.org/10.13026/h995-bt35
+DOI (latest version):
+https://doi.org/10.13026/mf9s-5r03
+Topics:
+health
+pediatric
+biomarkers
+bridge2ai
+voice
+Project Website:
+https://b2ai-voice.org/
+Project Views
+42
+Current Version
+119
+All Versions
+Project Views by Unique Registered Users
+View Details
+Corresponding Author
+You must be logged in to view the contact information.
+Versions
+1.0.0
+Dec. 17, 2025
+1.1.0
+May 1, 2026
+Files
+This is a restricted-access resource. To access the files, you must fulfill all of the following requirements:
+be a
+credentialed user
+sign the data use agreement
+for the project
+Maintained by the MIT Laboratory for Computational Physiology
+Supported by the National Institute of Biomedical Imaging and Bioengineering (NIBIB), National Heart Lung and Blood Institute (NHLBI), and NIH Office of the Director under NIH grant numbers U24EB037545 and R01EB030362
+Navigation
+Discover Data
+Share Data
+About
+News
+Explore
+Data
+Software
+Challenges
+Tutorials
+Accessibility
+
+
+================================================================================
+
+FILE: gdrive_1gTFzAM-FoYlM_X9qF0s7fXoswmaz8IqN_row13.txt
+PATH: data/preprocessed/individual/VOICE/gdrive_1gTFzAM-FoYlM_X9qF0s7fXoswmaz8IqN_row13.txt
+SIZE: 77201 bytes
+--------------------------------------------------------------------------------
+
+SOURCE METADATA
+Project: VOICE
+Source ID: irb_protocol
+Source type: IRB
+Source URL: https://docs.google.com/document/d/1gTFzAM-FoYlM_X9qF0s7fXoswmaz8IqN/edit
+Raw file: data/raw/VOICE/gdrive_1gTFzAM-FoYlM_X9qF0s7fXoswmaz8IqN_row13.docx
+--------------------------------------------------------------------------------
+PROTOCOL TITLE:
+Bridge2AI Voice Data Acquisition
+PRINCIPAL INVESTIGATOR:
+Yael Bensoussan, MD MSc, FRCSC
+Department of Otolaryngology- Head and Neck Surgery
+(323) 509-6483
+yaelbensoussan@usf.edu
+Other USF Co-investigators
+Yassmeen Abdel-Aty, MD – Deparment of Otolaryngology
+Stephen Aradi, MD – Assistant Professor, Department of Neurology
+Ruth Bahr, PhD CCC-SLP – Professor, Department of Communication Sciences & Disorders
+Micah Boyer, PhD – Clinical Research Associate
+Karim Hanna, MD – Assistant Professor, TCOP Department of Pharmacy Practice
+Matthew Mifsud, MD – Associate Professor, College of Medicine Otolaryngology
+Tempestt Neal PhD – Assistant Professor, Department of Engineering
+Christopher Nickel, MD – Assistant Professor, College of Medicine Otolaryngology
+Suketu Shah, MD – Assistant Professor, College of Medicine Otolaryngology
+Ahmed Shawkat, MD – Internal Medicine, Morsani College of Medicine
+John Templeton, PhD – Assistant Professor, Department of Computer Science and Engineering
+Stephanie Watts, PhD, CCC-SLP – Assistant Professor, Department of OTOHNS
+Theresa Zesiewicz, MD – Professor, Department of Neurology
+Participating institutions and investigators outside USF under Single IRB:
+Participating institutions and investigators outside USF under Separate REB (Canadian):
+VERSION NUMBER/DATE:
+V1. January 17th, 2023
+REVISION HISTORY
+*This table should only be used during submission of a Modification application to the IRB.
+Table of Contents
+1.0	Study Summary	4
+2.0	Objectives	7
+3.0	Background	7
+4.0	Safety Endpoints	11
+5.0	Study Intervention	11
+6.0	Procedures Involved	11
+7.0	Data and Specimen Storage for Future Research	15
+8.0	Sharing of Results with Subjects	16
+9.0	Study Timelines	16
+10.0	Inclusion and Exclusion Criteria	17
+11.0	Vulnerable Populations	18
+12.0	Local Number of Subjects	18
+13.0	Recruitment Methods	18
+14.0	Withdrawal of Subjects	19
+15.0	Risks to Subjects	19
+16.0	Potential Benefits to Subjects or Others	19
+17.0	Data Management and Confidentiality	20
+18.0	Provisions to Monitor the Data to Ensure the Safety of Subjects	21
+19.0	Provisions to Protect the Privacy Interests of Subjects	22
+20.0	Compensation for Research-Related Injury	22
+21.0	Subject Costs and Compensation	22
+22.0	Consent Process	22
+23.0	Setting	24
+24.0	References	24
+Study Summary
+1.1 Brief Summary of study:
+Objectives
+2.1 Our group aims to integrate the use of voice as biomarker of health with clinical care by generating a substantial multi-institutional, ethically sourced, and diverse voice database linked to multimodal health biomarkers to fuel voice AI research. Data collection will be made possible by software through a smartphone application linked to other health biomarkers such as radiomics, and genomics, and supported by federated learning technology to protect data privacy.
+ Primary: To create a database of human voices, speech and respiratory sounds linked to other health biomarkers such as imaging, demographic and clinical data.
+Secondary:
+To develop a software and cloud infrastructure to collect and store voice data safely and ethically (Weill Cornell Medicine)
+To develop, support and integrate federated learning platforms at USF and Cornell to provide a HIPAA compliant way to train ML models without sharing data within institutions. Federated learning is a technology that allows sharing data for AI analysis without the data leaving the institution. Algorithms are run on data at each institution and model updates are shared to a central node. Therefore, researchers can benefit from other institutions' data without the need to share the actual data. In academia and medicine, this is the solution to the most important boundaries to collaborative research due to the heavy legal and administrative burden linked to data sharing
+Background
+3.1 The human voice is often referred to as a unique print for each individual and contains biomarkers that have been linked to various diseases ranging from Parkinson’s disease to dementia, mood disorders and cancers [1].  Voice contains complex acoustic markers that depend on the coordination between respiration, phonation, articulation, and prosody. Recent advances in acoustic analysis technology, in particular those linked to machine learning, have shed new insights into the detection of diseases. As a biomarker, voice is unique, cost-effective, easy and safe to collect in low resource settings. Moreover, the human voice not only contains speech, but also other acoustic biomarkers such as respiratory sounds, and cough.
+The production of human voice involves the complex interaction among respiration, phonation, resonation, and articulation. The respiratory system provides the air flow and pressure to initiate and maintain vocal fold vibration. The vocal folds generate the sound source which is then modified within the vocal tract by the oral and nasal cavities and the articulators involved in speech production. Each of these processes is influenced by the speaker’s ability to adjust and shape these interacting systems.
+Although many use the terms voice and speech interchangeably, it is important to understand the distinction between the different terms used to describe human sounds:
+Voice: In the voice research field, refers to sound production and is the phonatory aspect of speech. In other words, it is the sound produced by the larynx and the resonators. For example, voice can be assessed by asking someone to produce a prolonged vowel sound like /e/.
+Speech: Speech is the result of the voice being modified by the articulators and is produced with intonation and prosody. For example, a patient having a stroke can have abnormal speech production due to difficulty with articulating words but have a normal voice. For this project, the term Voice as a Biomarker of Health will include speech in its definition.
+For voice to emerge as a biomarker of health, there is a pressing need for a large, high- quality, multi-institutional and diverse voice database linked to other health biomarkers from various data of different modality (demographics, imaging, genomics, risk factors, etc.) to fuel voice AI research and answer tangible clinical questions. Such endeavor is only achievable through multi-institutional collaborations between voice experts and AI engineers, supported by bioethicists and social scientists to ensure the creation of ethically sourced voice databases representing our populations.
+Objective of the Grand Challenge:
+              Our group aims to develop voice as a biomarker of health used in clinical care. To do so we will generate a large multi-institutional, ethically sourced, and diverse voice database linked to multimodal health biomarkers to fuel voice AI research. We will then build predictive models to assist in screening, diagnosis, and treatment of a broad range of diseases, including several diseases with unmet clinical needs. Data collection will be made possible via the development of cutting-edge software available as smartphone application. Data collection will be combined with other health biomarkers such as radiomics, and genomics. Importantly, this project will pioneer the use of federated learning technology to create multi-center machine learning models while strictly protecting data privacy. Rising ethical concerns regarding Voice AI such as legal implications of voice identification, voice AI hacking and voice data sharing and privacy, and impact of gender and racial diversity on Voice AI will be addressed.
+             Based on the existing literature and ongoing research in different fields of voice research, our group has identified 5 disease cohort categories for which voice changes have been associated to specific diseases with well-recognized unmet needs. We will center our data acquisition efforts on the following disease categories:
+Voice Disorders
+Neurological and Neurodegenerative Disorders
+Mood and Psychiatric Disorders
+Respiratory disorders
+Pediatric Voice and Speech Disorders
+The voice data acquisition efforts will be facilitated by partnerships with High Volume Expert Clinics as well as Community Clinics representing underserved populations.
+Data Sharing and Federated Learning
+Federated Learning is an emerging method in deep learning where multiple collaborators train a machine learning model in parallel, without trespassing institutional firewalls. This “decentralized” learning approach allows data to be kept within each collaborative institution protected servers, while their deep learning model updates are transferred to a central server to be aggregated in a consensus model. In contrast, the conventional “centralized” deep learning approach requires data to be uploaded to central servers, which becomes problematic when dealing with health data and patient-identifiers. Outside of the medical world, federated learning is actively used by technologists to augment datasets feeding AI systems. It is currently used by Google to “build better AI products with on-device data and privacy by default”. This novel approach has the potential to revolutionize health informatics and applications of artificial intelligence in medicine. For the purpose of this study, 2 levels of privacy will be built.
+1. A regular combined master de-identified database will be hosted through a HIPAA privacy preserving NIH Stride Partner (see definition above in section 1 table). Data Sharing and data use agreements will be put in place between participating institutions
+2. Through Federated learning technology where each institution will host their data and models can be trained without the data leaving the institution.
+3.2 Existing Pilot Data:
+Voice biomarkers are increasingly being used in the Voice AI world including academia and tech. Pilot Studies have shown promising preliminary results in the 5 disease categories described:
+1. Voice Disorders: Laryngeal disorders are the most studied pathologies linked to vocal changes. Benign and malignant lesions can affect the shape, mass, density, and tension of the vocal folds resulting in changes in vibratory function resulting in changes in phonation [2].
+Acoustic and aerodynamic analysis of the voice is an established component of the clinical laryngeal assessment, currently collected by speech-language pathologist trained in voice therapy, with an associated billing code. These measures have been used to identify pathologic vocal qualities, determine optimal management strategies, and evaluate treatment outcomes. They also provide quantitative objective measurements for scholarship pursuits. Currently, these analyses are performed in sound-proof rooms on proprietary hardware and software, such as the Computer Speech Lab by Kay-Pentax, from which a waveform file (WAV) can be extracted. Current standard acoustic measures collected at voice centers include fundamental frequency (pitch), intensity (loudness), jitter (variations in pitch), shimmer (variations in loudness), noise-to-harmonic ratio, and cepstral peak prominence (extent of harmonic structure in connected speech). Aerodynamic assessment quantifies laryngeal airflow and subglottic pressures during voice production. The latter require specialized aerodynamic equipment and cannot be collected via acoustic recording. Classic acoustic analysis has uncovered patterns of change in some standard parameters. However, small sample size and voice variability intra-and inter-subjects have limited generalizability. There has been a growing body of research using AI/ML models to screen for various voice disorders based on voice recording, all plagued by small sample size leading, limited external validity and algorithmic overfitting. For instance, spectrogram analysis by convolutional neural networks (CNNs) has demonstrated high accuracy in the identification of laryngeal disorders such as adductor spasmodic dysphonia, unilateral vocal fold paralysis, vocal fold polyp, polypoid corditis, and recurrent respiratory papillomatosis, based on voice samples from 10 speakers per disease [3]. Detection of laryngeal cancer from voice sample using CNNs attained high accuracy based on data from a cohort of 50 patients [4]. In order to be clinically relevant, AI models will need to help screen for conditions by differentiating the conditions that need urgent or active management, such as laryngeal cancer or vocal fold paralysis, from benign laryngitis so that patients can be referred to the right specialist and in a timely manner. Building a tool that contains enough voice data to differentiate between the various voice conditions requires very large numbers with standardized data collection protocols and diverse speakers [5].
+2. Respiratory disorders: Respiratory sounds, including breath, cough and voice have long been used for diagnostic purposes. For instance, pediatric croup can be suspected based on the presence of barking cough, stridor and dysphonia. With advances in acoustic recording and analysis in the second half on the twentieth century, increasing interest has emerged in the use of respiratory sounds for disease screening and therapeutic monitoring, especially with cough sounds. Though some of these efforts were promising, sample size remained low, which compounded with reliance on variable voluntary coughs, has limited generalizability of these attempts. More recently, the potential of using voice-related biomarkers for respiratory disorders screening has gained immense interest worldwide with the COVID-19 pandemic. As voice is a non-invasive, low-cost marker to connect, several academic teams, non-profit organizations and companies have investigated the value of voluntary cough sounds and voice recordings to detect COVID-19 using machine learning algorithms. Most of the data in these efforts was obtained via crowdsourcing efforts, with no standardized data acquisition protocol and no verification of data validity, with reliance of participants to designate their COVID-19 status. Furthermore, reproducibility studies are rare, even with existing open-sourced data [6]. For-profit enterprise is vastly invested in this space, although no FDA-approved or clinically useful algorithm has yet emerged. Sonde Health, an AI start-up whose mission is to unlock voice as a vital signal and a meaningful predictor of health” uses ML model to screen and manage progression of other respiratory diseases such as Chronic Obstructive Lung Disease or Cardiac Failure through longitudinal analysis of shortness of breath heard through voice data collection through smartphones [7]. As voice biomarkers continue to emerge, it will be crucial for the researcher community to have access to publicly available voice databases without reliance on the private sector.
+3. Mental Health and psychiatric disorders: Changes in voice have been linked to depression and other mood disorders. Individuals with depression have been found to have decreased fundamental frequency (f0) as well as a monotonous speech [8], while individuals with anxiety disorders have a significant increase in F0. Much of the literature examining the intersection of voice and speech changes in psychiatric conditions is plagued by small datasets with limited demographic diversity reporting, lack of standardized data collection protocol precluding meta-analysis and possible confounders, all limiting external validity and clinical usability [9]. There have been calls for creating open ML ready datasets for reproducible and generalizable AI voice research [10]. Approaches to data acquisition have varied, with some studies relying on small samples of voice data to analyze acoustic features such as F0, jitter or shimmer, while others focus on longitudinal voice and speech data collection through smartphones or wearable devices to screen for changes in mental health, such as manic and hypomanic episodes in bipolar disorder [11]. Prior literature thus suggests that software and hardware tools to collect voice and speech data for mental health screening, diagnosis and monitoring require a combination cross-sectional as well as longitudinal data acquisition. Science in this field should be hypothesis-driven and open, to allow for validation via reproducibility studies.
+4. Neurological and neurodegenerative disorders: Voice and speech are altered in many neurological and neurodegenerative conditions [12, 13, 14]. Acute strokes can present with slurred speech (Dysarthria) or expressive deficits speech (Aphasia). Voice and speech changes can be the presenting symptoms of many neurodegenerative conditions, such as Parkinson’s and ALS with changes such as slowed, low frequency, monotonous speech as well as vocal tremor [15]. A recent review by Bjorklund et al. reviewed the available voice and speech datasets for Parkinson’s and Alzheimer’s disease and concluded that although individual studies showed promising results, there was a need for collecting acoustic biomarkers in a minimally invasive, low-cost and standard way to create harmonized speech datasets [16]. Dr. Reza Hosseini Ghomi, chief medical officer at NeuroLex Laboratories, a startup focused on developing voice biomarker technology, recently stated “The field of digital biomarkers is still very fragmented because there are no standards for voice recording or an organizing force,” which is likely why there is still no FDA-approved technology in this space [17].
+5. Pediatric Speech disorders: The literature is sparser in terms of pediatric voice and speech analysis partly due to ethical concerns and challenges in data acquisition for this cohort [18]. However, many studies have investigated the use of machine learning models for voice and speech analysis for detection of Autism and Speech Delays in the pediatric population. A recent study on voice and speech difference in a cohort of 90 patients with autism spectrum disorders and 28 typical development patients and found that machine learning models could help distinguish between these two categories with higher performance when analyzing prosodic measures compared to articulation measures of the speech [19]. Due to the important variations in voice and speech with development of a child, creating a voice database of “normal cohort” of different age groups will be key to help machine learning models diagnose age specific speech delays and disorders.
+4.0 Safety Endpoints
+4.1 N/A
+5.0 Study Intervention
+5.1 N/A - This project will involve data collection only as the primary objective is to build a large multi-institutional database and there will be no intervention involved.
+5.2 N/A
+6.0 Procedures Involved
+6.1 This is a prospective cohort study over 4 years involving 11 different academic sites across the US with potential of adding extra data collection sites in phases 3-4 of the project. It involves collection of mainly acoustic data (voice, speech and respiratory sound) through smartphone applications as well as other clinical data (demographics, clinical information, imaging, validated questionnaires and genomic information for only 1 subset of the population (a separate IRB will be submitted for that sub-group). In the event where the caregiver's voice is recorded inadvertently, these clips can be discarded by 2 means: Rerecord manually during data collection or during data audit and postprocessing. Participants' cohorts will be identified based on known diagnosis from 5 different disease categories:
+Voice Disorders
+Respiratory Disorders
+Neuro Disorders
+Mood Disorders
+Pediatric speech disorders
+In addition to patient cohort data, participants will include individuals who do not have the conditions of interest to serve as controls in the dataset.
+There will also be a Feasibility Assessment:
+Throughout the data collection process, feasibility measures will be taken directly from the app. Measures such as time taken to complete each task, drop-out rates, and time taken in clinic will be captured. Qualitative data will also be captured to get feedback from participants on experience with using data collection tools and feasibility of protocols within clinical workflow (through questionnaires and voice recording).
+Please see Annex A for full Scope of Work (SOW) and deliverables for phase 1
+6.2 Please select the methods that will be employed in this study (select all that apply):
+
+Data will be collected at USF and 11 other participating institutions.
+High Volume Expert Clinics
+We define High Volume Expert Clinics (HVEC) as clinics/programs within academic institutions that have multidisciplinary programs targeted to the specific diseases listed in the disease cohorts table and have a volume of over 1000 patients per year.
+Community Outreach Clinics and underserved populations
+We define Community Outreach Clinics (COC) as clinics within or outside academic institution’s whose main mission is to provide health services to underserved and under-represented populations.
+Table 1
+Phased approach of Data Acquisition over a 4-year period
+Data types collected across all categories:
+Voice, Speech, and other acoustic data:
+Voice samples will be collected in a prospective manner, for all participants undergoing gold standard diagnostic evaluation in all the described disease categories. Voice, breath, cough, and speech data will be recorded. Data collected will include prolonged vowel sounds, free speech, and spontaneous speech, as well as snoring sounds, coughing sounds and breathing sounds.
+Demographics: Detailed demographic data will be collected through the smartphone application including Age, Sex, Gender, Race and Ethnicity, Language).
+Imaging: Different type of imaging modality will be collected from patients charts ONLY. For example, CXR will be collected for Asthma while Brain CT Scans and Brain MRIs will be collected for the Alzheimer's Cohort. NO ADDITIONAL IMAGING WILL BE PERFORMED IN THE CONTEXT OF THIS STUDY AND ONLY PREVIOUSLY COMPLETED IMAGING WILL BE REVIEWED AND COLLECTED.
+Validated tools: Validated tools for each disease category will be integrated within the app for data collection. For example, the Voice-Handicap Index-10 (see Annex B) will be used for the Voice Disorders. Scores will be automatically uploaded to the corresponding database.
+Genomic: No genetic information will be collected at the USF site. This will only be performed at MSH and UofT which are 2 Canadian participating institutions. Therefore, a separate REB will be submitted and obtained at these institutions for this portion of the study
+Table 2. Type of Data Modality Collected per Disease Category:
+*Imaging will be collected retrospectively. No additional imaging will be performed in this study.
+Sample Sizes
+For all participants mentioned above, complete data acquisition including multi-modal data will be performed for up to 5000 participants per category (disease category and controls). As this database is intended to fuel AI research and develop ML/AI models to assist diagnosis and treatment of health conditions, there is no sample size calculation applicable to our methodology. The sample sizes have been defined according to the existing literature. Currently published AI/ML models linking voice to these categories of diseases consist of datasets of small sizes ranging from 20-400 patients and reach high diagnostic accuracies.
+6.3 Voice/speech data collection will be conducted in two ways: through HVEC, and remotely. This type of data collection is not normally performed in HVEC for disease categories other than the voice disorder categories. In terms of validated questionnaires, these are commonly performed during regular clinical visits and would be expected to be performed within or outside of this study.
+HVEC and remote data collection occur through two platforms, the Bridge2AI Voice Web app and the Bridge2AI Voice iOS app. The iOS app is restricted to iOS-compatible devices, while the Web App can run on a computer, tablet, or phone device. No software is downloaded or installed. Both apps are themselves HIPAA-compliant, and only store data during the collection phase. The data are removed as soon as the page is closed. There is no login required. The data are sent similar to the in-clinic collection over a secure https protocol to a HIPAA-compliant storage server.
+6.4 Risk to Participants from Study Intervention:
+There are no direct significant risks due to the research conducted. The most important risk lies in protection of data privacy. To reduce that risk, all voice data will be collected through one of two client applications, the Bridge2AI Voice iOS app or the Bridge2AI Voice Web app. The applications will send data over a secure https protocol to one of the NIH Strides partners – these companies (Google, Microsoft, Amazon) have pre-negotiated contracts with the NIH to ensure data privacy and HIPAA protection of medical information.
+6. 5 Accessing or collecting existing data through:
+Charts of patients presenting at HVEC will be screened for inclusion and exclusion criteria before the clinic day. At USF, this will be conducted through the EPIC platform (through local site EHR for other participating institutions). Investigators, who are clinicians practicing in these clinics, have authority to screen through these existing patient lists.
+Existing clinical data within the EHR will be reviewed and the following information will be collected:
+Demographics: Detailed demographic data will be collected through the tool (See TDOM Module) including Age, Sex, Gender, Race and Ethnicity, Language).
+Imaging: CXR for the Respiratory Disease Category, Brain CT Scans and Brain MRIs for the Neurology Category will be collected
+Clinical data related to diagnosis: this includes disease type, severity, symptoms, management, validated questionnaires and scores
+Data will be entered into a REDCap database as part of the Case Report Form.
+6.6 Collecting biological specimens:
+There will be no biological specimens collected at USF or for this portion of the study. There will be genomic data collection performed ONLY at the University of Toronto and Mount Sinai Hospital who are participating institutions but will submit a separate research ethics proposal to their respective institution. All the genomic information will be collected, managed and analyzed at their sites. The REB (Canadian IRB) approval from these 2 participating sites will be sent to USF IRB once approved.
+6.7 Long-term follow-up beyond study period
+The current study period is 4 years. Within the consent process, individuals will be asked if they agree to be contacted in the future for further voice data collection if long-term follow up is required as part of an eventual extension of this grant. If they chose that option, they will agree to provide contact information including email and phone number. This data will be stored within the institutional database ONLY and not part of the data that is shared with the other centers and uploaded to the cloud. At this time, there is no plan to collect data beyond the study period. But since this represent a large multi-institutional, nationally funded grant with many potential derivative studies, it is crucial to give the option to participant to provide contact and agree to possible follow-up beyond the study period.
+6.8 N/A
+7.0 Data and Specimen Storage for Future Research
+7.1 The primary objective of this data generation project is to create an open-sourced multi-institutional human voice database. De-identified clinical and voice data will be shared between institutions on a cloud-based infrastructure hosted through an NIH STRIDES partner.  For the first 2 phases of the study, only authorized personnel who have been approved by the institution will have access to the data during the quality control and pilot period. By the end of phase 2, de-identified data will be made open-sourced and publicly available to other researchers through an NIH hosted platform.  There are many similar open-sourced databases hosted by the NIH such as the Clinical Genomic Database (https://research.nhgri.nih.gov/CGD/download/) and the (https://www.genome.gov/human-genome-project).  All data including voice and clinical data hosted on the open-sourced database will be de-identified.
+Data transfer and data use agreements between collaborating universities will be drafted alongside the patent and innovations office for the safe sharing of data.
+7.2 Type of Data shared:
+The meta-database will include acoustic samples (voice, speech, respiratory sounds) linked to other data modality:
+Demographic data (age, sex at birth, gender identity, race, ethnicity, languages spoken)
+Clinical data related to diagnosis (Disease category, disease severity, past medical history, treatment or medication for disease)
+Imaging
+Genomic data (only for the Alzheimer’s cohort that will be performed at UofT and MSH and therefore will have a separate protocol and REB approval)
+7.3 Local access to data will be available to approved study personal via the password protected database REDCap, authorized personal who have been approved by the institution and the PI will have access to it for the purpose of this study. Data Transfer agreements between collaborating universities will be drafted alongside the patent and innovations office for the safe sharing of data. The data is going to be hosted on server through NIH Stride partners. All institutions will collect data through a client application, the Bridge2AI Voice Web app. The application will send data over a secure https protocol to one of the Strides partners at NIH. The Strides partners are Amazon, Google, and Microsoft and they have agreements with the NIH already for data privacy and storage.
+8.0 Sharing of Results with Participants
+8.1 The primary objective of this study is to build a meta-database of human voices. Therefore, there will be no result of investigations or study intervention within the study period (4 years). This meta-database will become an open-source database for other researchers to use for future voice AI projects and therefore results from all future studies cannot be tracked. If any studies are performed by the study investigators during or after the study period using this database, the consortium name BRIDGE2AI- VOICE will be used for any journal publication. For future researchers, the open-source database will also be cited.  Due to this the participants will have access to this open-source data and potentially additional data based on potential contact with the ethics team. Any additional data participants will optionally have access to.
+9.0 Study Timelines
+9.1 This study is currently funded over 4 years. Individuals will be offered to enroll with the option to contribute with single time point data or longitudinal data (for certain disease cohorts).
+Single Time Point Data Collection:
+For single time point data collection, voice data collection will be performed in one of two ways.
+1. Voice data collection will be performed in clinic during the regular office visits. Patients will be offered to enroll in the study and escorted to a study room before or after their regular appointment. In some cases, the consent and data collection will be performed on the same day with the research assistant. In other cases, enrollment and consent may occur remotely through an application, and/or may occur at an earlier point in time than data collection. In some cases remote consent will not require the signature of the researcher; in this instance the consent form will leave off the final section (Statement of Person Obtaining Informed Consent) but be otherwise identical. Consent may take place electronically, within the app, or on paper. Electronic consent is housed in REDCap and is HIPAA compliant. The whole process will take from 30 to 60 minutes depending on vocal tasks from various disease categories.
+2. Data collection may occur remotely, through access to an application.
+Longitudinal data collection: For specific disease cohorts that are progressive or degenerative (i.e Alzheimer's, Parkinson’s, longitudinal data collection may be collected.
+The longitudinal data will be collected in 2 forms:
+1: Longitudinal data in clinic during clinic visits:
+This data collection will happen in clinic during REGULAR follow up visits. No additional visits outside of regular follow up plans for disease monitoring. The maximum follow-up time will not exceed the study period of 4 years.
+2: Longitudinal data “at home”:
+In between clinic visit, certain cohorts could be asked to perform voice data collection at home through a smartphone application that will be downloaded for them in clinic. This data collection will be asked at intervals of 1-6 months depending on disease cohorts and for a maximum of 4 years total duration. Participants can decide to leave the study at any point during that time.
+Table 3. Overall study timeline per phase
+10.0 Inclusion and Exclusion Criteria
+10.1 Eligibility screening:
+-Patients will be screened for eligibility prior to the consent process
+10.2 Inclusion criteria:
+For treatment population:
+- Being diagnosed and/or treated for a voice, respiratory, pediatric, mood, or neurological disorder affecting voice, cough, breath and/or speech (see Section 3: Background) at one of USF Health’s or participating institutions’ HVEC (see Annex C table 4 for participating institutions)
+- Consenting to provide a voice/speech sample for an open-sourced database
+- Being 18 years old or older (exception of pediatric data collection)
+- Speaking the English or Spanish language
+- At home or ‘in the wild” data collection participants will need to have their own smartphone that can be used for data collection
+For control population:
+- Not being diagnosed and/or treated for a voice, respiratory, pediatric, mood, or neurological disorder affecting voice, cough, breath and/or speech (see Section 3: Background)
+- Consenting to provide a voice/speech sample for an open-sourced database
+- Being 18 years old or older (exception of pediatric data collection)
+- Speaking the English or Spanish language
+- At home or ‘in the wild” data collection participants will need to have their own smartphone that can be used for data collection
+10.3 Exclusion criteria:
+- Not speaking the English or Spanish Language
+- Having had a surgical intervention significantly altering the symptoms of the disease studied
+- Not consenting (or, in the case of pediatric participants, not receiving consent from a parent or guardian) to voice and clinical de-identified data being uploaded to an open-sourced database
+10.4 N/A
+10.5 Specific populations: We will not specifically include or exclude students, employees, or wards of the state. There is a specific plan in place to enroll participants from socially/ economically disadvantaged and underserved population so that the database is diverse and FAIR while truly representing our populations. This will be performed through the Plan for Enhancing Diverse Perspectives (PEDP).
+11. Vulnerable Populations
+Pediatric patients will be enrolled ONLY through the pediatric sites and not at USF. Checklist HRP-416 for children under 21 has been completed and is appended to this protocol.
+12.  Local Number of Participants
+12.1 Total number of research participants
+- Through HEVC and COC within USF, we aim to enroll 5000 participants over the study period. The total number of 30 000 participants will be reached by collaboration with other participating institutions and existing cohorts
+12.2 N/A
+13. Recruitment Methods
+13.1 Potential participants will be recruited through clinic appointments at the participating facilities in this study. Additionally, recruitment flyers will be placed in well-trafficked areas to recruit participants in HVEC and COC. Recruitment for remote data collection will include flyers posted at other locations outside of HVEC. At some participating facilities, recruitment flyers will link through a QR code to a secure REDCap survey, which will be used to screen participants and facilitate enrollment. At some facilities where approval by the facilities has been granted, approved research staff will recruit individuals in waiting rooms, including those accompanying patients for clinical appointments. All entries to the REDCap system will be deleted once patients are enrolled, or within 90 days of their submission, whichever comes first. Recruitment will also take place through social media platforms, where information may be presented in the form of posts, reels, stories, or links. Platforms for recruitment will include: LinkedIn, X, Facebook, Instagram, YouTube, the Bridge2AI-Voice website (www.b2ai-voice.org), and the Bridge2AI website (www.bridge2ai.org). Recruitment will also take place through FlowTrials, an online platform where studies passively publicize their requests for participation. Participating facilities will recruit through their own websites in coming years. If specific diagnoses and/or severities are under-represented in the dataset, participants will be identified by medical record review, based on voice-disorder related diagnostic codes.
+The Bridge2AI Enrollment Web app is launched in a browser on the participant's computer, tablet, or phone device. No software is downloaded or installed. The app is itself HIPAA-compliant, and only stores data during the collection phase. The data are removed as soon as the page is closed. There is no login required. The data are sent similar to the in-clinic collection over a secure https protocol to a HIPAA-compliant storage server.
+13.2 Potential participants will be recruited through clinic appointments at the participating facilities in this study. Additionally, recruitment flyers will be placed in well-trafficked areas to recruit participants in HVEC and COC. Recruitment for remote data collection will include flyers posted at other locations outside of HVEC. At some participating facilities, recruitment flyers will link through a QR code to a secure REDCap survey, which will be used to screen participants and facilitate enrollment. At some facilities where approval by the facilities has been granted, approved research staff will recruit individuals in waiting rooms, including those accompanying patients for clinical appointments.
+Recruitment will also take place through social media platforms, where information may be presented in the form of posts, reels, stories, or links. Platforms for recruitment will include: LinkedIn, X, Facebook, Instagram, YouTube, the Bridge2AI-Voice website (www.b2ai-voice.org), and the Bridge2AI website (www.bridge2ai.org). Recruitment will also take place through FlowTrials, an online platform where studies passively publicize their requests for participation. Participating facilities will recruit through their own websites in coming years. If specific diagnoses and/or severities are under-represented in the dataset, participants will be identified by medical record review, based on voice-disorder related diagnostic codes.
+The Bridge2AI Enrollment Web app is launched in a browser on the participant's computer, tablet, or phone device. No software is downloaded or installed. The app is itself HIPAA-compliant, and only stores data during the collection phase. The data are removed as soon as the page is closed. There is no login required. The data are sent similar to the in-clinic collection over a secure https protocol to a HIPAA-compliant storage server.
+13.3 An informed consent process will take place where the participant and/or consenting parent/guardian is aware that this is fully voluntary and no undue influence or coercion will be possible since it is a voluntary participation that will take place during a typical patient care appointment.
+14.0 Withdrawal of Research Participants
+14.1 N/A
+14.2 If participants withdraw from the study after they complete the voice data collection the data they have provided will be kept until completion of study. If participants withdraw during or before the voice data collection is completed their data will not be included in the database. For longitudinal data collection, if participants withdraw at any time during the study process, the data they have completed will be used in the database as the purpose of this data generation project is not to analyze the data studied but provide a platform and open-source database for future research. The minimal requirement for study completion is 1 data collection time-point. Participants can decide to withdraw from the longitudinal data collection at any point throughout the study period.
+Participants that withdraw from the study will have the option to complete a satisfaction survey to better understand their reasons for withdrawal. This survey may also be provided to patients who decline participation, or to participants who express initial hesitation. Completion of the survey will be entirely optional and no PHI will be collected.
+15.0 Risks to Research Participants
+15.1 Risks associated with the study itself include the risk of personal information being mistakenly released. Voice collection is a safe non-invasive collection method with minimal risk to the participant. The confidentiality of records that could identify participants will be protected, respecting the privacy and confidentiality rules in accordance with the applicable regulatory requirement(s). Risks to the participants will be minimized by strict adherence to confidentiality rules. In addition, the study team will perform the study according to good clinical practices, and only the PI and the study team will have access to the medical records, REDCap records and identifiable clinical information. The only other risk is associated with questions asked for participants from certain disease cohorts such as mood disorders, depression, anxiety, etc. Answering some of these questions can lead to possible discomfort and could trigger negative emotions for the participants.
+15.2 N/A
+15.3 N/A
+16.0 Potential Benefits to Participants or Others
+16.1 There are no direct immediate benefits to participants during this study.  Overall, the study could provide more accessibility to underserved or marginal populations through AI advancements/machine learning and health care screenings normally only provided through a specialist that can take months with high monetary costs otherwise.
+16.2 This study has potential benefits to society. The primary aim of this study is to create a large database of human voices linked to diseases for AI analysis. This database could provide very valuable datasets to train AI models to screen or diagnose diseases in early staged based on voice. Utilizing objective AI could result in a more accurate assessment of a patient’s treatment progress and outcomes that might otherwise be susceptible to human error. This could also provide more accessibility to underserved or marginal populations through AI advancements/machine learning and health care screenings normally only provided through a specialist that can take months with high monetary costs otherwise.
+17.0 Data Management and Confidentiality
+17.1 The PI and study team will conduct the study using Good Clinical Practice guidelines. All members of the study team will respect the confidentiality of the records being accessed and the data being input to REDCap. All users will have individual usernames and passwords to access REDCap and the HIPAA-secure cloud server. These databases have security measures in place to protect the data.
+Participant’s personal information will remain confidential and will not be used if study information is published or presented at a scientific meeting.
+All institutions (see List of Institutions Annex C) will collect voice data through one of two mobile client applications, the Bridge2AI Voice Web app or the Bridge2AI Voice iOS app. The application will send data over a secure https protocol to one of the NIH Strides partners. The types of data that will be shared will be Voice, demographic data and clinical data.
+All clinical data will be hosted on cloud/servers through NIH STRIDE partners. NIH Stride partners have pre-determined agreements with the NIH to ensure HIPAA protection and participant safety. All information regarding STRIDE partners can be found at: https://datascience.nih.gov/strides.
+This project is a data generation project with the aim of building a large database of voices. There is no plan for data analysis for this project as the aim is to generate data.
+17.2  Levels of data privacy and study-related storage:
+1) Study related material:
+- All study related material at USF will be stored through the Florence platform in accordance with USF and NIH regulations. The USF IRB requires de-identified study data and original consent forms be stored for a minimum of 5 years after the completion of the study. Original paper consent documents cannot be destroyed until 5 years after study completion, even if they are uploaded into Florence. We will follow these procedures.
+2) Participant-related data containing identifying information:
+- Each institution will keep their identified data within their institution. Identifiable PHI will be kept on the REDCap databases with password protected access only for investigators at the institution where the data is collected
+3) De-identified participant-related data and de-identified voice samples:
+- De-identified data will be shared through the joint meta database hosted on the cloud infrastructure described above. Participant numbers and institution numbers will be created to allow institutions to track and have ownership of their institutional data
+All investigators and project related personnel with data access will need to follow the appropriate certification through their local institution including HIPAA and privacy training.
+17.3 Quality control of the data will be performed throughout the 4 years of the project.
+The smartphone application for voice data collection will include models to ensure acoustic data quality including volume standardization and noise cancellation.
+The team has hired 2 acoustic engineers and 3 AI data scientists who will analyze all samples from Year 1 exploratory data collection phase to ensure acoustic quality and ML readiness in terms of data preparations.
+Each subsequent year of the study (2-4) 10% of the data will be selected at random every month for quality control and ML readiness.
+17.4 Data Transfer agreements between collaborating universities will be drafted alongside the paten and innovations office for the safe sharing of data. The data is going to be hosted on server through NIH stride partners. All institutions will collect data through a client application, the Bridge2AI Voice Web app. The application will send data over a secure https protocol to one of the Strides partners at NIH. The Strides partners are Amazon, Google, and Microsoft and they have agreements with the NIH already for data privacy and storage. The types of data that will be shared will be VOICE, clinical history, age, sex, and DOB.
+The study team will also be utilizing federated learning. Federated learning is a technology that allows sharing data for AI analysis without the data actually leaving the institution. Algorithms are run on data at each institution and model updates are shared to a central node. Therefore, researchers can benefit from other institutions' data without the need to share the actual data. In academia and medicine, this is the solution to the most important boundaries to collaborative research dure to the heavy legal and administrative burden linked to data sharing.
+Identifiable data and datasheets linking participant numbers to participant information will be kept in each institution on local cloud storage for a maximum of 10 years after study completion. Identifiable data will then be destroyed. This will be the responsibility of each local PI.
+17.5 If you will review/access and/or collect/obtain Protected Health Information (PHI) during recruitment or the main study, select all that apply:
+We do not plan to share PHI (identifiers plus health information) with anyone outside the USF research staff.
+A partial HIPAA waiver is being requested for recruitment purposes to allow the study team to review EHR information for incoming clinic patients ahead of their appointments. PHI will be collected at this time to screen potential participants for qualification into the research study; the PHI collected at this time will therefore be limited to the study’s inclusion criteria. This criterion includes:
+ Inclusion criteria:
+For treatment population:
+- Being diagnosed and/or treated for a voice, respiratory, pediatric, mood, or neurological disorder affecting voice, cough, breath and/or speech (see Section 3: Background) at one of USF Health’s or participating institutions’ HVEC (see Annex C table 4 for participating institutions)
+- Consenting to provide a voice/speech sample for an open-sourced database
+- Being 18 years old or older (exception of pediatric data collection)
+- Speaking the English or Spanish language
+- At home or ‘in the wild” data collection participants will need to have their own smartphone that can be used for data collection
+For control population:
+- Not being diagnosed and/or treated for a voice, respiratory, pediatric, mood, or neurological disorder affecting voice, cough, breath and/or speech (see Section 3: Background)
+- Consenting to provide a voice/speech sample for an open-sourced database
+- Being 18 years old or older (exception of pediatric data collection)
+- Speaking the English or Spanish language
+- At home or ‘in the wild” data collection participants will need to have their own smartphone that can be used for data collection
+Exclusion criteria:
+- Not speaking the English or Spanish Language
+- Having had a surgical intervention significantly altering the symptoms of the disease studied
+- Not consenting (or, in the case of pediatric participants, not receiving consent from a parent or legal guardian) to voice and clinical de-identified data being uploaded to an open-sourced database
+This will allow the clinician to have a study team member available to consent a participant ahead of time and allow for a more seamless transition during the clinic appointment should the patient express interest in participating in research. PHI will not be reused/disclosed to any other person or entity except as required by law, for authorized oversight of the research project, or for other research which use/disclosure of PHI would be permitted by the HIPAA privacy regulations.
+We plan to protect identifiers collected under the waiver from improper use and/or disclosure by only allowing authorized study personnel to access it and storing any PHI in HIPAA protected data bases and cloud servers such as REDCap and through Federated Learning.
+We will destroy the identifiers collected under the waiver at the earliest opportunity consistent with the conduct of the research.
+It is not practicable to obtain signed HIPAA Authorizations from the participants before using or disclosing their PHI in our study because we want to be able to screen incoming clinic patients for qualifications to research before approaching them about the research. We do not want to offer someone to join research they do not qualify for and we need to be able to have research staff on hand the days that there are qualified interested potential participants to help with the consent process so this all requires planning and access prior to contact with the participant so consent before would not be possible.
+Our study cannot be conducted without access to and use of participants’ PHI because we need to be able to know if they qualify for the study based on the inclusion and exclusion criteria needed from their medical records/history.
+18.0 Provisions to Monitor the Data to Ensure the Safety of Research Participants
+18.1 N/A
+18.2  N/A
+19.0 Provisions to Protect the Privacy Interests of Research Participants
+19.1 The PI and the study team will be using participant voice data to build an ethically sourced data database, and throughout this 4-year project only approved study members will have access to the data. Throughout the study the team will be working on a way to attempt to provide participants with the ability to track the results of the research associated with their voice data and outcomes the database creates. If this is possible then the information on how to follow the data will be provided to the participants at that time. Voice data will be deidentified for the privacy protection of the participants but it is important to understand that even when removing all
+HIPAA protected information associated with the participant who provides the voice sample each person's voice is unique to them and their health at that time in their life and it is always possible even if unlikely that at some point someone could recognize the participant’s voice since we can never full deidentify one’s voice.
+19.2 The data set, collected by the data acquisition team will contain de-identified participant voice samples and analysis of same. Clinical team members with EPIC access will have initial access when necessary for recruiting and disease/cohort placement, by the PI to facilitate hand collection of additional clinicopathology or imaging data. The study data will be uploaded to the password protected network REDCap. which is behind the HIPAA firewall. Data transfer agreements will be approved and signed by each institution collecting or sharing data, and federated learning will be implemented once the application begins hosting/collecting data.
+20.0 Compensation for Research-Related Injury
+20.1  N/A - This study does not involve any physical risk to participants and therefore there is no risk of research-related injury.
+21.0 Participant Costs and Compensation
+21.1 Compensation will be provided to the adult population only.
+21.2 If you will provide compensation to participants, select all that apply:
+Participants will be compensated with gift cards. Participants will be given a $40 gift card for sessions lasting under 90 minutes, and an $80 gift card for sessions lasting over 90 minutes, for a maximum of three sessions and $120.
+22.0 Consent Process
+22.1 Select the consent options you will use during the course of the study. Each selection below must have a description in the subsequent section(s). Choose all that apply:
+22.2 	This is a human subjects research project, so an informed consent should be required by the IRB. We have an ethical obligation to provide the participants with the information provided during the consent process and offer the same due diligences we would offer if it were a human subject research project. This is to ensure that the participants are aware and sure of their choice to participate voluntarily.
+Please see Consent, Assent and Parental Permission Documents
+In most cases, consent/assent process will take place in the clinic setting of the recruiting HVEC and will be conducted by the research assistants. Consent may also take place remotely through REDCap survey forms, accessed electronically.
+Consent may also take place through video recording within an application. In this case, the standard consent document will be displayed on the app, and participants will be instructed to start recording, read a statement out loud, and send. The audio recording from the consent will be used to verify that the acoustic data submitted by the participant belongs to the consented individual. Video consent is meant to provide an additional level of security for participants, as it helps to verify identity and to distinguish participants from bots.
+In most cases, there will not be any delay period as the study aims to collect the voice data for the study during the same clinic appointment. In some cases, participants may wish to consent but want to schedule their data collection separately. Participants who consent remotely may also schedule data collection after consent. Where delays occur, participants will be notified of any changes to the study and re-consented before data collection.
+Participants may consent by signing a physical paper copy, by indicating electronic consent within the app or through REDCap surveys, or through video recording within the app. When used, paper consent documents will be uploaded and saved electronically in REDCap. All paper and electronic versions of consent will be stored for a minimum of 5 years after the completion of the study, following required USF procedure.
+During the consent process, it will be explained to participants that they may be asked to provide longitudinal data for some diseases. In these cases, participants will be counselled on how to download the application on their personal cell phones or tablets for further data collection from home.  For ongoing consent, an electronic consent through the app will be administered before each subsequent data collection to ensure ongoing consent.
+The participant and/or parent/guardian will be given any time they need to consider or ask questions before signing the consent and/or assent document in clinic. The participant will be made explicitly aware that this is optional and voluntary and deciding not to participate will not interfere with their normal standard of care in anyway. The participant will not be at risk of undue influence or coercion because it is strictly voluntary.
+When consent occurs in clinics, the investigators (see list of co-investigators Page 1 and Annex C) will be responsible for introducing the study to the individuals coming to the appointment. If individuals are interested in participating, they will be escorted to a research room where the research assistant will explain the study in details and conduct the consent process. About 30 minutes will be spent explaining the study and consent in detail with time for any questions or comments. Potential participants will be asked to explain what they have understood to the research assistant to confirm their understanding.
+Potential participants will be informed that participation in this study is voluntary and does not impact their medical care in any way.
+22.3
+Please see Consent, Assent and Parental Permission Documents
+In most cases, consent/assent process will take place in the clinic setting of the recruiting HVEC and will be conducted by the research assistants. Consent may also take place remotely through REDCap survey forms, accessed electronically. Electronic consent contains the same text as paper consent.
+In most cases, there will not be any delay period as the study aims to collect the voice data for the study during the same clinic appointment. In some cases, participants may wish to consent but want to schedule their data collection separately. Participants who consent remotely may also schedule data collection after consent. Where delays occur, participants will be notified of any changes to the study and re-consented before data collection.
+Participants may consent by signing a physical paper copy, or by indicating electronic consent within the app or through REDCap surveys. When used, paper consent documents will be uploaded and saved electronically in REDCap. All paper and electronic versions of consent will be stored for a minimum of 5 years after the completion of the study, following required USF procedure.
+In case of remote consent, participants will be able to contact researchers with any questions or concerns before signing.
+22.4 N/A
+22.5 N/A
+-
+22.6
+- No pediatric data collection will be performed at USF. Data Collection for Pediatric cohorts will ONLY be performed at the pediatric participating institutions.
+-When children will be participating in the research, parents or guardians will provide consent, and children will provide verbal assent where appropriate. Parental permission will be obtained from one or both parents; this research is minimal risk and does not require permission from both parents or legal guardians. Where young children cannot reasonably be asked to assent (due to limitations in understanding due to age and development) they will not be asked to do so. This typically holds for children under seven years of age. Assent will be documented (see form).
+23.0 Setting
+23.1 Part of the data collection will take place in High Volume Experts Clinics across the participating institutions. In this case, data collection will be performed during clinic visits by the research team including the investigator and research coordinators/research assistants. Morsani location is the central location for the USF-based team. Recruitment and data collection will also occur at three other USF specialty clinics: USF Health Byrd Institute; USF Health Park Clinic; and 17 Davis Medical Building; and at VUMC, the Shade Tree Clinic (part of VUMC) and the Academy Children’s Clinic. In some cases, data collection will occur remotely, through access to an application using a phone, tablet, or other device.
+24.0 References
+1. Anthes E. Alexa, do I have COVID-19?. Nature. 2020:22-5.
+2. Voice Disorders. American Speech-Language-Hearing Association. Accessed May 1, 2023. https://www.asha.org/practice-portal/clinical-topics/voice-disorders/
+3. Powell ME, Rodriguez Cancio M, Young D, Nock W, Abdelmessih B, Zeller A, Perez Morales I, Zhang P, Garrett CG, Schmidt D, White J. Decoding phonation with artificial intelligence (DeP AI): proof of concept. Laryngoscope Investigative Otolaryngology. 2019 Jun;4(3):328-34.
+4. Kim H, Jeon J, Han YJ, Joo Y, Lee J, Lee S, Im S. Convolutional neural network classifies pathological voice change in laryngeal cancer with high accuracy. Journal of Clinical Medicine. 2020 Oct 25;9(11):3415.
+5. Arora S, Baghai-Ravary L, Tsanas A. Developing a large scale population screening tool for the assessment of Parkinson's disease using telephone-quality voice. The Journal of the Acoustical Society of America. 2019 May 9;145(5):2871-84.
+6. Xia T, Han J, Mascolo C. Exploring machine learning for audio-based respiratory condition screening: A concise review of databases, methods, and open issues. Experimental Biology and Medicine. 2022 Nov;247(22):2053-61.
+7. Company. Sonde Health. Accessed May 1, 2023. https://www.sondehealth.com/about
+8. Higuchi M, Tokuno SH, Nakamura M, Shinohara SH, Mitsuyoshi S, Omiya Y, Hagiwara NA, Takano TA, Toda HI, Saito TA, Terashi H. Classification of bipolar disorder, major depressive disorder, and healthy state using voice. Asian Journal of Pharmaceutical and Clinical Research. 2018 Oct;11(3):89-93.
+9. Low DM, Bentley KH, Ghosh SS. Automated assessment of psychiatric disorders using speech: A systematic review. Laryngoscope Investig Otolaryngol. 2020;5(1):96-116. doi:10.1002/lio2.354
+10. Costantini G, Cesarini V, Di Leo P, Amato F, Suppa A, Asci F, Pisani A, Calculli A, Saggio G. Artificial Intelligence-Based Voice Assessment of Patients with Parkinson’s Disease Off and On Treatment: Machine vs. Deep-Learning Comparison. Sensors. 2023 Feb 18;23(4):2293.
+11. Faurholt-Jepsen M, Busk J, Frost M, et al. Voice analysis as an objective state marker in bipolar disorder. Transl Psychiatry. 2016;6(7):e856. doi:10.1038/tp.2016.123
+12. Atkinson-Clement, C., Sadat, J., & Pinto, S. (2015). Behavioral treatments for speech in Parkinson's disease: meta-analyses and review of the literature. Neurodegenerative Disease Management, 5(3), 233-248.
+13. Martínez-Nicolás, I., Llorente, T. E., Martínez-Sánchez, F., & Meilán, J. J. G. (2021). Ten years of research on automatic voice and speech analysis of people with Alzheimer's disease and mild cognitive impairment: a systematic review article. Frontiers in Psychology, 12, 620251.
+14. Godoy, J. F., Brasolotto, A. G., Berretin-Félix, G., & Fernandes, A. Y. (2014). Neuroradiology and voice findings in stroke. In CoDAS (Vol. 26, pp. 168-174). Sociedade Brasileira de Fonoaudiologia.
+15. Woodson, G. (2003). Neurological problems of the voice. Journal of Singing-The Official Journal of the National Association of Teachers of Singing, 59(4), 321-327.
+16. Bjorklund NL, Fillit H, Malzbender K, Purushothama S, Kourtis L. The need for a harmonized speech dataset for Alzheimer’s disease biomarker development. Explor Med. 2020;1:359–63.
+17. Wanucha G. Talk About a Revolution: The Future of Voice Biomarkers in the Neurology Clinic. Dimensions: UW Memory and Brain Wellness Center. 2019.
+18. Patel D, Hall GL, Broadhurst D, Smith A, Schultz A, Foong RE. Does machine learning have a role in the prediction of asthma in children?. Paediatric Respiratory Reviews. 2022 Mar 1;41:51-60.
+19. Asgari M, Chen L, Fombonne E. Quantifying voice characteristics for detecting autism. Frontiers in Psychology. 2021 Sep 7;12:665096.
+ANNEX A – SCOPE OF WORK DATA ACQUISITION B2AI YEAR 1  (SEE ADDITIONAL DOCUMENTS)
+Please note that not all deliverables from year 1 include patient studies and therefore these are not included in this IRB
+ANNEX B: VOICE HANDICAP INDEX (VHI-10)
+ANNEX C – PARTICIPATING INSTITUTIONS AND LEAD INVESTIGATORS PER SITE
+Table 4 Participating Institutions and Lead investigators per site
+Lead Investigator
+Weill Cornell Medicine (WCM)	Alexandros Sigaras, PhD
+Anais Rameau, MD, MPhil
+Olivier Elemento, PhD
+Massachusetts Institute of Technology (MIT)	Satrajit Ghosh, PhD
+Vanderbilt University Medical Center (VUMC)	Maria Powell, PhD
+Alexander Gelbard, MD
+Massachusetts Eye and Ear (MEEI)	Phillip Song MD
+Matthew Naunheim, MD
+Emory University	Anthony Law, MD PhD
+University of Toronto (UofT)	Frank Rudzicz, PhD
+Hospital for Sick Children (HSC)	Alistair Johnson, DPhil
+Mount Sinai Hospital (MSH)	Jordan Lerner-Ellis, PhD
+Revision #	Version Date	Summary of Changes	Consent Change?
+V2	May 3,2023	Modified to include pediatric cohort under single IRB	Yes
+V3	August 15, 2023	Modified to include compensation for participating adults	No
+V4	December 11, 2023	Modified to allow for electronic consent and change the options for consent levels. Added USF REDCap protocol language and social media recruitment.	Yes
+V5	January 31, 2024	Modified to include data collection for controls. Updated personnel (USF co-investigators and outside investigators). Added new disease categories of interest.	Yes
+V6	February 22, 2024	Removes Table: Disease Cohorts per Site of Data Collection	No
+V7	July 19, 2024	Included e-consent and remote consent options. Changed compensation amount for participation.	Yes
+V8	September 27, 2024	Included options for remote enrollment through an app used as a recruitment tool (Bridge2AI Enrollment Web app) and for remote data collection (Bridge2AI Voice Web app). Changed compensation amount for participation. Added USF co-investigator.	Yes
+V9	November 15, 2024	Updated protocol to clarify the current state of research.	No
+V10	January 17, 2025	Clarified that remote data collection will take place on two different platforms, the Bridge2AI Voice Web app and the Bridge2AI Voice iOS app. Added USF co-investigator.	No
+V11	February 10, 2025	Updated to include data collection from Spanish language speakers. Added a new platform for patient recruitment. Added USF co-investigator. Added further sites for USF data collection. Added satisfaction survey for participants who decide not to complete data collection.	Yes
+V12	May 6, 2025	Updated language about the platforms for remote consent and data collection.	No
+V13	July 11, 2025	Added sentence regarding the use of flyers for recruitment. Added sentence regarding other sites for recruitment at Vanderbilt.	No
+Study Title	Bridge2AI Voice Data Acquisition
+Study Design	Prospective Cohort Study
+Primary Objective/Purpose	To build a large multi-institutional database of human voices, speech and respiratory sounds that is ethically sourced, diverse, and linked to multimodal health biomarkers to fuel voice AI research
+Secondary Objective(s)/Purposes	To build a data collection application and IT infrastructure for human voice, speech and respiratory sounds linked to other health biomarkers such as radiomics, and genomics, and supported by federated learning technology to protect data privacy. Data collected through this application will exist in the database.
+Research Intervention(s)	N/A
+ClinicalTrials.gov NCT #	N/A
+Study Population	Participants with known diagnosed diseases from 5 disease categories (Respiratory disorders, Voice disorders, Neurological disorders, Mood disorders, Pediatric voice and speech disorders), as well as participants without the identified conditions from the above 5 disease categories who can serve as controls in the database.  Participants will be recruited primarily from individuals presenting at USF specialty clinics or at one of the participating institutions described below and included in the SINGLE IRB PROCESS.
+Sample Size	30 000 participants
+Study Duration for individual participants	Up to 4 years
+Study Specific Abbreviations/ Definitions	Abbreviations:
+
+Machine Learning (ML)
+Artificial Intelligence (AI)
+Smart Phones (SP)
+CAPE-V (Consensus Auditory Perceptual Evaluation of Voice)
+Rainbow Passage: a standard text that contains all the phonemes of the English language.
+HVEC- High Volume Expert Clinics
+COC- Community Outreach Clinics
+PEDP- Plan for Enhancing Diverse Perspectives
+(EHR)- Electronic Health Records
+
+Definitions:
+
+Participating institutions
+University of South Florida, Tampa, Florida, US (USF)
+Weill Cornell Medicine, New York, New York, US (WCM)
+Vanderbilt University Medical Center, Nashville, Tennessee, US (VUMC)
+University of Toronto, Toronto, Ontario, Canada (UofT)
+Mount Sinai Hospital, Toronto, Ontario, Canada (MSH)
+Massachusetts Institute of Technology (MIT), Boston, Massachusetts, US (MIT)
+Hospital for Sick Children, Toronto, Ontario, Canada (HSC)
+Massachusetts Eye and Ear Institute, Boston, Massachusetts, US (MEEI)
+Emory University, Atlanta, Georgia, US (EU)
+
+High Volume Expert Clinics:
+These are clinics within participating institutions who see a high volume of patients with the specific disease studied (ex; The Alzheimer’s and Mild Cognitive impairment clinic at USF for Alzheimer’s).
+
+All US-based institutions will abide to the SINGLE IRB Process. Once this protocol is approved at USF, each of the participating institution will submit review based on the SINGLE IRB at USF
+The exceptions to the single IRB are the following:
+Genomic data will only be collected and analyzed at the University of Toronto and Mount Sinai Hospital in Canada. Therefore, that team will have a separate protocol for genomic data collection and analysis. Once approved, a copy of the protocol and Research Ethics board approval will be submitted to USF IRB.
+Canadian Institutions (MSH, SickKids and UofT) do not abide to the SINGLE IRB process and will apply for a separate REB (research ethics board application) to comply with the Canadian regulations. A copy of this approved IRB will also be submitted with their application
+
+Longitudinal Data Collection:
+For specific disease cohorts that are progressive or degenerative (i.e Alzheimer's, Parkinson’s), Longitudinal data collection may be collected.
+The longitudinal data will be collected in 2 forms:
+1: Longitudinal data in clinic during clinic visits:
+This data collection will happen in clinic during REGULAR follow up visits. No additional visits outside of regular follow up plans for disease monitoring
+2: Longitudinal data “at home”:
+In between clinic visit, certain cohorts could be asked to perform voice data collection at home through participants’ own smartphone application that will be downloaded for them in clinic. This is just for longitudinal data cohort only. This data collection will be asked at intervals of 1-6 months depending on disease cohorts and for a maximum of 3 years total duration. Participants can decide to leave the study at any point during that time.
+NIH Stride Partner:
+  An initiative allows NIH to explore the use of cloud environments to streamline NIH data use by partnering with commercial providers. NIH’s STRIDES Initiative aims to modernize biomedical research by reducing economic and process barriers in utilizing commercial cloud services. These partnerships enable access to rich datasets and advanced computational infrastructure, tools, and services.
+Audio/Video Recording	Psychophysiological Recording
+Behavioral Interventions	Record Review - Educational
+Behavioral Observations and Experimentations	Record Review - Employee
+Deception	Record Review- Medical
+Focus Groups	Record Review - Other
+Interviews	Specimen collection and analysis
+Investigational Device – Non-Significant Risk (e.g. Mobile Applications)	Surveys and/or questionnaires
+Psychometric Testing	Other Social-Behavioral Procedures
+Phase 1	Phase 2	Phase 3	Phase 4
+Exploratory	Pilot	Expansion	Outreach
+IT and cloud infrastructure
+Software and app development
+Data collection for up to 180 participants (30 participants from each disease category and controls, at main sites only
+(Completed November 2023)	Data collection to cumulatively reach up to 600 participants (100 participants from each disease category and controls) at:
+Main sites
+HVEC in participating institutions
+(Begun November 2023, ongoing in November 2024)	Expansion to COC, other HVEC and expansion phase of data acquisition to cumulatively reach data collection from up to 3000 participants (500 from each disease category and controls)	Expansion to normal cohorts though partnerships, expansion through HVEC and COC to cumulatively reach 5000 participants
+Category	Acoustic	Imaging	Genomic	Descriptive/normative
+Voice Disorders	Voice and Speech	Video-Laryngoscopy images	Demographic data
+Validated Questionnaire Scores
+Respiratory Disorders	Voice and Speech
+Breathing Sounds	Chest X rays	Oxygen saturation
+Demographic data
+Validated Questionnaire Scores
+Forced Expiratory Volumes
+Mood Disorders	Voice and Speech	Demographic data
+Validated Questionnaire Scores
+Neurological Disorders	Voice and Speech	Brain CT Scan
+Brain MRI	Whole Genome Sequencing	Demographic data
+Validated Questionnaire Scores
+Pediatric Disorders	Voice and Speech	Demographic data
+Validated Questionnaire Scores
+Controls	Voice and Speech	Demographic data
+Validated Questionnaire Scores
+Phase 1: Exploratory	Phase 2
+Pilot	Phase 3
+Expansion	Phase 4
+Outreach
+Single IRB process @ USF
+Integration of participating institutions to Single IRB
+App Development
+Protocol and app refinement
+IT infrastructure and data storage platform development
+Preliminary data collection
+Pilot data collection (began November 2023)
+Expansion phase of data collection
+Outreach phase of Data collection
+Data sharing and access management
+Transfer of data sharing to open-source access
+Email	Online/Social Media Advertisement
+Flyer	Record Review
+Letter	SONA
+News Advertisement	Other
+Obtaining Signed Authorization	Waiver of HIPAA Authorization for Recruitment/Screening Purposes Only
+Obtaining Online or Verbal Authorization (Alteration of HIPAA Authorization)	Waiver of HIPAA Authorization for Entire Study
+Data Use Agreement	Business Associate Agreement
+No Compensation	Tokens (pens, food items, etc.)
+Financial Compensation (cash, gift cards)	Other
+Course Credit (i.e. extra credit, SONA points)
+Obtaining Signed Consent (Subject or Legally Authorized Representative)	Obtaining Consent Online (Waiver of Written Documentation of Consent )
+Obtaining Signed Parental Permission	Obtaining Verbal Consent (Waiver of Written Documentation of Consent)
+Obtaining Signed Assent for Children or Adults Unable to Consent	Waiving Consent and/or Parental Permission (Waiver of Consent Process)
+Obtaining Verbal Assent for Children or Adults Unable to Consent	Waiving Assent/Assent is Not Appropriate
+Lead Investigator	Role
+USF	Yael Bensoussan MD, MSc	Co-Lead of Data Acquisition
+WCM	Anais Rameau, MD, MPhil	Co-Lead of Data Acquisition
+WCM	Alexandros Sigaras, PhD	Co-Lead – Tools – Software and IT infrastructure
+WCM	Olivier Elemento, PhD	Co-Lead – Tools – Software and IT infrastructure
+USF	Stephanie Watts, PhD, CCC-SLP	Lead Respiratory Disorders
+USF	Ruth Bahr PhD, CCC-SLP	Lead Voice Disorders
+MIT	Satrajit Ghosh, PhD	Lead Mood Disorders
+UofT	Frank Rudzicz, PhD	Lead Neuro Disorders
+USF	Tempestt Neal, PhD	Investigator – Machine Learning Readiness
+USF	Karim Hanna, PhD	Investigator – Control data
+USF	Stephen Aradi, MD	Investigator - Neurology
+VUMC	Maria Powell, PhD	Investigator – Voice Disorders
+EU	Anthony Law, MD PhD	Investigator – Voice Disorders
+MEEI	Phillip Song MD	Investigator – Voice Disorders
+MEEI	Matthew Naunheim, MD	Investigator – Voice Disorders
+MSH	Jordan Lerner-Ellis, PhD	Lead – Genomic data (separate IRB)
+HSC	Alistair Johnson	Lead – data integration
+
+
+================================================================================
+
+FILE: docs_b2ai-voice_org_row10.txt
+PATH: data/preprocessed/individual/VOICE/docs_b2ai-voice_org_row10.txt
+SIZE: 70176 bytes
+--------------------------------------------------------------------------------
+
+SOURCE METADATA
+Project: VOICE
+Source ID: project_documentation
+Source type: documentation
+Source URL: https://docs.b2ai-voice.org/
+Raw file: data/raw/VOICE/docs_b2ai-voice_org_row10.html
+--------------------------------------------------------------------------------
+Bridge2AI - Voice
+Skip to content
+Home
+About
+Our Consortium
+Advisory Board and Collaborators
+Join Us
+Data & Tools
+Protocols
+Dataset
+Adult Dashboard
+Pediatric Dashboard
+Tools
+Training Resources
+Webinars
+Training and Mentorship
+Voice AI Symposium
+Voice AI Symposium
+Impact
+Publications
+Press
+Social Media
+Home
+About
+Our Consortium
+Advisory Board and Collaborators
+Join Us
+Data & Tools
+Protocols
+Dataset
+Adult Dashboard
+Pediatric Dashboard
+Tools
+Training Resources
+Webinars
+Training and Mentorship
+Voice AI Symposium
+Voice AI Symposium
+Impact
+Publications
+Press
+Social Media
+Bridge2AI-Voice Dataset
+The
+Bridge2AI-Voice
+(B2Ai-Voice) dataset is a large, ethically sourced, and demographically diverse voice dataset linked to health information, released by the NIH’s Bridge2AI initiative. The dataset includes many derived voice recordings (such as spectrograms and other acoustic features) rather than raw audio in the public release, along with detailed participant metadata: clinical diagnoses (including voice, neurological, mood, respiratory disorders), validated questionnaires, and demographics. It is collected from multiple sites across North America, with version 3.0 containing ~61,937 voice-derived recordings from 833 adult participants. The pediatric dataset v1.0 is now available containing data from 300 participants. Access to the original raw audio is restricted to controlled access due to privacy concerns. Access can be requested by emailing
+[email protected]
+B2AI-Voice v3.1.0 adult dataset and v1.1.0 pediatric dataset now available (with voice upon request)
+Access the Flagship B2Ai-Voice Dataset
+Register for Adult Dataset Access via PhysioNet
+Register for Pediatric Dataset Access via PhysioNet
+How to get data access
+Featurized dataset
+Featurized Adult and Pediatric Datasets are Available under Registered Access
+The adult and pediatric datasets are available through separate PhysioNet links under registered access. Credentialed users must be approved and sign DUA. Visit PhysioNet to begin process.
+Adult Dataset
+Pediatric Dataset
+Datasets with Audio Data
+Available under controlled access
+Users interested in access the audio data from any Bridge2AI-Voice dataset can request access by emailing
+[email protected]
+Raw audio data is disseminated through controlled access only to protect participants’ privacy.
+Documentation
+Training opportunities for using the dataset:
+https://www.b2aivoicescholars.org/
+.
+Overview
+Collection Methods
+Data Governance
+Study Metadata
+Healthsheet
+Data Pre-Processing
+AI-Readiness
+Bridge2AI-Voice is a Precision Public Health grand challenge project funded by the NIH Common Fund Bridge2AI Program. Bridge2AI-Voice seeks to create a flagship, standardized, and ethically sourced dataset of 10,000 voices linked to health information to fuel research and discovery in voice biomarkers.
+Our group aims to promote integration of voice as a biomarker of health in clinical care. To do so, we will generate a large multi-institutional, ethically sourced, and diverse voice dataset linked to multimodal health biomarkers to fuel voice AI research. Data collection is performed via a novel app (The Bridge2AI-Voice App) available as a smartphone application linked to electronic health records (EHR). The app collects breathing sounds and voice, speech, and linguistic tasks, along with a considerable amount of health information through surveys and validated questionnaires. Other multimodal data collected includes imaging, genomics, and respiratory function tests, among others. The consortium is also addressing the growing ethical, legal, and social challenges surrounding voice AI, including risks of voice re-identification, vulnerabilities like voice AI hacking, concerns around voice data sharing and privacy, and the influence of gender and racial diversity on the development and application of these technologies.
+Our best ethical practices, developed through ethical inquiry, have guided the development of the voice collection protocol as well as data dissemination practices.
+As voice is increasingly recognized as a biomarker of health by the tech world and voice AI is gaining attention from multinationals such as Google, Amazon, Mozilla, and Apple, many important issues related to patient privacy protection, ethical and fair representation of populations, and clinical accuracy are arising. As a multidisciplinary group of academic experts, we aim to influence and guide the world of voice AI by ensuring patient protection through ethical and fairness principles and by creating safe, innovative infrastructures to disseminate ethically sourced data for future generations of voice AI researchers.
+Based on the existing literature and ongoing research in different fields of voice research, our group has identified 5 disease cohort categories for which voice changes have been associated with specific diseases with well-recognized unmet needs and for which our data acquisition efforts are focused:
+Voice Disorders
+Neurological and Neurodegenerative Disorders
+Mood and Psychiatric Disorders
+Respiratory disorders
+Pediatric Voice and Speech Disorders
+Please Note:
+The public data releases do not contain an equal distribution of these categories of diseases. Further releases will contain additional data.
+Data Access
+Adult Dataset
+A derived dataset containing spectrograms and combined phenotypic data is available on PhysioNet under a permissioned access mechanism. Registration on PhysioNet and signing of a data use agreement will enable access. Raw audio is available under a controlled access mechanism. The latest version of the dataset is available at the following URL:
+Bridge2AI-Voice: An ethically-sourced, diverse voice dataset linked to health information
+Pediatric Dataset
+The Bridge2AI Voice consortium has also prepared a pediatric dataset. To access the Bridge2AI Voice pediatric dataset please click here
+Bridge2AI-Voice Pediatric Dataset
+Older Versions
+An earlier version of the feature-only dataset is available on HealthDataNexus, which provides cloud compute alongside the dataset rather than allowing data downloads.
+Request Data Access to v1.0 via Health Data Nexus
+Data is collected across five disease categories. The initial data release contains data collected from four of the five categories.
+Participants are recruited across different academic institutions from “high volume expert clinics” based on diagnosis and inclusion/exclusion criteria outlined below
+(
+Table 1
+)
+.
+Pediatric Participants:
+Pediatric participants are recruited strictly from the Hospital for Sick Children (SickKids) and are grouped by age.
+High Volume Expert Clinics:
+Outpatient clinics within hospital systems or academic institutions that have developed an expertise in a specific disease area and see more than 50 patients per month from the same disease category. Ex: Asthma/COPD pulmonary specialty clinic.
+Data is collected in the clinic with the assistance of a trained research assistant. Future data collection will also occur remotely; however, remote data collection did not occur for the initial dataset release. Voice samples are collected prospectively using a custom software application (the Bridge2AI-Voice App) with the Bridge2AI-Voice protocols.
+For Pediatrics, all data is collected using
+reproschema-ui
+with the Bridge2AI-Voice pediatric protocol.
+Clinical validation:
+Clinical validation is performed by a qualified physician or practitioner based on established gold standards for diagnosis
+(
+Table 1
+)
+.
+Acoustic Tasks:
+Voice, breathing, cough, and speech data are recorded with the app for adults and with reproschema-ui for pediatrics. A total of 22 acoustic tasks are recorded through the app
+(
+Table 2
+)
+.
+Demographic surveys and confounders:
+Detailed demographic data and surveys about confounding factors such as smoking and drinking history are collected through the smartphone application.
+Validated Questionnaires:
+The Bridge2AI-Voice protocols contain validated tools and questionnaires for each disease category within the app for data collection
+(
+Table 3
+)
+.
+Other Multimodal Data:
+The rest of the multimodal data, including imaging, genomic data (for the neuro cohort), laryngoscopy imaging, and other EHR data, is extracted from different sites independently and will be uploaded through the REDCap database. Please note that no external data is released in this v3.0.0 release.
+Please see the following publication for a description of protocol development:
+Bensoussan, Yael, et al. “Developing Multi-Disorder Voice Protocols: A team science approach involving clinical expertise, bioethics, standards, and DEI.” Proc. Interspeech 2024. 2024.
+https://www.isca-archive.org/interspeech_2024/bensoussan24_interspeech.html
+.
+The supporting REDCap data dictionary, metadata, and instrument PDFs are available at
+https://github.com/eipm/bridge2ai-redcap
+.
+When using the REDCap data dictionary and metadata, please cite:
+Bensoussan, Y., Ghosh, S. S., Rameau, A., Boyer, M., Bahr, R., Watts, S., Rudzicz, F., Bolser, D., Lerner-Ellis, J., Awan, S., Powell, M. E., Belisle-Pipon, J.-C., Ravitsky, V., Johnson, A., Zisimopoulos, P., Tang, J., Sigaras, A., Elemento, O., Dorr, D., … Bridge2AI-Voice. (2024). eipm/bridge2ai-redcap. Zenodo.
+https://zenodo.org/doi/10.5281/zenodo.12760724
+.
+Protocols can be found in the Bridge2AI-Voice documentation of the dataset for each cohort in the following:
+Voice Disorders
+Respiratory
+Mood/Psychiatric
+Neurological
+Controls
+Pediatrics
+Peds 10+
+Peds 6-10
+Peds 4-6
+Peds 2-4
+Table 1 – Disease cohort inclusion/exclusion criteria and validation methods
+Disease Cohort
+Diagnosis
+Inclusion Criteria
+Exclusion Criteria
+Gold Standard Validation Methods
+Voice Disorders Cohort
+Laryngeal Cancer
+Active laryngeal cancer T1-T4 Biopsy proven (if no biopsy at time of collection and suspicion is very high, provider will have to go back to confirm in the clinical validation section after the biopsy is obtained)
+Previously treated laryngeal cancer with no evidence of disease on scope
+Laryngoscopy Images Stroboscopy Videos
+Voice Disorders Cohort
+Laryngitis
+Acute laryngitis Chronic laryngitis Bacterial laryngitis Fungal laryngitis Autoimmune laryngitis *need to have evidence of information of the vocal cords on laryngoscopy as well as dysphonia
+Subjective laryngitis without evidence on scope
+Laryngoscopy Images Stroboscopy Videos
+Voice Disorders Cohort
+Pre-cancerous lesions
+Keratosis Leukoplakia (note if with or without dysplasia)
+Low grade –
+Laryngoscopy Images Stroboscopy Videos
+Voice Disorders Cohort
+Benign Lesions of the vocal cord (nodule, polyp, cyst)
+Vocal fold nodules Vocal fold polyp Vocal fold cyst Reinke’s Edema Vocal fold ulcers Recurrent respiratory Papilloma Fibrous mass Rheumatoid nodules Recurrent Laryngeal Papilloma (RLP)
+Patient has received surgery for any condition and does not have evidence of pathology when scoped Immediate post op prior less than 30 days from laryngeal surgery
+Laryngoscopy Images Stroboscopy Videos
+Voice Disorders Cohort
+Muscle Tension Dysphonia (MTD)
+Laryngology & SLP diagnosis
+Laryngoscopy Images Stroboscopy Videos
+Voice Disorders Cohort
+Spasmodic Dysphonia/Laryngeal Tremor
+Adductor laryngeal dystonia (ADLD) previously called spasmodic dysphonia Abductor laryngeal dystonia (ABLD) Vocal tremor Mixed laryngeal dystonia Singer’s laryngeal dystonia (SLD) Adductor laryngeal spasms during inspiration (ARLD)
+Laryngoscopy Images Stroboscopy Videos
+Voice Disorders Cohort
+Unilateral Vocal Fold Paralysis
+Laryngology & SLP diagnosis
+Vocal fold paresis Bilateral VF paralysis Immediately or less than 2 weeks post injection Immediately post-op thyroplasty (less than a month)
+Laryngoscopy Images Stroboscopy Videos CT scan Spirometry
+Voice Disorders Cohort
+Glottic insufficiency/presbyphonia
+Patients with glottic gap on STROBOSCOPY due to vocal fold atrophy related to aging, rapid weight loss, severe illness, or other causes
+Patients with glottic gap 2nd to unilateral paresis or paralysis
+Respiratory Disorders Cohort
+Airway Stenosis: Bilateral Vocal fold paralysis, Supraglottic stenosis, Glottic stenosis, Posterior glottic stenosis, subglottic stenosis, tracheal stenosis, multi-level upper airway stenosis
+Nasopharyngeal stenosis
+Spirometry and flow volume loops CT scan of neck/chest
+Respiratory Disorders Cohort
+Chronic Cough
+bothersome cough > 8 weeks, negative for exclusion criteria
+Cough less than 8 weeks, current smoking, lung/laryngeal cancer, COPD, asthma, GERD, bronchiectasis, TB infection, pneumonia, pulmonary granuloma, idiopathic pulmonary fibrosis, ACE inhibitor use, eosinophilic bronchitis, tracheomalacia, upper airway cough syndrome, laryngitis, chest Xray/CT indicative of airway foreign body
+Spirometry and flow volume loops
+Neurological and Neurodegenerative Disorders
+Mild Cognitive Impairment (MCI)
+clinical diagnosis of MCI/ cognitive decline/short term memory loss/cognitively impaired Being over the age of 44 and under 85 Able to read, speak the English language
+Not having a clinical diagnosis Being less than the age of 44 and above 85 Unable to speak and read the English language Having had a surgical intervention significantly altering the symptoms of the disease studied
+CT Brain MRI Brain Whole Genome Sequencing
+Neurological and Neurodegenerative Disorders
+Alzheimer’s disease (AD)
+clinical diagnosis of AD Being over the age of 44 and under 85 Able to read, speak the English language
+Not having a clinical diagnosis Being less than the age of 44 and above 85 Unable to speak and read the English language Having had a surgical intervention significantly altering the symptoms of the disease studied
+CT Brain MRI Brain Serum Bloodmarker Ptau proteins Whole Genome Sequencing
+Neurological and Neurodegenerative Disorders
+Other types of Dementia
+clinical diagnosis of frontotemporal dementia/ Lewy body dementia/ vascular dementia/ mixed dementia/ alcohol induced dementia (to make a note in diagnosis form) Being over the age of 44 and under 85 Able to read, speak the English language
+Not having a clinical diagnosis Being less than the age of 44 and above 85 Unable to speak and read the English language Having had a surgical intervention significantly altering the symptoms of the disease studied
+CT Brain MRI Brain Whole Genome Sequencing
+Neurological and Neurodegenerative Disorders
+Amyotrophic Lateral Sclerosis (ALS)
+clinical diagnosis of sporadic ALS/ Familial ALS/ Spinal or limb-onset ALS/ Bulbar-onset ALS Being over the age of 44 and under 85 Able to read, speak the English language
+Not having a clinical diagnosis Being less than the age of 44 and above 85 Unable to speak and read the English language Having had a surgical intervention significantly altering the symptoms of the disease studied
+CT Brain MRI Brain Whole Genome Sequencing
+Neurological and Neurodegenerative Disorders
+Parkinson’s Disease (PD)
+clinical diagnosis of idiopathic PD/multiple system atrophy/progressive Supranuclear palsy/ Corticobasal degeneration/dementia with Lewy bodies/other or atypical parkinsonism Parkinson’s patients enrolled in Deep Brain Stimulation studies (to make a note of this in diagnosis form)
+Not having a clinical diagnosis Being less than the age of 44 and above 85 Unable to speak and read the English language Having had a surgical intervention significantly altering the symptoms of the disease studied
+CT Brain MRI Brain Whole Genome Sequencing
+Mood and Psychiatric Disorders
+Alcohol or Substance Use Disorder
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Anxiety Disorder
+Existing clinical diagnosis of anxiety and/or currently experiencing an anxious episode.
+Not having a clinical diagnosis
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Attention-Deficit/Hyperactivity Disorder (ADHD)
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Q-Mood-ADHD Adult questionnaire is part of part B mood cohort
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Autism Spectrum Disorder (ASD)
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Bipolar Disorder
+Existing clinical diagnosis of bipolar I or II and/or currently experiencing a manic/depressive episode.
+Not having a clinical diagnosis
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Borderline Personality Disorder
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Depression or Major Depressive Disorder
+Existing clinical diagnosis of depression and/or currently experiencing a depressive episode.
+Not having a clinical diagnosis
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Eating Disorder (ED)
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Insomnia/Sleep Disorder
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Obsessive-Compulsive Disorder (OCD)
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Panic Disorder
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Post-Traumatic Stress Disorder (PTSD)
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Q-Mood-PTSD Adult questionnaire is part of part B of mood cohort
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Schizophrenia
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Social Anxiety Disorder
+Co-morbid with depression, bipolar disorder and anxiety disorder.
+Q-Mood-GAD7 questionnaire is part of part B of mood cohort
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Mood and Psychiatric Disorders
+Other Psychiatric Disorder
+Not applicable
+Not applicable
+Electronic health summary; clinical diagnosis from psychiatrist; medication history
+Table 2 – Acoustic Tasks in Protocol
+Name
+Task
+Description
+Part
+Non Voice/Non Speech
+Respiration Part A [
+Example
+]
+Breathing sounds
+A
+Non Voice/Non Speech
+Cough part A [
+Example
+]
+Voluntary Cough
+A
+Non Voice/Non Speech
+Breath Sounds [
+Example
+]
+Breathing sounds
+Resp
+Non Voice/Non Speech
+Voluntary Cough [
+Example
+]
+Voluntary Cough
+Resp
+Voice/Non Speech
+Prolonged Vowel [
+Example
+]
+vowel /e/
+A
+Voice/Non Speech
+Maximum Phonation Time [
+Example
+]
+vowel /e/
+A
+Voice/Non Speech
+Glides [
+Example
+]
+Lowest to Highest /e/
+A
+Voice/Non Speech
+Loudness [
+Example
+]
+/Hey/
+A
+Voice/Non Speech
+Diadochokinesis [
+Example
+]
+/pa/ta/ka/ /buttercup/
+A
+Speech
+Rainbow Passage [
+Example
+]
+validated passage
+A
+Speech
+Caterpillar Passage [
+Example
+]
+validated passage
+Voice
+Speech
+Cape-V Sentences [
+Example
+]
+validated sentences
+Voice
+Speech
+Free Speech Part A [
+Example
+]
+open questions
+A
+Speech
+Picture Description [
+Example
+]
+describing a picture
+A
+Speech
+Free Speech Voice [
+Example
+]
+open questions
+Voice
+Speech
+Story Recall [
+Example
+]
+speech after reading a story
+A
+Speech
+Animal Fluency [
+Example
+]
+name animals
+Mood
+Speech
+Open Response Questions [
+Example
+]
+open questions
+Mood
+Speech
+Word-Color Stroop [
+Example
+]
+color descriptions
+Neuro
+Speech
+Productive Vocabulary [
+Example
+]
+describing images
+Neuro
+Speech
+Random Item generation [
+Example
+]
+describing images
+Neuro
+Speech
+Cinderella Story [
+Example
+]
+story
+Neuro
+Speech
+ABC’s
+Recalling alphabet
+Peds
+Speech
+Ready For School
+Recalling a typical day preparing for School
+Peds
+Speech
+Favorite Show
+Recalling favorite shows
+Peds
+Speech
+Favorite Food
+Describing their favorite food
+Peds
+Speech
+Outside of School
+After school activities description
+Peds
+Speech
+Months
+Listing the months
+Peds
+Speech
+Counting
+Counting
+Peds
+Speech
+Naming Animals
+Listing animals
+Peds
+Speech
+Naming Food
+Listing foods
+Peds
+Speech
+Identifying Pictures
+Picture identification
+Peds
+Speech
+Picture Description (Pediatrics)
+describing a picture
+Peds
+Voice/Non Speech
+Long Sounds
+Sustained /ee/ and /ah/ sounds
+Peds
+Voice/Non Speech
+Noisy Sounds
+/jj/ /ah/ /ee/ /oo/ /sh/ /ss/ /muh/ /nuh/ /zz/ /hh/
+Peds
+Speech
+Caterpillar Passage (Pediatrics)
+validated passage
+Peds
+Speech
+Repeat Words
+Word repetition
+Peds
+Speech
+Role naming
+recalling days, months, and counting from 60 – 70
+Peds
+Speech
+Repeat Sentences
+Sentence Recall
+Peds
+Voice/Non Speech
+Silly Sounds
+/PUH/ /TUH/ /KUH/ /PUH TUH KUH/
+Peds
+Table 3 – Validated Questionnaires integrated into App
+Validated Questionnaire
+Voice Disorders
+Respiratory
+Mood/Psychiatric
+Neurological
+Controls
+Pediatrics
+Example
+Voice Handicap Index-10 (VHI-10)
+X
+X
+X
+X
+X
+PDF
+Patient Health Questionnaire (PHQ-9)
+X
+X
+X
+X
+X
+PDF
+General Anxiety Disorder (GAD-7)
+X
+X
+X
+X
+X
+PDF
+Positive and Negative Affect Schedule (PANAS)
+X
+X
+PDF
+Custom Affect scale
+X
+X
+PDF
+Post-Traumatic Stress Disorder Test (PTSD) Adult
+X
+X
+PDF
+Attention Deficit and Hyperactivity Disorder Questionnaire (ADHD-Adult)
+X
+X
+PDF
+The Diagnostic and Statistical Manual of Mental Disorders (DSM-5 Adult)
+X
+X
+PDF
+Dyspnea Index (DI)
+X
+X
+PDF
+Leicester Cough Questionnaire (LCQ)
+X
+X
+PDF
+Winograd Questionnaire
+X
+X
+PDF
+Montreal Cognitive Assessment (MOCA)*
+X
+X
+PDF
+Children’s Voice Handicap Index-10 (C-VHI-10)
+X
+PDF
+Pediatric Voice Outcomes Survey (PVOS)
+X
+PDF
+Pediatric Voice-Related Quality-of-Life (PVRQOL)
+X
+PDF
+Patient Health Questionnaire modified for Adolescents (PHQ-A)
+X
+PDF
+Accessing the Dataset
+The feature-only and raw audio datasets are available under distinct agreements appropriate for the sensitivity of their respective content.
+Registered Access (features-only data):
+Register on PhysioNet and confirm your identity (
+Registered Access License
+).
+Sign the Bridge2AI-Voice Registered Access Agreement, which outlines the terms and conditions for data use.
+Controlled Access (raw audio data):
+Complete the Data Access Request Form (DARF)
+Complete the Data Use Agreement (DUA)
+Submit your application to the Data Access Compliance Office for review
+Upon approval, ensure a Data Use and Transfer Agreement (DTUA) is signed by an authorized official at your institution.
+Memorandum: Ethical Justification for Controlled Access to Raw Voice Data Samples
+Click the button below to download a copy of the memorandum explaining the reasoning behind the governance structure.
+Download - Memorandum PDF
+Oversight
+Has the clinical study been reviewed and approved by at least one human subjects’ protection review board?
+Submitted and approved by the USF Single IRB and subsite IRBs through the Single IRB process.
+Is this clinical study for a drug product?
+No
+Is this clinical study for a medical device?
+No
+Was a data monitoring committee appointed for this study?
+No
+De-Identification Levels
+Level of de-identification for this dataset: Identifiable information (under HIPAA and the Common Rule), as well as data considered sensitive, have been removed from this dataset.
+Does this dataset remove direct identifiers?
+Yes
+Does this dataset apply the HIPAA de-identification rules?
+Yes
+Does this dataset rebase and/or replace dates by integers?
+Yes
+Does this dataset remove or generalize geographic information?
+Yes
+Does this dataset remove narrative text fields?
+Yes
+Does this dataset achieve K-anonymization (k>=2)?
+No
+De-identification Details
+All direct identifiers were removed, as these would reveal the identity of the research participant. These include name, civic address, and social security numbers. Indirect identifiers were removed where these created a significant risk of participant re-identification, for example through their combination with other public data available on social media, in government registries, or elsewhere. These include select geographic or demographic identifiers, as well as some information about household composition or cultural identity. Non-identifying elements of data that revealed highly sensitive information, such as information about household income, mental health status, traumatic life experiences, and the like, were also removed. All raw voice data was removed, as this data has the potential to cause individual re-identification or to be used for illicit or unauthorized purposes.
+Consent
+Consent Type
+Does this dataset allow only the non-commercial use of the data?
+No
+Does this dataset allow only the use of the data in a specific geographic location?
+No
+Does this dataset allow only the use of the data for a specific type of research?
+No
+Does this dataset allow only the use of the data for genetic research?
+No
+Does this dataset allow only the use of the data for research that does not involve the development of methods or algorithms?
+No
+Consent Details
+Research data that does not contain your direct identifiers will be shared with external researchers for future research through a secure database. Data that poses a low risk of causing individual re-identification will be shared in registered access with the general public. Data that would pose a heightened risk of re-identification if shared in full open access will be shared through a controlled access mechanism with authorized researchers.
+Official Title: Bridge2AI-Voice
+Design: Study Type – Observational
+Enrollment Count (Anticipated by 2027): 10,000
+Design Observation Model
+Cohort
+Design Time Perspective
+Cross-sectional
+Biospecimens: Respiratory, Voice and speech samples
+Biospecimens Description:
+The Bridge2AI-Voice dataset contains samples from conventional acoustic tasks including respiratory sounds, cough sounds, and free speech prompts, capturing voice, speech and language data relating to health. Participants who consent are asked to perform speaking tasks and complete self-reported demographic and medical history questionnaires, as well as disease-specific validated questionnaires. Participants who consent also permit investigators to access medical information through EHR platforms in order to perform gold standard validation of diagnoses and symptoms.
+Eligibility
+Sex
+All
+Gender Based
+No
+Minimum Age
+18 years (this will change when pediatric cohort is introduced, and metadata will be updated to reflect new eligibility criteria)
+Maximum Age
+120 years
+Healthy Volunteers
+Yes
+Inclusion Criteria
+See Collection Methods – Table 1
+Exclusion Criteria
+Does not read or speak English (Please note, the Spanish protocols and Data collection will be included in future releases)
+See Collection Methods – Table 1
+Study Population
+The current v.2.0.0 dataset contains only adult populations. As the study progresses, a pediatric cohort will be introduced. Inclusion/exclusion criteria and additional information regarding the dataset and study metadata will be updated at that time. In addition, the current dataset contains fluent English speakers but will expand to include data collection in Spanish.
+Sampling Method
+Non-Probability Sample
+Identification Information
+Organization Study ID
+OT2OD032720
+Organization Study Type
+U.S. National Institutes of Health (NIH) Grant/Contract Award Number
+Secondary ID:
+ID
+Link
+OT2OD032720
+https://reporter.nih.gov/search/4XtcXzBGEkWQlwG5v8odBA/project-details/10858564
+Collaborators
+University of South Florida
+Weill Cornell Medicine
+Oregon Health & Science University
+Massachusetts Institute of Technology
+University of Toronto
+Mount Sinai Hospital
+Hospital for Sick Children
+Simon Fraser University
+The Hastings Center
+Washington University in St. Louis
+University of Florida
+Vanderbilt University Medical Center
+URL How to CiteIf you use this dataset for any purpose, please cite the resources specified in the Bridge2AI-Voice documentation for version 2.0.0 of the dataset at (URL)
+Bridge2AI-Voice Consortium (2024). Flagship Voice Dataset from the Bridge2AI-Voice Project (2.0.0) [Dataset].
+Contact For any questions, suggestions, or feedback related to this dataset, please email
+[email protected]
+AcknowledgementBridge2AI-Voice is supported by NIH grant OT2OD032720 through the NIH Bridge2AI Common Fund program.
+General Information
+The Bridge2AI Voice dataset aims to enable the development, benchmarking, or validation of clinically applicable machine-learning models for diagnosing a wide range of health conditions using voice data, including vocal pathologies, neurological, psychiatric, respiratory, and pediatric voice disorders. This dataset contains voice recordings and key metadata, and it is structured to be Findable, Accessible, Interoperable, and Reusable (FAIR).
+Has the dataset been audited before? If yes, by whom and what are the results?
+The dataset has been audited internally for missingness and consistency by the data release team. A missingness table is included with the dataset. Certain aspects of the data (e.g., transcription) were generated using off-the-shelf models that have not been audited for correctness.
+Dataset Versioning
+Does the dataset get released as static versions or is it dynamically updated?
+Static
+Does the current version/subversion of the dataset come with predefined task(s), labels, and recommended data splits (e.g., for training, development/validation, testing)? If yes, please provide a high-level description of the introduced tasks, data splits, and labeling, and explain the rationale behind them. Please provide the related links and references. If not, is there any resource (website, portal, etc.) to keep track of all defined tasks and/or associated label definitions? (please note that more detailed questions w.r.t labeling is provided in further sections)
+Yes, the current version of the dataset comes with predefined tasks and labeling. The tasks are primarily designed for training machine-learning models for disease detection and classification using voice data. Labels include diagnostic categories such as vocal pathologies, neurological disorders, psychiatric conditions, and respiratory disorders. However, there are no predefined recommended data splits for training, validation, or testing. Researchers are encouraged to create their own data splits based on their specific requirements. More details regarding task definitions and labeling can be found in the dataset.
+Motivation
+For what purpose was the dataset created? Was there a specific task in mind? Was there a specific gap that needed to be filled? Please provide a description.
+The Bridge2AI Voice dataset was created to address a gap in the availability of large-scale, diverse, and well-documented voice data for use in clinical machine-learning applications. Previous studies on machine learning-based voice diagnosis produced promising results, but their sample sizes were too small, or they lacked the key metadata needed for training robust, clinically useful models. The dataset aims to bridge this gap by providing an ethically sourced, large, and diverse dataset to develop, benchmark, or validate clinically applicable AI/ML models. The goal is to facilitate the use of voice as a non-invasive, cost-effective biomarker for the screening, diagnosis, and monitoring of a wide range of health conditions.
+What are the applications that the dataset is meant to address? (e.g., administrative applications, software applications, research)
+The Bridge2AI Voice dataset is primarily intended for research applications, specifically in the development of AI and machine-learning models for healthcare. It aims to support clinical research in disease screening, diagnosis, and monitoring through voice biomarkers. The dataset can be used for AI model pretraining, fine-tuning, benchmarking, or validation.
+Are there any types of usage or applications that are discouraged from using this dataset? If so, why?
+Yes, there are restrictions on the use of this dataset, as detailed in the Registered Data Access Agreement. These restrictions reflect the B2AI-Voice Consortium’s commitment to advancing ethical and trustworthy research practices that respect and protect the rights and interests of research participants. Accordingly, the dataset is intended solely for commercial and non-commercial research purposes by Authorized Researchers. Specifically, the dataset is not to be used a) to attempt to re-identify research participants, nor any actions that could reasonably lead to re-identification; and b) for any purpose that could foreseeably cause harm or stigmatization to research participants, their families, communities, or specific populations. Lastly, intellectual property protections, database rights, or related rights may not be used in a manner that restricts or limits access to any part of the dataset or to any conclusions derived from it. This restriction ensures that future use of the dataset remains unrestricted, in alignment with the Open Science principles upheld by the B2AI-Voice Consortium. Specifically, the dataset should not be used for non-research applications, such as hiring decisions, insurance premium adjustments, or any form of surveillance that could lead to discrimination or harm. These limitations are intended to prevent unethical or biased outcomes that could negatively impact individuals based on their health conditions or voice characteristics.
+Who created this dataset (e.g., which team, research group), and on behalf of which entity (e.g., company, institution, organization)?
+Voice as a Biomarker of Health is being co-led by Dr. Yaël Bensoussan, MD, MSc, from USF Health Morsani College of Medicine and Olivier Elemento, PhD, from Weill Cornell Medicine, who are co-principal investigators for the project, which is funded by the NIH Common Fund within the Bridge2AI Program. The project also includes lead investigators from 10 other universities in North America; Alexandros Sigaras, MSc and Anaïs Rameau, MD, MPhil (Weill Cornell Medicine), Maria Powell, CCC-SLP, PhD (Vanderbilt University Medical Center), Ruth Bahr, CCC-SLP, PhD (USF Health Morsani College of Medicine), Jennifer Sui, MD (Hospital for Sick Children), Philip Payne, PhD (Washington University in St. Louis), David Dorr, MD (Oregon Health & Science University), Jean-Christophe Bélisle-Pipon, PhD (Simon Fraser University), Vardit Ravitsky, PhD (The Hastings Center), Satrajit Ghosh, PhD (Massachusetts Institute of Technology), Frank Rudzizc, PhD (University of Toronto), Jordan Lerner-Ellis, PhD (Sinai Health) and Don Bolser, PhD (University of Florida). There are over 50 other investigators, clinicians, scholars, and trainees who have contributed to the development of this dataset. Please see full list of collaborators here:
+The Bridge2AI-Voice Consortium (2024)
+Who funded the creation of the dataset? If there is an associated grant, please provide the name of the grantor and the grant name and number. If the funding institution differs from the research organization creating and managing the dataset, please state how.
+The NIH Common Fund
+3TF-OT2ActfOD032720Projectf01S1
+What is the distribution of backgrounds and experience/expertise of the dataset curators/generators?
+The curators and generators of the Bridge2AI Voice dataset come from a diverse range of backgrounds and areas of expertise, reflecting the interdisciplinary nature of the project. The team includes:
+Clinicians and Healthcare Professionals
+: Practicing doctors and healthcare workers involved in the direct collection of clinical data and providing practical insights into the medical relevance of the dataset.
+Biomedical Researchers
+: Experts in clinical medicine, neurology, and psychiatry, contributing deep knowledge of the medical conditions being studied.
+Machine Learning and AI Specialists
+: Researchers and engineers with expertise in machine learning, artificial intelligence, and data science, focusing on developing models and algorithms for analyzing voice data.
+Data Scientists and Statisticians
+: Professionals skilled in data curation, preprocessing, and statistical analysis, ensuring the dataset is robust and suitable for machine learning applications.
+Social Scientists and Ethicists
+: Experts in ethics, sociology, and human subjects research, ensuring the dataset is ethically sourced and meets standards for privacy and consent.
+Engineers and Technologists
+: Individuals with experience in software development, systems engineering, and data infrastructure, contributing to the technical aspects of data collection, storage, and dissemination.
+Data Composition
+What do the instances that comprise the dataset represent (e.g., documents, images, people, countries)? Are there multiple types of instances? Please provide a description.
+Each instance represents a person.
+How many instances are there in total (of each type, if appropriate) (breakdown based on schema, provide data stats)?
+There are currently around 833 instances.
+How many patients/subjects does this dataset represent? Answer this for both the preliminary dataset and the current version of the dataset.
+833
+Does the dataset contain all possible instances, or is it a sample (not necessarily random) of instances from a larger set? If the dataset is a sample, then what is the larger set? Is the sample representative of the larger set (e.g., geographic coverage)? If so, please describe how this representativeness was validated/verified. If it is not representative of the larger set, please describe why not (e.g., to cover a more diverse range of instances, because instances were withheld or unavailable). Answer this question for the preliminary version and the current version of the dataset in question.
+It is a sample of a larger, ongoing collection. The data is not representative because it was collected at a limited number of geographic locations. We hope to make it more representative by shifting to remote collection and designing our recruiting approach in a way that controls for more variables.
+What data modality does each patient data consist of? If the data is hierarchical, provide the modality details for all levels (e.g., text, image, physiological signal). Break down all levels and specify the modalities and devices.
+Audio recordings, questionnaire responses.
+What data does each instance consist of? “Raw” data (e.g., unprocessed text or images) or features? In either case, please provide a description.
+Raw audio and questionnaire response data, as well as extracted audio features.
+Is any information missing from individual instances? If so, please provide a description, explaining why this information is missing (e.g., because it was unavailable).
+Yes, some questions are optional. There may be data collection irregularities that caused some information to be missing from individual instances. Each individual answered a common set of questions and then responded to additional questions relevant to their primary diagnostic category.
+Are relationships between individual instances made explicit? (e.g., They are all part of the same clinical trial, or a patient has multiple hospital visits, and each visit is one instance)? If so, please describe how these relationships are made explicit.
+No, they are unrelated.
+Are there any errors, sources of noise, or redundancies in the dataset? If so, please provide a description. (e.g., losing data due to battery failure, or in survey data subjects skip the question, radiological sources of noise).
+Yes, different sites have different collection configurations. The collection protocol changed over the course of the study.
+Is the dataset self-contained, or does it link to or otherwise rely on external resources (e.g., websites, other datasets)? If it links to or relies on external resources:
+a. Are there guarantees that they will exist, and remain constant, over time?
+NA
+b. Are there official archival versions of the complete dataset (i.e., including the external resources as they existed at the time the dataset was created)?
+NA
+c. Are there any restrictions (e.g., licenses, fees) associated with any of the external resources that might apply to a future user? Please provide descriptions of all external resources and any restrictions associated with them, as well as links or other access points, as appropriate.
+It is self-contained.
+Does the dataset contain data that might be considered confidential (e.g., data that is protected by legal privilege or by doctor-patient confidentiality, data that includes the content of individuals’ non-public communications that is confidential)? If so, please provide a description.
+No
+Does the dataset contain data that, if viewed directly, might be offensive, insulting, threatening, or might otherwise pose any safety risk (such as psychological safety and anxiety)? If so, please describe why.
+This dataset includes the transcription of free speech tasks. While the inclusion of information of that type is unlikely, it cannot be completely avoided, as research participants are responsible for their choice of language.
+If the dataset has been de-identified, were any measures taken to avoid the re-identification of individuals? Examples of such measures: removing patients with rare pathologies or shifting time stamps.
+This dataset has been de-identified through removal of all audio data and certain sensitive fields identified by a team of ethicists.
+Does the dataset contain data that might be considered sensitive in any way (e.g., data that reveals racial or ethnic origins, sexual orientations, religious beliefs, political opinions or union memberships, or locations; financial or health data; biometric or genetic data; forms of government identification, such as social security numbers; criminal history)? If so, please provide a description.
+Yes:
+racial or ethnic origins:
+The dataset includes race information.
+sexual orientations:
+The dataset includes sexual orientation information.
+financial or health data:
+The dataset includes socioeconomic and health information.
+Devices and Contextual Attributes in Data Collection
+For data that requires a device or equipment for collection or the context of the experiment, answer the following additional questions or provide relevant information based on the device or context that is used (for example)
+Data is collected on iPads (9th or 10th generation), iPad Air (5th generation) using an Avid AE-36 microphone and an Apple dongle to connect it to the iPad.
+Challenges in Testing and Confounding Factors
+Which factors in the data might limit the generalization of potentially derived models? Is this information available as auxiliary labels for challenge tests? For instance:
+a. Number and diversity of devices included in the dataset.
+Distinct iPad devices were used at each site.
+b. Data recording specificities, e.g., the view for a chest x-ray image.
+The data were recorded with a head-mounted headset with a microphone that could be at slightly different distances. The clinical diagnosis, depending on the disorder, was performed by one clinician or based on an EHR record or prescription.
+c. Number and diversity of recording sites included in the dataset.
+There are five recording sites included in the dataset.
+d. Distribution shifts over time.
+Changes in diagnostic criteria or practices could be a source of distribution shift.
+What confounding factors might be present in the data?
+Noise artifacts, variations in diagnostic practices, inaccurate questionnaire responses, underreporting.
+What confounding factors might be present in the data?
+Noise artifacts, variations in diagnostic practices, inaccurate questionnaire responses, underreporting.
+a. Interactions between demographic or historically marginalized groups and data recordings, e.g., were women patients recorded in one site, and men in another?
+Groups that have less trust in the medical system, AI, or are less proximal to the collection sites would have been less likely to be recruited.
+b. Interactions between the labels and data recordings, e.g. were healthy patients recorded on one device and diseased patients on another?
+Participants were screened for different disorders based on site, so they also had their data collected with different devices.
+Collection and use of demographic information
+Does the dataset identify any demographic sub-populations (e.g., by age, gender, sex, ethnicity)?
+Age, Gender, Sex, Ethnicity, Socioeconomic status
+Pre-processing / de-identification
+Was there any pre-processing for the de-identification of the patients? Provide the answer for the preliminary and the current version of the dataset.
+Yes, the data were extracted from the raw audio to limit re-identification and only the extracted features are being released with the dataset.
+Was there any pre-processing for cleaning the data? Provide the answer for the preliminary and the current version of the dataset.
+No
+Was the “raw” data (post de-identification) saved in addition to the preprocessed/cleaned data (e.g., to support unanticipated future uses)? If so, please provide a link or other access point to the “raw” data.
+Yes, it is saved and is not accessible publicly.
+Were instances excluded from the dataset at the time of preprocessing? If so, why? For example, instances related to patients under 18 might be discarded.
+No
+Labeling and subjectivity of labeling
+Is there an explicit label or target associated with each data instance? Please respond for both the preliminary dataset and the current version.
+a. If yes:
+What are the labels provided?
+Who performed the labeling? For example, was the labeling done by a clinician, ML researcher, university or hospital?
+Diagnostic labels are the result of a clinical assessment of the participant. At each site, a local clinician provided the diagnosis based on a clinical interview and appropriate work-up. For the psychiatric disorders cohort, this assessment was determined by using the participants EHR record or using an active prescription, which was done outside of data collection by an appropriately licensed clinician.
+b. What labeling strategy was used?
+Gold standard label available in the data (diagnosed by a clinician).
+c. Human-labeled data:
+How many labelers were considered?
+Single labeler per data
+What is the demographic of the labelers? (countries of residence, of origin, number of years of experience, age, gender, race, ethnicity, etc.)
+Typically, the clinician at site of data collection, or external to (for prior diagnostic assessment)
+What guidelines did they follow?
+Per Bridge2AI Protocols and ICD-10 codes.
+How many labelers provide a label per instance?
+1
+What is the human-level performance in the applications that the dataset is supposed to address?
+It varies widely.
+Is the software used to preprocess/clean/label the instances available? If so, please provide a link or other access point.
+Yes.
+https://github.com/sensein/b2aiprep
+,
+https://github.com/sensein/senselab
+Is there any guideline that the future researchers are recommended to follow when creating new labels/defining new tasks?
+The process for any new labels should be described alongside any release of a model or publication. This process should include exact variables used for this determination.
+Collection Process
+Were any REB/IRB approval (e.g., by an institutional review board or research ethics board) received? If so, please provide a description of these review processes, including the outcomes, as well as a link or other access point to any supporting documentation.
+Yes
+How was the data associated with each instance acquired? Was the data directly observable (e.g., medical images, labs, or vitals), reported by subjects (e.g., survey responses, pain levels, itching/burning sensations), or indirectly inferred/derived from other data (e.g., part-of-speech tags, model-based guesses for age or language)? If data was reported by subjects or indirectly inferred/derived from other data, was the data validated/verified? If so, please describe how.
+The data was directly observable and reported by subjects. Clinical diagnoses were verified by clinicians reviewing audio and/or imaging data, looking at electronic health records, or medication prescriptions.
+What mechanisms or procedures were used to collect the data (e.g., hardware apparatus or sensor, manual human curation, software program, software API)? How were these mechanisms or procedures validated? Provide the answer for all modalities and collected data. Has this information been changed through the process? If so, explain why.
+The data were collected using an iPad app.
+Who was involved in the data collection process (e.g., patients, clinicians, doctors, ML researchers, hospital staff, vendors, etc.) and how were they compensated (e.g., how much were contributors paid)?
+Research teams, which may include medical, graduate, or undergraduate students, coordinated with clinicians/doctors to identify appropriate participants. These clinicians and doctors were listed under IRB as co-investigators, and were added to the consortium so that their names are included on consortium-level publications that emerge from the research. Hospital staff were not involved in scheduling but assisted in the logistics of coordinating data collection.
+Participants were compensated for their time through electronic gift cards. Participants currently receive $40 for a data collection session that takes less than 90 minutes, and $80 for a session that takes over 90 minutes, for no more than a total of 3 sessions and maximum compensation of $120.
+Over what timeframe was the data collected?
+The data was collected over a period of 12 months.
+Does the dataset relate to people?
+Yes
+Did you collect the data from the individuals in question directly, or obtain it via third parties or other sources (e.g., hospitals, app company)?
+Directly
+Were the individuals in question notified about the data collection?
+Yes, participants went through an IRB-approved consent process.
+Did the individuals in question consent to the collection and use of their data?
+Yes, all participants have been duly informed and agreed to the collection and the use of their data via prospective informed consent.
+If consent was obtained, were the consenting individuals provided with a mechanism to revoke their consent in the future or for certain uses?
+Consenting participants are informed that they may withdraw from the study at any point. If a participant chooses to withdraw during or before the voice data collection, their data will not be included in the database. Participants are informed that research data (including voice recordings) cannot be removed from the database once the voice data collection process is completed.
+In which countries was the data collected?
+USA and Canada
+Has an analysis of the potential impact of the dataset and its use on data subjects been conducted?
+No
+Inclusion Criteria-Accessibility in data collection
+Is there any language-based communication with patients (e.g.: English, French)? If yes, describe the choices of language(s) for communication. (for example, if there is an app used for communication, what are the language options?)
+English language was used for communication with study participants.
+The only language option for v2.0.0 is English. Spanish versions of the protocol are under development.
+What are the accessibility measurements and what aspects were considered when the study was designed and implemented?
+The protocol asks about disabilities. Collection accessibility was facilitated through the normal means of the collection sites, including reading questions to participants when needed.
+Uses
+Has the dataset been used for any tasks already? If so, please provide a description.
+A restricted version of the dataset containing raw audio has been used in the Bridge2AI Summer School and hackathon.
+Does using the dataset require the citation of the paper or any other forms of acknowledgement? If yes, is it easily accessible through google scholar or other repositories
+Bensoussan, Yael, et al. “Developing Multi-Disorder Voice Protocols: A team science approach involving clinical expertise, bioethics, standards, and DEI.” Proc. Interspeech 2024. 2024.
+https://www.isca-archive.org/interspeech_2024/bensoussan24_interspeech.html
+Is there a repository that links to any or all papers or systems that use the dataset? If so, please provide a link or other access point. (besides Google scholar)
+No
+Is there anything about the composition of the dataset or the way it was collected and preprocessed/cleaned/labeled that might impact future uses? For example, is there anything that a future user might need to know to avoid uses that could result in unfair treatment of individuals or groups (e.g., stereotyping, quality of service issues) or other undesirable harms (e.g., financial harms, legal risks) If so, please provide a description. Is there anything a future user could do to mitigate these undesirable harms?
+Yes, this dataset has skews based on disorder category, site, and other demographic factors. Users should consider the multivariate distribution when assessing utility for different questions.
+Are there tasks for which the dataset should not be used? If so, please provide a description.
+Yes, there are certain applications that are discouraged from using this dataset. Specifically, the dataset should not be used for non-clinical applications such as hiring decisions, insurance premium adjustments, or any form of surveillance that could lead to discrimination or harm. These discouraged uses are intended to prevent unethical or biased outcomes that could negatively impact individuals based on their health conditions or voice characteristics. The dataset is intended strictly for research that prioritize patient safety, privacy, and ethical use.
+Dataset Distribution
+Will the dataset be distributed to third parties outside of the entity (e.g., company, institution, organization) on behalf of which the dataset was created?
+The dataset will be distributed broadly to individuals outside of the entity who created the dataset.
+How will the dataset be distributed (e.g., tarball on website, API, GitHub)? Does the dataset have a digital object identifier (DOI)?
+The dataset will be distributed through a data publishing platform accessible at
+https://healthdatanexus.ai/
+This platform provides publicly accessible metadata regarding the dataset with a DOI for persistent resolution. The dataset itself requires registered access.
+When was/will the dataset be distributed?
+The data was published and made available at the end of November, 2024.
+Assuming the dataset is available, will it be/is the dataset distributed under a copyright or other intellectual property (IP) license, and/or under applicable terms of use (ToU)? If so, please describe this license and/or ToU, and provide a link or other access point to, or otherwise reproduce, any relevant licensing terms or ToU, as well as any fees associated with these restrictions.
+Users of the dataset must agree to terms laid out in the registered access agreement. The terms relating to intellectual property are repeated here for informational purposes only:
+INTELLECTUAL PROPERTY RIGHTS. You understand and acknowledge that the Data may be protected by copyright and other rights, including other intellectual property rights. Duplication, as reasonably required to carry out Your Research Project with the Data, is nonetheless permitted. Sale of all or part of the Data on any media is not permitted. You recognize that nothing in this Agreement shall operate to transfer to You any intellectual property rights in or relating to the Data. You agree not to make intellectual property claims on the Data. You agree not to use intellectual property protection in ways that would prevent or block access to, or use of, any element of these Data, or conclusions drawn directly from the Data. You can elect to perform further research that would add intellectual and resource capital to the Data and decide to obtain intellectual property rights on these downstream discoveries. You agree to implement licensing policies that will not obstruct further research. You agree to respect the Fort Lauderdale Agreement.
+There are no fees associated with these restrictions.
+Have any third parties imposed IP-based or other restrictions on the data associated with the instances? If so, please describe these restrictions, and provide a link or other access point to, or otherwise reproduce, any relevant licensing terms, as well as any fees associated with these restrictions.
+No IP-based restrictions have been imposed by third parties.
+Do any export controls or other regulatory restrictions apply to the dataset or to individual instances? If so, please describe these restrictions, and provide a link or other access point to, or otherwise reproduce, any supporting documentation.
+No export controls apply to the dataset.
+Maintenance
+Who is supporting/hosting/maintaining the dataset?
+The dataset is supported by the NIH via the Bridge2AI project.
+The dataset is hosted by the
+Health Data Nexus
+, a data publishing platform maintained by the Temerty Center for Artificial Intelligence Research and Education in Medicine (T-CAIREM) based at the University of Toronto. The Health Data Nexus maintains the technical infrastructure hosting dataset and provides continued access to interested researchers.
+How can the owner/curator/manager of the dataset be contacted (e.g. email address)?
+The platform team may be contacted through:
+[email protected]
+The curator of the data may be contacted through:
+[email protected]
+Is there an erratum? If so, please provide a link or other access point.
+There is no erratum. A changelog for each dataset version is published online with the dataset metadata.
+Will the dataset be updated (e.g., to correct labeling errors, add new instances, delete instances)? If so, please describe how often, by whom, and how updates will be communicated to users (e.g., mailing list, GitHub)?
+Yes, further versions of the dataset will be released on a semi-annual (twice a year) basis. These updates will be distributed as new versions of the dataset on the Health Data Nexus platform. Users will be notified through news items on the platform as well as through standard communication channels.
+If the dataset relates to people, are there applicable limits on the retention of the data associated with the instances (e.g., were individuals in question told that their data would be retained for a fixed period of time and then deleted)? If so, please describe these limits and explain how they will be enforced.
+Once data is contributed, the data will be retained as long as it is useful for research purposes, possibly indefinitely.
+Will older versions of the dataset continue to be supported/hosted/maintained? If so, please describe how and for how long. If not, please describe how its obsolescence will be communicated to users.
+By default, older versions of the dataset will continue to be supported, hosted, and made available to researchers. Each version of the dataset has a unique DOI. The dataset publishers reserve the right to remove access to older versions.
+If others want to extend/augment/build on/contribute to the dataset, is there a mechanism for them to do so?
+For dataset extensions and augmentations, it is possible for others to publish a derivative dataset on the Health Data Nexus which references the original source. These derivative datasets may be made available under the same conditions as the source data.
+For augmentations to the code used to produce the data, the open-source repositories have discussion forums and issue pages which allow for public discussion of data preprocessing. The repository also has a mechanism (“pull requests”) for contributing improvements to the data preprocessing code.
+The raw audio files and the questionnaire data retrieved from ReproSchema-UI or exported from REDCap were converted to be compliant with the
+Brain Imaging Data Structure v1.9.0
+.
+Pediatric data:
+Pediatric data collected through ReproSchema-UI is extracted and transformed into REDCap format, and subsequently converted to the Brain Imaging Data Structure (BIDS).
+The folder structure for the dataset is as follows:
+b2ai-voice-audio
+├── CHANGES.md
+├── README.md
+├── dataset_description.json
+├── phenotype
+├── confounders
+│
+├── confounders.json
+│
+└── confounders.tsv
+├── demographics
+│
+├── demographics.json
+│
+└── demographics.tsv
+├── diagnosis
+│
+├── adhd_adult.json
+│
+├── adhd_adult.tsv
+│
+├── airway_stenosis.json
+│
+├── airway_stenosis.tsv
+│
+├── amyotrophic_lateral_sclerosis.json
+│
+├── amyotrophic_lateral_sclerosis.tsv
+│
+├── anxiety.json
+│
+├── anxiety.tsv
+│
+├── benign_lesions.json
+│
+├── benign_lesions.tsv
+│
+├── bipolar_disorder.json
+│
+├── bipolar_disorder.tsv
+│
+├── cognitive_impairment.json
+│
+├── cognitive_impairment.tsv
+│
+├── control.json
+│
+├── control.tsv
+│
+├── copd_and_asthma.json
+│
+├── copd_and_asthma.tsv
+│
+├── depression.json
+│
+├── depression.tsv
+│
+├── glottic_insufficiency.json
+│
+├── glottic_insufficiency.tsv
+│
+├── laryngeal_cancer.json
+│
+├── laryngeal_cancer.tsv
+│
+├── laryngeal_dystonia.json
+│
+├── laryngeal_dystonia.tsv
+│
+├── laryngitis.json
+│
+├── laryngitis.tsv
+│
+├── muscle_tension_dysphonia.json
+│
+├── muscle_tension_dysphonia.tsv
+│
+├── parkinsons_disease.json
+│
+├── parkinsons_disease.tsv
+│
+├── precancerous_lesions.json
+│
+├── precancerous_lesions.tsv
+│
+├── psychiatric_history.json
+│
+├── psychiatric_history.tsv
+│
+├── ptsd_adult.json
+│
+├── ptsd_adult.tsv
+│
+├── unexplained_chronic_cough.json
+│
+├── unexplained_chronic_cough.tsv
+│
+├── unilateral_vocal_fold_paralysis.json
+│
+└── unilateral_vocal_fold_paralysis.tsv
+├── enrollment
+│
+├── eligibility.json
+│
+├── eligibility.tsv
+│
+├── enrollment_form.json
+│
+├── enrollment_form.tsv
+│
+├── participant.json
+│
+└── participant.tsv
+├── questionnaire
+│
+├── custom_affect_scale.json
+│
+├── custom_affect_scale.tsv
+│
+├── dsm5_adult.json
+│
+├── dsm5_adult.tsv
+│
+├── dyspnea_index.json
+│
+├── dyspnea_index.tsv
+│
+├── gad7_anxiety.json
+│
+├── gad7_anxiety.tsv
+│
+├── leicester_cough_questionnaire.json
+│
+├── leicester_cough_questionnaire.tsv
+│
+├── panas.json
+│
+├── panas.tsv
+│
+├── phq9.json
+│
+├── phq9.tsv
+│
+├── productive_vocabulary.json
+│
+├── productive_vocabulary.tsv
+│
+├── vhi10.json
+│
+├── vhi10.tsv
+│
+├── voice_perception.json
+│
+└── voice_perception.tsv
+└── task
+├── acoustic_task.json
+├── acoustic_task.tsv
+├── harvard_sentences.json
+├── harvard_sentences.tsv
+├── random_item_generation.json
+├── random_item_generation.tsv
+├── recording.json
+├── recording.tsv
+├── session.json
+├── session.tsv
+├── stroop.json
+├── stroop.tsv
+├── voice_perception.json
+├── voice_perception.tsv
+├── voice_problem_severity.json
+├── voice_problem_severity.tsv
+├── winograd.json
+└── winograd.tsv
+└── sub-<participant_id>
+└── ses-<participant_id>
+└── audio
+├── sub<participant_id>_ses<participant_id>_task-<task_name>.wav
+└── sub<participant_id>_ses<participant_id>_task-<task_name>.json
+Speech tasks included
+ABC’s
+Animal fluency
+Cape V sentences
+Caterpillar Passage
+Caterpillar Passage (Pediatrics)
+Cinderella Story
+Counting
+Diadochokinesis
+Favorite Foods
+Favorite Show/Movies
+Identifying Pictures
+Months
+Naming Animals
+Naming Foods
+Outside of School
+Picture description
+Picture Description (Pediatrics)
+Productive Vocabulary
+Prolonged vowel
+Rainbow Passage
+Random Item Generation
+Ready For School
+Repeat Words
+Repeat Sentences
+Role Naming
+Story recall
+Word-color Stroop
+AI-Ready derived datasets
+The feature-only dataset provides AI-ready derivations from the raw audio. Features extracted include:
+OpenSmile eGeMaps features per audio file
+Parselmouth/Praat speech features for any speech tasks
+Speech intelligibility metrics for speech tasks Time-varying features:
+Torchaudio-based pitch contour, spectrograms, mel spectrogram, and MFCCs
+Speech Articulatory Coding (sparc)-based features including electromagnetic articulography (EMA) estimates, plus loudness, periodicity, and pitch measures
+Phonetic posteriorgrams (PPGs)
+The waveform-derived features are stored using two formats:
+A fixed feature format that includes static features extracted from the entire waveform
+A temporal format that varies for each audio file depending on the length of recording.
+The questionnaire features are collected and distributed in the phenotype folder format shown above. These can be used for cohort selection.
+Methods of De-identification for v3.0.0
+All direct identifiers were removed, as these would reveal the identity of the research participant. These include name, civic address, and social security numbers. Indirect identifiers were removed where these created a significant risk of causing participant re-identification, for example through their combination with other public data available on social media, in government registries, or elsewhere. These include select geographic or demographic identifiers, as well as some information about household composition or cultural identity. Non-identifying elements of data that revealed highly sensitive information, such as information about household income, mental health status, traumatic life experiences, and the like, were also removed.
+Raw audio transcripts were reviewed, and any audio recordings that contained potentially identifying information and external voices were removed from the release.
+All sensitive fields were removed from the dataset at this stage. These correspond to data elements encoded as sensitive (column name: “Identifier?”) listed in the
+REDCap data dictionary (CSV)
+.
+In addition, all spectrograms, MFCCs, Mel spectrograms, transcriptions, EMAs, and PPGs from open-response prompts are removed from the feature-only dataset.
+Audit protocol
+Generate missingness tables
+Check distributions and outliers
+For categorical responses, check against schema
+For audio tasks, run quality control metrics
+For waveforms:
+Check amount of silence
+Duration
+For speech, check produced speech relative to intended passage
+All processing is performed using these toolkits:
+b2aiprep
+: organizing and preprocessing the dataset
+SenseLab
+: processing audio files for research tasks
+For detailed descriptions of each criterion, please see:
+AI-readiness for Biomedical Data: Bridge2AI Recommendations
+Table 4 – Precision Public Health (Voice) – Current Rating
+Criterion
+Criterion met? (Y=1; N=0)
+Total Score for Criterion (%)
+FAIRness (0)
+Findable (0.a)
+1
+100
+Accessible (0.b)
+1
+Interoperable (0.c)
+1
+Reusable (0.d)
+1
+Provenance (1)
+Transparent (1.a)
+1
+100
+Traceable (1.b)
+1
+Interpretable (1.c)
+1
+Key actors identified (1.d)
+1
+Characterization (2)
+Semantics (2.a)
+1
+80
+Statistics (2.b)
+1
+Standards (2.c)
+1
+Potential Sources of Bias (2.d)
+1
+Data Quality (2.e)
+0
+Pre-model explainability (3)
+Data documentation templates (3.a)
+1
+100
+Fit for purpose (3.c)
+1
+Verifiable (3.d)
+1
+Ethics (4)
+Ethically acquired (4.a)
+1
+100
+Ethically managed (4.b)
+1
+Ethically disseminated (4.c)
+1
+Secure (4.d)
+1
+Sustainability (5)
+Persistent (5.a)
+1
+50
+Domain-appropriate (5.b)
+0
+Well-governed (5.c)
+1
+Associated (5.d)
+0
+Computability (6)
+Standardized (6.a)
+1
+75
+Computational Accessibility (6.b)
+1
+Portable (6.c)
+1
+Contextualized (6.d)
+0
+Supporting Materials
+B2Ai-Voice | REDCap
+Description: Bridge2AI REDCap Data Dictionary and Metadata.
+License: MIT
+Navigate to Source Code
+B2Ai-Voice | Prep Library
+Description: The code used to preprocess the raw audio waveforms into the parquet file and to merge the source data into the phenotype files.
+License: Apache-2.0
+Navigate to Source Code
+B2Ai-Voice | Docs
+Description: Source code for the Docs and Dashboard for the Bridge2AI Voice Project at
+https://docs.b2ai-voice.org/.
+License: MIT
+Navigate to Source Code
+B2Ai-Voice | FHIR
+Description: FHIR profiles for voice as a biomarker.
+Navigate to Source Code
+View our dashboard
+and learn more about the data
+Go to the Bridge2AI Voice Adult Dashboard
+Go to the Bridge2AI Voice Pediatric Dashboard
+Join our mission to shape the future of voice in health. Collaborate, contribute, and explore today.
+About
+Blogs
+Contact Us
+Site Map
+Terms and Conditions
+Copyright © 2025 B2AI Voice. All Rights Reserved.
+Bridge2AI-Voice is part of the Bridge2AI Program, funded by the NIH Common Fund. Award #3Tf-OTOD03272001S2
+This repository is under review for potential modification in compliance with Administration directives.
+Youtube
+X-twitter
+Facebook
+Linkedin
+
+
+================================================================================
+
+FILE: reporter_nih_gov_project-details-11376382_row7.txt
+PATH: data/preprocessed/individual/VOICE/reporter_nih_gov_project-details-11376382_row7.txt
+SIZE: 6482 bytes
+--------------------------------------------------------------------------------
+
+SOURCE METADATA
+Project: VOICE
+Source ID: nih_reporter_project
+Source type: NIH project page
+Source URL: https://reporter.nih.gov/project-details/11376382
+Raw file: data/raw/VOICE/reporter_nih_gov_project-details-11376382_row7.txt
+--------------------------------------------------------------------------------
+NIH RePORTER Project
+Source: https://reporter.nih.gov/project-details/11376382
+Application ID: 11376382
+Project number: 3OT2OD032720-01S3
+Core project number: OT2OD032720
+Title: Bridge2AI: Voice as a Biomarker of Health - Building an ethically sourced, bioaccoustic database to understand disease like never before
+Principal investigator: BENSOUSSAN, YAEL EMILIE
+Organization: UNIVERSITY OF SOUTH FLORIDA
+Fiscal year: 2025
+Award amount: 4660942
+Project start: 2022-09-01T00:00:00
+Project end: 2026-11-30T00:00:00
+
+Our group aims to integrate the use of voice as biomarker of health in clinical care by generating a substantial multi-institutional, ethically sourced, and diverse voice database linked to multimodal health biomarkers to fuel voice AI research and build predictive models to assist in screening, diagnosis, and treatment of a broad range of diseases. Data collection will be made possible by software through a smartphone application linked to electronic health records (EHR) and other health biomarkers such as radiomics, and genomics, and supported by federated learning technology to protect data privacy.
+             Based on the existing literature and ongoing research in different fields of voice research, our group has identified 5 disease categories for which voice changes have been associated to specific diseases and around which we aim to center the data acquisition efforts:
+1.	Vocal Pathologies (Laryngeal cancers, Vocal fold paralysis, Benign laryngeal lesions)
+2.	Neurological and Neurodegenerative Disorders (Alzheimer’s, Parkinson’s, Stroke, ALS)
+3.	Mood and Psychiatric Disorders (Depression, Schizophrenia, Bipolar Disorders)
+4.	Respiratory disorders (Pneumonia, COPD, Heart Failure, OSA)
+5.	Pediatric diseases (Autism, Speech Delay)
+Specific Aim #1: Data Acquisition Module:
+-	To build a multi-modal, multi-institutional, large scale, diverse and ethically sourced human voice database linked to other biomarkers of health that is AI/ML friendly to fuel voice AI research
+Specific Aim #2: Standard Module:
+-	To introduce the field of acoustic biomarkers by developing new standards of acoustic and voice data collection and analysis for voice AI research.
+Specific Aim #3: Tool Development and optimization
+-	To develop a software and cloud infrastructure for automated voice data collection through a smartphone application that allows non-invasive, user-friendly, high quality voice data collection while minimizing human manipulation. This will include integrated acoustic amplifiers and acoustic quality standardization.
+-	To implement Federated Learning technology to allow analysis of multi-institutional data while minimizing data sharing and preserving patient privacy
+Specific Aim #4: Ethics Module
+-	To integrate existing scholarship, tools, and guidance with development of new standard and normative insights for identifying, anticipating, addressing, and providing guidance on ethical and trustworthy issues from voice data generation and AI/ML research and development to clinical adoption and downstream health decisions and outcomes.
+-	To develop new guidelines for consenting to voice data collection, voice data sharing and utilization in the context of voice AI technology
+Specific Aim # 5: Teaming Module:
+-	To build bridges between the medical voice research world, the acoustic engineers, and the AI/ML world to promote the integration of tangible clinical application for Voice AI algorithms
+Specific Aim #6: Skills and Workforce Development Module
+-	To develop a unique curriculum on voice biomarkers of health and the development, validation, and implementation for AI models that are FAIR and CARE
+-	To create a community of voice AI researchers, especially those from underserved communities, and foster collaborations to promote application of ML for Voice Research
+-	To engage a broad range of learners with competency assessment and mentorship
+
+As Voice is increasingly being recognized as a biomarker of health by the tech world and Voice AI is gaining attention from  multi-nationals such  as Google, Amazon, Mozilla  and Apple  amongst others, many important issues related to patient privacy protection, ethical and fair representation of population, and clinical accuracy are arising. As a multidisciplinary group of academic experts, we aim to influence and guide the world of Voice AI by ensuring patient protection through ethical and fairness principles and create safe, innovative infrastructures to disseminate ethically sourced data for the future generations of Voice AI researchers.
+
+Preferred terms:
+Acoustics;Address;Adoption;Alzheimer's Disease;Amplifiers;Apple;Attention;Benign;Biological Markers;Bipolar Disorder;Bridge to Artificial Intelligence;Categories;Childhood;Chronic Obstructive Pulmonary Disease;Clinical;Cloud Computing;Collaborations;Communities;Competence;Computer software;Consent;Data;Data Analyses;Data Collection;Data Protection;Databases;Development;Diagnosis;Disease;Educational Curriculum;Electronic Health Record;Engineering;Ensure;Ethics;FAIR principles;Fostering;Friends;Future Generations;Generations;Genomics;Guidelines;Health;Heart failure;Human;Infrastructure;Institution;Larynx;Lesion;Link;Literature;Malignant neoplasm of larynx;Medical;Mental Depression;Mental disorders;Mentorship;Mood Disorders;Nervous System Disorder;Neurodegenerative Disorders;Outcome;Paralysed;Parkinson Disease;Pathology;Patients;Pneumonia;Population;Research;Research Personnel;Respiration Disorders;Schizophrenia;Scholarship;Source;Speech Delay;Standardization;Stroke;Technology;Validation;Voice;Voice Quality;Workforce Development;artificial intelligence algorithm;artificial intelligence model;artificial intelligence technology;autism spectrum disorder;clinical application;clinical care;data acquisition;data preservation;data privacy;data sharing;federated learning;innovation;insight;multidisciplinary;multimodality;patient privacy;predictive modeling;privacy protection;radiomics;research and development;screening;skill acquisition;smartphone application;software infrastructure;tool;tool development;trustworthiness;underserved community;user-friendly;vocal cord
+
+
+================================================================================
+
+FILE: gdrive_1z4zZ_Z_Jb017IoVZn5btJnSLKdEOHZPA_row14.txt
+PATH: data/preprocessed/individual/VOICE/gdrive_1z4zZ_Z_Jb017IoVZn5btJnSLKdEOHZPA_row14.txt
+SIZE: 16811 bytes
+--------------------------------------------------------------------------------
+
+SOURCE METADATA
+Project: VOICE
+Source ID: data_transfer_use_agreement
+Source type: DUA
+Source URL: https://drive.google.com/file/d/1z4zZ_Z_Jb017IoVZn5btJnSLKdEOHZPA/view?usp=sharing
+Raw file: data/raw/VOICE/gdrive_1z4zZ_Z_Jb017IoVZn5btJnSLKdEOHZPA_row14.pdf
+--------------------------------------------------------------------------------
+Data Transfer and Use Agreement (“Agreement”)
+
+Provider Institution: University of South Florida Board of Trustees pursuant to Agreement
+concerning: Bridge2AI: Voice as a Biomarker of Health – Building an ethically sourced,
+bioaccoustic database to understand disease like never before.
+
+Recipient Institution / Company:
+
+Recipient Scientist:
+
+Recipient Authorized Institutional Offical:
+
+Project Title:
+
+Agreement Term:
+
+Start Date:
+
+End Date:  Two years after the Start Date, upon completion of the project, upon expiration of
+the applicable ethics approval, or termination by Provider Institution, whichever occurs first.
+
+1.  Reimbursement of Costs:
+
+Terms and Conditions:
+
+If applicable, Recipient shall reimburse Provider for any costs associated with the
+preparation, compilation, and transfer of the Data to the Recipient.  Costs shall not
+include payments for research effort by the Provider.
+
+A.  This Agreement is in support of Agreement # _______________, which shall
+
+cover reimbursement of costs.
+B.  Costs as set forth in Attachement I.
+
+2.  Provider shall provide the data set described in Attachment 1 (the “Data”) to Recipient
+
+for the research purpose set forth in Attachment 1 (the “Project”).
+
+3.   Recipient shall not use the Data except as authorized under this Agreement. The Data
+
+will be used solely to conduct the Project and solely by Recipient Scientist and
+Recipient’s faculty, employees, fellows, students, and agents (“Recipient Personnel”) (as
+approved and listed in Attachment 3) that have a need to use, or provide a service in
+respect of, the Data in connection with the Project and whose obligations of use are
+consistent with the terms of this Agreement (collectively, “Authorized Persons”).
+Collaborators at other research organizations, and other research teams at the same
+organization, must apply independently for access to the Data and sign a Data Transfer
+and Use Agreement (DTUA) with the Provider, before accessing the data.
+
+Page 1 of 9
+
+Approved for use through August 31, 2025
+
+
+
+
+
+
+
+4.  Except as authorized under this Agreement or otherwise required by law, Recipient
+
+agrees to retain control over the Data and shall not disclose, release, sell, rent, lease, loan,
+or otherwise grant access to the Data to any third party, except Authorized Persons,
+without the prior written consent of Provider. Recipient agrees to establish appropriate
+administrative, technical, and physical safeguards to prevent unauthorized use of or
+access to the Data and comply with any other special requirements relating to
+safeguarding of the Data as may be set forth in Attachment 2. Recipient must also bind
+Authorized Persons to hold the Data according to standards of confidentiality and
+security that are equivalent to those described in this Agreement.
+
+5.  Recipient agrees to use the Data in compliance with all applicable laws, rules, and
+regulations, as well as all professional standards applicable to such research.
+
+6.  Recipient is encouraged to make publicly available the results of the Project, in open-
+
+access journals or pre-print servers where possible.
+
+7.  Recipient agrees to recognize the contribution of the Provider as the source of the Data in
+all written, visual, or oral public disclosures of recipient’s research using the Data, as
+appropriate in accordance with scholarly standards and any specific format that has been
+indicated in Attachment 1.
+
+8.  Unless terminated earlier in accordance with this section or extended via a modification
+in accordance with Section 13, this Agreement shall expire as of the End Date set forth
+above. Either party may terminate this Agreement with thirty (30) days written notice to
+the other party’s Authorized Official as set forth below. Upon expiration or early
+termination of this Agreement, Recipient shall follow the disposition instructions
+provided in Attachment 1, provided, however, that Recipient may retain one (1) copy of
+the Data to the extent necessary to comply with the records retention requirements:
+
+I. under any law, regulation, or Recipient institutional policy, and
+
+II. for the purposes of research integrity and verification.
+
+The restrictions set forth in this Agreement (as applicable) shall survive and apply to such
+archival copy so long as Recipient holds the Data.
+
+9.  Except as provided below or prohibited by law, any Data delivered pursuant to this
+
+Agreement is understood to be provided “AS IS.” PROVIDER MAKES NO
+REPRESENTATIONS AND EXTENDS NO WARRANTIES OF ANY KIND, EITHER
+EXPRESSED OR IMPLIED. THERE ARE NO EXPRESS OR IMPLIED
+WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE, OR THAT THE USE OF THE DATA WILL NOT INFRINGE ANY
+PATENT, COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS.
+Notwithstanding, Provider, to the best of its knowledge and belief, has the right and
+authority to provide the Data to Recipient for use in the Project.
+
+Page 2 of 9
+
+Approved for use through August 31, 2025
+
+
+
+
+10. The Data Provider provides no guarantees that the Data is free of third-party intellectual
+property rights, database rights, and other related rights. Nothing in this Agreement shall
+operate to transfer to the Recipient any intellectual property rights in or relating to the
+Data. Recipient agrees not to use intellectual property protection, database rights, or
+related rights in a way that could prevent or limit access to, or use of, any element of the
+Data or research conclusion derived from it. Recipient can elect to perform further
+research that would add intellectual and resource capital to the Data and decide to obtain
+intellectual property rights on these downstream discoveries.
+
+11. Except to the extent prohibited by law, the Recipient assumes all liability for damages
+which may arise from its use, storage, disclosure, or disposal of the Data. The Provider
+will not be liable to the Recipient for any loss, claim, or demand made by the Recipient,
+or made against the Recipient by any other party, due to or arising from the use of the
+Data by the Recipient.  No indemnification for any loss, claim, damage, or liability is
+intended or provided by either party under this Agreement.
+
+12. Neither party shall use the other party’s name, trademarks, or other logos in any publicity,
+
+advertising, or news release without the prior written approval of an authorized
+representative of that party. The parties agree that each party may disclose factual
+information regarding the existence and purpose of the relationship that is the subject of
+this Agreement for other purposes without written permission from the other party
+provided that any such statement shall accurately and appropriately describe the
+relationship of the parties and shall not in any manner imply endorsement by the other
+party whose name is being used.
+
+13. Unless otherwise specified, this Agreement and the below listed Attachments embody the
+entire understanding between Provider and Recipient regarding the transfer of the Data to
+Recipient for the Project:
+
+I. Attachment 1: Project Specific Information.
+
+II. Attachment 2: Data-specific Terms and Conditions.
+
+III. Attachment 3: Identification of Permitted Collaborators (if any).
+
+14. No modification or waiver of this Agreement shall be valid unless in writing and
+
+executed by duly-authorized representatives of both parties.  This Agreement shall only
+be effective upon the review and subject ot the approval of the Data Access Compliance
+Office (“DACO”) requiring a distinct application.
+
+15. The undersigned Authorized Officials of Provider and Recipient expressly represent and
+affirm that the contents of any statements made herein are truthful and accurate and that
+they are duly authorized to sign this Agreement on behalf of their institution. This
+Agreement may be executed in counterparts, including both counterparts that are
+executed on paper and counterparts that are in the form of electronic records and are
+
+Page 3 of 9
+
+Approved for use through August 31, 2025
+
+
+
+
+executed electronically. All executed counterparts shall constitute one agreement, and
+each counterpart shall be deemed an original. The parties hereby acknowledge and agree
+that electronic records and electronic signatures may be used in connection with the
+execution of this Agreement and electronic signatures or signatures transmitted by
+electronic mail in so-called pdf format shall be legal and binding and shall have the same
+full force and effect as if a paper original of this Agreement had been delivered and
+signed using a handwritten signature.
+
+Signatures:
+
+Provider Institutional Offical:
+
+Provider Scientist:
+
+_______________________
+
+____________________
+
+Print:
+
+Recipient Institutional Offical:
+
+______________________
+
+Print:
+
+Print:
+
+Recipient Scientist:
+
+___________________
+
+Print:
+
+Notice Address:
+
+Notice Address:
+
+Page 4 of 9
+
+Approved for use through August 31, 2025
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+1.  Description of the Data:
+
+Attachment 1:
+
+The Bridge2AI-Voice dataset contains samples from conventional acoustic tasks including
+respiratory sounds, cough sounds, and free speech prompts, capturing voice, speech and
+language data relating to health and other health information. Participants who consent are
+asked  to  perform  speaking  tasks  and  complete  self-reported  demographic  and  medical
+history  questionnaires,  as  well  as  disease-specific  validated  questionnaires.  Participants
+who  consent  also  permit  investigators  to  access  medical  information  through  EHR
+platforms in order to perform gold standard validation of diagnoses and symptoms.
+
+2.  Description of Project:
+
+[Instructions to Drafter – Delete after completion.]
+
+This section of this attachment should provide sufficient information such that each party
+understands the project that the Recipient will perform using the Data. Content of this
+section will be very similar to the Statement of Work used in other types of Agreements.
+Examples of information that should be provided include:
+
+* Objective or purpose of the Recipient’s work
+
+* A general description of the actions to be performed by the Recipient using the Data
+and possibly the anticipated results
+
+* Include whether or not the Recipient is permitted to link the Data with other data sets
+(If yes, be sure to include any special disposition requirements related to the linked data
+sets in Section 4 of this attachment)
+
+* Include application of costs, if any.
+
+3.  Provider Support and Data Transmission:
+
+Provider shall transmit the Data to Recipient:
+
+Upon execution of this Agreement, Provider shall send any specific instructions
+necessary to complete the transfer of the Data to the contact person listed above, if not
+already included below in this section of Attachment 1.
+
+Page 5 of 9
+
+Approved for use through August 31, 2025
+
+
+
+
+
+
+4.  Disposition Requirements upon the termination or expiration of the Agreement:
+
+Two years after the Start Date, upon completion of the project, upon termination, or upon
+expiration of the applicable ethics approval, whichever occurs first.  Data shall be
+destroyed in accordance with instructions of Provider.  Recipient shall submit to Provider
+a written certification of such data destruction within thirty (30) days after termination or
+expiration signed by an appropriate representative of Recipient.
+
+Page 6 of 9
+
+Approved for use through August 31, 2025
+
+
+
+
+
+
+Additional Terms and Conditions:
+
+Attachment 2:
+
+1.  The Data is Personally Identifiable Information, as that is defined in OMB Memorandum
+
+M-07-16, and not covered under HIPAA, FERPA, or similar laws or regulations
+governing personal information that require the addition of special terms beyond those
+included in this Attachment.
+☐ If checked, the Data is subject to the Federal Privacy Act of 1974, as amended, at 5
+U.S.C. § 552a.
+
+x If checked, the Data is covered under a Certificate of Confidentiality, which must be
+asserted against compulsory legal demands, such as court orders and subpoenas for
+identifying information or characteristics of a research participant. See Certificates of
+Confidentiality (CoC) | Grants & Funding for further information.
+
+2.  Notwithstanding any statement herein to the contrary, Provider represents that it has full
+authority to share the Data it has collected with the Recipient and has confirmed that the
+Project is consistent with such consents as Provider may have obtained from individuals
+who are the subjects of the Data.
+
+3.  Unless otherwise required by law or legal process, Recipient shall not use or further
+
+disclose the Data other than as permitted by this Agreement. If Recipient believes it is
+required by law or legal process to use or disclose the Data, it will promptly notify
+Provider, to the extent allowed by law, prior to such use or disclosure and will disclose
+the least possible amount of Data necessary to fulfill its legal obligations.
+
+4.  In the event Recipient becomes aware of any use or disclosure of the Data not provided
+for by this Agreement, Recipient shall take any appropriate steps to minimize the impact
+of such unauthorized use or disclosure as soon as practicable and shall notify Provider of
+such use or disclosure as soon as possible, but no later than 5 business days after
+discovery of the unauthorized use or disclosure. Recipient shall cooperate with Provider
+to investigate, correct, and/or mitigate such unauthorized use or disclosure. Recipient
+acknowledges that Provider may have an obligation to make further notifications under
+applicable state law and shall cooperate with the Provider to the extent necessary to
+enable Provider to meet all such obligations.
+
+5.  Recipient will not use the Data, either alone or in concert with any other information, to
+
+make any effort to contact individuals who are the subjects of the Data without
+appropriate Institutional Review Board (IRB) approval, specific written approval from
+Provider, and informed consent from the individual, if required.
+
+Page 7 of 9
+
+Approved for use through August 31, 2025
+
+
+
+
+
+
+
+
+
+6.  Recipient agrees to store Data with security controls adequate to protect Personally
+
+Identifiable Information, to ensure that only Authorized Persons have access to the Data,
+and to maintain appropriate control over the Data at all times. The controls shall include
+administrative, physical, and technical safeguards that covered entities and business
+associates must put in place to secure individuals’ electronic protected health information.
+Recipient further agrees to remove and securely destroy or return, as directed by the
+Provider in Attachment 1, the Data at the earliest time at which removal and destruction
+or return can be accomplished, consistent with the purpose of the Project.
+
+7.  By signing this Agreement, Recipient provides assurance that its relevant institutional
+policies and applicable federal, state, or local laws and regulations (if any) have been
+followed, including the completion of any IRB review or approval that may be required
+prior to Recipient’s use of the Data. Upon Provider’s written request to the Recipient’s
+Contact for Formal Notices identified in the signature block, Recipient shall provide
+documentation of its IRB-Approved Protocol.
+
+8.  Recipient futher agrees to adhere to the specific requirements of PhysioNet.Org managed
+by the MIT Laboratory for Computational Physiology and supported by the National
+Institute of Biomedical Imaging and Bioengineering (NIBIB) under NIH grant number
+R01EB030362 or other data distribution as may be utilized by Provider.
+
+9.  Provider may unilaterally amend this Agreement should the Federal sponsor require
+
+revision.  Should recipient object to any amendment, this Agreement shall immediately
+terminate and Resipient shall immediately return or destroy all Data.
+
+10. The Authorized Representative of Recipient signing this agreement below warrants and
+declares, to the best of their knowledge and belief, that Recipeint does not use coercion
+for labor or services as defined in §787.06, F.S. This Agreement shall immediately
+terminate upon a breach of this section by Recipient.
+
+Page 8 of 9
+
+Approved for use through August 31, 2025
+
+
+
+
+
+
+
+
+
+
+
+
+Attachment 3:
+
+To be replaced with a list of approved recipient personnel.  [any changes to the list require
+amendment of the Agreement]
+
+Name, Title and Signature of each individual
+
+Page 9 of 9
+
+Approved for use through August 31, 2025
+
+
+================================================================================
+
+FILE: github_eipm_bridge2ai-docs_README_row22.txt
+PATH: data/preprocessed/individual/VOICE/github_eipm_bridge2ai-docs_README_row22.txt
+SIZE: 1621 bytes
+--------------------------------------------------------------------------------
+
+SOURCE METADATA
+Project: VOICE
+Source ID: documentation_repository
+Source type: documentation
+Source URL: https://github.com/eipm/bridge2ai-docs/tree/main/docs
+Raw file: data/raw/VOICE/github_eipm_bridge2ai-docs_README_row22.md
+--------------------------------------------------------------------------------
+<p align="center">
+    <img src="images/main_logo_black.svg#gh-light-mode-only" width="200" alt="B2AI Voice Logo">
+    <img src="images/main_logo_white.svg#gh-dark-mode-only" width="200" alt="B2AI Voice Logo"><br>
+    Voice as a Biomarker of Health
+</p>
+
+# bridge2ai-docs
+
+Docs for the Bridge2AI Voice Project.
+
+[![GitHub](https://img.shields.io/badge/github-3.0.1-green?style=flat&logo=github)](https://github.com/eipm/bridge2ai-docs) [![Python 3.12.0](https://img.shields.io/badge/python-3.12.0-blue.svg)](https://www.python.org/downloads/release/python-3120/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)  [![DOI](https://zenodo.org/badge/860006845.svg)](https://zenodo.org/doi/10.5281/zenodo.13834653)
+
+
+## 🤝 License
+See [LICENSE](./LICENSE)
+
+## 📚 How to Cite
+> Sigaras, A., Zisimopoulos, P., Tang, J., Bevers, I., Gallois, H., Bernier, A., Bensoussan, Y., Ghosh, S. S., Rameau, A., Powell, M. E., Belisle-Pipon, J.-C., Ravitsky, V., Johnson, A., Elemento, O., Dorr, D., … Bridge2AI-Voice. (2024). eipm/bridge2ai-docs. Zenodo. [https://zenodo.org/doi/10.5281/zenodo.13834653](https://zenodo.org/doi/10.5281/zenodo.13834653)
+
+## Prerequisites
+
+```bash
+pip install -r requirements.txt
+```
+
+## How to run the app
+
+```bash
+sh startup.sh
+```

--- a/data/preprocessed/source_manifest.yaml
+++ b/data/preprocessed/source_manifest.yaml
@@ -373,3 +373,45 @@ projects:
       url: https://github.com/eipm/bridge2ai-docs/tree/main/docs
       raw_file: github_eipm_bridge2ai-docs_README_row22.md
       processed_file: github_eipm_bridge2ai-docs_README_row22.txt
+  VOICE_PEDIATRIC:
+  - id: physionet_pediatric_1_1_0
+    source_type: data resource
+    url: https://physionet.org/content/b2ai-voice-pediatric/1.1.0/
+    raw_file: physionet_b2ai-voice-pediatric_1.1.0_2026-07-24.html
+    processed_file: physionet_b2ai-voice-pediatric_1.1.0_2026-07-24.txt
+    captured_at: '2026-07-24'
+    curation_note: Current Bridge2AI-Voice pediatric release, published 2026-05-01, 300 participants aged
+      2-18, 23,533 derived recordings, credentialed access. This is a separate PhysioNet project from the
+      adult b2ai-voice dataset, not a version of it; the two releases are distinct cohorts collected under
+      a separate pediatric protocol, with pediatric participants recruited at the Hospital for Sick Children
+      (SickKids). Raw pediatric audio is distributed via Synapse (syn73617068) rather than PhysioNet. Added
+      because the current VOICE documentation advertises pediatric v1.1.0 alongside adult v3.1.0 while the
+      input sheet lists no pediatric source at all. Pediatric v1.0.0 exists upstream but is superseded and
+      was not captured.
+    verification_url: https://physionet.org/content/b2ai-voice-pediatric/
+  - id: irb_protocol
+    source_type: IRB
+    url: https://docs.google.com/document/d/1gTFzAM-FoYlM_X9qF0s7fXoswmaz8IqN/edit
+    raw_file: gdrive_1gTFzAM-FoYlM_X9qF0s7fXoswmaz8IqN_row13.docx
+    processed_file: gdrive_1gTFzAM-FoYlM_X9qF0s7fXoswmaz8IqN_row13.txt
+  - id: project_documentation
+    source_type: documentation
+    url: https://docs.b2ai-voice.org/
+    raw_file: docs_b2ai-voice_org_row10.html
+    processed_file: docs_b2ai-voice_org_row10.txt
+  - id: nih_reporter_project
+    source_type: NIH project page
+    url: https://reporter.nih.gov/project-details/11376382
+    raw_file: reporter_nih_gov_project-details-11376382_row7.txt
+    processed_file: reporter_nih_gov_project-details-11376382_row7.txt
+    minimum_characters: 1000
+  - id: data_transfer_use_agreement
+    source_type: DUA
+    url: https://drive.google.com/file/d/1z4zZ_Z_Jb017IoVZn5btJnSLKdEOHZPA/view?usp=sharing
+    raw_file: gdrive_1z4zZ_Z_Jb017IoVZn5btJnSLKdEOHZPA_row14.pdf
+    processed_file: gdrive_1z4zZ_Z_Jb017IoVZn5btJnSLKdEOHZPA_row14.txt
+  - id: documentation_repository
+    source_type: documentation
+    url: https://github.com/eipm/bridge2ai-docs/tree/main/docs
+    raw_file: github_eipm_bridge2ai-docs_README_row22.md
+    processed_file: github_eipm_bridge2ai-docs_README_row22.txt

--- a/data/preprocessed/source_manifest.yaml
+++ b/data/preprocessed/source_manifest.yaml
@@ -373,6 +373,11 @@ projects:
       url: https://github.com/eipm/bridge2ai-docs/tree/main/docs
       raw_file: github_eipm_bridge2ai-docs_README_row22.md
       processed_file: github_eipm_bridge2ai-docs_README_row22.txt
+  # Selected from VOICE's downloads: the pediatric dataset is documented
+  # inside the same corpus, so it has no download directory of its own.
+  # Declared here rather than passed as a flag, so the bundle rebuilds
+  # from the manifest alone (#302).
+  VOICE_PEDIATRIC_source_dir: data/preprocessed/individual/VOICE
   VOICE_PEDIATRIC:
   - id: physionet_pediatric_1_1_0
     source_type: data resource

--- a/src/data_sheets_schema/cli/download.py
+++ b/src/data_sheets_schema/cli/download.py
@@ -5,6 +5,8 @@ Commands for downloading and preprocessing data sources.
 
 import click
 import sys
+
+import yaml
 from pathlib import Path
 from data_sheets_schema.constants import PROJECTS
 from data_sheets_schema.cli._repo_utils import setup_repo_imports, require_repo_context
@@ -134,7 +136,20 @@ def concatenate(project, input_dir, output_file, manifest):
     setup_repo_imports()
     from src.download.concatenate_documents import main as concat_main
 
-    input_path = Path(input_dir) / project
+    # A project may select from another project's downloads. VOICE_PEDIATRIC
+    # is documented inside VOICE's corpus and has no directory of its own, and
+    # the override used to build its bundle lived only in the command someone
+    # happened to type (#302). Declared in the manifest, it rebuilds from the
+    # manifest.
+    if str(input_dir) == 'data/preprocessed/individual':
+        try:
+            declared = (yaml.safe_load(Path(manifest).read_text(encoding="utf-8"))
+                        or {}).get("projects", {}).get(f"{project}_source_dir")
+        except (OSError, yaml.YAMLError):
+            declared = None
+        input_path = Path(declared) if declared else Path(input_dir) / project
+    else:
+        input_path = Path(input_dir) / project
     if not input_path.exists():
         click.echo(f"❌ Error: Input directory not found: {input_path}", err=True)
         sys.exit(1)

--- a/tests/test_voice_pediatric_bundle.py
+++ b/tests/test_voice_pediatric_bundle.py
@@ -96,5 +96,40 @@ class TestTheBundles(unittest.TestCase):
                 self.assertNotIn(adult, text)
 
 
+@unittest.skipUnless(MANIFEST.exists(), "manifest not present")
+class TestTheBundleRebuildsFromDeclaredInputs(unittest.TestCase):
+    """#302: the bundle was built with an undeclared --input-dir override.
+
+    That is #234 in a different file — a committed artifact its own documented
+    generator cannot reproduce. It matters more here than for a mapping,
+    because a generation run attests this bundle's md5, and an input nobody can
+    regenerate is one nobody can check.
+    """
+
+    def test_the_source_directory_is_declared_in_the_manifest(self):
+        """Beside the selection, not in whatever command someone typed.
+
+        The manifest already says *which* files a project selects; the
+        directory they are selected from belongs in the same place.
+        """
+        projects = yaml.safe_load(MANIFEST.read_text())["projects"]
+        self.assertEqual(projects.get("VOICE_PEDIATRIC_source_dir"),
+                         "data/preprocessed/individual/VOICE")
+
+    def test_a_declared_source_dir_names_a_real_directory(self):
+        projects = yaml.safe_load(MANIFEST.read_text())["projects"]
+        for key, value in projects.items():
+            if key.endswith("_source_dir"):
+                with self.subTest(key=key):
+                    self.assertTrue((REPO / value).is_dir(), value)
+
+    def test_every_declared_source_dir_belongs_to_a_project(self):
+        projects = yaml.safe_load(MANIFEST.read_text())["projects"]
+        for key in projects:
+            if key.endswith("_source_dir"):
+                with self.subTest(key=key):
+                    self.assertIn(key[: -len("_source_dir")], projects)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_voice_pediatric_bundle.py
+++ b/tests/test_voice_pediatric_bundle.py
@@ -1,0 +1,100 @@
+"""VOICE_PEDIATRIC is scoped by its bundle, not by its name (#292).
+
+Both datasets are documented in one corpus, so the question was how a run
+targeting the pediatric dataset is told which one to describe.
+
+**Not by `{MANIFEST_LINE}`.** An earlier note claimed that field could carry the
+scope. It cannot: it is substituted into the *output record's* header block, as
+a provenance comment, not into the instruction. The frozen prompt body says
+"DECLARED INPUT BUNDLE — your only source of dataset facts: {BUNDLE}", so the
+bundle is the scope, and scoping there needs no change to any frozen prompt.
+"""
+
+import hashlib
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+MANIFEST = REPO / "data" / "preprocessed" / "source_manifest.yaml"
+CONCAT = REPO / "data" / "preprocessed" / "concatenated"
+
+#: What the 49 runs subject to the live-provenance rule recorded for the VOICE
+#: bundle. Renaming or rebuilding it would invalidate their attestation.
+VOICE_BUNDLE_MD5 = "e637eb752ee8cab5f9f7a52782250469"
+
+
+@unittest.skipUnless(MANIFEST.exists(), "manifest not present")
+class TestTheManifestEntry(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.projects = yaml.safe_load(MANIFEST.read_text())["projects"]
+
+    def test_both_voice_datasets_are_declared(self):
+        self.assertIn("VOICE", self.projects)
+        self.assertIn("VOICE_PEDIATRIC", self.projects)
+
+    def test_the_pediatric_selection_leads_with_its_own_record(self):
+        first = self.projects["VOICE_PEDIATRIC"][0]["id"]
+        self.assertEqual(first, "physionet_pediatric_1_1_0")
+
+    def test_the_adult_version_pages_are_excluded(self):
+        """Including them would import adult facts into a pediatric datasheet —
+        the failure the fitness axis calls `target`."""
+        ids = {s["id"] for s in self.projects["VOICE_PEDIATRIC"]}
+        for adult in ("physionet_1_1", "physionet_3_0_0", "physionet_3_1_0"):
+            with self.subTest(source=adult):
+                self.assertNotIn(adult, ids)
+
+    def test_every_pediatric_source_is_a_voice_source(self):
+        """They share a corpus; the pediatric selection is a subset, not new
+        material."""
+        voice = {s["id"] for s in self.projects["VOICE"]}
+        for s in self.projects["VOICE_PEDIATRIC"]:
+            with self.subTest(source=s["id"]):
+                self.assertIn(s["id"], voice)
+
+    def test_the_voice_selection_is_unchanged(self):
+        self.assertEqual(len(self.projects["VOICE"]), 11)
+
+
+@unittest.skipUnless((CONCAT / "VOICE_preprocessed.txt").exists(),
+                     "bundles not present")
+class TestTheBundles(unittest.TestCase):
+
+    def _md5(self, path):
+        return hashlib.md5(path.read_bytes()).hexdigest()
+
+    def test_the_voice_bundle_still_matches_what_runs_attested(self):
+        """49 runs record this md5 in `inputs.bundle_md5`.
+
+        Adding a second dataset must not disturb the first — rebuilding or
+        renaming this file would invalidate their attestation, which is the
+        whole reason VOICE keeps its identifier.
+        """
+        self.assertEqual(self._md5(CONCAT / "VOICE_preprocessed.txt"),
+                         VOICE_BUNDLE_MD5)
+
+    def test_the_pediatric_bundle_exists_and_is_smaller(self):
+        ped = CONCAT / "VOICE_PEDIATRIC_preprocessed.txt"
+        self.assertTrue(ped.exists())
+        self.assertLess(ped.stat().st_size,
+                        (CONCAT / "VOICE_preprocessed.txt").stat().st_size)
+
+    def test_it_carries_the_pediatric_dataset_identifier(self):
+        text = (CONCAT / "VOICE_PEDIATRIC_preprocessed.txt").read_text(
+            errors="ignore")
+        self.assertIn("h995-bt35", text)
+
+    def test_it_carries_no_adult_version_pages(self):
+        text = (CONCAT / "VOICE_PEDIATRIC_preprocessed.txt").read_text(
+            errors="ignore")
+        for adult in ("b2ai-voice/3.1.0", "b2ai-voice/3.0.0"):
+            with self.subTest(page=adult):
+                self.assertNotIn(adult, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The free half of §9, plus a correction to what I wrote there.

## `{MANIFEST_LINE}` was the wrong mechanism

I claimed the two datasets could be distinguished by that field. **They can't** — it is substituted into the *output record's* header block as a provenance comment, not into the instruction.

The frozen body says *"DECLARED INPUT BUNDLE — your only source of dataset facts: {BUNDLE}"*, so **the bundle is the scope**. Scoping there needs no change to any frozen prompt, which is the property I wanted from the manifest line and didn't get.

## The pediatric selection

Six sources, led by the pediatric PhysioNet record — which carries **all 11** references to the dataset's DOI — plus the IRB protocol, project documentation, NIH RePORTER entry, DUA and docs repository, all of which cover the pediatric cohort explicitly.

| | files | size | `h995-bt35` | adult version pages |
|---|---|---|---|---|
| `VOICE` | 11 | 378 KB | 11 | present |
| `VOICE_PEDIATRIC` | 6 | 204 KB | 11 | **0** |

**Excluded**: the three adult PhysioNet version pages and the two adult-cohort papers. They carry zero "pediatric" mentions, and including them would import adult facts into a pediatric datasheet — the failure the fitness axis calls `target`, which is the thing the study measures.

**The VOICE bundle is untouched and byte-identical** — md5 `e637eb75`, what the 49 runs subject to the live-provenance rule attest. A test pins it, because the whole reason VOICE keeps its identifier is that its attested artifacts must not move.

## The rename — decided against, on evidence

You chose option C, and having attempted it I can now say why it was the right call rather than just arguing it.

The 567 path moves were clean: no clashes, no `VOICE_PEDIATRIC` mangling. **The content rewrite broke attestation two ways that care does not avoid:**

1. Record bodies carry `VOICE` in titles, ids and prose, and provenance records their **byte counts** — rewriting them failed **33 runs** outright.
2. `source_manifest.yaml` is keyed by project and its md5 is recorded by **115 runs**, so renaming the project necessarily changes a file those runs attest.

Renaming converts attested runs into reconstructed ones — the same property that got the 2026-04-10 series archived. Reverted; nothing was pushed.

## What remains in §9

The generation run — twelve phases for one project, paid. Everything it needs is now in place.

**1092 passed, 3 skipped** (+9).