### PR TITLE
Describe the output the agents actually instruct (#323)

### DIFF
--- a/scripts/render_evaluation_html_rubric10_semantic.py
+++ b/scripts/render_evaluation_html_rubric10_semantic.py
@@ -5,6 +5,7 @@ Render rubric10-semantic evaluation JSON files to HTML
 import json
 from pathlib import Path
 from datetime import datetime
+from data_sheets_schema.rubric_pooling import reported_percentage
 
 
 def generate_evaluation_html(eval_data, output_path):
@@ -22,7 +23,7 @@ def generate_evaluation_html(eval_data, output_path):
     summary = eval_data.get("summary_scores") or {
         "total_score": eval_data.get("overall_score", {}).get("total_points", 0),
         "total_max_score": eval_data.get("overall_score", {}).get("max_points", 50),
-        "overall_percentage": eval_data.get("overall_score", {}).get("percentage", 0),
+        "overall_percentage": reported_percentage(eval_data),
     }
     semantic = eval_data.get("semantic_analysis", {})
     assessment = eval_data.get("assessment", {})

--- a/scripts/render_evaluation_html_rubric20_semantic.py
+++ b/scripts/render_evaluation_html_rubric20_semantic.py
@@ -17,6 +17,7 @@ import json
 from pathlib import Path
 from datetime import datetime
 from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
+from data_sheets_schema.rubric_pooling import reported_percentage
 
 
 def generate_evaluation_html(eval_data, output_path):
@@ -34,7 +35,7 @@ def generate_evaluation_html(eval_data, output_path):
     overall = eval_data.get("overall_score", {})
     total_score = overall.get("total_points", 0)
     max_score = overall.get("max_points", RUBRIC20_MAX_SCORE)
-    percentage = overall.get("percentage", 0)
+    percentage = reported_percentage({'overall_score': overall})
 
     # Calculate grade
     if percentage >= 95:

--- a/scripts/summarize_rubric10_results.py
+++ b/scripts/summarize_rubric10_results.py
@@ -18,6 +18,7 @@ import csv
 from pathlib import Path
 from typing import List, Dict
 from datetime import datetime
+from data_sheets_schema.rubric_pooling import reported_percentage
 
 # Base directory
 BASE_DIR = Path(__file__).parent.parent
@@ -74,7 +75,7 @@ def create_csv_summary(results: List[Dict]):
             overall = result.get('overall_score', {})
             total_score = overall.get('total_points', 0)
             max_score = overall.get('max_points', 50)
-            percentage = overall.get('percentage', 0)
+            percentage = reported_percentage({'overall_score': overall})
 
             # Count elements passing (score >= 3/5)
             elements = result.get('elements', [])
@@ -134,7 +135,7 @@ def create_markdown_table(results: List[Dict]):
                 overall = result.get('overall_score', {})
                 total = overall.get('total_points', 0)
                 max_pts = overall.get('max_points', 50)
-                pct = overall.get('percentage', 0)
+                pct = reported_percentage({'overall_score': overall})
 
                 elements = result.get('elements', [])
                 elements_passing = sum(1 for el in elements if el.get('element_score', 0) >= 3)
@@ -161,7 +162,7 @@ def create_markdown_table(results: List[Dict]):
                 file_count = len(results_list)
 
                 avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in results_list) / file_count
-                avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in results_list) / file_count
+                avg_pct = sum(reported_percentage(r) for r in results_list) / file_count
 
                 avg_passing = sum(
                     sum(1 for el in r.get('elements', []) if el.get('element_score', 0) >= 3)
@@ -175,15 +176,15 @@ def create_markdown_table(results: List[Dict]):
     md += "| Project | Method | Type | Score | File |\n"
     md += "|---------|--------|------|-------|------|\n"
 
-    top_performers = [r for r in results if r.get('overall_score', {}).get('percentage', 0) >= 80]
-    top_performers.sort(key=lambda x: x.get('overall_score', {}).get('percentage', 0), reverse=True)
+    top_performers = [r for r in results if reported_percentage(r) >= 80]
+    top_performers.sort(key=lambda x: reported_percentage(x), reverse=True)
 
     for result in top_performers[:20]:  # Top 20
         project = result.get('project', 'unknown')
         method = result.get('method', 'unknown')
         eval_type = result.get('evaluation_type', 'unknown')
         overall = result.get('overall_score', {})
-        score_str = f"{overall.get('total_points', 0)}/{overall.get('max_points', 50)} ({overall.get('percentage', 0):.1f}%)"
+        score_str = f"{overall.get('total_points', 0)}/{overall.get('max_points', 50)} ({reported_percentage({'overall_score': overall}):.1f}%)"
         file_name = Path(result.get('d4d_file', '')).name
 
         md += f"| {project} | {method} | {eval_type} | {score_str} | {file_name} |\n"
@@ -211,11 +212,11 @@ def create_detailed_report(results: List[Dict]):
     # Calculate overall statistics
     total_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in results)
     max_possible = len(results) * 50
-    avg_percentage = sum(r.get('overall_score', {}).get('percentage', 0) for r in results) / len(results) if results else 0
+    avg_percentage = sum(reported_percentage(r) for r in results) / len(results) if results else 0
 
     report += f"- **Average Score:** {total_score / len(results):.1f}/50 ({avg_percentage:.1f}%)\n"
-    report += f"- **Best Score:** {max(results, key=lambda x: x.get('overall_score', {}).get('percentage', 0)).get('overall_score', {}).get('percentage', 0):.1f}%\n" if results else ""
-    report += f"- **Worst Score:** {min(results, key=lambda x: x.get('overall_score', {}).get('percentage', 0)).get('overall_score', {}).get('percentage', 0):.1f}%\n" if results else ""
+    report += f"- **Best Score:** {reported_percentage(max(results, key=reported_percentage)):.1f}%\n" if results else ""
+    report += f"- **Worst Score:** {reported_percentage(min(results, key=reported_percentage)):.1f}%\n" if results else ""
 
     # Method comparison
     report += "\n## Method Comparison\n\n"
@@ -224,7 +225,7 @@ def create_detailed_report(results: List[Dict]):
         method_results = [r for r in results if r.get('method') == method]
         if method_results:
             avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in method_results) / len(method_results)
-            avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in method_results) / len(method_results)
+            avg_pct = sum(reported_percentage(r) for r in method_results) / len(method_results)
             report += f"### {method}\n"
             report += f"- Files evaluated: {len(method_results)}\n"
             report += f"- Average score: {avg_score:.1f}/50 ({avg_pct:.1f}%)\n\n"
@@ -236,7 +237,7 @@ def create_detailed_report(results: List[Dict]):
         project_results = [r for r in results if r.get('project') == project]
         if project_results:
             avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in project_results) / len(project_results)
