### PR TITLE
Make the canonical mark readable, so #287 can be sized (#306)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -152,14 +152,20 @@ def canonical_cmd(project, config, paths_only, missing):
     replicate validates (#292).
     """
     from data_sheets_schema.constants import PROJECTS
-    from data_sheets_schema.runs import canonical_runs
+    from data_sheets_schema.runs import AmbiguousCanonical, canonical_runs
 
-    found = canonical_runs(config=config)
+    try:
+        found = canonical_runs(config=config)
+    except AmbiguousCanonical as exc:
+        # Naming the configurations, because --config is the answer and the
+        # user cannot pass it without knowing what to pass (#308).
+        click.echo(f"{exc}", err=True)
+        raise SystemExit(2)
     if project:
         found = {k: v for k, v in found.items() if k == project}
 
     if missing:
-        gap = [p for p in PROJECTS if p not in canonical_runs(config=config)]
+        gap = [p for p in PROJECTS if p not in found]
         if project:
             gap = [p for p in gap if p == project]
         for p in gap:

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -130,6 +130,68 @@ def restore(labels, projects, execute):
         click.echo("\nDry run. Re-run with --execute.")
 
 
+@runs.command("canonical")
+@click.option("--project", default=None, help="Report one project only.")
+@click.option("--config", default=None,
+              help="Only runs whose label starts with this, e.g. "
+                   "2026-07-31_claude-opus-5-generic-v2.")
+@click.option("--paths-only", is_flag=True,
+              help="Print record paths and nothing else, for piping.")
+@click.option("--missing", is_flag=True,
+              help="List projects that have no canonical record instead.")
+def canonical_cmd(project, config, paths_only, missing):
+    """Which record is the datasheet, per project.
+
+    `select` marks a replicate canonical and nothing read the mark (#306), so
+    the question it answers was answerable only by someone who knew to open
+    provenance. This reads it.
+
+    A project with no eligible replicate is absent rather than guessed at, and
+    `--missing` names those — the count that matters for scoping an evaluation
+    is how many projects *have* one, which is three of four while no VOICE
+    replicate validates (#292).
+    """
+    from data_sheets_schema.constants import PROJECTS
+    from data_sheets_schema.runs import canonical_runs
+
+    found = canonical_runs(config=config)
+    if project:
+        found = {k: v for k, v in found.items() if k == project}
+
+    if missing:
+        gap = [p for p in PROJECTS if p not in canonical_runs(config=config)]
+        if project:
+            gap = [p for p in gap if p == project]
+        for p in gap:
+            click.echo(p)
+        if not gap:
+            click.echo("Every project has a canonical record.", err=True)
+        return
+
+    if not found:
+        click.echo("No canonical record found. Run `d4d runs select --execute`.",
+                   err=True)
+        raise SystemExit(1)
+
+    if paths_only:
+        for entry in found.values():
+            for key in ("full", "core"):
+                if entry.get(key):
+                    click.echo(entry[key])
+        return
+
+    for name, entry in found.items():
+        click.echo(f"{name}")
+        click.echo(f"   label     {entry['label']}")
+        click.echo(f"   full      {entry['full']}")
+        click.echo(f"   core      {entry['core']}")
+        click.echo(f"   chosen    from {entry['candidates']} candidates — "
+                   f"{entry['criterion']}")
+    gap = [p for p in PROJECTS if p not in found and not project]
+    if gap:
+        click.echo(f"\nNo canonical record: {', '.join(gap)}", err=True)
+
+
 @runs.command("check")
 @click.option("--method", default=None)
 @click.option("--label", default=None)

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -225,6 +225,48 @@ def validation_status(method: str, label: str, project: str,
     return VALID if v["passed"] else INVALID
 
 
+def canonical_runs(concat_dir: Path = CONCAT_DIR,
+                   config: str | None = None) -> dict[str, dict]:
+    """project -> the run marked canonical for it, and where its records are.
+
+    `d4d runs select` writes a `canonical` block and nothing read it (#306). A
+    mark with no reader answers "which record *is* the CHORUS datasheet" only
+    for someone who already knows to go looking in provenance, which is not an
+    answer a pipeline can use — and #287's scoping needs to *enumerate* the
+    canonical set before it can be evaluated.
+
+    A project with no eligible replicate is simply absent. VOICE is the live
+    case: no replicate validates (#292), so it has no canonical record and any
+    count over projects is three of four, not four.
+    """
+    out: dict[str, dict] = {}
+    for prov in sorted(concat_dir.rglob("*_provenance.yaml")):
+        try:
+            data = yaml.safe_load(prov.read_text(encoding="utf-8")) or {}
+        except (yaml.YAMLError, OSError, UnicodeDecodeError):
+            continue
+        if not isinstance(data, dict) or "canonical" not in data:
+            continue
+        run = data.get("run") or {}
+        project, label = run.get("project"), run.get("label")
+        if not project or not label:
+            continue
+        if config and not label.startswith(config):
+            continue
+        outputs = data.get("outputs") or {}
+        out[project] = {
+            "project": project,
+            "label": label,
+            "method": run.get("method"),
+            "criterion": (data["canonical"] or {}).get("criterion"),
+            "candidates": len((data["canonical"] or {}).get("selected_from") or []),
+            "full": (outputs.get("full") or {}).get("path"),
+            "core": (outputs.get("core") or {}).get("path"),
+            "provenance": str(prov),
+        }
+    return dict(sorted(out.items()))
+
+
 def record_mode(method: str, label: str, project: str,
                 concat_dir: Path = CONCAT_DIR) -> str:
     """`live`, `reconstructed`, or `none` — how a run's provenance was obtained.

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -225,7 +225,11 @@ def validation_status(method: str, label: str, project: str,
     return VALID if v["passed"] else INVALID
 
 
-def canonical_runs(concat_dir: Path = CONCAT_DIR,
+class AmbiguousCanonical(RuntimeError):
+    """A project carries a canonical mark under more than one configuration."""
+
+
+def canonical_runs(concat_dir: Path | None = None,
                    config: str | None = None) -> dict[str, dict]:
     """project -> the run marked canonical for it, and where its records are.
 
@@ -239,7 +243,12 @@ def canonical_runs(concat_dir: Path = CONCAT_DIR,
     case: no replicate validates (#292), so it has no canonical record and any
     count over projects is three of four, not four.
     """
+    # Resolved at call time, not bound as a default. A default argument freezes
+    # CONCAT_DIR at import, which makes the corpus root unpatchable and the
+    # function untestable against a fixture.
+    concat_dir = Path(concat_dir) if concat_dir is not None else CONCAT_DIR
     out: dict[str, dict] = {}
+    seen: dict[str, list[str]] = {}
     for prov in sorted(concat_dir.rglob("*_provenance.yaml")):
         try:
             data = yaml.safe_load(prov.read_text(encoding="utf-8")) or {}
@@ -254,6 +263,7 @@ def canonical_runs(concat_dir: Path = CONCAT_DIR,
         if config and not label.startswith(config):
             continue
         outputs = data.get("outputs") or {}
+        seen.setdefault(project, []).append(label)
         out[project] = {
             "project": project,
             "label": label,
@@ -264,6 +274,17 @@ def canonical_runs(concat_dir: Path = CONCAT_DIR,
             "core": (outputs.get("core") or {}).get("path"),
             "provenance": str(prov),
         }
+    # Refuse rather than pick. `select --execute` does not clear a previous
+    # mark, so re-selecting under a new config leaves a project with two — and
+    # the dict build above would keep whichever label sorted last, which is a
+    # property of the string rather than of anything meaningful (#308).
+    ambiguous = {p: labels for p, labels in seen.items() if len(labels) > 1}
+    if ambiguous:
+        detail = "; ".join(f"{p}: {', '.join(sorted(labels))}"
+                           for p, labels in sorted(ambiguous.items()))
+        raise AmbiguousCanonical(
+            f"more than one canonical record per project ({detail}). "
+            "Pass config= to say which configuration you mean.")
     return dict(sorted(out.items()))
 
 

--- a/tests/test_canonical_resolver.py
+++ b/tests/test_canonical_resolver.py
@@ -1,0 +1,102 @@
+"""A canonical mark nobody can read answers nothing (#306).
+
+`d4d runs select` wrote a `canonical` block and the only reader in the tree was
+the test for the writer. #176 called selection the answer to "which record *is*
+the CHORUS datasheet"; until something could enumerate the marks, that was an
+answer only for someone who already knew to open provenance.
+
+#287's scoping needs the enumeration before it can size an evaluation: "one
+canonical record per project" is a number only if the set can be listed.
+"""
+
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from data_sheets_schema.cli.runs import runs
+from data_sheets_schema.constants import PROJECTS
+from data_sheets_schema.runs import canonical_runs
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+@unittest.skipUnless((REPO / "data" / "d4d_concatenated").exists(),
+                     "corpus not present")
+class TestCanonicalRuns(unittest.TestCase):
+
+    def setUp(self):
+        self.found = canonical_runs()
+
+    def test_it_finds_the_marked_records(self):
+        self.assertEqual(sorted(self.found), ["AI_READI", "CHORUS", "CM4AI"])
+
+    def test_voice_is_absent_rather_than_guessed(self):
+        """No VOICE replicate validates (#292), so it has no canonical record.
+
+        Absent, not least-bad: picking one would ship a record known to be
+        broken, which is what `select` refuses to do.
+        """
+        self.assertNotIn("VOICE", self.found)
+
+    def test_every_entry_resolves_to_records_that_exist(self):
+        for project, entry in self.found.items():
+            for variant in ("full", "core"):
+                with self.subTest(project=project, variant=variant):
+                    self.assertTrue((REPO / entry[variant]).is_file(),
+                                    entry[variant])
+
+    def test_each_entry_carries_its_criterion_and_candidates(self):
+        """A mark that does not say why is not auditable."""
+        for project, entry in self.found.items():
+            with self.subTest(project=project):
+                self.assertTrue(entry["criterion"])
+                self.assertEqual(entry["candidates"], 3)
+
+    def test_a_config_filter_narrows_it(self):
+        self.assertEqual(
+            canonical_runs(config="2026-07-31_claude-opus-5-generic-v2"),
+            self.found)
+        self.assertEqual(canonical_runs(config="no-such-config"), {})
+
+
+@unittest.skipUnless((REPO / "data" / "d4d_concatenated").exists(),
+                     "corpus not present")
+class TestTheCommand(unittest.TestCase):
+
+    def _run(self, *args):
+        return CliRunner().invoke(runs, ["canonical", *args])
+
+    def test_paths_only_is_pipeable(self):
+        """What an evaluation sweep consumes."""
+        out = self._run("--paths-only")
+        self.assertEqual(out.exit_code, 0, out.output)
+        lines = [l for l in out.output.splitlines() if l.strip()]
+        self.assertEqual(len(lines), 2 * len(canonical_runs()),
+                         "one full and one core per canonical project")
+        for line in lines:
+            self.assertTrue((REPO / line).is_file(), line)
+
+    def test_missing_names_the_gap(self):
+        out = self._run("--missing")
+        self.assertIn("VOICE", out.output)
+
+    def test_the_gap_is_every_project_without_a_mark(self):
+        out = self._run("--missing")
+        named = {l.strip() for l in out.output.splitlines() if l.strip()}
+        self.assertEqual(named, set(PROJECTS) - set(canonical_runs()))
+
+    def test_one_project_can_be_asked_for(self):
+        out = self._run("--project", "CHORUS")
+        self.assertEqual(out.exit_code, 0)
+        self.assertIn("CHORUS", out.output)
+        self.assertNotIn("CM4AI", out.output)
+
+    def test_asking_for_a_project_without_one_fails_rather_than_empties(self):
+        """Silence would read as "no canonical needed" rather than "none exists"."""
+        out = self._run("--project", "VOICE")
+        self.assertNotEqual(out.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_canonical_resolver.py
+++ b/tests/test_canonical_resolver.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 
 from data_sheets_schema.cli.runs import runs
 from data_sheets_schema.constants import PROJECTS
-from data_sheets_schema.runs import canonical_runs
+from data_sheets_schema.runs import AmbiguousCanonical, canonical_runs
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -96,6 +96,68 @@ class TestTheCommand(unittest.TestCase):
         """Silence would read as "no canonical needed" rather than "none exists"."""
         out = self._run("--project", "VOICE")
         self.assertNotEqual(out.exit_code, 0)
+
+
+class TestAmbiguity(unittest.TestCase):
+    """#308: `select --execute` does not clear a prior mark.
+
+    The plan in NEXT_TASKS §9 re-selects canonical after a v3 run, which leaves
+    every project carrying two marks. Keeping whichever label sorted last would
+    have made the answer a property of the string — and v3 labels sort after v2
+    ones, so it would have been right by accident until a label broke the
+    pattern.
+    """
+
+    def _corpus(self, tmp, labels):
+        import yaml
+        root = Path(tmp)
+        for label in labels:
+            d = root / "m_core" / label
+            d.mkdir(parents=True)
+            (d / "CHORUS_provenance.yaml").write_text(yaml.safe_dump({
+                "run": {"project": "CHORUS", "label": label, "method": "m"},
+                "canonical": {"criterion": "c", "selected_from": [{}, {}, {}]},
+                "outputs": {"full": {"path": f"{label}/f.yaml"},
+                            "core": {"path": f"{label}/c.yaml"}}}))
+        return root
+
+    def test_two_marks_for_one_project_raise(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._corpus(tmp, ["2026-01-01_config-a_rep1",
+                                      "2026-09-09_config-b_rep1"])
+            with self.assertRaises(AmbiguousCanonical) as ctx:
+                canonical_runs(concat_dir=root)
+            self.assertIn("CHORUS", str(ctx.exception))
+            self.assertIn("config-a", str(ctx.exception))
+            self.assertIn("config-b", str(ctx.exception))
+
+    def test_a_config_filter_resolves_the_ambiguity(self):
+        """--config already narrows correctly; it just had to be required."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._corpus(tmp, ["2026-01-01_config-a_rep1",
+                                      "2026-09-09_config-b_rep1"])
+            got = canonical_runs(concat_dir=root, config="2026-09-09")
+            self.assertEqual(got["CHORUS"]["label"], "2026-09-09_config-b_rep1")
+
+    def test_one_mark_does_not_raise(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._corpus(tmp, ["2026-01-01_config-a_rep1"])
+            self.assertEqual(list(canonical_runs(concat_dir=root)), ["CHORUS"])
+
+    def test_the_command_names_the_configurations(self):
+        """The user cannot pass --config without knowing what to pass."""
+        import tempfile
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._corpus(tmp, ["2026-01-01_config-a_rep1",
+                                      "2026-09-09_config-b_rep1"])
+            with mock.patch("data_sheets_schema.runs.CONCAT_DIR", root):
+                out = CliRunner().invoke(runs, ["canonical"])
+        self.assertEqual(out.exit_code, 2)
+        self.assertIn("config-a", out.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#287's blocker was never the decision — it was that nothing could enumerate what to evaluate.

## The mark had no reader

`d4d runs select` wrote a `canonical` block and the only reader in the tree was the test for the writer. #176 called selection the answer to *"which record **is** the CHORUS datasheet"*, but that was an answer only for someone who already knew to open provenance and which file to open. Every analysis path still treated all three replicates alike.

`canonical_runs()` returns `project -> {label, method, criterion, candidates, full, core, provenance}`, and `d4d runs canonical` reads it:

```
$ d4d runs canonical --paths-only
data/d4d_concatenated/claudecode_agent/…rep1/AI_READI_d4d.yaml
data/d4d_concatenated/claudecode_agent_core/…rep1/AI_READI_d4d_core.yaml
data/d4d_concatenated/claudecode_agent/…rep2/CHORUS_d4d.yaml
…
6 records

$ d4d runs canonical --missing
VOICE
VOICE_PEDIATRIC
```

A project with no eligible replicate is **absent rather than guessed at**, and asking for one by name exits non-zero rather than printing nothing — silence would read as "no canonical needed" instead of "none exists".

## It also corrects #287's arithmetic

The table there called *"canonical record per project, both rubrics"* **8 evaluations** — 4 projects × 2 rubrics, implicitly full records only. But the existing semantic corpus evaluates **both variants**: `rubric20_semantic` is 12 full and 12 core.

With three canonical projects:

| shape | evaluations |
|---|---|
| full only, 2 rubrics | **6** |
| full + core, 2 rubrics | **12** — matches the existing corpus |

Neither is wrong; they measure different things, and the table stated one number without saying which. The resolver prints the record set, so the count now follows from the set rather than from a number in a note.

## What this does not do

No evaluations are run. Generation is deferred to v3 (NEXT_TASKS §9), and evaluating v2 canonicals now would mean evaluating again when v3 lands — which is the reason #287 listed the preconditions in the first place.

**1105 passed, 3 skipped** (+10).