### PR TITLE
Score fields the schema actually has (#319)

### DIFF
--- a/.claude/agents/d4d-rubric20-semantic.md
+++ b/.claude/agents/d4d-rubric20-semantic.md
@@ -119,7 +119,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 1: Field Completeness
 **Description:** Proportion of mandatory schema fields populated (id, title, description, keywords, license).
 
-**Fields:** `id`, `title`, `description`, `keywords`, `license_and_use_terms`
+**Fields:** `id`, `title`, `description`, `keywords`, `license_and_use_terms`, `doi`, `page`, `creators`, `purposes`, `instances`, `resources`, `parent_datasets`, `variables`, `regulatory_restrictions.confidentiality_level`
 
 **Scoring (numeric 0-5):**
 - **0:** ≤40% fields populated
@@ -161,7 +161,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 4: File Enumeration and Type Variety
 **Description:** Number of distribution formats and file type diversity.
 
-**Fields:** `distribution_formats`, `format`, `media_type`
+**Fields:** `distribution_formats`, `conforms_to_schema`, `total_size_bytes`, `file_collections.total_bytes`
 
 **Scoring (numeric 0-5):**
 - **0:** 1 file type only
@@ -175,7 +175,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 5: Data File Size Availability
 **Description:** Presence of file size or instance count metadata.
 
-**Fields:** `bytes`, `instances`
+**Fields:** `total_size_bytes`, `file_collections.total_bytes`, `instances`, `subsets.is_data_split`, `splits`, `subsets.is_subpopulation`, `subpopulations`
 
 **Scoring (pass/fail):**
 - **Pass:** Numeric file size or instance count found
@@ -190,7 +190,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 6: Dataset Identification Metadata
 **Description:** Presence of unique identifiers such as DOI, RRID, or persistent URLs.
 
-**Fields:** `doi`, `rrid`, `page`
+**Fields:** `doi`, `page`, `id`, `publisher`
 
 **Scoring (pass/fail):**
 - **Pass:** At least one persistent ID found
@@ -233,7 +233,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 9: Access Requirements and Governance Documentation
 **Description:** Whether access policy, license, IP restrictions, regulatory restrictions, and confidentiality level are clearly defined.
 
-**Fields:** `license_and_use_terms`, `ip_restrictions`, `regulatory_restrictions`, `confidentiality_level`, `data_protection_impacts`, `regulatory_restrictions.governance_committee_contact`
+**Fields:** `license_and_use_terms`, `ip_restrictions`, `regulatory_restrictions`, `regulatory_restrictions.confidentiality_level`, `data_protection_impacts`, `regulatory_restrictions.governance_committee_contact`, `regulatory_restrictions.hipaa_compliant`, `regulatory_restrictions.other_compliance`
 
 **Scoring (numeric 0-5):**
 - **0:** No license or access info
@@ -249,7 +249,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 10: Interoperability, Standardization, and Cross-Platform Integration
 **Description:** Presence of standard formats, ontologies, schema conformance (e.g., Parquet, TSV, LinkML), cross-platform dataset linkages with typed relationships, AND dataset integration capability. Note: Evaluation aligned with Bridge2AI AI/ML readiness characterization criteria (FAIRness, semantic/statistical characterization, governance, quality, pre-model XAI, ethics, computability). Reference: https://www.biorxiv.org/content/10.1101/2024.12.18.629172v1 and Bridge2AI AI-readiness scorecard tool. All Bridge2AI datasets are designed for AI/ML use. This question evaluates HOW WELL the dataset supports AI/ML (interoperability, standardization), not WHETHER it supports AI/ML. Dataset integration capability: Check for common identifiers for cross-dataset linking, standardized formats for data harmonization, and documented integration procedures.
 
-**Fields:** `format`, `encoding`, `conforms_to`, `conforms_to_schema`, `external_resources`, `related_datasets`
+**Fields:** `distribution_formats`, `conforms_to_schema`, `file_collections.compression`, `conforms_to`, `external_resources`, `related_datasets`
 
 **Scoring (numeric 0-5):**
 - **0:** Non-standard or unspecified format
@@ -267,7 +267,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 11: Tool and Software Transparency
 **Description:** Mentions of preprocessing, cleaning, and labeling strategies with software tools used in data preparation, including annotation quality, imputation, and missing data documentation.
 
-**Fields:** `preprocessing_strategies`, `cleaning_strategies`, `labeling_strategies`, `software_and_tools`, `annotation_analyses`, `machine_annotation_tools`, `imputation_protocols`, `missing_data_documentation`
+**Fields:** `preprocessing_strategies`, `cleaning_strategies`, `labeling_strategies`, `machine_annotation_tools`, `annotation_analyses`, `imputation_protocols`, `missing_data_documentation`
 
 **Scoring (numeric 0-5):**
 - **0:** No software tools documented
@@ -299,7 +299,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 13: Version History, Maintenance, and Sustainability
 **Description:** Presence of version information, version access methods, errata, update plans, release notes with dates, AND data sustainability indicators (persistent identifiers, long-term governance plan, domain-appropriate repository, institutional commitment documentation). Note: Data sustainability evaluation checks for: (1) persistent identifiers (DOI, ARK, Handle), (2) long-term governance plan, (3) domain-appropriate repository (e.g., PhysioNet for biomedical data), (4) institutional commitment or preservation funding. Sustainable datasets have clear maintenance plans beyond initial publication.
 
-**Fields:** `version`, `version_access`, `errata`, `updates`, `release_notes`, `maintainers`, `doi`, `publisher`
+**Fields:** `version`, `version_access`, `errata`, `updates`, `maintainers`, `doi`, `publisher`
 
 **Scoring (numeric 0-5):**
 - **0:** Single version only, no sustainability plan
@@ -315,7 +315,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 14: Associated Publications
 **Description:** Presence of formal citations or external resources with DOI-linked references.
 
-**Fields:** `citation`, `external_resources`
+**Fields:** `citation`, `external_resources`, `doi`
 
 **Scoring (numeric 0-5):**
 - **0:** No publications cited
@@ -331,7 +331,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 15: Human Subject Representation
 **Description:** Inclusion of human subjects, demographic diversity, or subgroup details.
 
-**Fields:** `instances`, `subpopulations`, `DataSubset.is_data_split`, `DataSubset.is_subpopulation`
+**Fields:** `instances`, `subpopulations`, `subsets.is_data_split`, `subsets.is_subpopulation`, `at_risk_populations`, `missing_data_documentation`
 
 **Scoring (numeric 0-5):**
 - **0:** No human subject information
@@ -349,7 +349,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 16: Findability (Persistent Links)
 **Description:** Dataset includes persistent URLs for access and documentation.
 
-**Fields:** `page`, `download_url`, `external_resources`
+**Fields:** `page`, `download_url`, `external_resources`, `doi`, `id`
 
 **Scoring (pass/fail):**
 - **Pass:** At least one working external URL present
@@ -362,7 +362,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 17: Accessibility (Access Mechanism)
 **Description:** Describes how users can obtain the dataset (download, DUA, login).
 
-**Fields:** `distribution_formats`, `license_and_use_terms`
+**Fields:** `distribution_formats`, `license_and_use_terms`, `download_url`
 
 **Scoring (numeric 0-5):**
 - **0:** Unclear access method
@@ -392,7 +392,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 19: Data Integrity, Provenance Graph, and Quality
 **Description:** Presence of version access, errata, update plans, source derivation, parent dataset linkages, missing data documentation, data split indicators, AND provenance graph representation. Note: Provenance is a transparent graph of origins and processing of data (W3C PROV-O standard: https://www.w3.org/TR/prov-o/), NOT just version changes. Evaluation checks for: (1) Entity-activity-agent relationships, (2) Processing lineage, (3) Derivation paths. Scoring distinction: - Version history alone (version numbers, errata, updates) = 3 points - Full provenance graph (W3C PROV-O with entity-activity-agent relationships, processing lineage, derivation paths) = 5 points Provenance may be represented as text OR as W3C PROV-O graphs. Both formats are acceptable if they provide complete lineage information.
 
-**Fields:** `version_access`, `errata`, `updates`, `was_derived_from`, `parent_datasets`, `missing_data_documentation`, `is_data_split`, `raw_data_sources`
+**Fields:** `version_access`, `errata`, `updates`, `was_derived_from`, `parent_datasets`, `missing_data_documentation`, `subsets.is_data_split`, `splits`, `raw_data_sources`
 
 **Scoring (numeric 0-5):**
 - **0:** No provenance metadata

--- a/.claude/agents/d4d-rubric20-semantic.md
+++ b/.claude/agents/d4d-rubric20-semantic.md
@@ -161,7 +161,7 @@ Read the provided D4D YAML file and perform a **semantic quality assessment** th
 #### Question 4: File Enumeration and Type Variety
 **Description:** Number of distribution formats and file type diversity.
 
-**Fields:** `distribution_formats`, `conforms_to_schema`, `total_size_bytes`, `file_collections.total_bytes`
+**Fields:** `distribution_formats`, `file_collections`, `total_file_count`
 
 **Scoring (numeric 0-5):**
 - **0:** 1 file type only

--- a/.claude/agents/d4d-rubric20.md
+++ b/.claude/agents/d4d-rubric20.md
@@ -57,7 +57,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 1: Field Completeness
 **Description:** Proportion of mandatory schema fields populated (id, title, description, keywords, license).
 
-**Fields:** `id`, `title`, `description`, `keywords`, `license_and_use_terms`
+**Fields:** `id`, `title`, `description`, `keywords`, `license_and_use_terms`, `doi`, `page`, `creators`, `purposes`, `instances`, `resources`, `parent_datasets`, `variables`, `regulatory_restrictions.confidentiality_level`
 
 **Scoring (numeric 0-5):**
 - **0:** ≤40% fields populated
@@ -71,7 +71,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 2: Entry Length Adequacy
 **Description:** Whether narrative fields (description, motivation) have meaningful content length.
 
-**Fields:** `description`, `motivation`
+**Fields:** `description`, `purposes`, `addressing_gaps`
 
 **Scoring (numeric 0-5):**
 - **0:** <50 chars
@@ -99,7 +99,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 4: File Enumeration and Type Variety
 **Description:** Number of files and file type diversity in distribution_formats or files.listing.
 
-**Fields:** `files`, `distribution_formats`
+**Fields:** `file_collections`, `total_file_count`, `distribution_formats`, `conforms_to_schema`, `total_size_bytes`, `file_collections.total_bytes`
 
 **Scoring (numeric 0-5):**
 - **0:** 1 file type only
@@ -113,7 +113,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 5: Data File Size Availability
 **Description:** Presence of file size or dimensional metadata (e.g., 513×N spectrogram).
 
-**Fields:** `files`, `data_characteristics`
+**Fields:** `file_collections`, `total_file_count`, `total_size_bytes`, `file_collections.total_bytes`, `instances`, `subsets.is_data_split`, `splits`, `subsets.is_subpopulation`, `subpopulations`
 
 **Scoring (pass/fail):**
 - **Pass:** Numeric file size or dimension info found
@@ -128,7 +128,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 6: Dataset Identification Metadata
 **Description:** Presence of unique identifiers such as DOI, RRID, or persistent URLs.
 
-**Fields:** `doi`, `rrid`, `page`
+**Fields:** `doi`, `page`, `id`, `publisher`
 
 **Scoring (pass/fail):**
 - **Pass:** At least one persistent ID found
@@ -141,7 +141,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 7: Funding and Acknowledgements Completeness
 **Description:** Presence of funding sources, grants, or institutional sponsors.
 
-**Fields:** `funding_and_acknowledgements`, `funding`
+**Fields:** `funders`, `creators`
 
 **Scoring (numeric 0-5):**
 - **0:** No funding data
@@ -155,7 +155,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 8: Ethical and Privacy Declarations
 **Description:** Presence of deidentification methods, IRB approvals, or ethical sourcing notes.
 
-**Fields:** `deidentification_and_privacy`, `ethics`
+**Fields:** `is_deidentified`, `participant_privacy`, `ethical_reviews`, `human_subject_research`, `participant_compensation`, `at_risk_populations`, `informed_consent`, `data_protection_impacts`, `participant_privacy.reidentification_risk`
 
 **Scoring (numeric 0-5):**
 - **0:** No ethics fields present
@@ -171,7 +171,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 9: Access Requirements and Governance Documentation
 **Description:** Determines if access policy, license, IP restrictions, regulatory restrictions, confidentiality level, multi-jurisdiction compliance, and governance contacts are clearly defined. Note: In Bridge2AI, license types include: (1) CM4AI uses CC-BY-NC-SA (permissive license), (2) AI-READi, CHORUS, VOICE use Data Use Agreements (controlled access). Avoid misleading terms like "Open" or "Public" — instead use: permissive license (e.g., CC-BY, CC-BY-NC-SA) or openly accessible with DUA (requires signed agreement). Access tiers: (1) No authentication, (2) Registration required, (3) DUA required, (4) IRB/committee approval required.
 
-**Fields:** `license_and_use_terms`, `ip_restrictions`, `regulatory_restrictions`, `confidentiality_level`, `hipaa_compliant`, `other_compliance`, `governance_committee_contact`
+**Fields:** `license_and_use_terms`, `ip_restrictions`, `regulatory_restrictions`, `regulatory_restrictions.confidentiality_level`, `regulatory_restrictions.hipaa_compliant`, `regulatory_restrictions.other_compliance`, `regulatory_restrictions.governance_committee_contact`
 
 **Scoring (numeric 0-5):**
 - **0:** No license or access info
@@ -187,7 +187,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 10: Interoperability, Standardization, and Cross-Platform Integration
 **Description:** Presence of standard formats, ontologies, schema conformance (e.g., Parquet, TSV, LinkML), cross-platform dataset linkages with typed relationships, AND dataset integration capability. Note: Evaluation aligned with Bridge2AI AI/ML readiness characterization criteria (FAIRness, semantic/statistical characterization, governance, quality, pre-model XAI, ethics, computability). Reference: https://www.biorxiv.org/content/10.1101/2024.12.18.629172v1 and Bridge2AI AI-readiness scorecard tool. All Bridge2AI datasets are designed for AI/ML use. This question evaluates HOW WELL the dataset supports AI/ML (interoperability, standardization), not WHETHER it supports AI/ML. Dataset integration capability: Check for common identifiers for cross-dataset linking, standardized formats for data harmonization, and documented integration procedures.
 
-**Fields:** `format`, `encoding`, `conforms_to`, `conforms_to_schema`, `external_resources`, `related_datasets`
+**Fields:** `distribution_formats`, `conforms_to_schema`, `file_collections.compression`, `conforms_to`, `external_resources`, `related_datasets`
 
 **Scoring (numeric 0-5):**
 - **0:** Non-standard or unspecified format
@@ -205,7 +205,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 11: Tool and Software Transparency
 **Description:** Mentions of preprocessing libraries or tools used in data preparation.
 
-**Fields:** `software_and_tools`
+**Fields:** `machine_annotation_tools`, `preprocessing_strategies`, `cleaning_strategies`, `labeling_strategies`, `annotation_analyses`, `imputation_protocols`
 
 **Scoring (numeric 0-5):**
 - **0:** No software tools documented
@@ -221,7 +221,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 12: Collection Protocol Clarity
 **Description:** Description completeness of participant recruitment and data acquisition.
 
-**Fields:** `collection_process`
+**Fields:** `collection_mechanisms`, `acquisition_methods`, `data_collectors`, `collection_timeframes`, `raw_data_sources`
 
 **Scoring (numeric 0-5):**
 - **0:** No collection description
@@ -237,7 +237,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 13: Version History, Maintenance, and Sustainability
 **Description:** Presence of version information, version access methods, errata, update plans, release notes with dates, AND data sustainability indicators (persistent identifiers, long-term governance plan, domain-appropriate repository, institutional commitment documentation). Note: Data sustainability evaluation checks for: (1) persistent identifiers (DOI, ARK, Handle), (2) long-term governance plan, (3) domain-appropriate repository (e.g., PhysioNet for biomedical data), (4) institutional commitment or preservation funding. Sustainable datasets have clear maintenance plans beyond initial publication.
 
-**Fields:** `version`, `version_access`, `errata`, `updates`, `release_notes`, `maintainers`, `doi`, `publisher`
+**Fields:** `version`, `version_access`, `errata`, `updates`, `maintainers`, `doi`, `publisher`
 
 **Scoring (numeric 0-5):**
 - **0:** Single version only, no sustainability plan
@@ -253,7 +253,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 14: Associated Publications
 **Description:** Presence of formal citations or DOI-linked references.
 
-**Fields:** `citations`, `references`
+**Fields:** `citation`, `external_resources`, `doi`
 
 **Scoring (numeric 0-5):**
 - **0:** No publications cited
@@ -269,7 +269,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 15: Human Subject Representation
 **Description:** Inclusion of human subjects, demographic diversity, or subgroup details.
 
-**Fields:** `composition.population`, `subpopulations`
+**Fields:** `instances`, `subpopulations`, `at_risk_populations`, `subsets.is_subpopulation`, `missing_data_documentation`
 
 **Scoring (numeric 0-5):**
 - **0:** No human subject information
@@ -287,7 +287,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 16: Findability (Persistent Links)
 **Description:** Dataset includes persistent URLs for access and documentation.
 
-**Fields:** `page`, `download_url`, `external_resources`
+**Fields:** `page`, `download_url`, `external_resources`, `doi`, `id`
 
 **Scoring (pass/fail):**
 - **Pass:** At least one working external URL present
@@ -300,7 +300,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 17: Accessibility (Access Mechanism)
 **Description:** Describes how users can obtain the dataset (download, DUA, login).
 
-**Fields:** `distribution_formats`, `access_and_licensing`
+**Fields:** `distribution_formats`, `license_and_use_terms`, `download_url`
 
 **Scoring (numeric 0-5):**
 - **0:** Unclear access method
@@ -330,7 +330,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 19: Data Integrity, Provenance Graph, and Quality
 **Description:** Presence of version access, errata, update plans, source derivation, parent dataset linkages, missing data documentation, data split indicators, AND provenance graph representation. Note: Provenance is a transparent graph of origins and processing of data (W3C PROV-O standard: https://www.w3.org/TR/prov-o/), NOT just version changes. Evaluation checks for: (1) Entity-activity-agent relationships, (2) Processing lineage, (3) Derivation paths. Provenance may be represented as text OR as W3C PROV-O graphs. Both formats are acceptable if they provide complete lineage information.
 
-**Fields:** `version_access`, `errata`, `updates`, `was_derived_from`, `parent_datasets`, `missing_data_documentation`, `is_data_split`, `raw_data_sources`
+**Fields:** `version_access`, `errata`, `updates`, `was_derived_from`, `parent_datasets`, `missing_data_documentation`, `subsets.is_data_split`, `splits`, `raw_data_sources`
 
 **Scoring (numeric 0-5):**
 - **0:** No provenance metadata

--- a/.claude/agents/d4d-rubric20.md
+++ b/.claude/agents/d4d-rubric20.md
@@ -99,7 +99,7 @@ Read the provided D4D YAML file and perform a **quality-based assessment** acros
 #### Question 4: File Enumeration and Type Variety
 **Description:** Number of files and file type diversity in distribution_formats or files.listing.
 
-**Fields:** `file_collections`, `total_file_count`, `distribution_formats`, `conforms_to_schema`, `total_size_bytes`, `file_collections.total_bytes`
+**Fields:** `file_collections`, `total_file_count`, `distribution_formats`
 
 **Scoring (numeric 0-5):**
 - **0:** 1 file type only

--- a/data/rubric/rubric20.txt
+++ b/data/rubric/rubric20.txt
@@ -160,9 +160,9 @@ d4d_evaluation_rubric:
       description: >
         Proportion of mandatory schema fields populated including core identification,
         hierarchical structure, governance, and composition metadata.
-      field: ["id", "title", "description", "keywords", "license_and_use_terms",
-              "doi", "page", "creators", "purposes", "instances", "resources",
-              "parent_datasets", "variables", "confidentiality_level"]
+      field: ["id", "title", "description", "keywords", "license_and_use_terms", "doi",
+              "page", "creators", "purposes", "instances", "resources", "parent_datasets",
+              "variables", "regulatory_restrictions.confidentiality_level"]
       method: "Count non-empty required fields; score by proportion filled."
       score_type: numeric
       scoring:
@@ -210,7 +210,8 @@ d4d_evaluation_rubric:
         datasets integrated on participant_id/sample_id, OR (2) single dataset with multiple data
         types. Check for: unified participant/sample identifiers across modalities. Multimodality
         is evaluated separately from AI/ML readiness (Q10).
-      field: ["distribution_formats", "format", "media_type", "bytes"]
+      field: ["distribution_formats", "conforms_to_schema", "total_size_bytes",
+              "file_collections.total_bytes"]
       method: "Count total formats and unique media types."
       score_type: numeric
       scoring:
@@ -222,7 +223,9 @@ d4d_evaluation_rubric:
     - id: 5
       name: "Data File Size Availability"
       description: "Presence of file size or dimensional metadata (bytes, instance counts, data splits)."
-      field: ["bytes", "instances", "is_data_split", "is_subpopulation"]
+      field: ["total_size_bytes", "file_collections.total_bytes", "instances",
+              "subsets.is_data_split", "splits", "subsets.is_subpopulation",
+              "subpopulations"]
       method: "Detect numeric values for file size or instance counts."
       score_type: pass_fail
       scoring:
@@ -241,7 +244,7 @@ d4d_evaluation_rubric:
 
         Note: Dataset identification should include both persistent identifiers AND hosting
         platform information (e.g., PhysioNet, Dataverse, Zenodo, institutional repositories).
-      field: ["doi", "rrid", "id", "page", "publisher"]
+      field: ["doi", "id", "page", "publisher"]
       method: "Check for non-null DOI or equivalent identifier AND publisher/platform."
       score_type: pass_fail
       scoring:
@@ -271,8 +274,9 @@ d4d_evaluation_rubric:
         physical activity data (step counts), retinal images, genetic data, location data, biometric
         identifiers, and other individually identifiable health information requiring special protections.
       field: ["ethical_reviews", "human_subject_research", "is_deidentified",
-              "participant_privacy", "participant_compensation", "vulnerable_populations",
-              "informed_consent", "data_protection_impacts", "reidentification_risk"]
+              "participant_privacy", "participant_compensation", "at_risk_populations",
+              "informed_consent", "data_protection_impacts",
+              "participant_privacy.reidentification_risk"]
       score_type: numeric
       scoring:
         0: "No ethics fields present"
@@ -293,7 +297,10 @@ d4d_evaluation_rubric:
         or openly accessible with DUA (requires signed agreement). Access tiers: (1) No authentication,
         (2) Registration required, (3) DUA required, (4) IRB/committee approval required.
       field: ["license_and_use_terms", "ip_restrictions", "regulatory_restrictions",
-              "confidentiality_level", "hipaa_compliant", "other_compliance", "governance_committee_contact"]
+              "regulatory_restrictions.confidentiality_level",
+              "regulatory_restrictions.hipaa_compliant",
+              "regulatory_restrictions.other_compliance",
+              "regulatory_restrictions.governance_committee_contact"]
       score_type: numeric
       scoring:
         0: "No license or access info"
@@ -318,7 +325,8 @@ d4d_evaluation_rubric:
 
         Dataset integration capability: Check for common identifiers for cross-dataset linking,
         standardized formats for data harmonization, and documented integration procedures.
-      field: ["format", "encoding", "conforms_to", "conforms_to_schema", "external_resources", "related_datasets"]
+      field: ["distribution_formats", "conforms_to_schema", "file_collections.compression",
+              "conforms_to", "external_resources", "related_datasets"]
       score_type: numeric
       scoring:
         0: "Non-standard or unspecified format"
@@ -342,7 +350,7 @@ d4d_evaluation_rubric:
         relationships. Both formats are acceptable. Some datasets (e.g., CM4AI) describe preprocessing in
         provenance graphs rather than text.
       field: ["preprocessing_strategies", "cleaning_strategies", "labeling_strategies",
-              "software_and_tools", "annotation_analyses", "machine_annotation_tools", "imputation_protocols"]
+              "machine_annotation_tools", "annotation_analyses", "imputation_protocols"]
       score_type: numeric
       scoring:
         0: "No software tools documented"
