### PR TITLE
Defer the VOICE_PEDIATRIC run to v3 (NEXT_TASKS §9)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -309,7 +309,29 @@ broke nothing; the four-project list in 26 files is prose, not logic.
 
   The VOICE bundle is byte-identical (md5 `e637eb75`, what 49 runs attest), and
   a test pins it.
-- **A generation run.** Twelve phases for one project, paid.
+- **A generation run — deferred to v3, by decision.** Running under v2 now would
+  mean running again when v3 lands, so `VOICE_PEDIATRIC` is generated with
+  whichever config the v2-vs-v3 comparison settles on. v3 is drafted, wired and
+  tested (#272) but unrun.
+
+  `VOICE_PEDIATRIC` cannot join that comparison itself — it has no v1 or v2
+  baseline, so it is generated once under the winning config rather than as a
+  third arm.
+
+  **Regenerate VOICE in the same run.** Its three 2026-07-31 replicates are the
+  reason no VOICE record is canonical (#292), and both causes are now addressed
+  for future runs but not for those records:
+
+  - the enum values: `References` normalises to `references` on the write path,
+    and `related_to` still fails, which is correct — it names nothing in the
+    vocabulary;
+  - the inline object in `target_dataset`: with the pediatric dataset now its
+    own datasheet, VOICE should reference it by DOI, which is a string and
+    validates.
+
+  So a v3 run is the first opportunity for VOICE to have a canonical record at
+  all. Until then VOICE has none, and any "canonical record per project" count
+  is three of four.
 - **Whether `VOICE` becomes `VOICE_main` — decided: no.** Attempted and reverted.
   The path moves were clean (567 files, no clashes), but the content rewrite
   broke attestation two ways that no amount of care avoids: record bodies carry

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -325,13 +325,20 @@ broke nothing; the four-project list in 26 files is prose, not logic.
   - the enum values: `References` normalises to `references` on the write path,
     and `related_to` still fails, which is correct — it names nothing in the
     vocabulary;
-  - the inline object in `target_dataset`: with the pediatric dataset now its
-    own datasheet, VOICE should reference it by DOI, which is a string and
-    validates.
+  - the inline object in `target_dataset`: once the pediatric dataset **is** its
+    own record, VOICE references it by DOI, which is a string and validates.
+    Note the tense — it is a registered project with a bundle, not yet a
+    datasheet, and this bullet is what defers generating it. **Order matters:
+    the pediatric record has to exist before VOICE can point at it.** Generate
+    `VOICE_PEDIATRIC` first, or a regenerated VOICE either inlines the dataset
+    again and fails again, or omits the relationship entirely.
 
   So a v3 run is the first opportunity for VOICE to have a canonical record at
-  all. Until then VOICE has none, and any "canonical record per project" count
-  is three of four.
+  all, and only if the two are generated in that order.
+
+  On canonical counts: there are **none at all** on `main` today — the three
+  marks for AI_READI, CHORUS and CM4AI are in #293, still open. Once that lands
+  it is three of four, and VOICE is the gap.
 - **Whether `VOICE` becomes `VOICE_main` — decided: no.** Attempted and reverted.
   The path moves were clean (567 files, no clashes), but the content rewrite
   broke attestation two ways that no amount of care avoids: record bodies carry


### PR DESCRIPTION
Records the decision to wait for v3 rather than generate `VOICE_PEDIATRIC` under v2, and one consequence that is easy to miss.

**Stacked on #300** (base `voice-pediatric-manifest`), so this diff shows only the deferral. Both PRs edit NEXT_TASKS §9 — branching from `main` meant this one carried the stale text #300 corrects, and merging both would have restored the wrong claim about `{MANIFEST_LINE}`.

## The deferral

Generating under v2 now means generating again when v3 lands. `VOICE_PEDIATRIC` waits for whichever config the v2-vs-v3 comparison settles on. v3 is drafted, wired and tested (#272) but unrun.

It **cannot join that comparison itself** — no v1 or v2 baseline exists for it, so it is generated once under the winning config rather than standing as a third arm.

## Regenerate VOICE in the same run

Its three 2026-07-31 replicates are why no VOICE record is canonical (#292). Both causes are now addressed **for future runs but not for those records**:

| cause | status |
|---|---|
| `References` (casing) | normalised on the write path → `references` |
| `related_to` | still fails — correctly, it names nothing in the vocabulary |
| inline object in `target_dataset` | should not recur: the pediatric dataset is now its own datasheet, so VOICE references it by DOI — a string, which validates |

So **a v3 run is the first opportunity for VOICE to have a canonical record at all.** Until then it has none, and any "canonical record per project" count is three of four rather than four.

Docs-only. **1092 passed, 3 skipped**, with #300 underneath.