### PR TITLE
Name the nested keys a record may use (#325)

### DIFF
--- a/src/data_sheets_schema/schema_digest.py
+++ b/src/data_sheets_schema/schema_digest.py
@@ -41,6 +41,21 @@ DESCRIPTION_CHARS = 300
 # vocabulary costs 38 bytes more than the clipped one, in a cached prefix.
 MAX_ENUM_VALUES = 60
 
+# Attribute names every class inherits. Listing them on all 66 nested classes
+# would be 264 tokens saying nothing — the model already reaches for
+# `description`, which is the problem this listing exists to solve.
+UNIVERSAL_ATTRIBUTES = frozenset({"id", "name", "description", "used_software"})
+
+# Optional attributes listed per nested class before truncating.
+MAX_OPTIONAL_SHOWN = 24
+
+# Above this overlap with the top-level slot listing, a nested class is
+# described by reference instead of enumerated. Exactly three classes qualify —
+# `Dataset` (100%), `DataSubset` (98%) and `FileCollection` (85%) — and they are
+# the three large enough to be truncated, so listing the alphabetically-first 24
+# would spend the tokens on a redundant and arbitrary slice.
+MIRRORS_TOP_LEVEL = 0.8
+
 
 @dataclass
 class SlotDigest:
@@ -205,9 +220,37 @@ def render(digest: ClassDigest) -> str:
             "object, or the record fails validation.",
             "",
         ]
+        top_level = {s.name for s in digest.slots}
         for n in digest.nested:
             req = ", ".join(f"`{k}`" for k in n.required) if n.required else "none"
             lines.append(f"- **{n.name}** — required: {req}")
+            # `optional` was collected from the first version and never
+            # rendered, so the digest said which nested keys were *mandatory*
+            # and never which were *available*. 54 of 66 classes rendered as a
+            # bare "required: none", and 367 attributes were named nowhere.
+            #
+            # Measured on the 25 current records: not one populates
+            # `regulatory_restrictions.confidentiality_level`,
+            # `.hipaa_compliant`, `.other_compliance` or
+            # `.governance_committee_contact`. Every record instead writes prose
+            # into that object's `description`, and the prose *contains the
+            # answers* — "FDA Regulated: No", "De-identified Samples: Yes". The
+            # model had the facts and no structured place it had been told
+            # about. Q9 of rubric20 is capped at 3/5 on every record as a direct
+            # result.
+            optional = [k for k in n.optional if k not in UNIVERSAL_ATTRIBUTES]
+            if optional:
+                own = [k for k in optional if k not in top_level]
+                mirrors = 1 - len(own) / len(optional) >= MIRRORS_TOP_LEVEL
+                if mirrors:
+                    extra = (" plus " + ", ".join(f"`{k}`" for k in own)) if own else ""
+                    lines.append("    - also accepts the same slots as the "
+                                 f"top-level listing above{extra}")
+                else:
+                    shown = ", ".join(f"`{k}`" for k in optional[:MAX_OPTIONAL_SHOWN])
+                    over = len(optional) - MAX_OPTIONAL_SHOWN
+                    tail = f" (+{over} more)" if over > 0 else ""
+                    lines.append(f"    - also accepts: {shown}{tail}")
             # A controlled vocabulary on a nested slot has to be shown here or
             # nowhere: the top-level listing never reaches it.
             for slot_name, values in sorted(n.enums.items()):