@@ -377,7 +385,8 @@ d4d_evaluation_rubric:
         (2) long-term governance plan, (3) domain-appropriate repository (e.g., PhysioNet for biomedical
         data), (4) institutional commitment or preservation funding. Sustainable datasets have clear
         maintenance plans beyond initial publication.
-      field: ["version", "version_access", "errata", "updates", "release_notes", "maintainers", "doi", "publisher"]
+      field: ["version", "version_access", "errata", "updates", "maintainers", "doi",
+              "publisher"]
       score_type: numeric
       scoring:
         0: "Single version only, no sustainability plan"
@@ -409,7 +418,8 @@ d4d_evaluation_rubric:
       description: >
         Indicates inclusion of human subjects with demographic diversity, subpopulation details,
         vulnerable population protections, and missing data documentation.
-      field: ["subpopulations", "instances", "vulnerable_populations", "is_subpopulation", "missing_data_documentation"]
+      field: ["subpopulations", "instances", "at_risk_populations",
+              "subsets.is_subpopulation", "missing_data_documentation"]
       score_type: numeric
       scoring:
         0: "No human subject information"
@@ -456,7 +466,8 @@ d4d_evaluation_rubric:
         License is clearly defined with explicit use guidance including intended uses,
         prohibited uses, discouraged uses, AND comprehensive social impact analysis with risk
         identification and mitigation strategies (CROISSANT RAI aligned).
