### PR TITLE
Score the rubric the repository publishes (#314)

### DIFF
--- a/.claude/agents/d4d-rubric20-semantic.md
+++ b/.claude/agents/d4d-rubric20-semantic.md
@@ -90,7 +90,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
        | Condition | Satisfied when… | Gates |
        |---|---|---|
        | Human subjects | `description` or `keywords` reference human participants, patients, or clinical research, OR `collection_mechanisms` describes human participant recruitment — checked via Q1/Q2/Q3/Q12 fields only, never Q8's own fields | Q8, Q15 |
-       | Datasets shared & available for reuse | `distribution_formats` populated OR `download_url`/`page` links to accessible data OR license explicitly permits reuse | Q10, Q17, Q20 |
+       | Datasets shared & available for reuse | `distribution_formats` populated OR `download_url`/`page` links to accessible data OR license explicitly permits reuse | Q10, Q17 |
        | Software tools produced as dataset output | `external_resources` references a code repository, OR `description`/`purposes` explicitly identifies software production as a dataset output — checked via Q2/Q7/Q14 fields only, never Q11's own fields | Q11 |
        | Data collection identified AND datasets shared | Collection fields populated (`acquisition_methods`, `collection_mechanisms`, `data_collectors`, or `collection_timeframes`) AND the datasets shared condition above is met | Q12, Q13 |
        | Publication identified AND datasets shared | `citation` or `external_resources` includes at least one publication reference AND the datasets shared condition above is met | Q14 |
@@ -98,9 +98,9 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
      - **Step 2 — Apply the N/A encoding convention:** If a condition is not met, set `applicable: false` and `score: null` for every question it gates. Do not emit `0`. Subtract the question's `max_score` from the denominator per the N/A Question Convention in the Scoring Summary section.
      - **Ambiguity rule:** When a condition is borderline (e.g., a dataset page exists but access requires approval), default to `applicable: true` and score based on what is documented. This prevents silent N/A inflation on datasets that are partially shared.
      - **Anti-circular rule:** A question's own scoring fields may not be the sole basis for excluding it. If the only reason to set `applicable: false` is the absence of the question's own fields, treat the question as `applicable: true` and score accordingly (receiving 0 if those fields are absent). Applicability must be evidenced by fields belonging to a *different* question. Emit `applicability_status` and `applicability_evidence` before scoring every conditional question to make this determination explicit and auditable.
-     - EXAMPLE (applicable + scored): `distribution_formats` lists Parquet and TSV with a PhysioNet download URL → datasets shared condition is met → Q10, Q17, Q20 are applicable and scored.
+     - EXAMPLE (applicable + scored): `distribution_formats` lists Parquet and TSV with a PhysioNet download URL → datasets shared condition is met → Q10 and Q17 are applicable and scored. Q20 (bias documentation) is not gated by sharing: a dataset that is never released still has documentable biases.
      - EXAMPLE (applicable + reported, not scored): `human_subject_research.involves_human_subjects=True` but the datasheet is a core/instrument-only record with no ethics fields populated → Q8 and Q9 are reported (flag the gap) but the condition is met so they remain applicable and receive a low score, not N/A.
-     - EXAMPLE (not applicable): No `distribution_formats`, no accessible URL, license is proprietary/internal-only → datasets shared condition is NOT met → Q10, Q11, Q12, Q13, Q14, Q17, Q20 are all set to `applicable: false`, `score: null`, and excluded from the denominator.
+     - EXAMPLE (not applicable): No `distribution_formats`, no accessible URL, license is proprietary/internal-only → datasets shared condition is NOT met → Q10, Q11, Q12, Q13, Q14 and Q17 are all set to `applicable: false`, `score: null`, and excluded from the denominator. Q20 stays applicable and is scored.
 
 4. **Content Accuracy Assessment**
    - **Ethics Claims Plausibility:** Do `license_and_use_terms`, `ip_restrictions`, `data_protection_impacts`, and `participant_privacy.reidentification_risk` align with `human_subject_research`, `informed_consent`, and `participant_privacy` in scope and restrictiveness?
@@ -246,17 +246,17 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 
 ---
 
-#### Question 10: Interoperability and Standardization
-**Description:** Presence of standard formats, ontologies, or schema conformance.
+#### Question 10: Interoperability, Standardization, and Cross-Platform Integration
+**Description:** Presence of standard formats, ontologies, schema conformance (e.g., Parquet, TSV, LinkML), cross-platform dataset linkages with typed relationships, AND dataset integration capability. Note: Evaluation aligned with Bridge2AI AI/ML readiness characterization criteria (FAIRness, semantic/statistical characterization, governance, quality, pre-model XAI, ethics, computability). Reference: https://www.biorxiv.org/content/10.1101/2024.12.18.629172v1 and Bridge2AI AI-readiness scorecard tool. All Bridge2AI datasets are designed for AI/ML use. This question evaluates HOW WELL the dataset supports AI/ML (interoperability, standardization), not WHETHER it supports AI/ML. Dataset integration capability: Check for common identifiers for cross-dataset linking, standardized formats for data harmonization, and documented integration procedures.
 
-**Fields:** `format`, `encoding`, `conforms_to`, `conforms_to_schema`
+**Fields:** `format`, `encoding`, `conforms_to`, `conforms_to_schema`, `external_resources`, `related_datasets`
 
 **Scoring (numeric 0-5):**
 - **0:** Non-standard or unspecified format
 - **3:** Standard format but no schema reference
-- **5:** Standard formats + schema/ontology compliance
+- **5:** Standard formats + schema/ontology compliance + integration capability
 
-**Assessment:** Check for standard formats (Parquet, TSV, OMOP, FHIR, DICOM), encoding, and schema conformance references.
+**Assessment:** Score against the fields named above, from the record's content rather than its field presence.
 
 **Applies to:** Always report results of this question, but only score if datasets were identified elsewhere as shared and available for reuse.
 
@@ -296,17 +296,17 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 
 ---
 
-#### Question 13: Version History Documentation
-**Description:** Presence of version information, version access methods, errata, update plans, and release notes with dates.
+#### Question 13: Version History, Maintenance, and Sustainability
+**Description:** Presence of version information, version access methods, errata, update plans, release notes with dates, AND data sustainability indicators (persistent identifiers, long-term governance plan, domain-appropriate repository, institutional commitment documentation). Note: Data sustainability evaluation checks for: (1) persistent identifiers (DOI, ARK, Handle), (2) long-term governance plan, (3) domain-appropriate repository (e.g., PhysioNet for biomedical data), (4) institutional commitment or preservation funding. Sustainable datasets have clear maintenance plans beyond initial publication.
 
-**Fields:** `version`, `version_access`, `errata`, `updates`, `release_notes`
+**Fields:** `version`, `version_access`, `errata`, `updates`, `release_notes`, `maintainers`, `doi`, `publisher`
 
 **Scoring (numeric 0-5):**
-- **0:** Single version only
-- **3:** Version number + basic access info
-- **5:** Comprehensive versioning with errata, updates, and release notes
+- **0:** Single version only, no sustainability plan
+- **3:** Version number + basic access info + persistent ID
+- **5:** Comprehensive versioning + full sustainability documentation (governance + repository + commitment)
 
-**Assessment:** Evaluate completeness of version tracking infrastructure.
+**Assessment:** Score against the fields named above, from the record's content rather than its field presence.
 
 **Applies to:** Always report results of this question, but only score if data collection was identified elsewhere and datasets were shared and available for reuse.
 
@@ -375,46 +375,45 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 
 ---
 
-#### Question 18: Reusability (License Clarity)
-**Description:** License is clearly defined and permits identifiable reuse cases.
+#### Question 18: Reusability, Use Guidance, and Social Impact
+**Description:** License is clearly defined with explicit use guidance including intended uses, prohibited uses, discouraged uses, AND comprehensive social impact analysis with risk identification and mitigation strategies (CROISSANT RAI aligned).
 
-**Fields:** `license_and_use_terms`
+**Fields:** `license_and_use_terms`, `intended_uses`, `prohibited_uses`, `discouraged_uses`, `future_use_impacts`
 
 **Scoring (numeric 0-5):**
-- **0:** No license
-- **3:** License present but unclear reuse conditions
-- **5:** License explicitly defines reuse terms
+- **0:** No license or use guidance
+- **3:** License + basic use guidance
+- **5:** License + comprehensive use guidance + social impact analysis with mitigation strategies
 
-**Assessment:** Check license clarity and reuse permissions.
+**Assessment:** Score against the fields named above, from the record's content rather than its field presence.
 
 ---
 
-#### Question 19: Data Integrity and Provenance
-**Description:** Presence of change logs or provenance tracking.
+#### Question 19: Data Integrity, Provenance Graph, and Quality
+**Description:** Presence of version access, errata, update plans, source derivation, parent dataset linkages, missing data documentation, data split indicators, AND provenance graph representation. Note: Provenance is a transparent graph of origins and processing of data (W3C PROV-O standard: https://www.w3.org/TR/prov-o/), NOT just version changes. Evaluation checks for: (1) Entity-activity-agent relationships, (2) Processing lineage, (3) Derivation paths. Scoring distinction: - Version history alone (version numbers, errata, updates) = 3 points - Full provenance graph (W3C PROV-O with entity-activity-agent relationships, processing lineage, derivation paths) = 5 points Provenance may be represented as text OR as W3C PROV-O graphs. Both formats are acceptable if they provide complete lineage information.
 
-**Fields:** `updates`, `version_access`
+**Fields:** `version_access`, `errata`, `updates`, `was_derived_from`, `parent_datasets`, `missing_data_documentation`, `is_data_split`, `raw_data_sources`
 
 **Scoring (numeric 0-5):**
 - **0:** No provenance metadata
-- **3:** Change notes only
-- **5:** Structured version control with timestamps
+- **3:** Version history (version numbers, errata, updates) but no full provenance graph
+- **5:** Full provenance graph with entity-activity-agent relationships, processing lineage, and derivation paths
 
-**Assessment:** Evaluate provenance documentation quality.
+**Assessment:** Score against the fields named above, from the record's content rather than its field presence.
 
 ---
 
-#### Question 20: Interlinking Across Platforms
-**Description:** Metadata connects dataset records across multiple platforms.
+#### Question 20: Bias Documentation and Responsible AI Alignment
+**Description:** Metadata documents known biases using standardized taxonomies (BiasTypeEnum, AIO) aligned with CROISSANT RAI standards, and includes fairness analysis. Assesses whether biases are categorized systematically (e.g., selection_bias, measurement_bias, algorithmic_bias, ecological_fallacy) with mappings to AI Ontology (AIO).
 
-**Fields:** `external_resources`, `page`
+**Fields:** `known_biases`, `future_use_impacts`
 
-**Scoring (pass/fail):**
-- **Pass:** Cross-platform links verified
-- **Fail:** No external linkages found
+**Scoring (numeric 0-5):**
+- **0:** No bias documentation
+- **3:** Basic bias identification without taxonomy
+- **5:** Comprehensive bias categorization using standard taxonomy (AIO/CROISSANT RAI) + fairness analysis
 
-**Assessment:** Look for external resources linking to related platforms (FAIRhub, PhysioNet, GitHub, etc.).
-
-**Applies to:** Always report results of this question, but only score if datasets were identified elsewhere as shared and available for reuse.
+**Assessment:** Score against the fields named above, from the record's content rather than its field presence.
 
 ---
 
@@ -472,11 +471,11 @@ Return your evaluation as a **JSON object** with this EXACT structure:
   },
   "overall_score": {
     "total_points": 72.5,
-    "max_points": 84,
-    "excluded_max_points": 0,
-    "adjusted_max_points": 84,
-    "normalized_percentage": 86.3,
-    "questions_not_applicable": 0
+    "max_points": 88,
+    "excluded_max_points": 5,
+    "adjusted_max_points": 83,
+    "normalized_percentage": 87.3,
+    "questions_not_applicable": 1
   },
   "categories": [
     {
@@ -507,6 +506,22 @@ Return your evaluation as a **JSON object** with this EXACT structure:
           "evidence": "description: 420 chars, motivation: N/A",
           "quality_note": "Description is comprehensive at 420 characters"
         },
+        "... (remaining questions 3-5)"
+      ],
+      "category_score": 19,
+      "category_max": 21
+    },
+    {
+      "name": "Metadata Quality & Content",
+      "questions": [
+        "... (questions 6-10)"
+      ],
+      "category_score": 17,
+      "category_max": 21
+    },
+    {
+      "name": "Technical Documentation",
+      "questions": [
         {
           "id": 11,
           "name": "Tool and Software Transparency",
@@ -520,25 +535,9 @@ Return your evaluation as a **JSON object** with this EXACT structure:
           "evidence": "No shared software tools identified in this datasheet",
           "quality_note": "Excluded from denominator per 'Applies to' condition: software tools not shared"
         },
-        "... (remaining questions 3-5)"
+        "... (remaining questions 12-15)"
       ],
-      "category_score": 23,
-      "category_max": 24
-    },
-    {
-      "name": "Metadata Quality & Content",
-      "questions": [
-        "... (questions 6-10)"
-      ],
-      "category_score": 18,
-      "category_max": 22
-    },
-    {
-      "name": "Technical Documentation",
-      "questions": [
-        "... (questions 11-15)"
-      ],
-      "category_score": 19,
+      "category_score": 17,
       "category_max": 25
     },
     {
@@ -546,8 +545,8 @@ Return your evaluation as a **JSON object** with this EXACT structure:
       "questions": [
         "... (questions 16-20)"
       ],
-      "category_score": 12.5,
-      "category_max": 13
+      "category_score": 19.5,
+      "category_max": 21
     }
   ],
   "assessment": {
@@ -593,16 +592,16 @@ When evaluating **multiple D4D files** (batch mode), generate a comprehensive su
 ```yaml
 id: rubric20_semantic_evaluation_<timestamp>
 rubric_type: rubric20
-rubric_description: "20-question detailed rubric with semantic analysis: 4 categories (Structural Completeness, Metadata Quality, Technical Documentation, FAIRness), 0-5 scoring + pass/fail, maximum 84 points, enhanced with correctness validation, consistency checking, and semantic understanding"
+rubric_description: "20-question detailed rubric with semantic analysis: 4 categories (Structural Completeness, Metadata Quality, Technical Documentation, FAIRness), 0-5 scoring + pass/fail, maximum 88 points, enhanced with correctness validation, consistency checking, and semantic understanding"
 total_files_evaluated: 8
 evaluation_date: "<ISO 8601 date>"
 
 overall_performance:
   average_score: 52.3
-  max_score: 84
+  max_score: 88
   average_excluded_max_points: 8.5
-  average_adjusted_max_points: 75.5
-  average_normalized_percentage: 69.3
+  average_adjusted_max_points: 79.5
+  average_normalized_percentage: 65.8
   best_score: 68.0
   worst_score: 38.5
   best_performer:
@@ -611,31 +610,31 @@ overall_performance:
     project: AI_READI
     score: 68.0
     excluded_max_points: 5
-    adjusted_max_points: 79
-    normalized_percentage: 86.1
+    adjusted_max_points: 83
+    normalized_percentage: 81.9
   worst_performer:
     file: CHORUS_d4d.yaml
     method: gpt5
     project: CHORUS
     score: 38.5
     excluded_max_points: 10
-    adjusted_max_points: 74
-    normalized_percentage: 52.0
+    adjusted_max_points: 78
+    normalized_percentage: 49.4
 
 method_comparison:
   - method: claudecode_agent
     file_count: 4
     average_score: 56.2
     average_excluded_max_points: 7.5
-    average_adjusted_max_points: 76.5
-    average_normalized_percentage: 73.5
+    average_adjusted_max_points: 80.5
+    average_normalized_percentage: 69.8
     rank: 1
   - method: claudecode_assistant
     file_count: 4
     average_score: 48.4
     average_excluded_max_points: 9.5
-    average_adjusted_max_points: 74.5
-    average_normalized_percentage: 64.9
+    average_adjusted_max_points: 78.5
+    average_normalized_percentage: 61.7
     rank: 2
 
 project_comparison:
@@ -643,28 +642,28 @@ project_comparison:
     file_count: 2
     average_score: 61.5
     average_excluded_max_points: 5.0
-    average_adjusted_max_points: 79.0
-    average_normalized_percentage: 77.8
+    average_adjusted_max_points: 83.0
+    average_normalized_percentage: 74.1
     rank: 1
   - project: CM4AI
     file_count: 2
     average_score: 54.8
     average_excluded_max_points: 8.0
-    average_adjusted_max_points: 76.0
-    average_normalized_percentage: 72.1
+    average_adjusted_max_points: 80.0
+    average_normalized_percentage: 68.5
     rank: 2
 
 category_performance:
   - category_id: "1"
     category_name: "Structural Completeness and Core Metadata"
     average_score: 15.8
-    max_score: 24
-    average_normalized_percentage: 65.8
+    max_score: 21
+    average_normalized_percentage: 75.2
   - category_id: "2"
     category_name: "Metadata Quality and Detail"
     average_score: 14.2
-    max_score: 22
-    average_normalized_percentage: 64.5
+    max_score: 21
+    average_normalized_percentage: 67.6
   - category_id: "3"
     category_name: "Technical Documentation and Reproducibility"
     average_score: 12.5
@@ -673,8 +672,8 @@ category_performance:
   - category_id: "4"
     category_name: "FAIRness and Accessibility"
     average_score: 9.8
-    max_score: 13
-    average_normalized_percentage: 75.4
+    max_score: 21
+    average_normalized_percentage: 46.7
 
 common_strengths:
   - description: "Strong structural completeness with semantically validated fields"
@@ -702,7 +701,7 @@ key_insights:
     impact: high
   - insight: "Correctness validation found 15 identifier format issues requiring manual review"
     impact: high
-  - insight: "FAIRness category scores highest (75.4%) but with 10% identifier plausibility issues"
+  - insight: "Structural Completeness scores highest (75.2%); FAIRness trails at 46.7% with 10% identifier plausibility issues"
     impact: high
   - insight: "Technical Documentation weakest (50.0%) due to missing reproducibility details"
     impact: high
@@ -771,11 +770,11 @@ semantic_analysis_summary:
 
 ## Scoring Summary
 
-**Maximum Possible Score:** 84 points (before N/A exclusions)
-- **Structural Completeness (5 questions):** 24 points max (4 numeric @5 each + 1 pass/fail)
-- **Metadata Quality & Content (5 questions):** 22 points max (4 numeric @5 each + 1 pass/fail)
-- **Technical Documentation (5 questions):** 25 points max (5 numeric @5 each)
-- **FAIRness & Accessibility (5 questions):** 13 points max (3 numeric @5 each + 2 pass/fail)
+**Maximum Possible Score:** 88 points (before N/A exclusions) — 17 numeric questions @5 each + 3 pass/fail @1 each.
+- **Structural Completeness (Q1-5):** 21 points max (4 numeric @5 each + Q5 pass/fail)
+- **Metadata Quality & Content (Q6-10):** 21 points max (4 numeric @5 each + Q6 pass/fail)
+- **Technical Documentation (Q11-15):** 25 points max (5 numeric @5 each)
+- **FAIRness & Accessibility (Q16-20):** 21 points max (4 numeric @5 each + Q16 pass/fail)
 
 **N/A Question Convention:**
 

--- a/.claude/agents/d4d-rubric20.md
+++ b/.claude/agents/d4d-rubric20.md
@@ -168,33 +168,33 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 
 ---
 
-#### Question 9: Access Requirements Documentation
-**Description:** Whether access policy and license are clearly defined (open, registered, restricted).
+#### Question 9: Access Requirements and Governance Documentation
+**Description:** Determines if access policy, license, IP restrictions, regulatory restrictions, confidentiality level, multi-jurisdiction compliance, and governance contacts are clearly defined. Note: In Bridge2AI, license types include: (1) CM4AI uses CC-BY-NC-SA (permissive license), (2) AI-READi, CHORUS, VOICE use Data Use Agreements (controlled access). Avoid misleading terms like "Open" or "Public" — instead use: permissive license (e.g., CC-BY, CC-BY-NC-SA) or openly accessible with DUA (requires signed agreement). Access tiers: (1) No authentication, (2) Registration required, (3) DUA required, (4) IRB/committee approval required.
 
-**Fields:** `access_and_licensing`, `license_and_use_terms`
+**Fields:** `license_and_use_terms`, `ip_restrictions`, `regulatory_restrictions`, `confidentiality_level`, `hipaa_compliant`, `other_compliance`, `governance_committee_contact`
 
 **Scoring (numeric 0-5):**
-- **0:** No license info
-- **3:** License type only
-- **5:** License + Data Use Agreement + platform access description
+- **0:** No license or access info
+- **3:** License + basic restrictions
+- **5:** License + multi-jurisdiction compliance + confidentiality classification + governance contact
 
-**Assessment:** Evaluate clarity and completeness of access documentation.
+**Assessment:** Evaluate clarity and completeness of access and governance documentation.
 
 **Applies to:** Bridge2AI-Voice, Dataverse
 
 ---
 
-#### Question 10: Interoperability and Standardization
-**Description:** Presence of standard formats, ontologies, or schema conformance.
+#### Question 10: Interoperability, Standardization, and Cross-Platform Integration
+**Description:** Presence of standard formats, ontologies, schema conformance (e.g., Parquet, TSV, LinkML), cross-platform dataset linkages with typed relationships, AND dataset integration capability. Note: Evaluation aligned with Bridge2AI AI/ML readiness characterization criteria (FAIRness, semantic/statistical characterization, governance, quality, pre-model XAI, ethics, computability). Reference: https://www.biorxiv.org/content/10.1101/2024.12.18.629172v1 and Bridge2AI AI-readiness scorecard tool. All Bridge2AI datasets are designed for AI/ML use. This question evaluates HOW WELL the dataset supports AI/ML (interoperability, standardization), not WHETHER it supports AI/ML. Dataset integration capability: Check for common identifiers for cross-dataset linking, standardized formats for data harmonization, and documented integration procedures.
 
-**Fields:** `data_characteristics.data_formats`, `conforms_to`
+**Fields:** `format`, `encoding`, `conforms_to`, `conforms_to_schema`, `external_resources`, `related_datasets`
 
 **Scoring (numeric 0-5):**
 - **0:** Non-standard or unspecified format
 - **3:** Standard format but no schema reference
-- **5:** Standard formats + schema/ontology compliance
+- **5:** Standard formats + schema/ontology compliance + integration capability
 
-**Assessment:** Check for standard formats (Parquet, TSV, OMOP, FHIR, DICOM) and schema references.
+**Assessment:** Check for standard formats (Parquet, TSV, OMOP, FHIR, DICOM), encoding, schema references, and cross-dataset linkages.
 
 **Applies to:** Bridge2AI-Voice, Health Nexus
 
@@ -234,17 +234,17 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 
 ---
 
-#### Question 13: Version History Documentation
-**Description:** Presence of multiple version records and associated dates.
+#### Question 13: Version History, Maintenance, and Sustainability
+**Description:** Presence of version information, version access methods, errata, update plans, release notes with dates, AND data sustainability indicators (persistent identifiers, long-term governance plan, domain-appropriate repository, institutional commitment documentation). Note: Data sustainability evaluation checks for: (1) persistent identifiers (DOI, ARK, Handle), (2) long-term governance plan, (3) domain-appropriate repository (e.g., PhysioNet for biomedical data), (4) institutional commitment or preservation funding. Sustainable datasets have clear maintenance plans beyond initial publication.
 
-**Fields:** `release_notes`, `versions_available_on_platform`
+**Fields:** `version`, `version_access`, `errata`, `updates`, `release_notes`, `maintainers`, `doi`, `publisher`
 
 **Scoring (numeric 0-5):**
-- **0:** Single version only
-- **3:** Two versions listed without detail
-- **5:** ≥2 versions with change summaries and release dates
+- **0:** Single version only, no sustainability plan
+- **3:** Version number + basic access info + persistent ID
+- **5:** Comprehensive versioning + full sustainability documentation (governance + repository + commitment)
 
-**Assessment:** Count versions and evaluate quality of change documentation.
+**Assessment:** Evaluate version tracking infrastructure together with the maintenance and preservation commitments behind it.
 
 **Applies to:** Bridge2AI-Voice, Dataverse
 
@@ -313,46 +313,47 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 
 ---
 
-#### Question 18: Reusability (License Clarity)
-**Description:** License is clearly defined and permits identifiable reuse cases.
+#### Question 18: Reusability, Use Guidance, and Social Impact
+**Description:** License is clearly defined with explicit use guidance including intended uses, prohibited uses, discouraged uses, AND comprehensive social impact analysis with risk identification and mitigation strategies (CROISSANT RAI aligned).
 
-**Fields:** `license_and_use_terms`
+**Fields:** `license_and_use_terms`, `intended_uses`, `prohibited_uses`, `discouraged_uses`, `future_use_impacts`
 
 **Scoring (numeric 0-5):**
-- **0:** No license
-- **3:** License present but unclear reuse conditions
-- **5:** License explicitly defines reuse terms
+- **0:** No license or use guidance
+- **3:** License + basic use guidance
+- **5:** License + comprehensive use guidance + social impact analysis with mitigation strategies
 
-**Assessment:** Check license clarity and reuse permissions.
+**Assessment:** Check license clarity, the explicit use guidance around it, and the social impact analysis.
 
 ---
 
-#### Question 19: Data Integrity and Provenance
-**Description:** Presence of change logs or provenance tracking.
+#### Question 19: Data Integrity, Provenance Graph, and Quality
+**Description:** Presence of version access, errata, update plans, source derivation, parent dataset linkages, missing data documentation, data split indicators, AND provenance graph representation. Note: Provenance is a transparent graph of origins and processing of data (W3C PROV-O standard: https://www.w3.org/TR/prov-o/), NOT just version changes. Evaluation checks for: (1) Entity-activity-agent relationships, (2) Processing lineage, (3) Derivation paths. Provenance may be represented as text OR as W3C PROV-O graphs. Both formats are acceptable if they provide complete lineage information.
 
-**Fields:** `updates`, `version_access`
+**Fields:** `version_access`, `errata`, `updates`, `was_derived_from`, `parent_datasets`, `missing_data_documentation`, `is_data_split`, `raw_data_sources`
 
 **Scoring (numeric 0-5):**
 - **0:** No provenance metadata
-- **3:** Change notes only
-- **5:** Structured version control with timestamps
+- **3:** Version history (version numbers, errata, updates) but no full provenance graph
+- **5:** Full provenance graph with entity-activity-agent relationships, processing lineage, and derivation paths
 
-**Assessment:** Evaluate provenance documentation quality.
+**Assessment:** Evaluate provenance documentation quality, distinguishing version history from a complete lineage graph.
 
 ---
 
-#### Question 20: Interlinking Across Platforms
-**Description:** Metadata connects dataset records across multiple platforms.
+#### Question 20: Bias Documentation and Responsible AI Alignment
+**Description:** Metadata documents known biases using standardized taxonomies (BiasTypeEnum, AIO) aligned with CROISSANT RAI standards, and includes fairness analysis. Assesses whether biases are categorized systematically (e.g., selection_bias, measurement_bias, algorithmic_bias, ecological_fallacy) with mappings to AI Ontology (AIO).
 
-**Fields:** `external_resources`, `project_website`
+**Fields:** `known_biases`, `future_use_impacts`
 
-**Scoring (pass/fail):**
-- **Pass:** Cross-platform links verified
-- **Fail:** No external linkages found
+**Scoring (numeric 0-5):**
+- **0:** No bias documentation
+- **3:** Basic bias identification without taxonomy
+- **5:** Comprehensive bias categorization using standard taxonomy (AIO/CROISSANT RAI) + fairness analysis
 
-**Assessment:** Look for links to related platforms (FAIRhub, PhysioNet, GitHub).
+**Assessment:** Check whether biases are named, categorised against a standard taxonomy, and paired with fairness analysis.
 
-**Applies to:** Health Nexus, PhysioNet, FAIRhub
+**Applies to:** Bridge2AI-Voice, AI-READI, CM4AI, CHORUS
 
 ---
 
@@ -375,8 +376,8 @@ Return your evaluation as a **JSON object** with this EXACT structure:
   },
   "overall_score": {
     "total_points": 72.5,
-    "max_points": 84,
-    "percentage": 86.3
+    "max_points": 88,
+    "percentage": 82.4
   },
   "categories": [
     {
@@ -405,23 +406,23 @@ Return your evaluation as a **JSON object** with this EXACT structure:
         },
         ... (remaining questions 3-5)
       ],
-      "category_score": 23,
-      "category_max": 24
+      "category_score": 19,
+      "category_max": 21
     },
     {
       "name": "Metadata Quality & Content",
       "questions": [
         ... (questions 6-10)
       ],
-      "category_score": 18,
-      "category_max": 22
+      "category_score": 17,
+      "category_max": 21
     },
     {
       "name": "Technical Documentation",
       "questions": [
         ... (questions 11-15)
       ],
-      "category_score": 19,
+      "category_score": 17,
       "category_max": 25
     },
     {
@@ -429,8 +430,8 @@ Return your evaluation as a **JSON object** with this EXACT structure:
       "questions": [
         ... (questions 16-20)
       ],
-      "category_score": 12.5,
-      "category_max": 13
+      "category_score": 19.5,
+      "category_max": 21
     }
   ],
   "assessment": {
@@ -476,14 +477,14 @@ When evaluating **multiple D4D files** (batch mode), generate a comprehensive su
 ```yaml
 id: rubric20_evaluation_<timestamp>
 rubric_type: rubric20
-rubric_description: "20-question detailed rubric with 4 categories (Structural Completeness, Metadata Quality, Technical Documentation, FAIRness), 0-5 scoring scale + pass/fail, maximum 84 points"
+rubric_description: "20-question detailed rubric with 4 categories (Structural Completeness, Metadata Quality, Technical Documentation, FAIRness), 0-5 scoring scale + pass/fail, maximum 88 points"
 total_files_evaluated: 8
 evaluation_date: "<ISO 8601 date>"
 
 overall_performance:
   average_score: 52.3
-  max_score: 84
-  average_percentage: 62.3
+  max_score: 88
+  average_percentage: 59.4
   best_score: 68.0
   worst_score: 38.5
   best_performer:
@@ -491,49 +492,49 @@ overall_performance:
     method: claudecode_agent
     project: AI_READI
     score: 68.0
-    percentage: 81.0
+    percentage: 77.3
   worst_performer:
     file: CHORUS_d4d.yaml
     method: gpt5
     project: CHORUS
     score: 38.5
-    percentage: 45.8
+    percentage: 43.8
 
 method_comparison:
   - method: claudecode_agent
     file_count: 4
     average_score: 56.2
-    average_percentage: 66.9
+    average_percentage: 63.9
     rank: 1
   - method: claudecode_assistant
     file_count: 4
     average_score: 48.4
-    average_percentage: 57.6
+    average_percentage: 55.0
     rank: 2
 
 project_comparison:
   - project: AI_READI
     file_count: 2
     average_score: 61.5
-    average_percentage: 73.2
+    average_percentage: 69.9
     rank: 1
   - project: CM4AI
     file_count: 2
     average_score: 54.8
-    average_percentage: 65.2
+    average_percentage: 62.3
     rank: 2
 
 category_performance:
   - category_id: "1"
     category_name: "Structural Completeness and Core Metadata"
     average_score: 15.8
-    max_score: 24
-    average_percentage: 65.8
+    max_score: 21
+    average_percentage: 75.2
   - category_id: "2"
     category_name: "Metadata Quality and Detail"
     average_score: 14.2
-    max_score: 22
-    average_percentage: 64.5
+    max_score: 21
+    average_percentage: 67.6
   - category_id: "3"
     category_name: "Technical Documentation and Reproducibility"
     average_score: 12.5
@@ -542,8 +543,8 @@ category_performance:
   - category_id: "4"
     category_name: "FAIRness and Accessibility"
     average_score: 9.8
-    max_score: 13
-    average_percentage: 75.4
+    max_score: 21
+    average_percentage: 46.7
 
 common_strengths:
   - description: "Strong structural completeness (≥90% fields populated)"
@@ -589,11 +590,11 @@ key_insights:
 
 ## Scoring Summary
 
-**Maximum Possible Score:** 84 points
-- **Structural Completeness (5 questions):** 24 points max (4 numeric @5 each + 1 pass/fail)
-- **Metadata Quality & Content (5 questions):** 22 points max (4 numeric @5 each + 1 pass/fail)
-- **Technical Documentation (5 questions):** 25 points max (5 numeric @5 each)
-- **FAIRness & Accessibility (5 questions):** 13 points max (3 numeric @5 each + 2 pass/fail)
+**Maximum Possible Score:** 88 points — 17 numeric questions @5 each + 3 pass/fail @1 each.
+- **Structural Completeness (Q1-5):** 21 points max (4 numeric @5 each + Q5 pass/fail)
+- **Metadata Quality & Content (Q6-10):** 21 points max (4 numeric @5 each + Q6 pass/fail)
+- **Technical Documentation (Q11-15):** 25 points max (5 numeric @5 each)
+- **FAIRness & Accessibility (Q16-20):** 21 points max (4 numeric @5 each + Q16 pass/fail)
 
 ## Key Principles
 

--- a/notes/codex_rerun_readiness_review_2026-08-04.md
+++ b/notes/codex_rerun_readiness_review_2026-08-04.md
@@ -1,0 +1,107 @@
+# Codex review: readiness for the final D4D generation rerun
+
+External review, 2026-08-04. Run through the Codex CLI (`gpt-5.3-codex`), session
+`019fcf48-c145-7b41-96f0-f0d9f7d44e89`, 13m 19s, against main at `f0d61d43179f`.
+
+Asked two questions: whether any unmerged branch holds work that must land before
+the rerun, and what remains on main to prepare for it. It was given the planned
+sequence, the relevant notes, and the open issues, and asked to read the actual
+diffs rather than judge branches by name.
+
+**Reproduced verbatim.** File paths are absolute, as the review emitted them.
+Two things it reported are worth reading with the environment in mind: it could
+not run the full suite (no writable temp directory in its sandbox) and it saw
+`gh` unauthenticated, so it took issue and branch state from the GitHub service
+rather than local refs. Its git-level findings — merge-bases, patch-ids,
+divergence counts — were computed locally and are checkable.
+
+---
+
+## 1. Must land before rerun
+
+**None of the inspected branches must be merged.** Main is at `f0d61d43179f`; no open PR supplies missing generation, schema, selection, canonical-enumeration, or semantic-evaluation functionality.
+
+The plausible branches either contain obsolete schema work or changes already superseded on main. In particular, neither `origin/slot_uris` nor `slot_uris_2_backup` implements the class-level or `schema:`/`dcat:` structural mappings requested by #294. The preparation blockers identified below therefore require new changes on main, not merging an existing branch.
+
+## 2. Stale / can be closed
+
+- `origin/explorer-sync-update` — tip `449431203d73`, merge-base `ecc8012bf3d5`, main/branch divergence `131/19`; its entire current net diff is six path/name edits in `utils/d4d_to_synapse_table.py`, changing old HTML locations and `AI-READI` to `AI_READI`. No generation, schema, or evaluation code remains unique.
+
+- `origin/slot_uris` — tip `343dbf54a448`, merge-base `4322abb025dc`, divergence `158/19`; it has 213 parsed `slot_uri` mappings versus main’s 342, including obsolete conflicts such as `target_dataset: schema:identifier` where main now uses `dcterms:relation`. It contains only older comprehensive SSSOM scripts, not the structural generator capability required by #294.
+
+- `slot_uris_2_backup` — tip `ad732a260e32`, merge-base `9a522ecc928a`, divergence `156/30`; main’s reviewed squash `13c2a00a` is nearly its schema result, while current main has 342 mappings versus the backup’s 276. Against `origin/slot_uris` it is `3/16` commits divergent, so **neither is a strict subset or superset** of the other.
+
+- `fix-curated-mislabel` — tip `8379a85d6448`, merge-base `594b0d582e46`, divergence `124/4`; its four commits (`2b730155`, `681aa3d8`, `893f6c47`, `8379a85d`) are a feature subset/precursor of main squash `999f43ba`, which retains the corrected “not hand-curated” provenance and label-aware evaluation work.
+
+- `unified-cli-constants` — tip `dd67cef0e6db`, merge-base `81800d69ae2f`, divergence `154/15`; its aggregate patch-id exactly equals main commit `84637af7` (`8e074a4bd4071bfb935bb111d0bf1363aa89c880`), and the direct tree diff at that point is empty. It is an exact content subset already on main.
+
+- `origin/d4d/add-ai-readi-flagship-datasheet` — `392806cb`; adds 174 lines to an old extracted YAML/HTML pair, including `data/extracted_by_column/AI_READI/ai_readi_flagship_d4d.yaml`; no source or schema changes.
+
+- `origin/d4d/add-cm4ai-comprehensive-datasheet` — `71c4db53`; adds 38 lines to an old extracted YAML/HTML pair only.
+
+- `origin/d4d/add-cm4ai-consolidated-datasheet` — `021f9449`; adds 279 lines solely to `data/sheets_d4dassistant/cm4ai_d4d.yaml`.
+
+- `origin/d4d/add-cm4ai-datasheet` — `7363339b`; adds 340 lines solely to the same legacy `data/sheets_d4dassistant/cm4ai_d4d.yaml` path.
+
+- `origin/d4d/add-cm4ai-minimal-datasheet` — `ab0a0eeb`; adds 121 lines across a legacy YAML and generated HTML.
+
+- `origin/d4d/add-gene-ontology-datasheet` — `f5895e98`; adds 168 lines solely to `data/sheets_d4dassistant/gene_ontology_d4d.yaml`.
+
+- `origin/d4d/add-hpo-dated-datasheet` — `3fa5efbc`; adds 101 lines to one legacy HPO YAML.
+
+- `origin/d4d/add-human-phenotype-ontology-datasheet` — `ba4d8345`; adds 379 lines across an HPO YAML and generated HTML.
+
+- `origin/d4d/add-phenopackets-datasheet` — `e032574a`; adds 407 lines across one extracted YAML and generated HTML.
+
+- `origin/d4d/add-t2d-datasheet` — `ccfffdf4`; adds 40 lines across one YAML and generated HTML.
+
+- `origin/d4d/add-voice-comprehensive-datasheet` — tip `dad39d71` after `1aa65d13` and `b4db7ce8`; adds 786 lines solely to `data/extracted_by_column/VOICE/b2ai_voice_comprehensive_d4d.yaml`.
+
+- `origin/poster_panels` — `6df5f13280ea`; deletes one DOT line and regenerates `data/poster_assets/figures/fig6_d4d_full.png`, with no executable or schema changes.
+
+- `origin/gh-pages` — `944cfba48f49`, “Deployed 323bb918 with MkDocs 1.5.3”; it has no merge-base with main and consists of generated `index.html` pages and deployment assets. Do not merge it; retain it only if GitHub Pages still deploys from this branch.
+
+## 3. Remaining prep on main
+
+Registration and basic reachability are already satisfied: `VOICE_PEDIATRIC` is present in [projects.py](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/src/data_sheets_schema/constants/projects.py:25), `generic_v3` is registered in [api_runner.py](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/src/data_sheets_schema/api_runner.py:50), and a source-level dry run successfully planned all five projects under `generic_v3`.
+
+1. **Resolve the experiment/evaluation scope mismatch before spending calls.** [generic_v3_analysis_plan.md](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/notes/generic_v3_analysis_plan.md) specifies the four-project, three-replicate v2-versus-v3 comparison; [NEXT_TASKS.md](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/NEXT_TASKS.md) says `VOICE_PEDIATRIC` should be generated once under the winning condition because it has no v1/v2 baseline. Also, five selected projects × full/core × two rubrics equals **20**, not 12, semantic evaluations. Decide and record whether pediatric is outside the comparison and which projects the 12 evaluations cover. This is the blocking part of #287.
+
+2. **Repair rubric20 semantic evaluation before running it.** The canonical [rubric20.txt](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/data/rubric/rubric20.txt:493) has 17 numeric questions, three pass/fail questions, Q20 “Bias Documentation and Responsible AI Alignment,” and an 88-point maximum. In contrast:
+
+   - [.claude/agents/d4d-rubric20-semantic.md](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/.claude/agents/d4d-rubric20-semantic.md:406) still has the former pass/fail “Interlinking Across Platforms” Q20 and repeatedly calculates an 84-point maximum.
+   - [rubric20_semantic_schema.json](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/src/download/prompts/rubric20_semantic_schema.json:65) enforces `const: 84`.
+   - [D4D_Evaluation_Summary.yaml](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/src/data_sheets_schema/schema/D4D_Evaluation_Summary.yaml:472) describes rubric20 as max 84.
+   - [rubric20_output_format.json](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/src/download/prompts/rubric20_output_format.json:13) is also stale at 84.
+
+   Align these files with the canonical rubric and add a test comparing semantic-agent question text/types and denominators directly to `data/rubric/rubric20.txt`. Existing scoring tests only cover scripts and the non-semantic system prompt, which is why this survived #275’s correction.
+
+3. **Make the five-project CLI invocation explicit and reproducible.** [cli/api.py](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/src/data_sheets_schema/cli/api.py:158) still defaults to `AI_READI,CHORUS,CM4AI,VOICE` and its help text omits pediatric. Either update the default/help from the project registry or freeze the complete explicit `--projects` argument in the runbook. The explicit five-project dry run works today.
+
+4. **Predeclare the VOICE selection-failure policy.** [test_enum_alias_normalisation.py](/Users/marcin/Documents/VIMSS/ontology/bridge2ai/data-sheets-schema/tests/test_enum_alias_normalisation.py:88) intentionally leaves invalid `related_to` values uncorrected, and `NEXT_TASKS.md` records this as a likely VOICE failure mode. Decide whether a failed candidate is discarded, regenerated unchanged, or handled through a separately documented correction. Do not silently modify generic-v3’s prompt: its one-rule delta is part of the preregistered comparison.
+
+5. **Separate the paid rerun from existing workspace artifacts.** This checkout is currently not clean: twelve root-level `D4D_*.yaml` files are untracked, and the `aurelian` submodule is dirty/ahead with untracked download directories. Preserve, relocate, or intentionally record those artifacts before generating so they cannot be mistaken for rerun outputs.
+
+6. **Run the full verification suite in a writable environment after the semantic fixes.** Current provenance is healthy: source invocation of `d4d runs check --strict` reports `131 run(s) checked, 49 subject, 0 failing`; canonical enumeration currently returns six paths for AI_READI, CHORUS, and CM4AI, with VOICE and VOICE_PEDIATRIC correctly reported missing. Re-run all 1,114 tests plus the new semantic-parity tests, then repeat the five-project `generic_v3` dry run.
+
+7. **Use this issue disposition for this rerun:**
+
+   - Blocking/pre-rerun decision: #287’s corpus/scope arithmetic and the rubric20 semantic inconsistency associated with the historical #275 transition.
+   - Deferrable: #242’s 434-call legacy re-judge, because the planned workflow does not rerun judge agreement; #286’s archived summaries, provided fresh results remain separately labeled; #294’s SSSOM structural generator; and #297’s string-versus-inline-object limitation.
+   - Already completed: #258 and #262 are closed; #275 is closed for the 84→88 scoring correction, although it did not update the semantic prompt files.
+   - Issue state is stale: #306 remains open, but `d4d runs canonical --paths-only` is implemented on main by `4ac9d45b`.
+
+## 4. Open questions / could not verify
+
+- The intended evaluation corpus remains ambiguous: “12 evaluations” is consistent with three canonical projects, while selecting all five projects creates 20 full/core × rubric evaluations. This must be answered before execution.
+
+- `gh auth status` reported an invalid CLI token. Live issue and branch state was obtained through the connected GitHub service, but I could not independently refresh the local remote-tracking refs with `git fetch` in this read-only workspace.
+
+- I could not reproduce the full claimed 1,114-test run. A targeted run produced 50 passing tests and 60 passing subtests; four cases failed solely because `tempfile.TemporaryDirectory` could not obtain a writable temporary directory under this sandbox.
+
+- The installed `d4d` executable is absent in this environment, although the `pyproject.toml` entry point exists and invoking the CLI directly from `src/` successfully exercised `generic_v3`, all five project bundles, strict checks, and canonical enumeration.
+
+- The supplied “main is clean” state does not match this checkout’s present status because of the untracked root YAMLs and dirty `aurelian` submodule; I did not alter or remove them.
+
+Codex session ID: 019fcf48-c145-7b41-96f0-f0d9f7d44e89
+Resume in Codex: codex resume 019fcf48-c145-7b41-96f0-f0d9f7d44e89

--- a/scripts/batch_evaluate_rubric20_hybrid.py
+++ b/scripts/batch_evaluate_rubric20_hybrid.py
@@ -22,6 +22,13 @@ import hashlib
 import re
 from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
 
+#: `BiasTypeEnum` permissible values, for Q20's taxonomy check.
+BIAS_TYPE_ENUM = frozenset({
+    'selection_bias', 'measurement_bias', 'historical_bias', 'representation_bias',
+    'aggregation_bias', 'algorithmic_bias', 'sampling_bias', 'annotation_bias',
+    'confirmation_bias',
+})
+
 # Base directory
 BASE_DIR = Path(__file__).parent.parent
 
@@ -104,9 +111,9 @@ RUBRIC20_QUESTIONS = {
     },
     10: {
         "category": "Metadata Quality & Content",
-        "name": "Interoperability and Standardization",
-        "description": "Standard formats, encoding, ontologies, schema conformance",
-        "fields": ["format", "encoding", "conforms_to", "conforms_to_schema", "distribution_formats", "data_characteristics.data_formats"],
+        "name": "Interoperability, Standardization, and Cross-Platform Integration",
+        "description": "Standard formats, encoding, ontologies, schema conformance, and cross-dataset integration capability",
+        "fields": ["format", "encoding", "conforms_to", "conforms_to_schema", "distribution_formats", "data_characteristics.data_formats", "external_resources", "related_datasets"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -130,9 +137,9 @@ RUBRIC20_QUESTIONS = {
     },
     13: {
         "category": "Technical Documentation",
-        "name": "Version History Documentation",
-        "description": "Version info, version access, errata, update plans, release notes",
-        "fields": ["version", "version_access", "errata", "updates", "release_notes", "versions_available_on_platform"],
+        "name": "Version History, Maintenance, and Sustainability",
+        "description": "Version info, version access, errata, update plans, release notes, and sustainability indicators (persistent ID, repository, institutional commitment)",
+        "fields": ["version", "version_access", "errata", "updates", "release_notes", "versions_available_on_platform", "maintainers", "doi", "publisher"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -172,29 +179,51 @@ RUBRIC20_QUESTIONS = {
     },
     18: {
         "category": "FAIRness & Accessibility",
-        "name": "Reusability (License and Use Guidance)",
-        "description": "License with explicit use guidance (intended/prohibited/discouraged)",
-        "fields": ["license_and_use_terms", "intended_uses", "prohibited_uses", "discouraged_uses"],
+        "name": "Reusability, Use Guidance, and Social Impact",
+        "description": "License with explicit use guidance (intended/prohibited/discouraged) and social impact analysis with mitigation strategies",
+        "fields": ["license_and_use_terms", "intended_uses", "prohibited_uses", "discouraged_uses", "future_use_impacts"],
         "score_type": "numeric",
         "max_score": 5
     },
     19: {
         "category": "FAIRness & Accessibility",
-        "name": "Data Integrity and Provenance",
-        "description": "Version access, errata, updates, source derivation, parent datasets",
-        "fields": ["version_access", "errata", "updates", "was_derived_from", "parent_datasets", "release_notes"],
+        "name": "Data Integrity, Provenance Graph, and Quality",
+        "description": "Version access, errata, updates, source derivation, parent datasets, missing data documentation, and provenance graph representation",
+        "fields": ["version_access", "errata", "updates", "was_derived_from", "parent_datasets", "release_notes", "missing_data_documentation", "is_data_split", "raw_data_sources"],
         "score_type": "numeric",
         "max_score": 5
     },
     20: {
         "category": "FAIRness & Accessibility",
-        "name": "Interlinking Across Platforms and Datasets",
-        "description": "External resources and dataset relationships (typed relationships, hierarchical linkages)",
-        "fields": ["external_resources", "related_datasets", "parent_datasets", "resources", "project_website", "same_as"],
-        "score_type": "pass_fail",
-        "max_score": 1
+        "name": "Bias Documentation and Responsible AI Alignment",
+        "description": "Known biases categorised against a standard taxonomy (BiasTypeEnum, AIO) with fairness analysis, CROISSANT RAI aligned",
+        "fields": ["known_biases", "future_use_impacts"],
+        "score_type": "numeric",
+        "max_score": 5
     }
 }
+
+
+def derived_maximum() -> int:
+    """The largest score the question table can actually award.
+
+    Derived rather than imported. `max_total = RUBRIC20_MAX_SCORE` was the
+    defect: #275 corrected the constant to 88 while this table still summed to
+    84, so a record scoring every available point was reported as 95.5% and no
+    percentage could reach 100. Deriving it makes the two disagree loudly
+    instead of quietly.
+    """
+    total = sum(spec["max_score"] for spec in RUBRIC20_QUESTIONS.values())
+    if total != RUBRIC20_MAX_SCORE:
+        raise ValueError(
+            f"rubric20 question table sums to {total}, but RUBRIC20_MAX_SCORE is "
+            f"{RUBRIC20_MAX_SCORE} — the table has drifted from "
+            f"data/rubric/rubric20.txt")
+    return total
+
+
+# Fail at import rather than partway through a batch.
+derived_maximum()
 
 
 def get_nested_value(data: Dict, path: str) -> Optional[Any]:
@@ -642,21 +671,34 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
             score = 0
             quality_note = "No provenance metadata"
 
-    # Q20: Interlinking Across Platforms (pass/fail)
+    # Q20: Bias Documentation and Responsible AI Alignment (numeric)
+    #
+    # The taxonomy check is what separates 3 from 5, so it reads `bias_type`
+    # structurally rather than grepping the record for the word "bias": prose
+    # that happens to say "selection bias" is the 3-point case, and a populated
+    # `bias_type` against BiasTypeEnum is the 5-point one.
     elif question_id == 20:
-        external = data.get('external_resources', [])
-        same_as = data.get('same_as', [])
+        biases = data.get('known_biases') or []
+        if isinstance(biases, dict):
+            biases = [biases]
+        typed = [b for b in biases
+                 if isinstance(b, dict) and b.get('bias_type') in BIAS_TYPE_ENUM]
+        fairness = [b for b in biases
+                    if isinstance(b, dict)
+                    and (b.get('mitigation_strategy') or b.get('affected_subsets'))]
 
-        # Look for multiple platform mentions
-        platform_text = str(external) + str(same_as) + str(data.get('page', ''))
-        platforms = set(re.findall(r'\b(PhysioNet|Dataverse|FAIRhub|Zenodo|doi\.org|github\.com)\b', platform_text, re.I))
-
-        if len(platforms) >= 2:
-            score = 1
-            quality_note = f"Pass: Cross-platform links ({', '.join(platforms)})"
+        if typed and fairness:
+            score = 5
+            quality_note = (f"{len(typed)}/{len(biases)} biases categorised against "
+                            f"BiasTypeEnum, {len(fairness)} with mitigation or affected "
+                            "subsets")
+        elif biases:
+            score = 3
+            quality_note = (f"{len(biases)} bias(es) documented without taxonomy "
+                            "categorisation or fairness analysis")
         else:
             score = 0
-            quality_note = "Fail: No cross-platform linkages"
+            quality_note = "No bias documentation"
 
     # Default: presence = full score
     else:
@@ -704,7 +746,7 @@ def evaluate_d4d_file(file_path: Path, project: str, method: str, eval_type: str
     }
 
     total_score = 0
-    max_total = RUBRIC20_MAX_SCORE  # 17 numeric x 5 + 3 pass/fail x 1
+    max_total = derived_maximum()
 
     # Group by category
     categories = {}

--- a/scripts/batch_evaluate_rubric20_hybrid.py
+++ b/scripts/batch_evaluate_rubric20_hybrid.py
@@ -23,6 +23,11 @@ import re
 from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
 
 #: `BiasTypeEnum` permissible values, for Q20's taxonomy check.
+#:
+#: Restated rather than read via SchemaView, which would put a merged-schema
+#: load in the import path of a batch script. `test_the_taxonomy_matches_the
+#: _schema` pins it to `BiasTypeEnum`, so a value added to the schema fails a
+#: test instead of quietly costing records two points (#317).
 BIAS_TYPE_ENUM = frozenset({
     'selection_bias', 'measurement_bias', 'historical_bias', 'representation_bias',
     'aggregation_bias', 'algorithmic_bias', 'sampling_bias', 'annotation_bias',
@@ -683,19 +688,25 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
             biases = [biases]
         typed = [b for b in biases
                  if isinstance(b, dict) and b.get('bias_type') in BIAS_TYPE_ENUM]
-        fairness = [b for b in biases
-                    if isinstance(b, dict)
-                    and (b.get('mitigation_strategy') or b.get('affected_subsets'))]
+        # Fairness is required *of the categorised biases*, not merely somewhere
+        # in the record: computing the two independently let one bias supply the
+        # taxonomy and a different one supply the mitigation (#318).
+        analysed = [b for b in typed
+                    if b.get('mitigation_strategy') or b.get('affected_subsets')]
 
-        if typed and fairness:
+        # "Comprehensive" is read as every documented bias categorised. A
+        # majority rule would let a record with nine untyped biases and one
+        # typed one take the top band, which is the 3 case by any reading.
+        if biases and len(typed) == len(biases) and analysed:
             score = 5
-            quality_note = (f"{len(typed)}/{len(biases)} biases categorised against "
-                            f"BiasTypeEnum, {len(fairness)} with mitigation or affected "
-                            "subsets")
+            quality_note = (f"all {len(typed)} biases categorised against "
+                            f"BiasTypeEnum, {len(analysed)} with mitigation or "
+                            "affected subsets")
         elif biases:
             score = 3
-            quality_note = (f"{len(biases)} bias(es) documented without taxonomy "
-                            "categorisation or fairness analysis")
+            quality_note = (f"{len(typed)}/{len(biases)} bias(es) categorised against "
+                            "BiasTypeEnum; comprehensive categorisation with fairness "
+                            "analysis not evidenced")
         else:
             score = 0
             quality_note = "No bias documentation"

--- a/src/data_sheets_schema/schema/D4D_Evaluation_Summary.yaml
+++ b/src/data_sheets_schema/schema/D4D_Evaluation_Summary.yaml
@@ -472,7 +472,7 @@ enums:
       rubric10:
         description: 10-element hierarchical rubric (50 sub-elements, max 50 points)
       rubric20:
-        description: 20-question detailed rubric (4 categories, max 84 points)
+        description: 20-question detailed rubric (4 categories, max 88 points)
 
   GenerationMethodEnum:
     description: D4D generation methods.

--- a/src/download/prompts/rubric20_output_format.json
+++ b/src/download/prompts/rubric20_output_format.json
@@ -11,9 +11,9 @@
     "evaluation_type": "llm_as_judge"
   },
   "overall_score": {
-    "total_points": 72.5,
-    "max_points": 84,
-    "percentage": 86.3
+    "total_points": 62,
+    "max_points": 88,
+    "percentage": 70.5
   },
   "categories": [
     {
@@ -116,19 +116,19 @@
         },
         {
           "id": 9,
-          "name": "Access Requirements Documentation",
-          "description": "Determines if access policy and license are clearly defined (open, registered, restricted).",
+          "name": "Access Requirements and Governance Documentation",
+          "description": "Determines if access policy, license, IP restrictions, regulatory restrictions, confidentiality level, multi-jurisdiction compliance, and governance contacts are clearly defined.",
           "score_type": "numeric",
-          "score": 5,
+          "score": 3,
           "max_score": 5,
-          "score_label": "License + Data Use Agreement + platform access description",
+          "score_label": "License + basic restrictions",
           "evidence": "license_and_use_terms: Bridge2AI Voice Registered Access License with DUA requirement, access via PhysioNet",
-          "quality_note": "Clear license, DUA requirement, and platform access path fully documented"
+          "quality_note": "License and DUA requirement documented, but no confidentiality classification and no governance committee contact"
         },
         {
           "id": 10,
-          "name": "Interoperability and Standardization",
-          "description": "Presence of standard formats, ontologies, or schema conformance (e.g., Parquet, TSV, LinkML).",
+          "name": "Interoperability, Standardization, and Cross-Platform Integration",
+          "description": "Presence of standard formats, ontologies, schema conformance (e.g., Parquet, TSV, LinkML), cross-platform dataset linkages with typed relationships, and dataset integration capability.",
           "score_type": "numeric",
           "score": 3,
           "max_score": 5,
@@ -137,8 +137,8 @@
           "quality_note": "Standard formats used but no explicit schema/ontology conformance (conforms_to) field"
         }
       ],
-      "category_score": 14,
-      "category_max": 17
+      "category_score": 12,
+      "category_max": 21
     },
     {
       "name": "Technical Documentation",
@@ -167,14 +167,14 @@
         },
         {
           "id": 13,
-          "name": "Version History Documentation",
-          "description": "Presence of multiple version records and associated dates.",
+          "name": "Version History, Maintenance, and Sustainability",
+          "description": "Presence of version information, version access methods, errata, update plans, release notes with dates, and data sustainability indicators (persistent identifiers, long-term governance plan, domain-appropriate repository, institutional commitment).",
           "score_type": "numeric",
-          "score": 5,
+          "score": 3,
           "max_score": 5,
-          "score_label": "≥2 versions with change summaries and release dates",
+          "score_label": "Version number + basic access info + persistent ID",
           "evidence": "version_access: v1.0, v1.1 (2025-01-17), v2.0.0 (2025-04-16), v2.0.1 (2025-08-18) with release notes",
-          "quality_note": "4 versions documented with release dates and change summaries (e.g., v1.1 added MFCCs)"
+          "quality_note": "4 versions documented with release dates and a PhysioNet DOI, but no long-term governance plan or institutional preservation commitment"
         },
         {
           "id": 14,
@@ -199,7 +199,7 @@
           "quality_note": "Comprehensive participant demographics with clear subpopulation breakdown and condition groups"
         }
       ],
-      "category_score": 16,
+      "category_score": 14,
       "category_max": 25
     },
     {
@@ -229,40 +229,40 @@
         },
         {
           "id": 18,
-          "name": "Reusability (License Clarity)",
-          "description": "License is clearly defined and permits identifiable reuse cases.",
+          "name": "Reusability, Use Guidance, and Social Impact",
+          "description": "License is clearly defined with explicit use guidance including intended, prohibited and discouraged uses, and comprehensive social impact analysis with risk identification and mitigation strategies (CROISSANT RAI aligned).",
           "score_type": "numeric",
-          "score": 5,
+          "score": 3,
           "max_score": 5,
-          "score_label": "License explicitly defines reuse terms",
+          "score_label": "License + basic use guidance",
           "evidence": "license_and_use_terms: Bridge2AI Voice Registered Access License with explicit terms for research data sharing",
-          "quality_note": "License clearly defined with specific reuse terms for research purposes"
+          "quality_note": "License defines reuse terms, but no prohibited/discouraged uses and no social impact analysis"
         },
         {
           "id": 19,
-          "name": "Data Integrity and Provenance",
-          "description": "Presence of change logs or provenance tracking (e.g., versioned documentation).",
+          "name": "Data Integrity, Provenance Graph, and Quality",
+          "description": "Presence of version access, errata, update plans, source derivation, parent dataset linkages, missing data documentation, data split indicators, and provenance graph representation (W3C PROV-O).",
           "score_type": "numeric",
-          "score": 5,
+          "score": 3,
           "max_score": 5,
-          "score_label": "Structured version control with timestamps",
+          "score_label": "Version history (version numbers, errata, updates) but no full provenance graph",
           "evidence": "updates.update_details: v1.1 released 2025-01-17, v2.0.0 released 2025-04-16, v2.0.1 released 2025-08-18 with specific dates and changes",
-          "quality_note": "Well-structured version control with timestamps and change descriptions"
+          "quality_note": "Release dates and change descriptions present; no entity-activity-agent relationships, processing lineage or derivation paths"
         },
         {
           "id": 20,
-          "name": "Interlinking Across Platforms",
-          "description": "Metadata connects dataset records across multiple platforms (e.g., FAIRhub + PhysioNet).",
-          "score_type": "pass_fail",
-          "score": 0,
-          "max_score": 1,
-          "score_label": "Fail",
-          "evidence": "No external_resources with cross-platform links found",
-          "quality_note": "Missing links to related platforms (GitHub, FAIRhub, Bridge2AI portal)"
+          "name": "Bias Documentation and Responsible AI Alignment",
+          "description": "Metadata documents known biases using standardized taxonomies (BiasTypeEnum, AIO) aligned with CROISSANT RAI standards, and includes fairness analysis.",
+          "score_type": "numeric",
+          "score": 3,
+          "max_score": 5,
+          "score_label": "Basic bias identification without taxonomy",
+          "evidence": "known_biases: recruitment concentrated at five specialty clinics may over-represent treatment-seeking patients",
+          "quality_note": "Selection bias named in prose but not categorised against BiasTypeEnum or AIO, and no fairness analysis"
         }
       ],
-      "category_score": 16,
-      "category_max": 17
+      "category_score": 15,
+      "category_max": 21
     }
   ],
   "assessment": {
@@ -270,7 +270,7 @@
       "Excellent structural completeness with all mandatory fields populated and comprehensive descriptions (>200 chars)",
       "Strong ethical documentation including IRB approval, HIPAA Safe Harbor deidentification, and informed consent procedures",
       "Clear FAIR compliance with DOI, persistent URLs, registered access mechanism, and well-defined license terms",
-      "Comprehensive version history with 4 documented releases (v1.0 through v2.0.1) including dates and change notes",
+      "Version history with 4 documented releases (v1.0 through v2.0.1) including dates and change notes",
       "Detailed human subject representation with 306 participants across 4 condition groups and demographic details"
     ],
     "weaknesses": [
@@ -278,14 +278,15 @@
       "No associated publication DOIs or formal citations in references field",
       "Limited interoperability documentation (no explicit schema conformance or conforms_to field)",
       "Preprocessing tools listed without version numbers or repository links",
-      "No cross-platform interlinking to related resources (GitHub, FAIRhub, Bridge2AI portal)"
+      "No governance committee contact or confidentiality classification alongside the license",
+      "Bias documentation is prose only: no BiasTypeEnum/AIO categorisation and no fairness analysis"
     ],
     "recommendations": [
       "Add funding_and_acknowledgements.funding with NIH Bridge2AI grant information (agency, award number, acknowledgements)",
       "Include references section with DOIs to related publications and dataset papers",
       "Add conforms_to field specifying schema conformance (e.g., LinkML D4D schema, schema.org Dataset)",
       "Document software_and_tools with version numbers and GitHub repository links (openSMILE 3.0, Whisper large-v3, etc.)",
-      "Add external_resources with cross-platform links (Bridge2AI portal, project GitHub, related datasets)"
+      "Categorise known_biases against BiasTypeEnum/AIO and add a fairness analysis with mitigation strategies"
     ]
   },
   "metadata": {

--- a/src/download/prompts/rubric20_semantic_schema.json
+++ b/src/download/prompts/rubric20_semantic_schema.json
@@ -64,7 +64,7 @@
         },
         "max_points": {
           "type": "number",
-          "const": 84,
+          "const": 88,
           "description": "Maximum possible points (20 questions × average 4.2 points)"
         },
         "percentage": {

--- a/tests/test_evaluation/test_rubric20_hybrid_parity.py
+++ b/tests/test_evaluation/test_rubric20_hybrid_parity.py
@@ -1,0 +1,192 @@
+"""The hybrid rubric20 scorer must score the rubric the repository publishes (#314).
+
+`scripts/batch_evaluate_rubric20_hybrid.py` carries its own copy of the 20
+questions and writes the records under `data/evaluation_llm/rubric20/`. Its copy
+had drifted from `data/rubric/rubric20.txt` on five questions, and Q20 was not a
+rename: the script scored a retired "Interlinking Across Platforms and Datasets"
+as pass/fail worth 1 where the rubric defines "Bias Documentation and
+Responsible AI Alignment" as numeric worth 5.
+
+That produced a worse failure than the agents'. #275 corrected
+`RUBRIC20_MAX_SCORE` to 88 and the script's `max_total = RUBRIC20_MAX_SCORE`
+went with it, but the question table still summed to **84** — so a record that
+scored every available point was reported as 95.5%, and no percentage the script
+emitted could reach 100. A denominator imported from a constant cannot notice
+that its own numerator has a different ceiling.
+
+Hence `TestTheDenominator`: the fix is not "set it to
+88", it is deriving the maximum from the table and refusing to run when the two
+disagree.
+"""
+
+import importlib.util
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
+from data_sheets_schema.constants.evaluation import RUBRIC20_PATH
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "batch_evaluate_rubric20_hybrid.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("rubric20_hybrid", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _questions():
+    return yaml.safe_load(Path(RUBRIC20_PATH).read_text())[
+        "d4d_evaluation_rubric"]["rubric"]
+
+
+@unittest.skipUnless(SCRIPT.exists(), "hybrid scorer not present")
+class TestQuestionTableParity(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.table = _load().RUBRIC20_QUESTIONS
+        cls.canon = _questions()
+
+    def test_every_rubric_question_is_scored(self):
+        self.assertEqual(sorted(self.table), list(range(1, len(self.canon) + 1)))
+
+    def test_names_match(self):
+        for i, q in enumerate(self.canon, 1):
+            with self.subTest(question=i):
+                self.assertEqual(self.table[i]["name"].strip().lower(),
+                                 q["name"].strip().lower())
+
+    def test_score_types_and_maxima_match(self):
+        """Q20 as pass/fail worth 1 against numeric worth 5 is the whole 84."""
+        for i, q in enumerate(self.canon, 1):
+            want_type = q.get("score_type")
+            want_max = 1 if want_type == "pass_fail" else 5
+            with self.subTest(question=i):
+                self.assertEqual(self.table[i]["score_type"], want_type)
+                self.assertEqual(self.table[i]["max_score"], want_max)
+
+    def test_the_retired_question_is_gone(self):
+        names = {spec["name"] for spec in self.table.values()}
+        self.assertNotIn("Interlinking Across Platforms and Datasets", names)
+
+    def test_the_table_reaches_the_published_maximum(self):
+        self.assertEqual(sum(s["max_score"] for s in self.table.values()),
+                         RUBRIC20_MAX_SCORE)
+
+
+@unittest.skipUnless(SCRIPT.exists(), "hybrid scorer not present")
+class TestTheDenominator(unittest.TestCase):
+
+    def test_the_intact_table_yields_the_published_maximum(self):
+        """`84/88` was not visible as an error anywhere — every percentage
+        simply stopped short of 100."""
+        self.assertEqual(_load().derived_maximum(), RUBRIC20_MAX_SCORE)
+
+    def test_a_drifted_table_stops_the_run(self):
+        """Shrinking one question's maximum is exactly the shape the defect
+        had: the table can no longer reach `RUBRIC20_MAX_SCORE`, and before the
+        fix that produced percentages with an unreachable ceiling rather than
+        an error."""
+        module = _load()
+        module.RUBRIC20_QUESTIONS[20]["max_score"] = 1  # re-open the 84
+        with self.assertRaises(ValueError) as caught:
+            module.derived_maximum()
+        self.assertIn("drifted", str(caught.exception))
+
+    def test_the_scorer_itself_refuses_a_drifted_table(self):
+        """Not just the helper — the call site has to reach it.
+
+        Asserted by scoring a real file, because the previous version of this
+        test asserted on the script's source text and would have passed against
+        a `derived_maximum()` that nothing called.
+        """
+        module = _load()
+        with tempfile.TemporaryDirectory(dir=REPO) as tmp:
+            record = Path(tmp) / "VOICE_d4d.yaml"
+            record.write_text("id: https://example.org/d4d/voice\ntitle: VOICE\n")
+
+            scored = module.evaluate_d4d_file(record, "VOICE", "m", "concatenated")
+            self.assertEqual(scored["overall_score"]["max_points"],
+                             RUBRIC20_MAX_SCORE)
+
+            module.RUBRIC20_QUESTIONS[20]["max_score"] = 1  # re-open the 84
+            with self.assertRaises(ValueError) as caught:
+                module.evaluate_d4d_file(record, "VOICE", "m", "concatenated")
+            self.assertIn("drifted", str(caught.exception))
+
+    def test_the_guard_runs_at_import(self):
+        """Partway through a batch is too late to discover it.
+
+        Q20 is shrunk in the *source* and the module executed from scratch, so
+        the only thing that can raise is module-scope execution — a guard that
+        only ran from `evaluate_d4d_file` would let the import succeed.
+        """
+        source = SCRIPT.read_text()
+        tampered = re.sub(r'("fields": \["known_biases", "future_use_impacts"\],\n\s+'
+                          r'"score_type": "numeric",\n\s+"max_score": )5',
+                          r"\g<1>1", source)
+        self.assertNotEqual(tampered, source, "could not shrink Q20 in the source")
+        namespace = {"__name__": "tampered_rubric20_hybrid", "__file__": str(SCRIPT)}
+        with self.assertRaises(ValueError) as caught:
+            exec(compile(tampered, str(SCRIPT), "exec"), namespace)
+        self.assertIn("drifted", str(caught.exception))
+
+
+@unittest.skipUnless(SCRIPT.exists(), "hybrid scorer not present")
+class TestBiasDocumentationScoring(unittest.TestCase):
+    """Q20's bands, which no longer exist anywhere else to compare against.
+
+    The taxonomy check reads `bias_type` structurally rather than grepping for
+    the word "bias", so prose that says "selection bias" scores 3 and a
+    populated `bias_type` scores 5. That distinction is the rubric's, and it is
+    the only thing separating the two bands.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _load()
+
+    def _score(self, data):
+        return self.module.evaluate_question(data, 20)[0]
+
+    def test_absent_scores_zero(self):
+        self.assertEqual(self._score({}), 0)
+
+    def test_prose_without_a_taxonomy_scores_three(self):
+        self.assertEqual(self._score(
+            {"known_biases": [{"bias_description": "Recruitment favoured urban clinics"}]}), 3)
+
+    def test_a_taxonomy_without_fairness_analysis_scores_three(self):
+        """Both halves are required for 5 — categorisation alone is not enough."""
+        self.assertEqual(self._score(
+            {"known_biases": [{"bias_type": "selection_bias",
+                               "bias_description": "urban clinics"}]}), 3)
+
+    def test_taxonomy_plus_mitigation_scores_five(self):
+        self.assertEqual(self._score(
+            {"known_biases": [{"bias_type": "selection_bias",
+                               "bias_description": "urban clinics",
+                               "mitigation_strategy": "oversample rural sites"}]}), 5)
+
+    def test_a_single_mapping_is_accepted_as_well_as_a_list(self):
+        """`known_biases` is multivalued, but records emit a bare mapping."""
+        self.assertEqual(self._score(
+            {"known_biases": {"bias_type": "sampling_bias",
+                              "affected_subsets": ["female participants"]}}), 5)
+
+    def test_a_value_outside_the_enum_is_not_a_taxonomy(self):
+        """Otherwise any string in `bias_type` buys the 5."""
+        self.assertEqual(self._score(
+            {"known_biases": [{"bias_type": "vibes_bias",
+                               "mitigation_strategy": "none"}]}), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation/test_rubric20_hybrid_parity.py
+++ b/tests/test_evaluation/test_rubric20_hybrid_parity.py
@@ -187,6 +187,41 @@ class TestBiasDocumentationScoring(unittest.TestCase):
             {"known_biases": [{"bias_type": "vibes_bias",
                                "mitigation_strategy": "none"}]}), 3)
 
+    def test_one_typed_bias_among_many_is_not_comprehensive(self):
+        """#318. Band 5 is "Comprehensive bias categorization"; nine untyped
+        biases beside one typed one is the 3 band by any reading."""
+        self.assertEqual(self._score({"known_biases":
+            [{"bias_type": "selection_bias", "mitigation_strategy": "x"}]
+            + [{"bias_description": f"bias {i}"} for i in range(9)]}), 3)
+
+    def test_the_taxonomy_and_the_fairness_analysis_must_meet(self):
+        """#318. Computing the two lists independently let one bias supply the
+        `bias_type` and an entirely different one supply the mitigation."""
+        self.assertEqual(self._score({"known_biases": [
+            {"bias_type": "selection_bias", "bias_description": "urban clinics"},
+            {"bias_description": "unrelated", "mitigation_strategy": "something"}]}), 3)
+
+    def test_every_bias_typed_with_one_analysed_scores_five(self):
+        """The complement: the rule must remain satisfiable."""
+        self.assertEqual(self._score({"known_biases": [
+            {"bias_type": "selection_bias", "mitigation_strategy": "oversample rural"},
+            {"bias_type": "measurement_bias", "bias_description": "device variance"}]}), 5)
+
+    def test_the_taxonomy_matches_the_schema(self):
+        """#317. The script restates `BiasTypeEnum` rather than loading the
+        merged schema in a batch script's import path, so this is what keeps the
+        two in step.
+
+        Drift is silent otherwise: a record categorising a bias with a value the
+        schema added scores 3 where the rubric says 5, and is penalised for
+        using the vocabulary the schema told it to use.
+        """
+        from linkml_runtime.utils.schemaview import SchemaView
+        schema = REPO / "src" / "data_sheets_schema" / "schema" / "data_sheets_schema_all.yaml"
+        declared = {str(v) for v in
+                    SchemaView(str(schema)).get_enum("BiasTypeEnum").permissible_values}
+        self.assertEqual(set(self.module.BIAS_TYPE_ENUM), declared)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_evaluation/test_semantic_agent_parity.py
+++ b/tests/test_evaluation/test_semantic_agent_parity.py
@@ -32,7 +32,8 @@ from pathlib import Path
 
 import yaml
 
-from data_sheets_schema.constants.evaluation import RUBRIC20_PATH
+from data_sheets_schema.constants.evaluation import (RUBRIC10_PATH,
+                                                     RUBRIC20_PATH)
 
 REPO = Path(__file__).resolve().parents[2]
 AGENTS = {
@@ -44,15 +45,25 @@ OUTPUT_FORMAT = REPO / "src" / "download" / "prompts" / "rubric20_output_format.
 SUMMARY_SCHEMA = (REPO / "src" / "data_sheets_schema" / "schema"
                   / "D4D_Evaluation_Summary.yaml")
 
-#: Where a maximum is *asserted* rather than merely occurring as a digit.
+#: Where the *whole-rubric* maximum is stated, and nowhere else.
 #:
-#: `[:*\s]+` rather than `[:\s]+`: the headline site is written
-#: `**Maximum Possible Score:** 88 points`, and a separator class that does not
-#: admit the bold markers skips the one place a reader looks first. A mutation
-#: check caught exactly that — reverting it to 84 left every test green.
+#: Two rounds of mutation testing shaped this:
+#:
+#: 1. `[:*\s]+` rather than `[:\s]+` — the headline site is written
+#:    `**Maximum Possible Score:** 88 points`, and a separator class that does
+#:    not admit the bold markers skips the one place a reader looks first.
+#: 2. `max\b` as well as `maximum` — `D4D_Evaluation_Summary.yaml` writes
+#:    `max 88 points`.
+#:
+#: Every match must *equal* the computed maximum, which is why per-category and
+#: N/A-adjusted figures must not match: `adjusted_max_points` is legitimately
+#: 83, and `max_score:` under `category_performance` is legitimately 21. The
+#: lookbehind keeps `adjusted_max_points` out, and the two-space anchor admits
+#: only the `max_score:` directly under `overall_performance`.
 STATED_MAXIMUM = re.compile(
-    r"""(?:maximum(?:\s+possible)?(?:\s+score)?[:*\s]+|"max_points":\s*|
-         "adjusted_max_points":\s*|max_score:\s*|max_points:\s*)(\d+)""",
+    r"""(?:max(?:imum)?(?:\s+possible)?(?:\s+score)?[:*\s]+
+        |(?<![\w])max_points"?:\s*
+        |(?m:^\ \ max_score:\s*))(\d+)""",
     re.I | re.X)
 
 
@@ -140,15 +151,20 @@ class TestDenominatorParity(unittest.TestCase):
         self.assertEqual(_maximum(), 88)
 
     def test_no_agent_states_a_maximum_other_than_the_computed_one(self):
-        """Matches where a maximum is asserted, so an incidental `84` inside a
-        participant count or a UUID cannot mask or fake a failure."""
+        """Equality, not `!= 84`.
+
+        An earlier version rejected 84 specifically and accepted anything else,
+        so any *other* wrong total passed. Matching only where the whole-rubric
+        maximum is stated is what makes equality safe to demand — an incidental
+        84 in a participant count or a UUID is not a match at all.
+        """
         for name, path in AGENTS.items():
             for stated in STATED_MAXIMUM.findall(path.read_text(encoding="utf-8")):
                 with self.subTest(agent=name, stated=stated):
-                    self.assertNotEqual(int(stated), 84,
-                                        "the superseded 84-point maximum")
+                    self.assertEqual(int(stated), _maximum())
 
     def test_each_agent_states_the_computed_maximum(self):
+        """The complement — equality above is vacuous if nothing matches."""
         for name, path in AGENTS.items():
             stated = {int(n) for n in
                       STATED_MAXIMUM.findall(path.read_text(encoding="utf-8"))}
@@ -184,10 +200,18 @@ class TestDenominatorParity(unittest.TestCase):
 
     @unittest.skipUnless(SUMMARY_SCHEMA.exists(), "summary schema not present")
     def test_the_evaluation_summary_schema_agrees(self):
-        for line in SUMMARY_SCHEMA.read_text().splitlines():
-            if "rubric20" in line.lower():
-                with self.subTest(line=line.strip()[:60]):
-                    self.assertNotIn("84", line)
+        """Read as YAML, not filtered line by line (#322).
+
+        The maximum lives on the `description:` line and `rubric20:` is the key
+        above it, so a line filter never sees the two together — a mutation
+        check found exactly that, with `max 84 points` passing.
+        """
+        enum = yaml.safe_load(SUMMARY_SCHEMA.read_text())["enums"]["RubricTypeEnum"]
+        described = enum["permissible_values"]["rubric20"]["description"]
+        stated = [int(n) for n in STATED_MAXIMUM.findall(described)]
+        self.assertTrue(stated, f"no maximum stated in {described!r}")
+        for one in stated:
+            self.assertEqual(one, _maximum())
 
 
 @unittest.skipUnless(OUTPUT_FORMAT.exists(), "output format not present")
@@ -231,6 +255,64 @@ class TestTheWorkedExample(unittest.TestCase):
         self.assertEqual(overall["max_points"], _maximum())
         self.assertAlmostEqual(overall["percentage"],
                                round(total / _maximum() * 100, 1), places=1)
+
+
+RUBRIC10_AGENTS = {
+    "rubric10": REPO / ".claude" / "agents" / "d4d-rubric10.md",
+    "rubric10-semantic": REPO / ".claude" / "agents" / "d4d-rubric10-semantic.md",
+}
+
+
+def _elements():
+    return yaml.safe_load(Path(RUBRIC10_PATH).read_text())[
+        "d4d_complex_proxy_rubric"]["rubric"]
+
+
+class TestRubric10Parity(unittest.TestCase):
+    """The same comparison for the other rubric (#321).
+
+    rubric10 is clean today — both agents name the rubric's ten elements and
+    state its 50 points. That is the argument for the test rather than against
+    it: rubric20 was clean once too, and what let it rot was that nothing
+    compared the scorers to the rubric. Six of the planned rerun's semantic
+    evaluations are rubric10.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.canon = _elements()
+        cls.headings = {}
+        for name, path in RUBRIC10_AGENTS.items():
+            cls.headings[name] = {
+                int(n): title.strip() for n, title in
+                re.findall(r"^#+ Element (\d+): (.+)$",
+                           path.read_text(encoding="utf-8"), re.M)}
+
+    def test_the_rubric_defines_ten_elements_of_five_sub_elements(self):
+        """The premise. If the rubric ever stops being 10x5 the maximum below
+        is no longer 50 and this fails rather than silently passing."""
+        self.assertEqual(len(self.canon), 10)
+        for i, element in enumerate(self.canon, 1):
+            with self.subTest(element=i):
+                self.assertEqual(len(element.get("sub_elements") or []), 5)
+
+    def test_each_agent_names_every_element(self):
+        for name in RUBRIC10_AGENTS:
+            for i, element in enumerate(self.canon, 1):
+                with self.subTest(agent=name, element=i):
+                    self.assertEqual(self.headings[name].get(i, "").lower(),
+                                     (element.get("name") or "").strip().lower())
+
+    def test_each_agent_states_the_computed_maximum_and_no_other(self):
+        computed = sum(len(e.get("sub_elements") or []) for e in self.canon)
+        self.assertEqual(computed, 50)
+        for name, path in RUBRIC10_AGENTS.items():
+            stated = [int(n) for n in
+                      STATED_MAXIMUM.findall(path.read_text(encoding="utf-8"))]
+            with self.subTest(agent=name):
+                self.assertIn(computed, stated)
+                for one in stated:
+                    self.assertEqual(one, computed)
 
 
 if __name__ == "__main__":

--- a/tests/test_evaluation/test_semantic_agent_parity.py
+++ b/tests/test_evaluation/test_semantic_agent_parity.py
@@ -1,0 +1,237 @@
+"""The rubric20 agents must score the rubric the repository publishes (#314).
+
+`rubric20-semantic` scored five questions the rubric does not define, and the
+conversational `rubric20` agent scored six. Most were the rubric broadening
+scope while the agents kept the narrower wording; one was not a rename at all —
+both agents scored a retired "Interlinking Across Platforms" while the rubric's
+Q20 is "Bias Documentation and Responsible AI Alignment", so the responsible-AI
+question was **not scored by either agent at all**.
+
+That also explains the denominator. Both treated Q20 as pass/fail worth 1 point
+where the rubric defines it numeric worth 5, which is exactly the 84 against 88.
+
+#275 corrected the denominator in the constants, the summariser scripts and the
+API judge's system prompt, and its tests assert against those. Nothing compared
+the *agents* to `data/rubric/rubric20.txt`, which is why they kept both the old
+total and the old questions. This is that comparison.
+
+`rubric20_system_prompt.md` is deliberately absent from `AGENTS`: it interpolates
+`{RUBRIC_SPECIFICATION}` from the rubric file at run time, so its questions
+cannot drift. It is the shape the agents do not have.
+
+A note on the denominator assertions. The obvious form — `assertNotIn("84", …)`
+— cannot be used: it fires on `4,184 participants` and on a UUID, and would have
+had to be deleted the first time someone wrote a plausible number. These match
+the maximum where it is *stated*, which is where a stale value does harm.
+"""
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.constants.evaluation import RUBRIC20_PATH
+
+REPO = Path(__file__).resolve().parents[2]
+AGENTS = {
+    "rubric20": REPO / ".claude" / "agents" / "d4d-rubric20.md",
+    "rubric20-semantic": REPO / ".claude" / "agents" / "d4d-rubric20-semantic.md",
+}
+SCHEMA = REPO / "src" / "download" / "prompts" / "rubric20_semantic_schema.json"
+OUTPUT_FORMAT = REPO / "src" / "download" / "prompts" / "rubric20_output_format.json"
+SUMMARY_SCHEMA = (REPO / "src" / "data_sheets_schema" / "schema"
+                  / "D4D_Evaluation_Summary.yaml")
+
+#: Where a maximum is *asserted* rather than merely occurring as a digit.
+#:
+#: `[:*\s]+` rather than `[:\s]+`: the headline site is written
+#: `**Maximum Possible Score:** 88 points`, and a separator class that does not
+#: admit the bold markers skips the one place a reader looks first. A mutation
+#: check caught exactly that — reverting it to 84 left every test green.
+STATED_MAXIMUM = re.compile(
+    r"""(?:maximum(?:\s+possible)?(?:\s+score)?[:*\s]+|"max_points":\s*|
+         "adjusted_max_points":\s*|max_score:\s*|max_points:\s*)(\d+)""",
+    re.I | re.X)
+
+
+def _questions():
+    return yaml.safe_load(Path(RUBRIC20_PATH).read_text())[
+        "d4d_evaluation_rubric"]["rubric"]
+
+
+def _max_score(question):
+    return 1 if question.get("score_type") == "pass_fail" else 5
+
+
+def _maximum():
+    return sum(_max_score(q) for q in _questions())
+
+
+class TestQuestionParity(unittest.TestCase):
+    """Names and score types, per agent, against `rubric20.txt`."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.canon = _questions()
+        cls.text = {}
+        cls.headings = {}
+        for name, path in AGENTS.items():
+            text = path.read_text(encoding="utf-8")
+            cls.text[name] = text
+            cls.headings[name] = {
+                int(n): title.strip() for n, title in
+                re.findall(r"^#### Question (\d+): (.+)$", text, re.M)}
+
+    def test_every_agent_definition_exists(self):
+        for name, path in AGENTS.items():
+            with self.subTest(agent=name):
+                self.assertTrue(path.exists(), f"{path} is missing")
+
+    def test_each_agent_defines_every_question_the_rubric_does(self):
+        for name in AGENTS:
+            with self.subTest(agent=name):
+                self.assertEqual(sorted(self.headings[name]),
+                                 list(range(1, len(self.canon) + 1)))
+
+    def test_every_question_name_matches(self):
+        """Names, not just numbers.
+
+        Most of the drifted questions kept a narrower older name while the
+        rubric broadened the scope, which is invisible if only the count is
+        checked.
+        """
+        for name in AGENTS:
+            for i, q in enumerate(self.canon, 1):
+                with self.subTest(agent=name, question=i):
+                    self.assertEqual(self.headings[name][i].lower(),
+                                     (q.get("name") or "").strip().lower())
+
+    def test_the_retired_question_is_gone(self):
+        """`Interlinking Across Platforms` was Q20 and is no longer in the rubric."""
+        for name, text in self.text.items():
+            with self.subTest(agent=name):
+                self.assertNotIn("Interlinking Across Platforms", text)
+
+    def test_the_responsible_ai_question_is_scored(self):
+        """The one both agents were silently omitting."""
+        for name, text in self.text.items():
+            with self.subTest(agent=name):
+                self.assertIn("Bias Documentation and Responsible AI Alignment",
+                              text)
+
+    def test_score_types_match(self):
+        """A pass/fail question worth 1 where the rubric says numeric worth 5
+        is where the 84-against-88 came from."""
+        for name, text in self.text.items():
+            for i, q in enumerate(self.canon, 1):
+                declared = "pass/fail" if q.get("score_type") == "pass_fail" \
+                    else "numeric 0-5"
+                block = text.split(f"#### Question {i}: ", 1)[1].split("---", 1)[0]
+                with self.subTest(agent=name, question=i):
+                    self.assertIn(f"**Scoring ({declared}):**", block)
+
+
+class TestDenominatorParity(unittest.TestCase):
+    """Every place a maximum is stated must agree with the questions."""
+
+    def test_the_computed_maximum_is_what_the_questions_define(self):
+        self.assertEqual(_maximum(), 88)
+
+    def test_no_agent_states_a_maximum_other_than_the_computed_one(self):
+        """Matches where a maximum is asserted, so an incidental `84` inside a
+        participant count or a UUID cannot mask or fake a failure."""
+        for name, path in AGENTS.items():
+            for stated in STATED_MAXIMUM.findall(path.read_text(encoding="utf-8")):
+                with self.subTest(agent=name, stated=stated):
+                    self.assertNotEqual(int(stated), 84,
+                                        "the superseded 84-point maximum")
+
+    def test_each_agent_states_the_computed_maximum(self):
+        for name, path in AGENTS.items():
+            stated = {int(n) for n in
+                      STATED_MAXIMUM.findall(path.read_text(encoding="utf-8"))}
+            with self.subTest(agent=name):
+                self.assertIn(_maximum(), stated)
+
+    def test_the_per_category_maxima_sum_to_the_total(self):
+        """The 84 survived a header-only fix once already.
+
+        Each agent decomposes the maximum by category; a judge shown category
+        maxima that sum to 84 will reproduce 84 whatever the header says.
+        """
+        line = re.compile(r"^- \*\*.+?\(Q(\d+)-(\d+)\):\*\* (\d+) points max", re.M)
+        canon = _questions()
+        for name, path in AGENTS.items():
+            found = line.findall(path.read_text(encoding="utf-8"))
+            with self.subTest(agent=name):
+                self.assertTrue(found, "no per-category decomposition found")
+                self.assertEqual(sum(int(m[2]) for m in found), _maximum())
+                for first, last, stated in found:
+                    want = sum(_max_score(q)
+                               for q in canon[int(first) - 1:int(last)])
+                    with self.subTest(category=f"Q{first}-{last}"):
+                        self.assertEqual(int(stated), want)
+
+    @unittest.skipUnless(SCHEMA.exists(), "semantic schema not present")
+    def test_the_schema_const_does_not_reject_a_correct_score(self):
+        """It is a `const`, so a stale value does not merely mislead — it
+        rejects any evaluation reporting the right maximum."""
+        node = json.loads(SCHEMA.read_text())["properties"]["overall_score"] \
+            ["properties"]["max_points"]
+        self.assertEqual(node.get("const"), _maximum())
+
+    @unittest.skipUnless(SUMMARY_SCHEMA.exists(), "summary schema not present")
+    def test_the_evaluation_summary_schema_agrees(self):
+        for line in SUMMARY_SCHEMA.read_text().splitlines():
+            if "rubric20" in line.lower():
+                with self.subTest(line=line.strip()[:60]):
+                    self.assertNotIn("84", line)
+
+
+@unittest.skipUnless(OUTPUT_FORMAT.exists(), "output format not present")
+class TestTheWorkedExample(unittest.TestCase):
+    """`rubric20_output_format.json` is a filled-in evaluation.
+
+    No code reads it, which is exactly why it rotted: it demonstrated the
+    retired Q20 as pass/fail. An example that contradicts the specification is
+    the version a model will copy.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = json.loads(OUTPUT_FORMAT.read_text())
+        cls.canon = _questions()
+        cls.by_id = {q["id"]: q for c in cls.doc["categories"]
+                     for q in c["questions"] if isinstance(q, dict)}
+
+    def test_the_example_scores_the_rubrics_questions(self):
+        for i, q in enumerate(self.canon, 1):
+            with self.subTest(question=i):
+                self.assertIn(i, self.by_id)
+                self.assertEqual(self.by_id[i]["name"].lower(),
+                                 q["name"].strip().lower())
+                self.assertEqual(self.by_id[i]["score_type"],
+                                 q.get("score_type"))
+                self.assertEqual(self.by_id[i]["max_score"], _max_score(q))
+
+    def test_the_examples_arithmetic_holds(self):
+        total = 0
+        for c in self.doc["categories"]:
+            qs = [q for q in c["questions"] if isinstance(q, dict)]
+            with self.subTest(category=c["name"]):
+                self.assertEqual(c["category_score"],
+                                 sum(q["score"] for q in qs))
+                self.assertEqual(c["category_max"],
+                                 sum(q["max_score"] for q in qs))
+            total += c["category_score"]
+        overall = self.doc["overall_score"]
+        self.assertEqual(overall["total_points"], total)
+        self.assertEqual(overall["max_points"], _maximum())
+        self.assertAlmostEqual(overall["percentage"],
+                               round(total / _maximum() * 100, 1), places=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #314.

## What was wrong

Three rubric20 scorers each carry their own copy of the 20 questions. All three
had drifted from `data/rubric/rubric20.txt`:

| scorer | questions wrong | denominator |
|---|---|---|
| `.claude/agents/d4d-rubric20-semantic.md` | 5 | 84 |
| `.claude/agents/d4d-rubric20.md` | 6 | 84 |
| `scripts/batch_evaluate_rubric20_hybrid.py` | 5 | table summed to 84, divided by 88 |

Four drifted questions were the rubric broadening scope while the scorers kept
the narrower name (Q9, Q10, Q13, Q18, Q19 vary by file). The fifth was not a
rename: **all three scored a retired "Interlinking Across Platforms" as
pass/fail worth 1** where the rubric's Q20 has been "Bias Documentation and
Responsible AI Alignment", numeric worth 5, since `schema_version: 2.0`.

So the responsible-AI question was not scored by any path, and `84` against
`88` is exactly that one substitution — 17 numeric x 5 + 3 pass/fail x 1.

`src/download/prompts/rubric20_system_prompt.md` is the shape that did not
drift: it interpolates `{RUBRIC_SPECIFICATION}` from the rubric file at run
time. Untouched here, and the reason its questions could not go stale.

## The hybrid scorer, which the last fix made worse

#275 corrected `RUBRIC20_MAX_SCORE` to 88, and
`batch_evaluate_rubric20_hybrid.py`'s `max_total = RUBRIC20_MAX_SCORE` followed
it. Its question table still summed to 84. A record scoring every available
point was therefore reported as **95.5%**, and no percentage the script emitted
could reach 100.

`max_total` is now `derived_maximum()` — computed from the table, raising when
it disagrees with the constant, called at import so a drifted table stops the
run rather than surfacing partway through a batch.

## Also corrected

A judge shown a worked example that contradicts the specification follows the
example.

- **Every worked example.** The agents' category maxima decomposed to
  24/22/25/13 and `rubric20_output_format.json` still demonstrated Q20 as
  pass/fail. Categories are 21/21/25/21; every derived percentage recomputed.
- **`rubric20_semantic_schema.json`** pinned `max_points` with `const: 84`, so
  it would have *rejected* an evaluation reporting the right maximum.
- **Q20's applicability gate.** It sat behind "datasets shared & available for
  reuse", which made sense for cross-platform links and does not for bias: a
  dataset that is never released still has documentable biases, and the rubric
  applies Q20 to all four programs. Q10 and Q13 keep the field-based gates the
  rewrite dropped.
- **A Q20 scorer in the hybrid path.** Reads `bias_type` structurally against
  `BiasTypeEnum` rather than grepping for the word "bias", so prose naming a
  selection bias scores 3 and a categorised bias with a mitigation strategy or
  affected subsets scores 5 — the rubric's own distinction.

## Testing

29 tests in two files, comparing each scorer to `rubric20.txt` rather than to
each other. `1143 passed, 3 skipped`.

Mutation-checked: 19 reintroductions of the defects above, each confirmed to
fail. One found a hole in the test itself — `**Maximum Possible Score:** 88` was
invisible to a separator class that did not admit markdown bold markers, so
reverting the headline figure to 84 left every test green. Fixed and re-checked.

## Not in scope, will be filed

The field lists and scoring-band wording have drifted much further than the
names — the hybrid scorer and both agents disagree with the rubric's `field:`
on most questions. That needs judgement per question (some are path spellings
of the same slot, some are real substitutions) and is not mechanical.

## Second commit

`notes/codex_rerun_readiness_review_2026-08-04.md`, written 2026-08-04 and left
uncommitted. Unrelated to #314; carried here so it stops living only in a
working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)