--- a/tests/test_schema/test_schema_digest_optional.py
+++ b/tests/test_schema/test_schema_digest_optional.py
@@ -1,0 +1,174 @@
+"""The digest must name the nested keys a record may use, not only the required ones (#325).
+
+`NestedClass` has carried an `optional` list since the first version. `build()`
+populated it. `render()` never emitted it. So the digest told a run which nested
+keys were *mandatory* and never which were *available*: 54 of 66 nested classes
+rendered as a bare `required: none`, and 367 attributes were named nowhere in
+the text the model receives.
+
+The measurement that made this concrete. Across the 25 current records, not one
+populates `regulatory_restrictions.confidentiality_level`, `.hipaa_compliant`,
+`.other_compliance` or `.governance_committee_contact` — all four real slots.
+Every record instead writes prose into that object's `description`, and the
+prose *contains the answers*: "FDA Regulated: No", "De-identified Samples: Yes",
+a license clause about data security and privacy standards. The model had the
+facts and no structured place it had been told about.
+
+Downstream, rubric20's Q9 asks for confidentiality classification and a
+governance contact at band 5, so it scores exactly 3/5 on every record —
+constant, and not because the datasheets are uniform.
+
+Two of the four were already visible, because enum-ranged nested slots have
+always been rendered with their vocabularies. That is why this file asserts the
+*listing*, not the outcome: making a field addressable is what the digest can
+do. Whether a run then fills it is a question for the next generation, and one
+these tests deliberately do not pretend to answer.
+"""
+
+import unittest
+
+from data_sheets_schema import schema_digest
+from data_sheets_schema.schema_digest import (MIRRORS_TOP_LEVEL,
+                                              UNIVERSAL_ATTRIBUTES)
+
+
+class TestOptionalAttributesAreRendered(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.digest = schema_digest.build("Dataset")
+        cls.text = schema_digest.render(cls.digest)
+        cls.nested = {n.name: n for n in cls.digest.nested}
+
+    def test_the_premise_the_class_has_no_required_attributes(self):
+        """If it ever gains one, `required: none` stops being the whole story
+        and this file's motivating example needs rewriting rather than passing
+        by accident."""
+        self.assertEqual(self.nested["ExportControlRegulatoryRestrictions"].required,
+                         [])
+
+    def test_the_governance_fields_are_named(self):
+        """The four that no record populates. Two were visible via their enums;
+        `other_compliance` and `governance_committee_contact` were not named
+        anywhere at all."""
+        for attribute in ("confidentiality_level", "hipaa_compliant",
+                          "other_compliance", "governance_committee_contact"):
+            with self.subTest(attribute=attribute):
+                self.assertIn(f"`{attribute}`", self.text)
+
+    def test_no_class_is_rendered_with_nothing_but_required_none(self):
+        """54 of 66 were. A class described only by what it does not require
+        tells a run nothing it can act on."""
+        blind = [n.name for n in self.digest.nested
+                 if not n.required and not n.enums
+                 and [k for k in n.optional if k not in UNIVERSAL_ATTRIBUTES]
+                 and f"**{n.name}** — required: none\n" == self._block(n.name)]
+        self.assertEqual(blind, [])
+
+    def _block(self, name):
+        """The rendered line for a class plus its indented continuations."""
+        lines = self.text.splitlines()
+        for i, line in enumerate(lines):
+            if line.startswith(f"- **{name}** — required:"):
+                out = [line[2:] + "\n"]
+                for follow in lines[i + 1:]:
+                    if not follow.startswith("    "):
+                        break
+                    out.append(follow + "\n")
+                return "".join(out)
+        return ""
+
+    def test_universal_attributes_are_not_repeated_on_every_class(self):
+        """`id`, `name`, `description` and `used_software` are on all 66. Naming
+        them each time is tokens spent saying nothing — and `description` is the
+        slot runs already over-use, which is the problem, not the fix."""
+        for name in ("ExportControlRegulatoryRestrictions", "ParticipantPrivacy"):
+            block = self._block(name)
+            for attribute in sorted(UNIVERSAL_ATTRIBUTES):
+                with self.subTest(nested=name, attribute=attribute):
+                    self.assertNotIn(f"`{attribute}`", block)
+
+
+class TestTheByReferenceShortcut(unittest.TestCase):
+    """Three classes mostly repeat the top-level slot listing.
+
+    Enumerating 24 alphabetically-first names for them would be redundant and
+    arbitrary, so they are described by reference. The risk of that shortcut is
+    swallowing the attributes that make the class *different* — which is the
+    only reason to read its entry.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.digest = schema_digest.build("Dataset")
+        cls.text = schema_digest.render(cls.digest)
+        cls.top_level = {s.name for s in cls.digest.slots}
+        cls.nested = {n.name: n for n in cls.digest.nested}
+
+    def _own(self, name):
+        return [k for k in self.nested[name].optional
+                if k not in self.top_level and k not in UNIVERSAL_ATTRIBUTES]
+
+    def test_a_mirroring_class_is_described_by_reference(self):
+        self.assertIn("also accepts the same slots as the top-level listing above",
+                      self.text)
+
+    def test_the_distinguishing_attributes_survive_the_shortcut(self):
+        """`DataSubset` is 98% the top-level listing; the 2% is the whole point
+        of it being a separate class."""
+        for name in ("DataSubset", "FileCollection"):
+            own = self._own(name)
+            with self.subTest(nested=name):
+                self.assertTrue(own, f"{name} has no distinguishing attributes")
+                for attribute in own:
+                    self.assertIn(f"`{attribute}`", self._block(name),
+                                  f"{name}.{attribute} is named nowhere")
+
+    def test_data_subset_keeps_its_two_discriminators(self):
+        """Named explicitly because rubric20 Q5 and Q19 score them."""
+        block = self._block("DataSubset")
+        self.assertIn("`is_data_split`", block)
+        self.assertIn("`is_subpopulation`", block)
+
+    def test_only_classes_that_really_mirror_take_the_shortcut(self):
+        for name, n in self.nested.items():
+            optional = [k for k in n.optional if k not in UNIVERSAL_ATTRIBUTES]
+            if not optional:
+                continue
+            own = [k for k in optional if k not in self.top_level]
+            overlap = 1 - len(own) / len(optional)
+            shortcut = "also accepts the same slots" in self._block(name)
+            with self.subTest(nested=name, overlap=round(overlap, 2)):
+                self.assertEqual(shortcut, overlap >= MIRRORS_TOP_LEVEL)
+
+    def _block(self, name):
+        lines = self.text.splitlines()
+        for i, line in enumerate(lines):
+            if line.startswith(f"- **{name}** — required:"):
+                out = [line]
+                for follow in lines[i + 1:]:
+                    if not follow.startswith("    "):
+                        break
+                    out.append(follow)
+                return "\n".join(out)
+        return ""
+
+
+class TestTheDigestStaysCompact(unittest.TestCase):
+    """The digest exists because the merged schema is 254 KB and most of it says
+    nothing about how to fill a record. Naming 367 more attributes has to stay
+    worth its tokens."""
+
+    def test_the_digest_is_far_smaller_than_the_schema_it_replaces(self):
+        text = schema_digest.digest_text("Dataset")
+        merged = schema_digest.FULL_SCHEMA.read_text()
+        self.assertLess(len(text), len(merged) / 5)
+
+    def test_the_listing_did_not_double_the_digest(self):
+        """It grew ~20%. A regression that enumerated the mirroring classes in
+        full would roughly double it, and this is the cheapest way to notice."""
+        self.assertLess(len(schema_digest.digest_text("Dataset")), 40_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema/test_schema_digest_optional.py
+++ b/tests/test_schema/test_schema_digest_optional.py
@@ -28,8 +28,35 @@ these tests deliberately do not pretend to answer.
 import unittest
 
 from data_sheets_schema import schema_digest
-from data_sheets_schema.schema_digest import (MIRRORS_TOP_LEVEL,
-                                              UNIVERSAL_ATTRIBUTES)
+from data_sheets_schema.schema_digest import (CLASS_SCHEMA, MAX_OPTIONAL_SHOWN,
+                                              MIRRORS_TOP_LEVEL,
+                                              UNIVERSAL_ATTRIBUTES,
+                                              ClassDigest, NestedClass)
+
+#: Both targets, not just `Dataset` (#331). `CoreDataset` lives in its own
+#: merged artifact, is the `*_core` arm of every run, and takes a *different
+#: branch*: its top-level listing is smaller, so one nested class mirrors it
+#: against three for `Dataset`.
+TARGETS = sorted(CLASS_SCHEMA)
+
+
+def _rendered(target):
+    digest = schema_digest.build(target)
+    return digest, schema_digest.render(digest)
+
+
+def _block(text, name):
+    """A class's rendered line plus its indented continuations."""
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith(f"- **{name}** — required:"):
+            out = [line]
+            for follow in lines[i + 1:]:
+                if not follow.startswith("    "):
+                    break
+                out.append(follow)
+            return "\n".join(out)
+    return ""
 
 
 class TestOptionalAttributesAreRendered(unittest.TestCase):
@@ -58,12 +85,24 @@ class TestOptionalAttributesAreRendered(unittest.TestCase):
 
     def test_no_class_is_rendered_with_nothing_but_required_none(self):
         """54 of 66 were. A class described only by what it does not require
-        tells a run nothing it can act on."""
-        blind = [n.name for n in self.digest.nested
-                 if not n.required and not n.enums
-                 and [k for k in n.optional if k not in UNIVERSAL_ATTRIBUTES]
-                 and f"**{n.name}** — required: none\n" == self._block(n.name)]
-        self.assertEqual(blind, [])
+        tells a run nothing it can act on. Both targets (#331)."""
+        for target in TARGETS:
+            digest, text = _rendered(target)
+            blind = [n.name for n in digest.nested
+                     if not n.required and not n.enums
+                     and [k for k in n.optional if k not in UNIVERSAL_ATTRIBUTES]
+                     and _block(text, n.name) == f"- **{n.name}** — required: none"]
+            with self.subTest(target=target):
+                self.assertEqual(blind, [])
+
+    def test_the_governance_fields_are_named_for_both_targets(self):
+        """The `*_core` arm scores the same Q9 (#331)."""
+        for target in TARGETS:
+            text = schema_digest.digest_text(target)
+            for attribute in ("confidentiality_level", "hipaa_compliant",
+                              "other_compliance", "governance_committee_contact"):
+                with self.subTest(target=target, attribute=attribute):
+                    self.assertIn(f"`{attribute}`", text)
 
     def _block(self, name):
         """The rendered line for a class plus its indented continuations."""
@@ -82,11 +121,15 @@ class TestOptionalAttributesAreRendered(unittest.TestCase):
         """`id`, `name`, `description` and `used_software` are on all 66. Naming
         them each time is tokens spent saying nothing — and `description` is the
         slot runs already over-use, which is the problem, not the fix."""
-        for name in ("ExportControlRegulatoryRestrictions", "ParticipantPrivacy"):
-            block = self._block(name)
-            for attribute in sorted(UNIVERSAL_ATTRIBUTES):
-                with self.subTest(nested=name, attribute=attribute):
-                    self.assertNotIn(f"`{attribute}`", block)
+        for target in TARGETS:
+            _, text = _rendered(target)
+            for name in ("ExportControlRegulatoryRestrictions", "ParticipantPrivacy"):
+                block = _block(text, name)
+                if not block:
+                    continue
+                for attribute in sorted(UNIVERSAL_ATTRIBUTES):
+                    with self.subTest(target=target, nested=name, attribute=attribute):
+                        self.assertNotIn(f"`{attribute}`", block)
 
 
 class TestTheByReferenceShortcut(unittest.TestCase):
@@ -131,15 +174,37 @@ class TestTheByReferenceShortcut(unittest.TestCase):
         self.assertIn("`is_subpopulation`", block)
 
     def test_only_classes_that_really_mirror_take_the_shortcut(self):
-        for name, n in self.nested.items():
-            optional = [k for k in n.optional if k not in UNIVERSAL_ATTRIBUTES]
-            if not optional:
-                continue
-            own = [k for k in optional if k not in self.top_level]
-            overlap = 1 - len(own) / len(optional)
-            shortcut = "also accepts the same slots" in self._block(name)
-            with self.subTest(nested=name, overlap=round(overlap, 2)):
-                self.assertEqual(shortcut, overlap >= MIRRORS_TOP_LEVEL)
+        """Both targets: `CoreDataset` has a smaller top-level listing, so one
+        class mirrors it against three for `Dataset` (#331)."""
+        for target in TARGETS:
+            digest, text = _rendered(target)
+            top_level = {s.name for s in digest.slots}
+            for n in digest.nested:
+                optional = [k for k in n.optional if k not in UNIVERSAL_ATTRIBUTES]
+                if not optional:
+                    continue
+                own = [k for k in optional if k not in top_level]
+                overlap = 1 - len(own) / len(optional)
+                shortcut = "also accepts the same slots" in _block(text, n.name)
+                with self.subTest(target=target, nested=n.name,
+                                  overlap=round(overlap, 2)):
+                    self.assertEqual(shortcut, overlap >= MIRRORS_TOP_LEVEL)
+
+    def test_no_distinguishing_attribute_is_lost_on_either_target(self):
+        """The by-reference shortcut's whole risk, checked everywhere it runs."""
+        for target in TARGETS:
+            digest, text = _rendered(target)
+            top_level = {s.name for s in digest.slots}
+            for n in digest.nested:
+                block = _block(text, n.name)
+                if "also accepts the same slots" not in block:
+                    continue
+                own = [k for k in n.optional
+                       if k not in top_level and k not in UNIVERSAL_ATTRIBUTES]
+                for attribute in own:
+                    with self.subTest(target=target, nested=n.name,
+                                      attribute=attribute):
+                        self.assertIn(f"`{attribute}`", block)
 
     def _block(self, name):
         lines = self.text.splitlines()
@@ -159,15 +224,59 @@ class TestTheDigestStaysCompact(unittest.TestCase):
     nothing about how to fill a record. Naming 367 more attributes has to stay
     worth its tokens."""
 
-    def test_the_digest_is_far_smaller_than_the_schema_it_replaces(self):
-        text = schema_digest.digest_text("Dataset")
-        merged = schema_digest.FULL_SCHEMA.read_text()
-        self.assertLess(len(text), len(merged) / 5)
+    def test_each_digest_is_far_smaller_than_the_schema_it_replaces(self):
+        for target in TARGETS:
+            with self.subTest(target=target):
+                text = schema_digest.digest_text(target)
+                merged = CLASS_SCHEMA[target].read_text()
+                self.assertLess(len(text), len(merged) / 5)
 
     def test_the_listing_did_not_double_the_digest(self):
         """It grew ~20%. A regression that enumerated the mirroring classes in
         full would roughly double it, and this is the cheapest way to notice."""
-        self.assertLess(len(schema_digest.digest_text("Dataset")), 40_000)
+        for target in TARGETS:
+            with self.subTest(target=target):
+                self.assertLess(len(schema_digest.digest_text(target)), 40_000)
+
+
+class TestTheTruncationSafeguard(unittest.TestCase):
+    """The cap has never run against a real schema (#330).
+
+    Both targets' large nested classes mirror the top-level listing and take
+    that branch instead, so `MAX_OPTIONAL_SHOWN`, the slice and the `(+N more)`
+    tail were dead code — a safeguard that reads as verified and is not. If the
+    schema later gains a large class that does *not* mirror, the first run of
+    that branch would be in a paid generation run.
+
+    Exercised here against a synthetic digest, which is the only way to reach
+    it without waiting for the schema to grow one.
+    """
+
+    def _render(self, count):
+        nested = NestedClass(
+            name="Sprawling", required=[],
+            optional=sorted(f"attribute_{i:03d}" for i in range(count)))
+        return schema_digest.render(
+            ClassDigest(class_name="Dataset",
+                        schema_path=schema_digest.FULL_SCHEMA,
+                        slots=[], nested=[nested]))
+
+    def test_a_large_non_mirroring_class_is_truncated(self):
+        text = self._render(MAX_OPTIONAL_SHOWN + 9)
+        self.assertIn("(+9 more)", text)
+        self.assertIn("`attribute_000`", text)
+        self.assertNotIn(f"`attribute_{MAX_OPTIONAL_SHOWN:03d}`", text)
+
+    def test_it_does_not_take_the_by_reference_path(self):
+        """With no top-level slots to overlap, nothing mirrors — which is what
+        makes this the branch the real schema never reaches."""
+        self.assertNotIn("also accepts the same slots",
+                         self._render(MAX_OPTIONAL_SHOWN + 9))
+
+    def test_a_class_at_the_cap_is_not_truncated(self):
+        text = self._render(MAX_OPTIONAL_SHOWN)
+        self.assertNotIn("more)", text)
+        self.assertIn(f"`attribute_{MAX_OPTIONAL_SHOWN - 1:03d}`", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #325's actionable half. The measurement half is answered below and left
for the manuscript.

## Root cause, which is not where the issue guessed

#325 asked whether the v3 prompt should ask for `regulatory_restrictions`
sub-fields. It should not need to: the model was never told they exist.

`NestedClass` has carried an `optional` list since the first version. `build()`
populated it. `render()` never emitted it. So the digest said which nested keys
were **mandatory** and never which were **available**:

- **54 of 66** nested classes rendered as a bare `required: none`
- **367** attributes were named nowhere in the text the model receives

`ExportControlRegulatoryRestrictions` requires nothing, so a run saw exactly:

```
- **ExportControlRegulatoryRestrictions** — required: none
```

**What the records do instead is the tell.** Every one writes prose into that
object's `description`, and the prose *contains the answers*: "FDA Regulated:
No", "De-identified Samples: Yes", a license clause about data security and
privacy standards. The model had the facts and no structured place it had been
told about.

## Why the digest and not the prompt

The digest is the layer that says what shape an answer takes, it is shared by
every arm, and fixing it there keeps generic-v3 a controlled condition rather
than one carrying a field-specific instruction. It was also simply incomplete —
it drops half its own data structure.

## The by-reference shortcut, and its risk

Three classes mostly repeat the top-level slot listing — `Dataset` (100%),
`DataSubset` (98%), `FileCollection` (85%) — and are the only ones large enough
to truncate. Listing their alphabetically-first 24 would be redundant *and*
arbitrary, so they are described by reference **plus** what makes them
different:

```
- **DataSubset** — required: `id`
    - also accepts the same slots as the top-level listing above plus
      `is_data_split`, `is_subpopulation`
```

Those two are exactly what rubric20 Q5 and Q19 score. A shortcut that swallowed
them would have removed the only reason to read the entry, so a test asserts
every non-overlapping attribute survives it.

## Cost

`24,273 → 29,114` chars, **+19.9%**, roughly +1,200 tokens in a cached prefix.
Still an eighth of the 254 KB merged schema. A regression that enumerated the
three mirroring classes in full would roughly double the digest; a test bounds it.

**No attestation is affected.** `schema_digest_md5` is written by `api_runner`
but appears in **0** existing run provenances, so nothing verifies against the
old fingerprint. The rerun records the new one.

## What these tests do not claim

They assert the *listing*, not the outcome. Making a field addressable is what
the digest can do; whether a run then fills it is a question for the next
generation. Two of the four Q9 fields were already visible via their enum
vocabularies and still went unfilled in 25/25 records — so I am not claiming
this fixes Q9, only that it removes the one cause that was certain.

## #325's other half, not addressed here

Five questions (Q2, Q6, Q7, Q12, Q16 — 11 of 88 points) are awarded to every
record unconditionally. That is saturation, not a defect, and what to do about
it is an analysis decision for the manuscript rather than a code change. Left in
#325.

10 tests, mutation-checked with 5 reintroductions, no survivors.
`1197 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)