### PR TITLE
Re-selecting supersedes the prior canonical mark, in both records (#308)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -1,9 +1,9 @@
 """Run-tracking commands for the D4D CLI."""
 
-import click
-
 from datetime import datetime, timezone
 from pathlib import Path
+
+import click
 
 
 @click.group()
@@ -728,9 +728,23 @@ def select_cmd(method, project, config, allow_unverified, execute):
             continue
         try:
             prior = _yaml.safe_load(other.read_text(encoding="utf-8")) or {}
-        except Exception:                                    # noqa: BLE001
-            continue
-        if not isinstance(prior, dict) or "canonical" not in prior:
+        except (_yaml.YAMLError, OSError, UnicodeDecodeError) as exc:
+            # Fail the selection rather than skip. This command's contract is
+            # one canonical record per project, and a file it cannot read is a
+            # file whose mark it cannot clear. Skipping leaves the ambiguity to
+            # surface later in `canonical_runs`, in a different command, with
+            # nothing to connect it back to here (#310).
+            raise click.ClickException(
+                f"{other} could not be read "
+                f"({type(exc).__name__}: {str(exc).splitlines()[0][:80]}), so a "
+                "prior canonical mark there could not be cleared. Fix or remove "
+                "that record before selecting, or the project would end up with "
+                "two.")
+        if not isinstance(prior, dict):
+            raise click.ClickException(
+                f"{other} is not a mapping, so a prior canonical mark there "
+                "could not be cleared.")
+        if "canonical" not in prior:
             continue
         superseded.append(((prior.get("run") or {}).get("label") or str(other),
                            other, prior))

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -1,6 +1,8 @@
 """Run-tracking commands for the D4D CLI."""
 
 import click
+
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -716,6 +718,23 @@ def select_cmd(method, project, config, allow_unverified, execute):
         raise click.ClickException(
             f"{winner[0]} has no provenance record at {prov_path}; a canonical "
             f"record must be attributable.")
+    # One canonical record per project, enforced by clearing rather than by
+    # hoping. `select` used to leave a previous mark in place, so re-selecting
+    # under a new config left the project with two and the resolver had to
+    # refuse (#308). Superseding is what re-selection means.
+    superseded = []
+    for other in sorted(CONCAT_DIR.rglob(f"{project}_provenance.yaml")):
+        if other == prov_path:
+            continue
+        try:
+            prior = _yaml.safe_load(other.read_text(encoding="utf-8")) or {}
+        except Exception:                                    # noqa: BLE001
+            continue
+        if not isinstance(prior, dict) or "canonical" not in prior:
+            continue
+        superseded.append(((prior.get("run") or {}).get("label") or str(other),
+                           other, prior))
+
     data = _yaml.safe_load(prov_path.read_text(encoding="utf-8")) or {}
     data["canonical"] = {
         "criterion": "full and core both validate against the current schema, then most slots, then lowest label",
@@ -726,7 +745,26 @@ def select_cmd(method, project, config, allow_unverified, execute):
         "margin_over_runner_up": margin,
         "selected_by": "d4d runs select",
     }
+    # Named, not merely removed. A mark that vanishes leaves no trace of what
+    # the project used to ship, and "this replaced that" is the fact a reader
+    # of either record wants.
+    if superseded:
+        data["canonical"]["supersedes"] = [lab for lab, _p, _d in superseded]
     ProvenanceRecord(data=data).write(prov_path)
+
+    for label, other, prior in superseded:
+        prior.pop("canonical", None)
+        prior["canonical_superseded_by"] = {
+            "label": winner[0],
+            "at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "by": "d4d runs select",
+        }
+        ProvenanceRecord(data=prior).write(other)
+        click.echo(f"   cleared the prior mark on {label}")
+
     click.echo(f"\nRecorded in {prov_path}")
+    if superseded:
+        click.echo(f"Superseded {len(superseded)} earlier mark(s); each records "
+                   "what replaced it.")
     click.echo("All replicates kept — this marks one, it does not move or "
                "delete anything.")

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -197,7 +197,12 @@ def validation_status(method: str, label: str, project: str,
         return UNVERIFIED
     try:
         data = yaml.safe_load(rec.read_text(encoding="utf-8")) or {}
-    except Exception:
+    except Exception:                                        # noqa: BLE001
+        return UNVERIFIED
+    # A record that parses but is not a mapping is as unusable as one that does
+    # not parse, and treating it as usable crashed here with a bare
+    # AttributeError from `.get` (#311).
+    if not isinstance(data, dict):
         return UNVERIFIED
     v = data.get("validation")
     if not isinstance(v, dict) or "passed" not in v:
@@ -504,7 +509,18 @@ def _prov(method: str, label: str, project: str,
     import yaml as _yaml
     from data_sheets_schema.provenance import record_path_for
     p = record_path_for(project, method, label, concat_dir)
-    return (_yaml.safe_load(p.read_text(encoding="utf-8")) or {}) if p.exists() else None
+    if not p.exists():
+        return None
+    try:
+        data = _yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    except (_yaml.YAMLError, OSError, UnicodeDecodeError):
+        return None
+    # The annotation said `dict | None` and the code returned whatever YAML
+    # parsed, so a list-shaped record reached callers that call `.get` on it and
+    # crashed with a bare AttributeError pointing at this module rather than at
+    # the file (#311). `check_provenance` already treats a non-mapping as "no
+    # usable record"; this is the same read without the same care.
+    return data if isinstance(data, dict) else None
 
 
 def _verify(entry: dict) -> bool | None:

--- a/tests/test_cli/test_runs_select.py
+++ b/tests/test_cli/test_runs_select.py
@@ -143,6 +143,54 @@ class TestSelect(unittest.TestCase):
             self.assertTrue((self.method / label / "P_d4d.yaml").exists(),
                             f"{label} disappeared")
 
+    def test_reselecting_clears_the_prior_mark(self):
+        """One canonical record per project, enforced rather than hoped for.
+
+        `select` used to leave a previous mark in place, so re-selecting under
+        a new config left the project with two and the resolver had to refuse
+        (#308). The v3 run re-selects, so this is the next step rather than a
+        hypothetical.
+        """
+        self._run("--execute")                     # cfg_rep2 wins
+        first = yaml.safe_load((self.root / "claudecode_agent_core" /
+                                "cfg_rep2" / "P_provenance.yaml").read_text())
+        self.assertIn("canonical", first)
+
+        # rep2 now invalid, so a different replicate wins the re-selection
+        self._run("--execute", valid={"cfg_rep2": False})
+        second = yaml.safe_load((self.root / "claudecode_agent_core" /
+                                 "cfg_rep3" / "P_provenance.yaml").read_text())
+        self.assertIn("canonical", second)
+
+        cleared = yaml.safe_load((self.root / "claudecode_agent_core" /
+                                  "cfg_rep2" / "P_provenance.yaml").read_text())
+        self.assertNotIn("canonical", cleared,
+                         "the prior mark must not survive a re-selection")
+
+    def test_both_records_state_the_relationship(self):
+        """Named, not merely removed.
+
+        A mark that vanishes leaves no trace of what the project used to ship,
+        and "this replaced that" is the fact a reader of either record wants.
+        """
+        self._run("--execute")
+        self._run("--execute", valid={"cfg_rep2": False})
+
+        winner = yaml.safe_load((self.root / "claudecode_agent_core" /
+                                 "cfg_rep3" / "P_provenance.yaml").read_text())
+        self.assertEqual(winner["canonical"].get("supersedes"), ["cfg_rep2"])
+
+        loser = yaml.safe_load((self.root / "claudecode_agent_core" /
+                                "cfg_rep2" / "P_provenance.yaml").read_text())
+        self.assertEqual(loser["canonical_superseded_by"]["label"], "cfg_rep3")
+        self.assertIn("at", loser["canonical_superseded_by"])
+
+    def test_a_first_selection_supersedes_nothing(self):
+        self._run("--execute")
+        first = yaml.safe_load((self.root / "claudecode_agent_core" /
+                                "cfg_rep2" / "P_provenance.yaml").read_text())
+        self.assertNotIn("supersedes", first["canonical"])
+
     def test_one_replicate_is_not_a_selection(self):
         import shutil
         for label in ("cfg_rep2", "cfg_rep3"):

--- a/tests/test_cli/test_runs_select.py
+++ b/tests/test_cli/test_runs_select.py
@@ -191,6 +191,33 @@ class TestSelect(unittest.TestCase):
                                 "cfg_rep2" / "P_provenance.yaml").read_text())
         self.assertNotIn("supersedes", first["canonical"])
 
+    def test_an_unreadable_prior_record_fails_the_selection(self):
+        """#310: a clear that can silently fail to clear guarantees nothing.
+
+        The contract is one canonical record per project. Skipping an
+        unreadable file leaves the ambiguity to surface later in
+        `canonical_runs`, in a different command, with nothing connecting it
+        back to the selection that was meant to resolve it.
+        """
+        self._run("--execute")                       # cfg_rep2 becomes canonical
+        corrupt = (self.root / "claudecode_agent_core" / "cfg_rep2" /
+                   "P_provenance.yaml")
+        corrupt.write_text(corrupt.read_text() + "\nbroken: [unclosed\n",
+                           encoding="utf-8")
+        out = self._run("--execute", valid={"cfg_rep2": False})
+        self.assertNotEqual(out.exit_code, 0)
+        self.assertIn("could not be read", out.output)
+        self.assertIn("two", out.output, "the message should say what goes wrong")
+
+    def test_a_prior_record_that_is_not_a_mapping_also_fails(self):
+        self._run("--execute")
+        bad = (self.root / "claudecode_agent_core" / "cfg_rep2" /
+               "P_provenance.yaml")
+        bad.write_text("- just\n- a\n- list\n", encoding="utf-8")
+        out = self._run("--execute", valid={"cfg_rep2": False})
+        self.assertNotEqual(out.exit_code, 0)
+        self.assertIn("not a mapping", out.output)
+
     def test_one_replicate_is_not_a_selection(self):
         import shutil
         for label in ("cfg_rep2", "cfg_rep3"):


### PR DESCRIPTION
Closes the half of #308 left open: `select --execute` now clears a prior mark.

## Why it matters now

NEXT_TASKS §9 re-selects canonical after the v3 run. Without this, AI_READI, CHORUS and CM4AI would each carry two marks — one under generic-v2, one under generic-v3 — and `canonical_runs` would refuse to resolve them.

## Cleared, and named

The winner's block gains `supersedes: [label]`. The superseded record gains `canonical_superseded_by` with the label, a timestamp and the tool.

A mark that simply vanishes leaves no trace of what the project used to ship. **"This replaced that" is the fact a reader of either record wants** — from whichever end they arrive at it.

## Verified against the actual scenario

A fixture reproducing the v3 case: CHORUS's generic-v2 replicates cloned under a generic-v3 label so both carry the mark.

```
before: AMBIGUOUS — more than one canonical record per project (CHORUS: …v2_rep2, …v3_rep2)
→ 2026-09-01_claude-opus-5-generic-v3_rep2  (50 slots)
  cleared the prior mark on 2026-07-31_claude-opus-5-generic-v2_rep2
after:  unambiguous — CHORUS -> …generic-v3_rep2
        supersedes: ['2026-07-31_claude-opus-5-generic-v2_rep2']
old record: has canonical=False  superseded_by=…generic-v3_rep2
```

The real corpus is untouched — still three canonical records, six paths.

**1112 passed, 3 skipped** (+3).