-            avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in project_results) / len(project_results)
+            avg_pct = sum(reported_percentage(r) for r in project_results) / len(project_results)
             report += f"### {project}\n"
             report += f"- Files evaluated: {len(project_results)}\n"
             report += f"- Average score: {avg_score:.1f}/50 ({avg_pct:.1f}%)\n\n"

--- a/scripts/summarize_rubric20_results.py
+++ b/scripts/summarize_rubric20_results.py
@@ -23,7 +23,8 @@ from datetime import datetime
 # It was 84 here while the questions defined 88 (#270 thread).
 from data_sheets_schema.constants import RUBRIC20_MAX_SCORE
 from data_sheets_schema.rubric_pooling import (
-    denominator_label, group_by_denominator, pooling_warning)
+    denominator_label, group_by_denominator, pooling_warning,
+    reported_percentage)
 
 # Base directory
 BASE_DIR = Path(__file__).parent.parent
@@ -81,7 +82,7 @@ def create_csv_summary(results: List[Dict]):
             overall = result.get('overall_score', {})
             total_score = overall.get('total_points', 0)
             max_score = overall.get('max_points', RUBRIC20_MAX_SCORE)
-            percentage = overall.get('percentage', 0)
+            percentage = reported_percentage({'overall_score': overall})
 
             # Category scores
             categories = result.get('categories', {})
@@ -146,7 +147,7 @@ def create_markdown_table(results: List[Dict]):
                 overall = result.get('overall_score', {})
                 total = overall.get('total_points', 0)
                 max_pts = overall.get('max_points', RUBRIC20_MAX_SCORE)
-                pct = overall.get('percentage', 0)
+                pct = reported_percentage({'overall_score': overall})
 
                 # Category scores
                 categories = result.get('categories', {})
@@ -182,7 +183,7 @@ def create_markdown_table(results: List[Dict]):
                 file_count = len(results_list)
 
                 avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in results_list) / file_count
-                avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in results_list) / file_count
+                avg_pct = sum(reported_percentage(r) for r in results_list) / file_count
 
                 # The records carry their own denominator, and 167 committed
                 # rubric20 evaluations were scored against 84 (#275). Printing a
@@ -210,8 +211,8 @@ def create_markdown_table(results: List[Dict]):
     # valid ranking is worse than two shorter ones that are.
     for denom, group in group_by_denominator(results).items():
         ranked = [r for r in group
-                  if r.get('overall_score', {}).get('percentage', 0) >= 80]
-        ranked.sort(key=lambda x: x.get('overall_score', {}).get('percentage', 0),
+                  if reported_percentage(r) >= 80]
+        ranked.sort(key=lambda x: reported_percentage(x),
                     reverse=True)
         if not ranked:
             continue
@@ -224,7 +225,7 @@ def create_markdown_table(results: List[Dict]):
             eval_type = result.get('evaluation_type', 'unknown')
             overall = result.get('overall_score', {})
             score_str = (f"{overall.get('total_points', 0)}/{denom} "
-                         f"({overall.get('percentage', 0):.1f}%)")
+                         f"({reported_percentage({'overall_score': overall}):.1f}%)")
             file_name = Path(result.get('d4d_file', '')).name
             md += f"| {project} | {method} | {eval_type} | {score_str} | {file_name} |\n"
 
@@ -256,13 +257,13 @@ def create_detailed_report(results: List[Dict]):
         if not group:
             continue
         total_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in group)
-        avg_percentage = sum(r.get('overall_score', {}).get('percentage', 0) for r in group) / len(group)
-        best = max(group, key=lambda x: x.get('overall_score', {}).get('percentage', 0))
-        worst = min(group, key=lambda x: x.get('overall_score', {}).get('percentage', 0))
+        avg_percentage = sum(reported_percentage(r) for r in group) / len(group)
+        best = max(group, key=lambda x: reported_percentage(x))
+        worst = min(group, key=lambda x: reported_percentage(x))
         report += f"### Scored out of {denom} ({len(group)} evaluation(s))\n\n"
         report += f"- **Average Score:** {total_score / len(group):.1f}/{denom} ({avg_percentage:.1f}%)\n"
-        report += f"- **Best Score:** {best.get('overall_score', {}).get('percentage', 0):.1f}%\n"
-        report += f"- **Worst Score:** {worst.get('overall_score', {}).get('percentage', 0):.1f}%\n\n"
+        report += f"- **Best Score:** {reported_percentage(best):.1f}%\n"
+        report += f"- **Worst Score:** {reported_percentage(worst):.1f}%\n\n"
 
     # Method comparison
     report += "\n## Method Comparison\n\n"
@@ -276,7 +277,7 @@ def create_detailed_report(results: List[Dict]):
             # would rank it against itself measured two different ways (#275).
             for denom, group in group_by_denominator(method_results).items():
                 avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in group) / len(group)
-                avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in group) / len(group)
+                avg_pct = sum(reported_percentage(r) for r in group) / len(group)
                 report += (f"- Average score: {avg_score:.1f}/{denom} "
                            f"({avg_pct:.1f}%) over {len(group)} evaluation(s)\n")
             report += "\n"
@@ -293,7 +294,7 @@ def create_detailed_report(results: List[Dict]):
             # would rank it against itself measured two different ways (#275).
             for denom, group in group_by_denominator(project_results).items():
                 avg_score = sum(r.get('overall_score', {}).get('total_points', 0) for r in group) / len(group)
-                avg_pct = sum(r.get('overall_score', {}).get('percentage', 0) for r in group) / len(group)
+                avg_pct = sum(reported_percentage(r) for r in group) / len(group)
                 report += (f"- Average score: {avg_score:.1f}/{denom} "
                            f"({avg_pct:.1f}%) over {len(group)} evaluation(s)\n")
             report += "\n"

--- a/scripts/validate_evaluation_schema.py
+++ b/scripts/validate_evaluation_schema.py
@@ -31,23 +31,43 @@ def load_evaluation(eval_path: Path) -> Dict:
         return json.load(f)
 
 