-      field: ["license_and_use_terms", "intended_uses", "prohibited_uses", "discouraged_uses", "future_use_impacts"]
+      field: ["license_and_use_terms", "intended_uses", "prohibited_uses",
+              "discouraged_uses", "future_use_impacts"]
       score_type: numeric
       scoring:
         0: "No license or use guidance"
@@ -482,7 +493,8 @@ d4d_evaluation_rubric:
         Provenance may be represented as text OR as W3C PROV-O graphs. Both formats are acceptable
         if they provide complete lineage information.
       field: ["version_access", "errata", "updates", "was_derived_from", "parent_datasets",
-              "missing_data_documentation", "is_data_split", "raw_data_sources"]
+              "missing_data_documentation", "subsets.is_data_split", "splits",
+              "raw_data_sources"]
       score_type: numeric
       scoring:
         0: "No provenance metadata"

--- a/data/rubric/rubric20.txt
+++ b/data/rubric/rubric20.txt
@@ -210,8 +210,7 @@ d4d_evaluation_rubric:
         datasets integrated on participant_id/sample_id, OR (2) single dataset with multiple data
         types. Check for: unified participant/sample identifiers across modalities. Multimodality
         is evaluated separately from AI/ML readiness (Q10).
-      field: ["distribution_formats", "conforms_to_schema", "total_size_bytes",
-              "file_collections.total_bytes"]
+      field: ["distribution_formats", "file_collections", "total_file_count"]
       method: "Count total formats and unique media types."
       score_type: numeric
       scoring:

--- a/scripts/batch_evaluate_rubric20_hybrid.py
+++ b/scripts/batch_evaluate_rubric20_hybrid.py
@@ -44,7 +44,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Structural Completeness",
         "name": "Field Completeness",
         "description": "Proportion of mandatory schema fields populated including hierarchical structure and governance",
-        "fields": ["id", "title", "description", "keywords", "license_and_use_terms", "doi", "page", "creators", "purposes", "instances", "resources", "parent_datasets", "variables", "confidentiality_level"],
+        "fields": ["id", "title", "description", "keywords", "license_and_use_terms", "doi", "page", "creators", "purposes", "instances", "resources", "parent_datasets", "variables", "regulatory_restrictions.confidentiality_level"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -52,7 +52,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Structural Completeness",
         "name": "Entry Length Adequacy",
         "description": "Narrative fields have meaningful content length",
-        "fields": ["description", "motivation", "purposes"],
+        "fields": ["description", "purposes", "addressing_gaps"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -68,7 +68,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Structural Completeness",
         "name": "File Enumeration and Type Variety",
         "description": "Number of distribution formats and file type diversity",
-        "fields": ["distribution_formats", "format", "media_type", "bytes", "files", "subsets"],
+        "fields": ["distribution_formats", "conforms_to_schema", "total_size_bytes", "file_collections.total_bytes", "file_collections", "total_file_count", "subsets"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -76,7 +76,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Structural Completeness",
         "name": "Data File Size Availability",
         "description": "Presence of file size or dimensional metadata (bytes, instance counts)",
-        "fields": ["bytes", "instances", "files", "data_characteristics", "subsets"],
+        "fields": ["total_size_bytes", "file_collections.total_bytes", "instances", "file_collections", "total_file_count", "subsets", "subsets.is_data_split", "splits", "subsets.is_subpopulation", "subpopulations"],
         "score_type": "pass_fail",
         "max_score": 1
     },
@@ -86,7 +86,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Metadata Quality & Content",
         "name": "Dataset Identification Metadata",
         "description": "Presence of unique identifiers (DOI, RRID, URLs)",
-        "fields": ["doi", "rrid", "page", "id"],
+        "fields": ["doi", "page", "id", "publisher"],
         "score_type": "pass_fail",
         "max_score": 1
     },
@@ -94,7 +94,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Metadata Quality & Content",
         "name": "Funding and Acknowledgements Completeness",
         "description": "Funding sources, grants, sponsors, and creator affiliations",
-        "fields": ["funders", "creators", "funding_and_acknowledgements"],
+        "fields": ["funders", "creators"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -102,7 +102,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Metadata Quality & Content",
         "name": "Ethical and Privacy Declarations",
         "description": "Comprehensive ethics: IRB, deidentification, privacy, consent, compensation, vulnerable populations",
-        "fields": ["ethical_reviews", "human_subject_research", "is_deidentified", "participant_privacy", "participant_compensation", "vulnerable_populations", "informed_consent", "deidentification_and_privacy", "ethics"],
+        "fields": ["ethical_reviews", "human_subject_research", "is_deidentified", "participant_privacy", "participant_compensation", "at_risk_populations", "informed_consent", "data_protection_impacts", "participant_privacy.reidentification_risk"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -110,7 +110,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Metadata Quality & Content",
         "name": "Access Requirements and Governance Documentation",
         "description": "Access policy, license, IP restrictions, regulatory restrictions, confidentiality level",
-        "fields": ["license_and_use_terms", "ip_restrictions", "regulatory_restrictions", "confidentiality_level", "access_and_licensing"],
+        "fields": ["license_and_use_terms", "ip_restrictions", "regulatory_restrictions", "regulatory_restrictions.confidentiality_level", "regulatory_restrictions.hipaa_compliant", "regulatory_restrictions.other_compliance", "regulatory_restrictions.governance_committee_contact"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -118,7 +118,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Metadata Quality & Content",
         "name": "Interoperability, Standardization, and Cross-Platform Integration",
         "description": "Standard formats, encoding, ontologies, schema conformance, and cross-dataset integration capability",
-        "fields": ["format", "encoding", "conforms_to", "conforms_to_schema", "distribution_formats", "data_characteristics.data_formats", "external_resources", "related_datasets"],
+        "fields": ["distribution_formats", "conforms_to_schema", "file_collections.compression", "conforms_to", "external_resources", "related_datasets"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -128,7 +128,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Technical Documentation",
         "name": "Tool and Software Transparency",
         "description": "Preprocessing, cleaning, labeling strategies with software tools",
-        "fields": ["preprocessing_strategies", "cleaning_strategies", "labeling_strategies", "software_and_tools"],
+        "fields": ["preprocessing_strategies", "cleaning_strategies", "labeling_strategies", "machine_annotation_tools", "annotation_analyses", "imputation_protocols"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -136,7 +136,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Technical Documentation",
         "name": "Collection Protocol Clarity",
         "description": "Collection mechanisms, acquisition methods, data collectors, timeframes",
-        "fields": ["acquisition_methods", "collection_mechanisms", "data_collectors", "collection_timeframes", "collection_process", "sampling_strategies"],
+        "fields": ["acquisition_methods", "collection_mechanisms", "data_collectors", "collection_timeframes", "sampling_strategies", "raw_data_sources"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -144,7 +144,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Technical Documentation",
         "name": "Version History, Maintenance, and Sustainability",
         "description": "Version info, version access, errata, update plans, release notes, and sustainability indicators (persistent ID, repository, institutional commitment)",
-        "fields": ["version", "version_access", "errata", "updates", "release_notes", "versions_available_on_platform", "maintainers", "doi", "publisher"],
+        "fields": ["version", "version_access", "errata", "updates", "maintainers", "doi", "publisher"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -152,7 +152,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Technical Documentation",
         "name": "Associated Publications",
         "description": "Citations or DOI-linked references",
-        "fields": ["citation", "external_resources", "citations", "references"],
+        "fields": ["citation", "external_resources", "doi"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -160,7 +160,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Technical Documentation",
         "name": "Human Subject Representation",
         "description": "Demographics, subpopulations, vulnerable population protections",
-        "fields": ["subpopulations", "instances", "vulnerable_populations", "composition.population"],
+        "fields": ["subpopulations", "instances", "at_risk_populations", "subsets.is_subpopulation", "missing_data_documentation"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -178,7 +178,7 @@ RUBRIC20_QUESTIONS = {
         "category": "FAIRness & Accessibility",
         "name": "Accessibility (Access Mechanism)",
         "description": "Download URL, distribution formats, access policy",
-        "fields": ["download_url", "distribution_formats", "license_and_use_terms", "access_and_licensing"],
+        "fields": ["download_url", "distribution_formats", "license_and_use_terms"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -194,7 +194,7 @@ RUBRIC20_QUESTIONS = {
         "category": "FAIRness & Accessibility",
         "name": "Data Integrity, Provenance Graph, and Quality",
         "description": "Version access, errata, updates, source derivation, parent datasets, missing data documentation, and provenance graph representation",
-        "fields": ["version_access", "errata", "updates", "was_derived_from", "parent_datasets", "release_notes", "missing_data_documentation", "is_data_split", "raw_data_sources"],
+        "fields": ["version_access", "errata", "updates", "was_derived_from", "parent_datasets", "missing_data_documentation", "subsets.is_data_split", "splits", "raw_data_sources"],
         "score_type": "numeric",
         "max_score": 5
     },
@@ -377,8 +377,14 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q5: Data File Size Availability (pass/fail)
     elif question_id == 5:
-        # Look for numeric dimensions or file sizes
-        combined = str(data.get('subsets', '')) + str(data.get('data_characteristics', ''))
+        # Look for numeric dimensions or file sizes.
+        #
+        # `data_characteristics` has never been a slot of Dataset, and `subsets`
+        # alone carries no numbers, so this scored 0 on every one of the 25
+        # current records — the point was unreachable rather than unearned.
+        combined = ' '.join(str(data.get(k, '')) for k in
+                            ('total_size_bytes', 'total_file_count', 'file_collections',
+                             'instances', 'subsets', 'splits'))
         # Pattern: NxM dimensions, file sizes, sampling rates
         has_dimensions = bool(re.search(r'\d+\s*[x×]\s*\d+|\d+\s*[kKmMgG][bB]|\d+\s*kHz', combined))
 
@@ -392,7 +398,9 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
     # Q6: Dataset Identification Metadata (pass/fail)
     elif question_id == 6:
         has_doi = 'doi.org' in str(data.get('doi', '')) or 'doi.org' in str(data.get('id', ''))
-        has_rrid = 'RRID:' in str(data.get('rrid', ''))
+        # `rrid` is not a slot anywhere in the schema, so the old RRID test
+        # could never fire. An RRID, when present, is written into `id`.
+        has_rrid = 'RRID:' in str(data.get('id', ''))
         has_page = bool(data.get('page'))
 
         if has_doi or has_rrid or has_page:
@@ -404,22 +412,18 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q7: Funding and Acknowledgements Completeness
     elif question_id == 7:
-        funders = data.get('funders', [])
-        funding = get_nested_value(data, 'funding_and_acknowledgements.funding')
+        # `funding_and_acknowledgements` is not a slot of Dataset; the branch
+        # reading it was unreachable. `funders` and `creators` are where this
+        # lives now.
+        funders = data.get('funders') or []
+        if isinstance(funders, dict):
+            funders = [funders]
+        funder_str = str(funders) + str(data.get('creators') or '')
 
-        has_agency = False
-        has_award = False
-        has_acknowledgements = False
-
-        if funders and isinstance(funders, list):
-            funder_str = str(funders)
-            has_agency = any(keyword in funder_str for keyword in ['NIH', 'NSF', 'National', 'Fund'])
-            has_award = bool(re.search(r'\d[A-Z0-9]{7,}', funder_str))
-            has_acknowledgements = len(funders) > 0
-        elif funding:
-            has_agency = bool(get_nested_value(data, 'funding_and_acknowledgements.funding.agency'))
-            has_award = bool(get_nested_value(data, 'funding_and_acknowledgements.funding.award_number'))
-            has_acknowledgements = bool(get_nested_value(data, 'funding_and_acknowledgements.acknowledgements'))
+        has_agency = bool(funders) and any(
+            k in funder_str for k in ['NIH', 'NSF', 'National', 'Fund', 'Institute'])
+        has_award = bool(re.search(r'\d[A-Z0-9]{7,}', funder_str))
+        has_acknowledgements = bool(funders)
 
         if has_agency and has_award and has_acknowledgements:
             score = 5
@@ -436,10 +440,18 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q8: Ethical and Privacy Declarations
     elif question_id == 8:
-        has_irb = bool(get_nested_value(data, 'ethics.irb_approval') or data.get('ethical_reviews'))
-        has_deident = bool(get_nested_value(data, 'deidentification_and_privacy.approach') or data.get('is_deidentified'))
-        has_consent = bool(get_nested_value(data, 'collection_process.consent') or data.get('informed_consent'))
-        has_ethical = bool(get_nested_value(data, 'ethics.ethical_position') or 'ethic' in str(data.get('purposes', '')).lower())
+        # `ethics`, `deidentification_and_privacy` and `collection_process` are
+        # not slots of Dataset. Each was the dead half of an `or` except
+        # `ethics.ethical_position`, which left `has_ethical` resting on the
+        # word "ethic" appearing in `purposes`.
+        has_irb = bool(get_nested_value(data, 'human_subject_research.irb_approval')
+                       or data.get('ethical_reviews'))
+        has_deident = bool(get_nested_value(data, 'is_deidentified.method')
+                           or data.get('is_deidentified'))
+        has_consent = bool(data.get('informed_consent') or data.get('collection_consents'))
+        has_ethical = bool(data.get('data_protection_impacts')
+                           or data.get('participant_privacy')
+                           or data.get('sensitive_elements'))
 
         ethics_count = sum([has_irb, has_deident, has_consent, has_ethical])
 
@@ -458,9 +470,19 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
         license_terms = data.get('license_and_use_terms', {})
         has_license = bool(license_terms)
         has_dua = 'DUA' in str(license_terms) or 'Data Use Agreement' in str(license_terms)
-        has_policy = bool(get_nested_value(data, 'access_and_licensing.access_policy'))
+        # `access_and_licensing` is not a slot of Dataset, so `has_policy` was
+        # always False and band 5 was unreachable: all 25 current records
+        # scored exactly 3. The rubric's band 5 asks for compliance,
+        # confidentiality classification and a governance contact, which live
+        # under `regulatory_restrictions`.
+        reg = data.get('regulatory_restrictions') or {}
+        has_policy = bool(data.get('ip_restrictions') or reg)
+        has_governance = bool(
+            isinstance(reg, dict)
+            and (reg.get('confidentiality_level') or reg.get('governance_committee_contact')
+                 or reg.get('hipaa_compliant') or reg.get('other_compliance')))
 
-        if has_license and has_dua and has_policy:
+        if has_license and has_dua and has_policy and has_governance:
             score = 5
             quality_note = "License + DUA + access policy"
         elif has_license:
@@ -472,12 +494,17 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q10: Interoperability and Standardization
     elif question_id == 10:
-        has_formats = bool(get_nested_value(data, 'data_characteristics.data_formats') or data.get('distribution_formats'))
-        has_schema = bool(data.get('conforms_to'))
+        # `formats_str = str(has_formats)` stringified a *bool*, so no format
+        # name was ever found in "True" and this scored 0 on all 25 current
+        # records whatever they contained. The formats themselves are what has
+        # to be searched.
+        formats = data.get('distribution_formats') or []
+        has_schema = bool(data.get('conforms_to') or data.get('conforms_to_schema'))
 
-        standard_formats = ['Parquet', 'TSV', 'CSV', 'JSON', 'HDF5', 'DICOM']
-        formats_str = str(has_formats)
-        has_standard = any(fmt in formats_str for fmt in standard_formats)
+        standard_formats = ['Parquet', 'TSV', 'CSV', 'JSON', 'HDF5', 'DICOM',
+                            'NIfTI', 'Zarr', 'Parquet', 'BIDS', 'OMOP', 'FHIR']
+        formats_str = str(formats) + str(data.get('file_collections') or '')
+        has_standard = any(fmt.lower() in formats_str.lower() for fmt in standard_formats)
 
         if has_standard and has_schema:
             score = 5
@@ -491,10 +518,12 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q11: Tool and Software Transparency
     elif question_id == 11:
-        software = data.get('software_and_tools', {})
-        preprocessing = data.get('preprocessing_strategies', [])
-
-        tool_mentions = str(software) + str(preprocessing)
+        # `software_and_tools` is not a slot of Dataset. Tool names appear in
+        # the annotation, preprocessing, cleaning and labeling strategies.
+        tool_mentions = ' '.join(str(data.get(k) or '') for k in
+                                 ('machine_annotation_tools', 'preprocessing_strategies',
+                                  'cleaning_strategies', 'labeling_strategies',
+                                  'annotation_analyses', 'imputation_protocols'))
         # Count tool names
         tools = re.findall(r'\b(openSMILE|Parselmouth|Whisper|Praat|UMAP|Python|R|MATLAB|TensorFlow|PyTorch)\b', tool_mentions, re.I)
 
@@ -510,13 +539,12 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q12: Collection Protocol Clarity
     elif question_id == 12:
-        collection = data.get('collection_process', {})
-        acquisition = data.get('acquisition_methods', [])
-        sampling = data.get('sampling_strategies', [])
-
-        has_setting = bool(get_nested_value(data, 'collection_process.setting') or data.get('data_collectors'))
-        has_method = bool(get_nested_value(data, 'collection_process.data_capture') or acquisition)
-        has_sampling = bool(sampling)
+        # `collection_process` is not a slot of Dataset; both reads of it were
+        # the dead half of an `or`. `collection_mechanisms` and
+        # `collection_timeframes` are the parts that had no live equivalent.
+        has_setting = bool(data.get('data_collectors') or data.get('collection_mechanisms'))
+        has_method = bool(data.get('acquisition_methods'))
+        has_sampling = bool(data.get('sampling_strategies') or data.get('collection_timeframes'))
 
         detail_count = sum([has_setting, has_method, has_sampling])
 
@@ -534,7 +562,8 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
     elif question_id == 13:
         updates = data.get('updates', {})
         version_access = data.get('version_access', {})
-        release_notes = data.get('release_notes', {})
+        # `release_notes` is not a slot of Dataset; `errata` is.
+        release_notes = data.get('errata') or {}
 
         # Count version mentions
         version_text = str(updates) + str(version_access) + str(release_notes)
@@ -552,9 +581,9 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q14: Associated Publications
     elif question_id == 14:
-        references = data.get('references', [])
+        references = data.get('external_resources', [])
         external = data.get('external_resources', [])
-        citations = data.get('citations', [])
+        citations = data.get('citation', [])
 
         # Count DOIs
         ref_text = str(references) + str(external) + str(citations)
@@ -572,13 +601,15 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q15: Human Subject Representation
     elif question_id == 15:
-        population = get_nested_value(data, 'composition.population')
-        subpops = data.get('subpopulations', [])
-        instances = data.get('instances', [])
+        # `composition` is not a slot of Dataset, so `population` was always
+        # None — which also kept `subpopulations` out of `combined`, leaving
+        # the count and diversity tests reading `instances` alone.
+        subpops = data.get('subpopulations') or []
+        instances = data.get('instances') or []
+        at_risk = data.get('at_risk_populations') or []
 
-        has_demographics = bool(population) or bool(subpops)
-        # Look for participant counts
-        combined = str(instances) + str(population)
+        has_demographics = bool(subpops) or bool(at_risk)
+        combined = str(instances) + str(subpops) + str(at_risk)
         has_counts = bool(re.search(r'\d+\s+(?:participants?|subjects?|samples?)', combined, re.I))
         # Look for diversity mentions
         has_diversity = bool(re.search(r'(?:demographic|diversity|inclusion|exclusion|criteria)', combined, re.I))
@@ -597,7 +628,7 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
 
     # Q16: Findability (pass/fail)
     elif question_id == 16:
-        has_links = bool(data.get('page') or data.get('download_url') or data.get('external_resources'))
+        has_links = bool(data.get('page') or data.get('page') or data.get('external_resources'))
 
         if has_links:
             score = 1
@@ -609,7 +640,7 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
     # Q17: Accessibility (Access Mechanism)
     elif question_id == 17:
         dist_formats = data.get('distribution_formats', [])
-        access = data.get('access_and_licensing', {})
+        access = data.get('regulatory_restrictions', {})
         license_terms = data.get('license_and_use_terms', {})
 
         has_platform = bool(re.search(r'(?:PhysioNet|Dataverse|FAIRhub|Zenodo)', str(dist_formats) + str(access), re.I))
@@ -656,7 +687,8 @@ def evaluate_question(data: Dict, question_id: int) -> Tuple[int, str, str]:
     elif question_id == 19:
         updates = data.get('updates', {})
         version_access = data.get('version_access', {})
-        release_notes = data.get('release_notes', {})
+        # `release_notes` is not a slot of Dataset; `errata` is.
+        release_notes = data.get('errata') or {}
 
         has_changes = bool(updates or release_notes)
         # Look for timestamps

--- a/scripts/batch_evaluate_rubric20_hybrid.py
+++ b/scripts/batch_evaluate_rubric20_hybrid.py
@@ -68,7 +68,7 @@ RUBRIC20_QUESTIONS = {
         "category": "Structural Completeness",
         "name": "File Enumeration and Type Variety",
         "description": "Number of distribution formats and file type diversity",
-        "fields": ["distribution_formats", "conforms_to_schema", "total_size_bytes", "file_collections.total_bytes", "file_collections", "total_file_count", "subsets"],
+        "fields": ["distribution_formats", "file_collections", "total_file_count", "subsets"],
         "score_type": "numeric",
         "max_score": 5
     },

--- a/tests/test_evaluation/test_rubric20_fields_resolve.py
+++ b/tests/test_evaluation/test_rubric20_fields_resolve.py
@@ -1,0 +1,288 @@
+"""Every field a rubric20 scorer names must exist in the schema (#319).
+
+#316 aligned the scorers' question *names* with `data/rubric/rubric20.txt`.
+Their `field:` lists were still written against a schema the project no longer
+has. Measured across the 25 current records, 29 of the 93 distinct paths named
+by the rubric or a scorer could not resolve from `Dataset` at all.
+
+A field that does not resolve does not fail — it reads as absent, forever. Two
+questions were therefore unscoreable on every record ever produced:
+
+    Q5   Data File Size Availability     0/1 on all 25 records
+    Q10  Interoperability ...            0/5 on all 25 records
+
+Q10 also carried a plain type bug — `formats_str = str(has_formats)` stringified
+a *bool*, so no format name was ever found in `"True"`. Six of 88 points were
+unreachable regardless of what a record contained.
+
+The distinction this file rests on: a path that **cannot resolve** produces a
+meaningless 0, and a path that **resolves but is empty** produces a true one.
+`regulatory_restrictions.confidentiality_level` is the second kind — no current
+record fills it, Q9 scores 3 on all 25, and that is a real finding about the
+records rather than a broken scorer. Bare `confidentiality_level` was the first
+kind, and reported the same number for the wrong reason.
+
+So the test is resolution, not population. It would be wrong to require every
+named field to appear in some record — that would forbid the rubric from asking
+for anything the generator does not yet produce, which is most of what a rubric
+is for.
+"""
+
+import functools
+import importlib.util
+import json
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.constants.evaluation import RUBRIC20_PATH
+
+REPO = Path(__file__).resolve().parents[2]
+SCHEMA = REPO / "src" / "data_sheets_schema" / "schema" / "data_sheets_schema_all.yaml"
+HYBRID = REPO / "scripts" / "batch_evaluate_rubric20_hybrid.py"
+AGENTS = {
+    "rubric20": REPO / ".claude" / "agents" / "d4d-rubric20.md",
+    "rubric20-semantic": REPO / ".claude" / "agents" / "d4d-rubric20-semantic.md",
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _view():
+    from linkml_runtime import SchemaView
+    return SchemaView(str(SCHEMA))
+
+
+@functools.lru_cache(maxsize=None)
+def _slots(class_name):
+    try:
+        return {s.name: s for s in _view().class_induced_slots(class_name)}
+    except Exception:
+        return {}
+
+
+def resolves(path, start="Dataset"):
+    """Walk a dotted path from `start`, as a scorer reading a record would."""
+    cls = start
+    parts = path.split(".")
+    for i, part in enumerate(parts):
+        slots = _slots(cls)
+        if part not in slots:
+            return False
+        if i < len(parts) - 1:
+            rng = slots[part].range
+            if not _view().get_class(rng):
+                return False
+            cls = rng
+    return True
+
+
+def _json_keys(node):
+    """Every key name in a JSON document, at any depth."""
+    if isinstance(node, dict):
+        return set(node) | {k for v in node.values() for k in _json_keys(v)}
+    if isinstance(node, list):
+        return {k for v in node for k in _json_keys(v)}
+    return set()
+
+
+def _rubric():
+    return yaml.safe_load(Path(RUBRIC20_PATH).read_text())[
+        "d4d_evaluation_rubric"]["rubric"]
+
+
+def _hybrid():
+    spec = importlib.util.spec_from_file_location("rubric20_hybrid", HYBRID)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _agent_fields(path):
+    """`**Fields:**` per question, keyed by the nearest preceding heading."""
+    out, current = {}, None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        heading = re.match(r"^#### Question (\d+): ", line)
+        if heading:
+            current = int(heading.group(1))
+            continue
+        fields = re.match(r"^\*\*Fields:\*\* (.+?)\s*$", line)
+        if fields and current is not None:
+            out[current] = re.findall(r"`([^`]+)`", fields.group(1))
+            current = None
+    return out
+
+
+class TestThePremise(unittest.TestCase):
+    """`resolves` has to be able to say no, or every test below is vacuous."""
+
+    def test_a_real_top_level_slot_resolves(self):
+        self.assertTrue(resolves("license_and_use_terms"))
+
+    def test_a_real_nested_path_resolves(self):
+        self.assertTrue(resolves("regulatory_restrictions.confidentiality_level"))
+
+    def test_a_leaf_without_its_path_does_not(self):
+        """This is the whole defect in one line: `confidentiality_level` is a
+        real field, on a class that is not `Dataset`."""
+        self.assertFalse(resolves("confidentiality_level"))
+
+    def test_an_invented_slot_does_not(self):
+        self.assertFalse(resolves("data_characteristics"))
+        self.assertFalse(resolves("software_and_tools"))
+
+
+class TestTheRubricResolves(unittest.TestCase):
+    """The rubric is the source: `rubric20_system_prompt.md` interpolates it
+    into the API judge, so a dead field there reaches every scorer at once."""
+
+    def test_every_field_the_rubric_names_resolves(self):
+        for question in _rubric():
+            for name in question.get("field") or []:
+                with self.subTest(question=question["id"], field=name):
+                    self.assertTrue(
+                        resolves(name),
+                        f"Q{question['id']} scores `{name}`, which cannot be "
+                        "reached from Dataset — it reads as absent forever")
+
+    def test_every_question_names_at_least_one_field(self):
+        for question in _rubric():
+            with self.subTest(question=question["id"]):
+                self.assertTrue(question.get("field"),
+                                "a question with no fields cannot be scored")
+
+
+@unittest.skipUnless(HYBRID.exists(), "hybrid scorer not present")
+class TestTheScorersResolve(unittest.TestCase):
+
+    def test_every_field_the_hybrid_scorer_names_resolves(self):
+        for q, spec in _hybrid().RUBRIC20_QUESTIONS.items():
+            for name in spec["fields"]:
+                with self.subTest(question=q, field=name):
+                    self.assertTrue(resolves(name), f"Q{q} scores `{name}`")
+
+    def test_every_field_the_agents_name_resolves(self):
+        for agent, path in AGENTS.items():
+            for q, fields in _agent_fields(path).items():
+                for name in fields:
+                    with self.subTest(agent=agent, question=q, field=name):
+                        self.assertTrue(resolves(name), f"Q{q} scores `{name}`")
+
+    def test_the_scorers_cover_the_rubrics_fields(self):
+        """A scorer may add fields; it may not quietly drop the rubric's.
+
+        Dropping is how a question keeps its name while scoring something
+        narrower, which is the drift #316 fixed at the level of names.
+        """
+        rubric = {q["id"]: set(q.get("field") or []) for q in _rubric()}
+        tables = {"hybrid": {q: set(s["fields"])
+                             for q, s in _hybrid().RUBRIC20_QUESTIONS.items()}}
+        for agent, path in AGENTS.items():
+            tables[agent] = {q: set(f) for q, f in _agent_fields(path).items()}
+        for who, table in tables.items():
+            for q, want in rubric.items():
+                with self.subTest(scorer=who, question=q):
+                    self.assertEqual(want - table.get(q, set()), set())
+
+
+class TestTheAgentsProse(unittest.TestCase):
+    """`**Fields:**` is not the only place the agents name record fields.
+
+    The cross-field consistency rules name them too — "IF
+    `human_subject_research.involves_human_subjects=True` THEN EXPECT
+    `ethical_reviews` populated". A dead name there tells the judge to compare
+    against something that cannot exist, and no test of the Fields lines can
+    see it. A mutation check found this gap: swapping
+    `participant_privacy.reidentification_risk` for the bare leaf in a
+    consistency rule left every other test green.
+
+    Backticked snake_case tokens that are *not* record fields — the agent's own
+    output keys and the filenames it writes — are excluded by provenance rather
+    than by a hand-maintained list: they are read from the two JSON contracts
+    the agent emits against.
+    """
+
+    #: Names of artifacts the agent writes, which are neither record fields nor
+    #: output keys. Small and closed, so a literal is honest here.
+    ARTIFACTS = {"all_scores.csv", "evaluation_summary.yaml", "summary_report.md"}
+
+    #: Output keys of the N/A convention. These *should* come from
+    #: `rubric20_semantic_schema.json` with the rest, and do not, because that
+    #: schema still declares the pre-N/A shape — it requires `percentage`, which
+    #: the agent no longer emits, and all 28 recorded semantic evaluations fail
+    #: it. Listed here rather than silently widened so the gap stays visible.
+    #: See #323.
+    UNDECLARED_OUTPUT_KEYS = {
+        "adjusted_max_points", "excluded_max_points", "normalized_percentage",
+        "questions_not_applicable", "average_adjusted_max_points",
+        "average_excluded_max_points", "average_normalized_percentage",
+        "applicability_status", "applicability_evidence",
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        cls.output_keys = set()
+        for name in ("rubric20_semantic_schema.json", "rubric20_output_format.json"):
+            path = REPO / "src" / "download" / "prompts" / name
+            if path.exists():
+                cls.output_keys |= _json_keys(json.loads(path.read_text()))
+
+    def test_every_field_named_anywhere_in_an_agent_resolves(self):
+        for agent, path in AGENTS.items():
+            text = path.read_text(encoding="utf-8")
+            tokens = set(re.findall(
+                r"`([a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*)`", text))
+            ignore = self.output_keys | self.ARTIFACTS | self.UNDECLARED_OUTPUT_KEYS
+            for token in sorted(tokens - ignore):
+                with self.subTest(agent=agent, token=token):
+                    self.assertTrue(
+                        resolves(token),
+                        f"`{token}` is named in {agent} but cannot be reached "
+                        "from Dataset")
+
+
+@unittest.skipUnless(HYBRID.exists(), "hybrid scorer not present")
+class TestTheUnreachableQuestions(unittest.TestCase):
+    """Q5 and Q10 scored the same value on all 25 current records.
+
+    Resolution alone does not catch these: Q10's fields resolved and it still
+    scored 0 every time, because `str(has_formats)` searched the text of a
+    boolean. So these assert the scores, on records shaped like the real ones.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _hybrid()
+
+    def _score(self, data, q):
+        return self.module.evaluate_question(data, q)[0]
+
+    def test_standard_formats_and_a_schema_reach_the_top_band(self):
+        """Q10. `formats_str = str(has_formats)` is `"True"`, and no format
+        name is a substring of that — 5 points were unreachable."""
+        self.assertEqual(self._score(
+            {"distribution_formats": [{"name": "Parquet"}, {"name": "TSV"}],
+             "conforms_to": "https://w3id.org/linkml/d4d"}, 10), 5)
+
+    def test_standard_formats_without_a_schema_reach_the_middle_band(self):
+        self.assertEqual(self._score(
+            {"distribution_formats": [{"name": "Parquet"}]}, 10), 3)
+
+    def test_no_recognisable_format_still_scores_zero(self):
+        """The complement — the fix must not make the question unfailable."""
+        self.assertEqual(self._score(
+            {"distribution_formats": [{"name": "bespoke binary blob"}]}, 10), 0)
+
+    def test_a_recorded_size_passes_the_file_size_question(self):
+        """Q5 read `data_characteristics`, which has never been a slot."""
+        self.assertEqual(self._score({"total_size_bytes": 4096000000}, 5), 0)
+        self.assertEqual(self._score(
+            {"file_collections": [{"total_bytes": "12 GB"}]}, 5), 1)
+
+    def test_no_size_anywhere_still_fails(self):
+        self.assertEqual(self._score({"instances": [{"name": "participant"}]}, 5), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation/test_rubric20_fields_resolve.py
+++ b/tests/test_evaluation/test_rubric20_fields_resolve.py
@@ -92,6 +92,10 @@ def _rubric():
         "d4d_evaluation_rubric"]["rubric"]
 
 
+def _question(number):
+    return next(q for q in _rubric() if q["id"] == number)
+
+
 def _hybrid():
     spec = importlib.util.spec_from_file_location("rubric20_hybrid", HYBRID)
     module = importlib.util.module_from_spec(spec)
@@ -151,6 +155,40 @@ class TestTheRubricResolves(unittest.TestCase):
             with self.subTest(question=question["id"]):
                 self.assertTrue(question.get("field"),
                                 "a question with no fields cannot be scored")
+
+
+class TestFieldsMatchWhatTheQuestionMeasures(unittest.TestCase):
+    """Resolution is necessary and not sufficient.
+
+    One dead name does not have one replacement. `format` in Q4 — a count of
+    file *types*, scored "1 type / 2-3 / >3" — is not `format` in Q10, which is
+    about schema conformance. Remapping both to the same thing gave Q4 a schema
+    URL and two byte-size fields: every path resolved, every existing test
+    passed, and the question no longer measured what its own `method:` and
+    scoring bands say it measures.
+
+    Caught in review of the change that caused it. These two questions are the
+    pair most easily conflated, so they are pinned by concept rather than by a
+    literal list — a scorer may add fields, but not swap which of the two it is.
+    """
+
+    SIZE = {"total_size_bytes", "file_collections.total_bytes"}
+    ENUMERATION = {"distribution_formats", "file_collections", "total_file_count"}
+
+    def test_the_type_variety_question_does_not_score_sizes(self):
+        """Q4 counts types; a byte total says nothing about how many."""
+        fields = set(_question(4)["field"])
+        self.assertEqual(fields & self.SIZE, set())
+        self.assertTrue(fields & self.ENUMERATION)
+
+    def test_the_file_size_question_does_score_sizes(self):
+        """The complement, so the rule above cannot be satisfied by emptying
+        both lists."""
+        self.assertTrue(set(_question(5)["field"]) & self.SIZE)
+
+    def test_the_interoperability_question_scores_schema_conformance(self):
+        """Q10 is where `conforms_to_schema` belongs."""
+        self.assertIn("conforms_to_schema", _question(10)["field"])
 
 
 @unittest.skipUnless(HYBRID.exists(), "hybrid scorer not present")


### PR DESCRIPTION
Closes #319. **Stacked on #316** — will retarget to `main` before that merges.

## What was wrong

#316 aligned the three rubric20 scorers' question *names* with
`data/rubric/rubric20.txt`. Their `field:` lists were still written against a
schema the project no longer has. Of the 93 distinct paths named by the rubric
or a scorer, **29 could not resolve from `Dataset` at all**.

A field that does not resolve does not fail. It reads as absent, forever.

## What it cost, measured

Two questions were unscoreable on every record ever produced. Q10 carried a
second, independent defect: `formats_str = str(has_formats)` stringified a
*bool*, so no format name was ever a substring of `"True"` — its 5 points were
unreachable even where the fields resolved.

Six of 88 points could not be earned by any record, and nothing reported an error.

Across the 25 current records, before → after:

| | before | after |
|---|---|---|
| Q5 Data File Size Availability | **0.0/1 constant** | 0.2/1 |
| Q10 Interoperability… | **0.0/5 constant** | 4.8/5 |
| Q8 Ethical and Privacy Declarations | 4.8/5 | **4.4/5** |
| Q11 Tool and Software Transparency | 1.6/5 | 2.0/5 |
| Q15 Human Subject Representation | 4.1/5 | 4.8/5 |
| **total** | 62.7/88 | 68.9/88 |
| sd | 10.53 | 11.04 |

**Q8 going down is the point.** `has_ethical` rested on
`get_nested_value(data, 'ethics.ethical_position')` — never resolvable — *or*
the substring `"ethic"` appearing anywhere in `purposes`. With the dead half
inert, the live half was a word search, and it was passing records documenting
no ethics fields at all.

## The fix

`rubric20.txt` first, because `rubric20_system_prompt.md` interpolates it as
`{RUBRIC_SPECIFICATION}` — a dead field there reaches the API judge directly.
The two agents and the hybrid scorer are then brought up to it, keeping their
own additions where those resolve.

Two kinds of replacement, kept distinct:

- **A leaf that only needed its path.** `confidentiality_level` is a real field,
  on `ExportControlRegulatoryRestrictions`, reachable as
  `regulatory_restrictions.confidentiality_level`. Same for `hipaa_compliant`,
  `other_compliance`, `governance_committee_contact`, `reidentification_risk`,
  `is_data_split`, `is_subpopulation`, `bytes`.
- **A slot the schema no longer has**, replaced by current equivalents:
  `ethics`, `deidentification_and_privacy`, `collection_process`,
  `data_characteristics`, `access_and_licensing`, `software_and_tools`,
  `funding_and_acknowledgements`, `release_notes`, `files`, `motivation`,
  `citations`/`references`, `composition.population`. `rrid` is dropped — not
  in the schema at all, and `doi`/`id`/`page` already carry that check.

`vulnerable_populations` resolved the other way: the semantic agent's
`at_risk_populations` was right and the rubric was wrong. The rubric moved.

## The distinction the tests rest on

**Q9 still scores 3 on all 25 records, and now that is a true statement.**
`access_and_licensing.access_policy` never resolved, so band 5 was unreachable
by construction. It now reads `regulatory_restrictions`, which every record
leaves empty — a real gap in generation rather than an artefact of the scorer.

So the tests assert **resolution, never population**. Requiring every named
field to appear in some record would forbid the rubric from asking for anything
the generator does not yet produce, which is most of what a rubric is for.

## Testing

15 tests. Mutation-checked with 11 reintroductions, no survivors. One found a
gap the Fields-line tests could not see: the agents also name record fields in
their cross-field consistency rules ("IF `human_subject_research.…` THEN EXPECT
`ethical_reviews` populated"), where a dead name instructs the judge to compare
against something that cannot exist. Now covered.

`1165 passed, 3 skipped`.

## Found on the way, filed not fixed

**#323 — every recorded semantic evaluation fails its own JSON schema.**
`scripts/validate_evaluation_schema.py` reports `Valid: 0, Invalid: 28`. The
rubric20 schema requires `overall_score.percentage`; the agent emits
`normalized_percentage` and the N/A vocabulary instead. This is on the critical
path for the rerun's twelve semantic evaluations, and fixing it means deciding
which percentage is the reported one — a call I did not want to make silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)