-def validate_evaluation(eval_data: Dict, schema: Dict) -> Tuple[bool, List[str]]:
-    """
-    Validate evaluation data against schema.
+#: Top-level keys of the shape that preceded the current agent contract.
+#: rubric10 evaluations recorded before 2026 report `summary_scores` and
+#: `element_scores`; the agents have instructed `overall_score` and `elements`
+#: since. Such a record is not wrong, it is a different vintage — reporting it
+#: as invalid buries the records that really are.
+SUPERSEDED_SHAPE_KEYS = ("summary_scores", "element_scores")
 
-    Returns:
-        (is_valid, errors): Tuple of validation status and error messages
+
+def classify(eval_data: Dict, schema: Dict) -> Tuple[str, List[str]]:
+    """Validate, distinguishing a superseded shape from a wrong value.
+
+    Returns `("valid" | "superseded" | "invalid", errors)`.
+
+    The distinction is the point. All 28 recorded evaluations failed before the
+    schemas were brought up to the agents (#323), and "Invalid: 28" said nothing
+    about which were merely old. Of the 20 that still fail, 12 predate the
+    contract and 8 report `max_points: 84` — a maximum the rubric has never had
+    (#314). Only the second kind is a defect in a record.
     """
     errors = []
     try:
         validate(instance=eval_data, schema=schema)
-        return True, []
+        return "valid", []
     except ValidationError as e:
         errors.append(f"Validation error: {e.message}")
         errors.append(f"  Path: {' -> '.join(str(p) for p in e.path)}")
         if e.schema_path:
             errors.append(f"  Schema path: {' -> '.join(str(p) for p in e.schema_path)}")
-        return False, errors
+        if any(k in eval_data for k in SUPERSEDED_SHAPE_KEYS):
+            return "superseded", errors
+        return "invalid", errors
+
+
+def validate_evaluation(eval_data: Dict, schema: Dict) -> Tuple[bool, List[str]]:
+    """Back-compatible wrapper: superseded records are not valid."""
+    status, errors = classify(eval_data, schema)
+    return status == "valid", errors
 
 
 def main():
@@ -80,6 +100,7 @@ def main():
     # Validate each file
     valid_count = 0
     invalid_count = 0
+    superseded_count = 0
 
     for eval_file in sorted(eval_files):
         print(f"Validating: {eval_file.name}")
@@ -99,11 +120,15 @@ def main():
             continue
 
         # Validate
-        is_valid, errors = validate_evaluation(eval_data, schemas[rubric])
+        status, errors = classify(eval_data, schemas[rubric])
 
-        if is_valid:
+        if status == "valid":
             print(f"  ✅ Valid")
             valid_count += 1
+        elif status == "superseded":
+            print(f"  🕐 Superseded shape (pre-2026 rubric10 output):")
+            print(f"     {errors[0]}")
+            superseded_count += 1
         else:
             print(f"  ❌ Invalid:")
             for error in errors:
@@ -115,11 +140,14 @@ def main():
     # Summary
     print("=" * 60)
     print(f"SUMMARY:")
-    print(f"  ✅ Valid:   {valid_count}")
-    print(f"  ❌ Invalid: {invalid_count}")
-    print(f"  📊 Total:   {valid_count + invalid_count}")
+    print(f"  ✅ Valid:      {valid_count}")
+    print(f"  🕐 Superseded: {superseded_count}")
+    print(f"  ❌ Invalid:    {invalid_count}")
+    print(f"  📊 Total:      {valid_count + superseded_count + invalid_count}")
     print("=" * 60)
 
+    # Superseded records do not fail the run: they are historical output of a
+    # contract that no longer applies, and nothing can be done to them.
     return 0 if invalid_count == 0 else 1
 
 

--- a/src/data_sheets_schema/rubric_pooling.py
+++ b/src/data_sheets_schema/rubric_pooling.py
@@ -45,6 +45,36 @@ def denominator_of(result: dict[str, Any],
     return (result.get("overall_score") or {}).get("max_points") or default
 
 
+class MissingPercentage(KeyError):
+    """A record reports no percentage under any recognised key."""
+
+    def __init__(self, keys: Iterable[str]):
+        self.keys = sorted(keys)
+        super().__init__(
+            f"no percentage in overall_score (keys: {self.keys}). Expected "
+            f"`normalized_percentage`, or `percentage` on a pre-2026 record.")
+
+
+def reported_percentage(result: dict[str, Any]) -> float:
+    """The percentage a record reports, refusing when it reports none.
+
+    Every consumer read `overall_score.get("percentage", 0)`. The N/A
+    convention renamed that key to `normalized_percentage` — total over the
+    denominator *after* excluding non-applicable items — and the default of `0`
+    turned the absence into a score. Measured across the current corpus: **16 of
+    16 current-shape records reported 0.0%** through the summarisers and the
+    HTML renderer, while their real scores ran 72-99%. Every one was graded F.
+
+    A missing percentage raises. `0` is a real score a record can earn, so it
+    cannot double as "absent" — that conflation is the whole defect.
+    """
+    overall = result.get("overall_score") or {}
+    for key in ("normalized_percentage", "percentage"):
+        if overall.get(key) is not None:
+            return float(overall[key])
+    raise MissingPercentage(overall.keys())
+
+
 def denominators(results: Iterable[dict[str, Any]],
                  default: int = RUBRIC20_MAX_SCORE) -> set[int]:
     return {denominator_of(r, default) for r in results}

--- a/src/download/prompts/rubric10_semantic_schema.json
+++ b/src/download/prompts/rubric10_semantic_schema.json
@@ -4,7 +4,18 @@
   "title": "Rubric10-Semantic Evaluation Schema",
   "description": "Schema for D4D evaluation results using the Rubric10-Semantic framework with semantic validation (10 elements, 50 sub-elements)",
   "type": "object",
-  "required": ["rubric", "version", "d4d_file", "project", "method", "evaluation_timestamp", "model", "summary_scores", "element_scores", "semantic_analysis"],
+  "required": [
+    "rubric",
+    "version",
+    "d4d_file",
+    "project",
+    "method",
+    "evaluation_timestamp",
+    "model",
+    "overall_score",
+    "elements",
+    "semantic_analysis"
+  ],
   "properties": {
     "rubric": {
       "type": "string",
@@ -22,13 +33,33 @@
     },
     "project": {
       "type": "string",
-      "enum": ["AI_READI", "CHORUS", "CM4AI", "VOICE"],
+      "enum": [
+        "AI_READI",
+        "CHORUS",
+        "CM4AI",
+        "VOICE"
+      ],
       "description": "Project name"
     },
     "method": {
       "type": "string",
-      "enum": ["claudecode_agent", "claudecode_assistant", "claudecode", "gpt5", "curated"],
-      "description": "Generation method"
+      "enum": [
+        "curated",
+        "gpt5",
+        "claudecode",
+        "claudecode_agent",
+        "claudecode_agent_core",
+        "claudecode_assistant",
+        "rocrate_mapped",
+        "rocrate_static_map",
+        "claudecode_agent_crate",
+        "claudecode_agent_crate_core",
+        "claudecode_agent_healthsheet",
+        "claudecode_agent_healthsheet_core",
+        "claudecode_agent_crate_only",
+        "claudecode_agent_crate_only_core"
+      ],
+      "description": "Generation method. Mirrors data_sheets_schema.constants.METHODS; pinned by tests/test_evaluation/test_semantic_evaluation_contract.py"
     },
     "evaluation_timestamp": {
       "type": "string",
@@ -37,7 +68,11 @@
     },
     "model": {
       "type": "object",
-      "required": ["name", "temperature", "evaluation_type"],
+      "required": [
+        "name",
+        "temperature",
+        "evaluation_type"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -51,46 +86,73 @@
         },
         "evaluation_type": {
           "type": "string",
-          "enum": ["semantic_llm_judge", "llm_as_judge"],
+          "enum": [
+            "semantic_llm_judge",
+            "llm_as_judge"
+          ],
           "description": "Type of evaluation"
         }
       }
     },
-    "summary_scores": {
+    "overall_score": {
       "type": "object",
-      "required": ["total_score", "total_max_score", "overall_percentage"],
+      "required": [
+        "total_points",
+        "max_points",
+        "excluded_max_points",
+        "adjusted_max_points",
+        "normalized_percentage",
+        "sub_elements_not_applicable"
+      ],
       "properties": {
-        "total_score": {
+        "total_points": {
           "type": "number",
           "minimum": 0,
-          "maximum": 50,
-          "description": "Total points earned (sum of all element scores)"
+          "description": "Points earned across applicable items"
         },
-        "total_max_score": {
+        "max_points": {
           "type": "number",
           "const": 50,
-          "description": "Maximum possible points (10 elements × 5 sub-elements each)"
+          "description": "Maximum before N/A exclusions"
         },
-        "overall_percentage": {
+        "excluded_max_points": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Sum of max_score over items marked applicable: false"
+        },
+        "adjusted_max_points": {
+          "type": "number",
+          "minimum": 0,
+          "description": "max_points minus excluded_max_points"
+        },
+        "normalized_percentage": {
           "type": "number",
           "minimum": 0,
           "maximum": 100,
-          "description": "Percentage score (total_score / total_max_score × 100)"
+          "description": "total_points / adjusted_max_points x 100. The only percentage reported: comparable across records regardless of how many items are excluded."
         },
-        "grade": {
-          "type": "string",
-          "description": "Optional letter grade (A+, A, B+, etc.)"
+        "sub_elements_not_applicable": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of sub-elements marked applicable: false"
         }
       }
     },
-    "element_scores": {
+    "elements": {
       "type": "array",
       "minItems": 10,
       "maxItems": 10,
       "description": "Ten evaluation elements (each with 5 sub-elements)",
       "items": {
         "type": "object",
-        "required": ["id", "name", "description", "sub_elements", "element_score", "element_max"],
+        "required": [
+          "id",
+          "name",
+          "description",
+          "sub_elements",
+          "element_score",
+          "element_max"
+        ],
         "properties": {
           "id": {
             "type": "integer",
@@ -113,16 +175,28 @@
             "description": "Five sub-elements per element (binary 0/1 scoring)",
             "items": {
               "type": "object",
-              "required": ["name", "score", "evidence", "quality_note"],
+              "required": [
+                "name",
+                "score",
+                "evidence",
+                "quality_note"
+              ],
               "properties": {
                 "name": {
                   "type": "string",
                   "description": "Sub-element name/criterion"
                 },
                 "score": {
-                  "type": "integer",
-                  "enum": [0, 1],
-                  "description": "Binary score: 1 = present/satisfied, 0 = absent/not satisfied"
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "enum": [
+                    0,
+                    1,
+                    null
+                  ],
+                  "description": "Binary score: 1 met, 0 not met, null when the sub-element is not applicable. null is a different claim from 0, which says the sub-element was assessed and not met."
                 },
                 "evidence": {
                   "type": "string",
@@ -146,101 +220,127 @@
             "description": "Sum of sub-element scores (0-5)"
           },
           "element_max": {
-            "type": "integer",
-            "const": 5,
-            "description": "Maximum score for element (always 5)"
+            "type": "number",
+            "minimum": 0,
+            "maximum": 5,
+            "description": "Points available for this element after N/A exclusions. Not a constant 5: the convention subtracts excluded sub-elements from the denominator, and records already carry element_max of 3."
           }
         }
       }
     },
     "semantic_analysis": {
       "type": "object",
-      "description": "Semantic validation and quality assessment",
+      "required": [
+        "issues_detected",
+        "semantic_insights",
+        "consistency_checks",
+        "correctness_validations"
+      ],
       "properties": {
         "issues_detected": {
           "type": "array",
-          "description": "List of semantic or format issues found",
+          "description": "Semantic issues found during evaluation",
           "items": {
             "type": "object",
-            "required": ["type", "severity", "description"],
+            "required": [
+              "type",
+              "severity",
+              "description",
+              "fields_involved",
+              "recommendation"
+            ],
             "properties": {
               "type": {
                 "type": "string",
-                "description": "Issue type (format_error, inconsistency, missing_data, etc.)"
+                "description": "Issue type (e.g. correctness, consistency, completeness, content_accuracy, semantic_understanding)"
               },
               "severity": {
                 "type": "string",
-                "enum": ["critical", "warning", "info"],
-                "description": "Issue severity level"
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "description": "Issue severity"
               },
               "description": {
                 "type": "string",
-                "description": "Detailed issue description"
+                "description": "Issue description"
               },
               "fields_involved": {
                 "type": "array",
-                "items": {"type": "string"},
-                "description": "D4D fields related to this issue"
+                "items": {
+                  "type": "string"
+                },
+                "description": "D4D fields involved"
               },
               "recommendation": {
                 "type": "string",
-                "description": "Suggested fix or improvement"
+                "description": "Recommendation for fixing"
               }
             }
           }
         },
+        "semantic_insights": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Positive semantic observations"
+        },
         "consistency_checks": {
           "type": "object",
-          "description": "Internal consistency validation results",
+          "required": [
+            "passed",
+            "failed",
+            "warnings"
+          ],
           "properties": {
             "passed": {
-              "type": "array",
-              "items": {"type": "string"},
-              "description": "Consistency checks that passed"
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of consistency checks passed"
             },
             "failed": {
-              "type": "array",
-              "items": {"type": "string"},
-              "description": "Consistency checks that failed"
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of consistency checks failed"
             },
             "warnings": {
-              "type": "array",
-              "items": {"type": "string"},
-              "description": "Consistency warnings"
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of warnings issued"
             }
           }
         },
         "correctness_validations": {
           "type": "object",
-          "description": "Format and correctness validation results",
+          "description": "Format validation results (valid/invalid/not_applicable/not_present, may include specific validators like valid_nih, valid_zenodo)",
           "properties": {
             "doi_format": {
               "type": "string",
-              "enum": ["valid", "invalid", "missing"],
-              "description": "DOI format validation"
+              "description": "DOI format validation (e.g., valid, valid_zenodo, invalid, not_applicable, not_present)"
             },
-            "grant_format": {
+            "grant_number_format": {
               "type": "string",
-              "enum": ["valid", "invalid", "missing"],
-              "description": "Grant number format validation"
+              "description": "Grant number format validation (e.g., valid, valid_nih, invalid, not_applicable, not_present)"
             },
             "rrid_format": {
               "type": "string",
-              "enum": ["valid", "invalid", "missing"],
-              "description": "RRID format validation"
+              "description": "RRID format validation (e.g., valid, invalid, not_applicable, not_present)"
             },
             "url_validity": {
               "type": "string",
-              "enum": ["all_valid", "some_invalid", "not_checked"],
-              "description": "URL format and accessibility check"
+              "description": "URL validation status (e.g., all_valid, some_invalid, not_applicable, not_present)"
             }
+          },
+          "additionalProperties": {
+            "type": "string",
+            "description": "Additional validation results"
           }
-        },
-        "semantic_insights": {
-          "type": "string",
-          "description": "High-level semantic analysis insights and observations"
         }
-      }
+      },
+      "description": "Semantic validation and quality assessment"
     },
     "recommendations": {
       "type": "array",

--- a/src/download/prompts/rubric20_semantic_schema.json
+++ b/src/download/prompts/rubric20_semantic_schema.json
@@ -4,7 +4,18 @@
   "title": "Rubric20-Semantic Evaluation Schema",
   "description": "Schema for D4D evaluation results using the Rubric20-Semantic framework with semantic validation",
   "type": "object",
-  "required": ["rubric", "version", "d4d_file", "project", "method", "evaluation_timestamp", "model", "overall_score", "categories", "semantic_analysis"],
+  "required": [
+    "rubric",
+    "version",
+    "d4d_file",
+    "project",
+    "method",
+    "evaluation_timestamp",
+    "model",
+    "overall_score",
+    "categories",
+    "semantic_analysis"
+  ],
   "properties": {
     "rubric": {
       "type": "string",
@@ -26,7 +37,23 @@
     },
     "method": {
       "type": "string",
-      "description": "Generation method (claudecode_agent, claudecode_assistant, gpt5, curated)"
+      "enum": [
+        "curated",
+        "gpt5",
+        "claudecode",
+        "claudecode_agent",
+        "claudecode_agent_core",
+        "claudecode_assistant",
+        "rocrate_mapped",
+        "rocrate_static_map",
+        "claudecode_agent_crate",
+        "claudecode_agent_crate_core",
+        "claudecode_agent_healthsheet",
+        "claudecode_agent_healthsheet_core",
+        "claudecode_agent_crate_only",
+        "claudecode_agent_crate_only_core"
+      ],
+      "description": "Generation method. Mirrors data_sheets_schema.constants.METHODS; pinned by tests/test_evaluation/test_semantic_evaluation_contract.py"
     },
     "evaluation_timestamp": {
       "type": "string",
@@ -35,7 +62,11 @@
     },
     "model": {
       "type": "object",
-      "required": ["name", "temperature", "evaluation_type"],
+      "required": [
+        "name",
+        "temperature",
+        "evaluation_type"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -55,23 +86,45 @@
     },
     "overall_score": {
       "type": "object",
-      "required": ["total_points", "max_points", "percentage"],
+      "required": [
+        "total_points",
+        "max_points",
+        "excluded_max_points",
+        "adjusted_max_points",
+        "normalized_percentage",
+        "questions_not_applicable"
+      ],
       "properties": {
         "total_points": {
           "type": "number",
           "minimum": 0,
-          "description": "Total points earned"
+          "description": "Points earned across applicable items"
         },
         "max_points": {
           "type": "number",
           "const": 88,
-          "description": "Maximum possible points (20 questions × average 4.2 points)"
+          "description": "Maximum before N/A exclusions"
         },
-        "percentage": {
+        "excluded_max_points": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Sum of max_score over items marked applicable: false"
+        },
+        "adjusted_max_points": {
+          "type": "number",
+          "minimum": 0,
+          "description": "max_points minus excluded_max_points"
+        },
+        "normalized_percentage": {
           "type": "number",
           "minimum": 0,
           "maximum": 100,
-          "description": "Percentage score"
+          "description": "total_points / adjusted_max_points x 100. The only percentage reported: comparable across records regardless of how many items are excluded."
+        },
+        "questions_not_applicable": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of questions marked applicable: false"
         }
       }
     },
@@ -82,7 +135,10 @@
       "description": "Four evaluation categories",
       "items": {
         "type": "object",
-        "required": ["name", "questions"],
+        "required": [
+          "name",
+          "questions"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -94,7 +150,17 @@
             "description": "Questions in this category",
             "items": {
               "type": "object",
-              "required": ["id", "name", "description", "score_type", "score", "max_score", "score_label", "evidence", "quality_note"],
+              "required": [
+                "id",
+                "name",
+                "description",
+                "score_type",
+                "score",
+                "max_score",
+                "score_label",
+                "evidence",
+                "quality_note"
+              ],
               "properties": {
                 "id": {
                   "type": "integer",
@@ -112,13 +178,18 @@
                 },
                 "score_type": {
                   "type": "string",
-                  "enum": ["numeric", "pass_fail"],
+                  "enum": [
+                    "numeric",
+                    "pass_fail"
+                  ],
                   "description": "Scoring type"
                 },
                 "score": {
-                  "type": "number",
-                  "minimum": 0,
-                  "description": "Points awarded"
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "description": "Points awarded. null when applicable is false — distinct from 0, which means scored and earned nothing."
                 },
                 "max_score": {
                   "type": "number",
@@ -141,6 +212,21 @@
                 "semantic_analysis": {
                   "type": "string",
                   "description": "Semantic validation notes (optional)"
+                },
+                "applicable": {
+                  "type": [
+                    "boolean",
+                    "string"
+                  ],
+                  "description": "Whether the question's 'Applies to' condition is met"
+                },
+                "applicability_status": {
+                  "type": "string",
+                  "description": "always_applicable | applicable | not_applicable"
+                },
+                "applicability_evidence": {
+                  "type": "string",
+                  "description": "Fields belonging to a different question that evidence the applicability decision (the anti-circular rule)"
                 }
               }
             }
@@ -150,23 +236,37 @@
     },
     "semantic_analysis": {
       "type": "object",
-      "required": ["issues_detected", "semantic_insights", "consistency_checks", "correctness_validations"],
+      "required": [
+        "issues_detected",
+        "semantic_insights",
+        "consistency_checks",
+        "correctness_validations"
+      ],
       "properties": {
         "issues_detected": {
           "type": "array",
           "description": "Semantic issues found during evaluation",
           "items": {
             "type": "object",
-            "required": ["type", "severity", "description", "fields_involved", "recommendation"],
+            "required": [
+              "type",
+              "severity",
+              "description",
+              "fields_involved",
+              "recommendation"
+            ],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["correctness", "consistency", "completeness", "semantic_understanding"],
-                "description": "Issue type"
+                "description": "Issue type (e.g. correctness, consistency, completeness, content_accuracy, semantic_understanding)"
               },
               "severity": {
                 "type": "string",
-                "enum": ["low", "medium", "high"],
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
                 "description": "Issue severity"
               },
               "description": {
@@ -175,7 +275,9 @@
               },
               "fields_involved": {
                 "type": "array",
-                "items": {"type": "string"},
+                "items": {
+                  "type": "string"
+                },
                 "description": "D4D fields involved"
               },
               "recommendation": {
@@ -187,12 +289,18 @@
         },
         "semantic_insights": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "description": "Positive semantic observations"
         },
         "consistency_checks": {
           "type": "object",
-          "required": ["passed", "failed", "warnings"],
+          "required": [
+            "passed",
+            "failed",
+            "warnings"
+          ],
           "properties": {
             "passed": {
               "type": "integer",
@@ -245,17 +353,23 @@
       "properties": {
         "strengths": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "description": "Overall strengths"
         },
         "weaknesses": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "description": "Overall weaknesses"
         },
         "recommendations": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "description": "Recommendations for improvement"
         }
       }

--- a/tests/test_evaluation/test_semantic_evaluation_contract.py
+++ b/tests/test_evaluation/test_semantic_evaluation_contract.py
@@ -1,0 +1,310 @@
+"""The semantic schemas must describe what the agents instruct (#323).
+
+`scripts/validate_evaluation_schema.py` reported `Valid: 0, Invalid: 28` — not
+one recorded semantic evaluation conformed to its own JSON schema. Nothing ran
+the validator, so nothing said so.
+
+Six independent drifts, all the same shape: the schemas described the 2025-12
+output and the agents moved on.
+
+    rubric20  overall_score required `percentage`; the agent emits the N/A
+              vocabulary (`normalized_percentage`, `adjusted_max_points`, …)
+    rubric10  required `summary_scores` / `element_scores`; the agent has
+              instructed `overall_score` / `elements` since 2026-07
+    both      `score` typed `number`, so `score: null` — the N/A convention's
+              way of saying "not assessed", already on disk 6 times — failed
+    rubric10  `semantic_insights` typed `string` against an array
+    rubric10  `severity` enumerated critical|warning|info against the agent's
+              low|medium|high, `consistency_checks` typed as arrays against
+              three counters, `grant_format` against `grant_number_format`
+    rubric10  `method` enumerated a hand-written subset that rejected
+              `claudecode_agent_core`, a method the pipeline has produced for
+              months
+    rubric10  `element_max` fixed at `const: 5`, which the N/A convention
+              contradicts — records already carry `element_max: 3`
+
+The tests below assert the *contract*, not that historical records pass. Twenty
+still fail and should: 12 predate the contract, and 8 report `max_points: 84`,
+a maximum the rubric has never had (#314). Weakening the schema to admit those
+would be the opposite of the fix.
+
+The load-bearing test is `TestTheContractIsSatisfiable`: a record built to what
+the agent documents must validate. That is what the rerun will produce, and it
+is the only test here that would have failed for every one of the six drifts at
+once.
+"""
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.constants import METHODS
+from data_sheets_schema.constants.evaluation import RUBRIC10_PATH, RUBRIC20_PATH
+
+REPO = Path(__file__).resolve().parents[2]
+PROMPTS = REPO / "src" / "download" / "prompts"
+SCHEMAS = {
+    "rubric10-semantic": PROMPTS / "rubric10_semantic_schema.json",
+    "rubric20-semantic": PROMPTS / "rubric20_semantic_schema.json",
+}
+VALIDATOR = REPO / "scripts" / "validate_evaluation_schema.py"
+
+
+def _schema(name):
+    return json.loads(SCHEMAS[name].read_text())
+
+
+def _validator():
+    spec = importlib.util.spec_from_file_location("validate_evaluation_schema", VALIDATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _rubric20_maximum():
+    questions = yaml.safe_load(Path(RUBRIC20_PATH).read_text())[
+        "d4d_evaluation_rubric"]["rubric"]
+    return sum(1 if q.get("score_type") == "pass_fail" else 5 for q in questions)
+
+
+def _rubric10_maximum():
+    elements = yaml.safe_load(Path(RUBRIC10_PATH).read_text())[
+        "d4d_complex_proxy_rubric"]["rubric"]
+    return sum(len(e.get("sub_elements") or []) for e in elements)
+
+
+def _semantic_analysis():
+    """The block both agents instruct, identically."""
+    return {
+        "issues_detected": [{
+            "type": "consistency",
+            "severity": "medium",
+            "description": "human_subject_research is true with no ethical_reviews",
+            "fields_involved": ["human_subject_research", "ethical_reviews"],
+            "recommendation": "Populate ethical_reviews",
+        }],
+        "semantic_insights": ["PhysioNet DOI prefix (10.13026) correctly used"],
+        "consistency_checks": {"passed": 15, "failed": 2, "warnings": 3},
+        "correctness_validations": {
+            "doi_format": "valid",
+            "grant_number_format": "valid",
+            "rrid_format": "not_present",
+            "url_validity": "all_valid",
+        },
+    }
+
+
+def _rubric20_record(**overrides):
+    """A rubric20-semantic evaluation shaped as the agent documents it.
+
+    Built from `rubric20.txt` rather than hand-written, so it carries all 20
+    questions in the four categories the schema requires, with each question's
+    real name and score type. A one-category stub passed the checks that matter
+    here while failing `minItems: 4`, which is the schema being right.
+    """
+    questions = yaml.safe_load(Path(RUBRIC20_PATH).read_text())[
+        "d4d_evaluation_rubric"]["rubric"]
+    names = ["Structural Completeness", "Metadata Quality & Content",
+             "Technical Documentation", "FAIRness & Accessibility"]
+    categories = []
+    for index, name in enumerate(names):
+        block = questions[index * 5:(index + 1) * 5]
+        rendered, earned, available = [], 0, 0
+        for q in block:
+            pass_fail = q.get("score_type") == "pass_fail"
+            top = 1 if pass_fail else 5
+            entry = {
+                "id": q["id"], "name": q["name"],
+                "description": (q.get("description") or "")[:120],
+                "score_type": q.get("score_type"), "score": top,
+                "max_score": top, "score_label": "top band",
+                "evidence": "quoted from the record",
+                "quality_note": "assessed against the named fields",
+            }
+            if q["id"] == 11:
+                # The N/A convention, which `score: {type: number}` rejected.
+                entry.update({"score": None, "applicable": "false",
+                              "applicability_status": "not_applicable",
+                              "applicability_evidence":
+                                  "no code repository in external_resources",
+                              "score_label": "Not applicable",
+                              "quality_note": "Excluded from the denominator"})
+            else:
+                earned += top
+            available += top
+            rendered.append(entry)
+        categories.append({"name": name, "questions": rendered,
+                           "category_score": earned, "category_max": available})
+
+    top = _rubric20_maximum()
+    record = {
+        "rubric": "rubric20-semantic",
+        "version": "1.0",
+        "d4d_file": "AI_READI_d4d.yaml",
+        "project": "AI_READI",
+        "method": "claudecode_agent_core",
+        "evaluation_timestamp": "2026-08-05T00:00:00Z",
+        "model": {"name": "claude-fable-5", "temperature": 0.0,
+                  "evaluation_type": "semantic_llm_judge"},
+        "overall_score": {
+            "total_points": top - 5, "max_points": top,
+            "excluded_max_points": 5, "adjusted_max_points": top - 5,
+            "normalized_percentage": 100.0, "questions_not_applicable": 1,
+        },
+        "categories": categories,
+        "semantic_analysis": _semantic_analysis(),
+    }
+    record.update(overrides)
+    return record
+
+
+def _rubric10_record(**overrides):
+    """A rubric10-semantic evaluation shaped as the agent documents it."""
+    record = {
+        "rubric": "rubric10-semantic",
+        "version": "1.0",
+        "d4d_file": "AI_READI_d4d.yaml",
+        "project": "AI_READI",
+        "method": "claudecode_agent_core",
+        "evaluation_timestamp": "2026-08-05T00:00:00Z",
+        "model": {"name": "claude-fable-5", "temperature": 0.0,
+                  "evaluation_type": "semantic_llm_judge"},
+        "overall_score": {
+            "total_points": 38, "max_points": _rubric10_maximum(),
+            "excluded_max_points": 2, "adjusted_max_points": _rubric10_maximum() - 2,
+            "normalized_percentage": 79.2, "sub_elements_not_applicable": 2,
+        },
+        "elements": [
+            {"id": i, "name": f"Element {i}", "description": "…",
+             "sub_elements": [
+                 {"name": f"sub {j}", "score": 1, "evidence": "…",
+                  "quality_note": "…"} for j in range(1, 6)],
+             "element_score": 5, "element_max": 5}
+            for i in range(1, 11)
+        ],
+        "semantic_analysis": _semantic_analysis(),
+    }
+    # Element 8 carries the N/A convention: two sub-elements excluded, so its
+    # maximum is 3 rather than 5. `const: 5` forbade exactly this.
+    record["elements"][7]["sub_elements"][0]["score"] = None
+    record["elements"][7]["sub_elements"][1]["score"] = None
+    record["elements"][7]["element_score"] = 3
+    record["elements"][7]["element_max"] = 3
+    record.update(overrides)
+    return record
+
+
+class TestTheContractIsSatisfiable(unittest.TestCase):
+    """A record shaped as the agent documents must validate.
+
+    Every one of the six drifts would fail this, which is why it is here rather
+    than a test per drift. If the agents change again, this is what breaks.
+    """
+
+    def _assert_valid(self, record, schema_name):
+        import jsonschema
+        errors = sorted(jsonschema.Draft7Validator(_schema(schema_name)).iter_errors(record),
+                        key=lambda e: list(e.absolute_path))
+        self.assertEqual(
+            [], [f"{list(e.absolute_path)}: {e.message}" for e in errors])
+
+    def test_a_rubric20_record_as_the_agent_documents_it_validates(self):
+        self._assert_valid(_rubric20_record(), "rubric20-semantic")
+
+    def test_a_rubric10_record_as_the_agent_documents_it_validates(self):
+        self._assert_valid(_rubric10_record(), "rubric10-semantic")
+
+    def test_a_record_with_no_exclusions_validates(self):
+        """The N/A vocabulary is required, not conditional on anything being
+        excluded — a record that excludes nothing still reports zeros."""
+        top = _rubric20_maximum()
+        self._assert_valid(_rubric20_record(overall_score={
+            "total_points": 80, "max_points": top, "excluded_max_points": 0,
+            "adjusted_max_points": top, "normalized_percentage": 90.9,
+            "questions_not_applicable": 0}), "rubric20-semantic")
+
+
+class TestTheSchemasStillReject(unittest.TestCase):
+    """The contract has to be able to say no, or the tests above are vacuous."""
+
+    def _errors(self, record, schema_name):
+        import jsonschema
+        return list(jsonschema.Draft7Validator(_schema(schema_name)).iter_errors(record))
+
+    def test_the_superseded_maximum_is_rejected(self):
+        """The 8 recorded rubric20 evaluations report 84 and should fail."""
+        bad = _rubric20_record()
+        bad["overall_score"]["max_points"] = 84
+        self.assertTrue(self._errors(bad, "rubric20-semantic"))
+
+    def test_an_unknown_method_is_rejected(self):
+        bad = _rubric20_record(method="claudecode_agent_corex")
+        self.assertTrue(self._errors(bad, "rubric20-semantic"))
+
+    def test_a_missing_normalized_percentage_is_rejected(self):
+        bad = _rubric20_record()
+        del bad["overall_score"]["normalized_percentage"]
+        self.assertTrue(self._errors(bad, "rubric20-semantic"))
+
+    def test_a_sub_element_score_outside_the_vocabulary_is_rejected(self):
+        bad = _rubric10_record()
+        bad["elements"][0]["sub_elements"][0]["score"] = 3
+        self.assertTrue(self._errors(bad, "rubric10-semantic"))
+
+
+class TestTheDenominators(unittest.TestCase):
+    """Pinned to the rubrics, not restated."""
+
+    def test_rubric20_max_points_matches_the_questions(self):
+        node = _schema("rubric20-semantic")["properties"]["overall_score"] \
+            ["properties"]["max_points"]
+        self.assertEqual(node.get("const"), _rubric20_maximum())
+
+    def test_rubric10_max_points_matches_the_sub_elements(self):
+        node = _schema("rubric10-semantic")["properties"]["overall_score"] \
+            ["properties"]["max_points"]
+        self.assertEqual(node.get("const"), _rubric10_maximum())
+
+
+class TestTheMethodVocabulary(unittest.TestCase):
+    """A hand-written subset rejected `claudecode_agent_core` for months."""
+
+    def test_both_schemas_enumerate_the_canonical_methods(self):
+        for name in SCHEMAS:
+            with self.subTest(schema=name):
+                self.assertEqual(_schema(name)["properties"]["method"].get("enum"),
+                                 list(METHODS))
+
+
+class TestTheValidatorClassifies(unittest.TestCase):
+    """`Invalid: 28` said nothing about which records were merely old."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _validator()
+
+    def test_a_conformant_record_is_valid(self):
+        status, _ = self.module.classify(_rubric20_record(), _schema("rubric20-semantic"))
+        self.assertEqual(status, "valid")
+
+    def test_a_pre_contract_shape_is_superseded_not_invalid(self):
+        old = _rubric10_record()
+        old["summary_scores"] = old.pop("overall_score")
+        old["element_scores"] = old.pop("elements")
+        status, _ = self.module.classify(old, _schema("rubric10-semantic"))
+        self.assertEqual(status, "superseded")
+
+    def test_a_wrong_value_in_the_current_shape_is_invalid(self):
+        """The distinction that matters: an 84-denominator record has the right
+        shape and the wrong number, and must not be excused as old."""
+        bad = _rubric20_record()
+        bad["overall_score"]["max_points"] = 84
+        status, _ = self.module.classify(bad, _schema("rubric20-semantic"))
+        self.assertEqual(status, "invalid")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation/test_semantic_evaluation_contract.py
+++ b/tests/test_evaluation/test_semantic_evaluation_contract.py
@@ -306,5 +306,79 @@ class TestTheValidatorClassifies(unittest.TestCase):
         self.assertEqual(status, "invalid")
 
 
+class TestTheReportedPercentage(unittest.TestCase):
+    """Every consumer read `overall_score.get("percentage", 0)`.
+
+    The N/A convention renamed that key to `normalized_percentage`, and the
+    default of `0` turned the absence into a score. Measured across the corpus:
+    **16 of 16 current-shape records reported 0.0%** through both summarisers
+    and both HTML renderers, while their real scores ran 72-99%. The rubric20
+    renderer grades on that number, so every current record was graded F.
+
+    Silent, because `0` is a plausible reading. That is exactly why it cannot
+    double as "absent".
+    """
+
+    def test_the_current_key_is_read(self):
+        from data_sheets_schema.rubric_pooling import reported_percentage
+        self.assertEqual(reported_percentage(_rubric20_record()), 100.0)
+
+    def test_a_pre_2026_record_is_still_readable(self):
+        from data_sheets_schema.rubric_pooling import reported_percentage
+        self.assertEqual(
+            reported_percentage({"overall_score": {"percentage": 61.0}}), 61.0)
+
+    def test_zero_is_a_score_not_an_absence(self):
+        """The distinction the default destroyed."""
+        from data_sheets_schema.rubric_pooling import reported_percentage
+        self.assertEqual(
+            reported_percentage({"overall_score": {"normalized_percentage": 0}}), 0.0)
+
+    def test_a_record_with_no_percentage_raises(self):
+        from data_sheets_schema.rubric_pooling import (MissingPercentage,
+                                                       reported_percentage)
+        with self.assertRaises(MissingPercentage):
+            reported_percentage({"overall_score": {"total_points": 40}})
+
+    def test_every_recorded_current_shape_record_reads_back_nonzero(self):
+        """The measurement, as a test: before the fix this was 0.0 for all 16."""
+        import glob
+        from data_sheets_schema.rubric_pooling import reported_percentage
+        seen = 0
+        for path in glob.glob(str(REPO / "data" / "evaluation_llm" /
+                                  "*_semantic" / "concatenated" / "*.json")):
+            record = json.loads(Path(path).read_text())
+            if "overall_score" not in record:
+                continue  # pre-contract shape, covered by the validator
+            seen += 1
+            with self.subTest(record=Path(path).name):
+                self.assertGreater(reported_percentage(record), 0.0)
+        self.assertGreaterEqual(seen, 8, "no current-shape records found to check")
+
+    def test_no_consumer_defaults_a_missing_percentage_to_zero(self):
+        """The reader is only a fix if the callers use it.
+
+        Source-level, deliberately: the defect is the *absence* of a call, and
+        running each script needs a corpus and writes reports.
+        """
+        import re
+        # Only the overall-score read. Element-level percentages are a
+        # different structure with their own denominator, and matching them
+        # would make this test fail for something it is not about.
+        pattern = re.compile(
+            r"""overall_score["'],\s*\{\}\)\.get\(['"]percentage['"],\s*0\)"""
+            r"""|\boverall\.get\(['"]percentage['"],\s*0\)""")
+        for name in ("summarize_rubric10_results.py",
+                     "summarize_rubric20_results.py",
+                     "render_evaluation_html_rubric10_semantic.py",
+                     "render_evaluation_html_rubric20_semantic.py"):
+            path = REPO / "scripts" / name
+            if not path.exists():
+                continue
+            with self.subTest(script=name):
+                self.assertIsNone(pattern.search(path.read_text()),
+                                  f"{name} still defaults a missing percentage to 0")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #323.

## What was wrong

`scripts/validate_evaluation_schema.py` reported `Valid: 0, Invalid: 28`. Not one
recorded semantic evaluation conformed to its own JSON schema. Nothing runs the
validator, so nothing said so — and the rerun's twelve semantic evaluations would
have been rejected the same way.

Six independent drifts, all the same shape: the schemas describe the 2025-12
output and the agents moved on.

| | drift |
|---|---|
| rubric20 | `overall_score` required `percentage`; the agent emits the N/A vocabulary and says the normalized one is *the only percentage reported* |
| rubric10 | required `summary_scores`/`element_scores`; the agent has instructed `overall_score`/`elements` since 2026-07 |
| both | `score` typed `number`, so `score: null` — "not assessed" — failed. Already on disk 6 times. |
| rubric10 | `semantic_insights` typed `string` against an array; `severity` enumerated `critical\|warning\|info` against the agent's `low\|medium\|high`; `consistency_checks` typed as arrays against three counters; `grant_format` against `grant_number_format` |
| rubric10 | `method` enumerated a hand-written subset that rejected `claudecode_agent_core`, a method the pipeline has produced for months |
| rubric10 | `element_max` fixed at `const: 5`, contradicting the N/A convention — records already carry `element_max: 3` |

## Decisions I made rather than leaving open

**`normalized_percentage` is the reported figure.** The agent says so
explicitly ("This is the only percentage reported; it is comparable across
datasheets regardless of how many questions are excluded"), and all 24 records
emit it. `percentage` is gone rather than kept as an alias — two percentages
with different denominators is how this kind of thing goes wrong again.

**Two vocabularies dropped rather than widened.** The issue `type` and
rubric10's `correctness_validations` enumerated values the agents never
documented and records outgrew (`content_accuracy`, `not_present`,
`mostly_valid`). rubric20 had already taken this line for the latter. A schema
that rejects real work over a taxonomy nobody maintains is worse than no
constraint; the vocabulary is now documented in the description.

**`method` mirrors `constants.METHODS`**, pinned by a test — the same shape as
#317's `BiasTypeEnum`.

## Twenty records still fail, and should

    ✅ Valid:      8
    🕐 Superseded: 12   pre-2026 rubric10 shape; nothing to be done to them
    ❌ Invalid:     8   `max_points: 84`, a maximum the rubric never had (#314)

`Invalid: 28` said nothing about which records were merely old. Weakening the
schema to admit the 84-denominator records would be the opposite of the fix, so
`classify()` separates a superseded *shape* from a wrong *value*, and only the
second fails the run.

## Testing

13 tests. The load-bearing one builds a record from `rubric20.txt` — all 20
questions in the four categories the schema requires, one carrying the N/A
convention — and asserts it validates. That is what the rerun will produce, and
it is the single test that would have failed for all six drifts at once.

Its first version used one category: it passed every check that mattered while
failing `minItems: 4`, which was the schema being right and the fixture being
lazy.

Mutation-checked with 12 reintroductions, no survivors. `1181 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)