### PR TITLE
Refuse to repair records newer than the repair tool (#328); measure the saturation (#325)

### DIFF
--- a/notes/rubric20_saturation_2026-08-04.md
+++ b/notes/rubric20_saturation_2026-08-04.md
@@ -1,0 +1,82 @@
+# Six rubric20 questions score identically on every record
+
+**Recommended wording for the manuscript is in the last section.** The rest is
+the measurement behind it.
+
+Measured 2026-08-04 over the 25 current `claudecode_agent` records
+(`2026-07-31`, generic and generic-v2), scored with the hybrid scorer as
+corrected in #319. **These figures are not comparable to any rubric20 number
+reported before that date** — six of 88 points were unearnable by any record
+until it landed.
+
+## What saturates
+
+Six of twenty questions award the same score to all 25 records:
+
+| | question | score | of |
+|---|---|---|---|
+| Q2 | Entry Length Adequacy | 5 | 5 |
+| Q6 | Dataset Identification Metadata | 1 | 1 |
+| Q7 | Funding and Acknowledgements Completeness | 5 | 5 |
+| Q9 | Access Requirements and Governance Documentation | **3** | 5 |
+| Q12 | Collection Protocol Clarity | 5 | 5 |
+| Q16 | Findability (Persistent Links) | 1 | 1 |
+
+**20 of 88 points are awarded unconditionally.** An earlier note in #325 said
+"11 points across five questions"; both figures were wrong — it omitted Q9 and
+the arithmetic did not add up. The measured figure is six questions and 20
+points.
+
+Q9 is the one that differs in kind. The other five saturate *at their maximum*:
+every datasheet in the corpus genuinely answers them well. Q9 saturates at 3 of
+5 because its top band requires a confidentiality classification and a governance
+contact, and no record populates `regulatory_restrictions.confidentiality_level`,
+`.hipaa_compliant`, `.other_compliance` or `.governance_committee_contact` —
+0 of 25. Until #329 the digest never named those fields, so no run was told they
+existed. Whether the next generation fills them is open.
+
+## Why this does not affect comparisons
+
+The saturated questions contribute a constant to every record, so they move the
+mean and leave the variance untouched. Removing them changes nothing about how
+records rank or how far apart they are:
+
+```
+full 88-point score      mean 68.9   sd 11.0413
+66-point subscore        mean 48.9   sd 11.0413
+```
+
+The standard deviations are identical to four decimal places — not
+approximately, but by construction. **Every point of between-record variation
+comes from the 14 discriminating questions.**
+
+So the saturated questions are not a confound for any between-method or
+between-condition comparison. What they do is inflate the absolute percentage:
+68.9/88 is 78.3%, of which 22.7 percentage points are awarded before any
+datasheet is read.
+
+## Recommended wording
+
+> Scores are reported against the full 88-point rubric20 instrument. Six of its
+> twenty questions (Q2, Q6, Q7, Q9, Q12, Q16) awarded an identical score to all
+> 25 records in this corpus, contributing 20 points unconditionally. Because
+> these contribute a constant, they do not affect any comparison reported here —
+> the standard deviation of the 66-point discriminating subscore is identical to
+> that of the full score (11.04 in both cases) — but absolute percentages should
+> be read with the 20-point floor in mind. Five of the six saturate at their
+> maximum, indicating questions the corpus answers uniformly well; Q9 saturates
+> at 3 of 5 because no record populates the governance sub-fields its top band
+> requires.
+
+## What not to do
+
+**Do not drop the saturated questions from the instrument.** rubric20 is the
+published rubric; a 66-point variant would not be comparable to anything already
+scored, including the presence path and the manuscript's own earlier figures, and
+the saturation is a property of *this corpus* rather than of the questions. Four
+projects is a small sample: a fifth that omits its funders would un-saturate Q7
+immediately.
+
+**Do not report the subscore as the headline.** It is a diagnostic, not a
+result. Reporting it as the score would silently change the instrument between
+this paper and the next.

--- a/scripts/fix_evaluation_scores.py
+++ b/scripts/fix_evaluation_scores.py
@@ -24,6 +24,46 @@ from typing import Dict, List, Tuple, Optional
 import argparse
 
 
+class CurrentShapeRecord(ValueError):
+    """This tool predates the N/A convention and would corrupt such a record."""
+
+    def __init__(self, path: Path, marker: str):
+        super().__init__(
+            f"{path.name} is in the current shape (`overall_score.{marker}`) and "
+            "this script predates it. Re-running the evaluation is the way to "
+            "correct such a record; see #328.")
+
+
+#: Keys the N/A convention added to `overall_score`. Their presence is what
+#: separates a record this tool can repair from one it would damage.
+CURRENT_SHAPE_MARKERS = ("normalized_percentage", "adjusted_max_points",
+                         "excluded_max_points")
+
+
+def refuse_current_shape(eval_data: Dict, eval_path: Path) -> None:
+    """Refuse a record written after the N/A convention (#328).
+
+    This script recomputes a percentage as `total / max` and writes it to
+    `overall_score.percentage`. Both halves are wrong for a current record:
+
+    - the reported figure is `normalized_percentage`, computed over
+      `adjusted_max_points` — the maximum *after* excluding non-applicable
+      items — so `total / max_points` is a different number whenever anything
+      is excluded; and
+    - `percentage` is not declared by either semantic schema (#323), so writing
+      it turns a conformant record into a non-conformant one.
+
+    Everything this tool could still legitimately repair — the 12 superseded
+    and 8 invalid records — is being regenerated, so migrating it to the N/A
+    vocabulary would be work spent on a corpus about to be replaced. Refusing
+    is the whole remaining fix.
+    """
+    overall = eval_data.get("overall_score") or {}
+    for marker in CURRENT_SHAPE_MARKERS:
+        if marker in overall:
+            raise CurrentShapeRecord(eval_path, marker)
+
+
 def calculate_rubric20_score(eval_data: Dict) -> Tuple[float, float]:
     """
     Calculate total score from rubric20 categories/questions.
@@ -101,6 +141,9 @@ def fix_evaluation_scores(eval_path: Path, dry_run: bool = False) -> Tuple[bool,
     # Load evaluation
     with open(eval_path, 'r') as f:
         eval_data = json.load(f)
+
+    # Before anything else: this tool predates the N/A convention (#328).
+    refuse_current_shape(eval_data, eval_path)
 
     # Detect rubric type
     rubric_type = detect_rubric_type(eval_data, eval_path)
@@ -327,6 +370,7 @@ def main():
     # Process each file
     fixed_count = 0
     skipped_count = 0
+    refused_count = 0
 
     for eval_file in sorted(eval_files):
         print(f"Processing: {eval_file.name}")
@@ -339,6 +383,12 @@ def main():
                 fixed_count += 1
             else:
                 skipped_count += 1
+
+        except CurrentShapeRecord as e:
+            # Not an error: the record is newer than this tool (#328). A
+            # traceback here would read as a fault in the corpus.
+            print(f"  🚫 Refused: {e}")
+            refused_count += 1
 
         except Exception as e:
             print(f"  ERROR: {e}")
@@ -353,7 +403,8 @@ def main():
     print("SUMMARY:")
     print(f"  ✅ Fixed:   {fixed_count}")
     print(f"  ⏭️  Skipped: {skipped_count}")
-    print(f"  📊 Total:   {fixed_count + skipped_count}")
+    print(f"  🚫 Refused: {refused_count}   (newer than this tool — re-run the evaluation)")
+    print(f"  📊 Total:   {fixed_count + skipped_count + refused_count}")
     print("=" * 60)
 
     if args.dry_run and fixed_count > 0:

--- a/scripts/fix_evaluation_scores.py
+++ b/scripts/fix_evaluation_scores.py
@@ -361,7 +361,14 @@ def main():
     elif "rubric20" in str(eval_dir):
         rubric_type = "rubric20-semantic"
 
-    print(f"Found {len(eval_files)} evaluation files in {eval_dir.relative_to(Path.cwd())}")
+    # `relative_to` raises when the directory is outside the working tree, so
+    # `--input-dir /tmp/...` crashed before doing anything. Pre-existing; found
+    # by a test that ran the CLI from a temp directory.
+    try:
+        shown = eval_dir.relative_to(Path.cwd())
+    except ValueError:
+        shown = eval_dir
+    print(f"Found {len(eval_files)} evaluation files in {shown}")
     print(f"Rubric type: {rubric_type}")
     if args.dry_run:
         print("\n*** DRY RUN MODE - No files will be modified ***\n")
@@ -409,6 +416,13 @@ def main():
 
     if args.dry_run and fixed_count > 0:
         print("\nRun without --dry-run to apply fixes")
+
+    if refused_count and not fixed_count:
+        # Everything in this directory is newer than the tool. Exiting 0 would
+        # tell a caller the repair succeeded when nothing was repairable, which
+        # is the same silence the guard exists to break (#328).
+        print("\nNothing repairable here: every record postdates this tool.")
+        return 1
 
     return 0
 

--- a/tests/test_evaluation/test_legacy_score_repair_refuses.py
+++ b/tests/test_evaluation/test_legacy_score_repair_refuses.py
@@ -180,5 +180,37 @@ class TestTheLiveCorpus(unittest.TestCase):
             "every record in the current shape must be refused, and no other")
 
 
+@unittest.skipUnless(SCRIPT.exists(), "repair script not present")
+class TestTheExitCode(unittest.TestCase):
+    """A caller has to be able to see the refusal.
+
+    `main()` returned 0 unconditionally, so a directory in which every record
+    was refused reported success having done nothing — the same silence the
+    guard exists to break.
+    """
+
+    def _run(self, records):
+        import subprocess
+        import sys
+        with tempfile.TemporaryDirectory() as tmp:
+            for name, record in records.items():
+                (Path(tmp) / name).write_text(json.dumps(record))
+            return subprocess.run(
+                [sys.executable, str(SCRIPT), "--dry-run", "--input-dir", tmp],
+                capture_output=True, text=True, cwd=REPO)
+
+    def test_all_refused_exits_nonzero(self):
+        result = self._run({"AI_READI_claudecode_agent_evaluation.json":
+                            _current_record()})
+        self.assertNotEqual(result.returncode, 0, result.stdout[-400:])
+        self.assertIn("Refused", result.stdout)
+
+    def test_a_repairable_directory_still_exits_zero(self):
+        """The guard must not turn the tool into one that always fails."""
+        result = self._run({"AI_READI_claudecode_agent_evaluation.json":
+                            _legacy_record()})
+        self.assertEqual(result.returncode, 0, result.stdout[-400:])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_evaluation/test_legacy_score_repair_refuses.py
+++ b/tests/test_evaluation/test_legacy_score_repair_refuses.py
@@ -1,0 +1,184 @@
+"""The legacy score-repair tool must refuse records newer than itself (#328).
+
+`scripts/fix_evaluation_scores.py` recomputes an evaluation's totals and writes
+`overall_score.percentage`. Both halves are wrong for a record written after the
+N/A convention:
+
+- the reported figure is `normalized_percentage`, computed over
+  `adjusted_max_points` — the maximum *after* excluding non-applicable items —
+  so `total_points / max_points` is a different number whenever anything is
+  excluded; and
+- `percentage` is not declared by either semantic schema (#323), so writing it
+  turns a conformant record into a non-conformant one.
+
+Nothing in the pipeline invokes this script, and everything it could still
+legitimately repair — the 12 superseded and 8 invalid records — is being
+regenerated. So migrating it to the N/A vocabulary would be work spent on a
+corpus about to be replaced. Refusing is the whole remaining fix, and these
+tests are what make the refusal real.
+
+A refusal is not an error. The caller reports it separately from a fault,
+because a traceback here would read as a problem with the corpus rather than a
+tool that is out of date.
+"""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "fix_evaluation_scores.py"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("fix_evaluation_scores", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _legacy_record():
+    """The shape this tool was written for: one percentage, no exclusions."""
+    return {
+        "rubric": "rubric20-semantic",
+        "version": "1.0",
+        "project": "AI_READI",
+        "method": "claudecode_agent",
+        "overall_score": {"total_points": 70, "max_points": 88, "percentage": 79.5},
+        "categories": [{"name": "Structural Completeness", "questions": [
+            {"id": 1, "name": "Field Completeness", "score": 5, "max_score": 5}]}],
+    }
+
+
+def _current_record(marker="normalized_percentage"):
+    """The shape the agents have instructed since the N/A convention."""
+    overall = {"total_points": 70, "max_points": 88, "excluded_max_points": 5,
+               "adjusted_max_points": 83, "normalized_percentage": 84.3,
+               "questions_not_applicable": 1}
+    record = _legacy_record()
+    record["overall_score"] = {k: v for k, v in overall.items()
+                               if k == marker or k in ("total_points", "max_points")}
+    return record
+
+
+@unittest.skipUnless(SCRIPT.exists(), "repair script not present")
+class TestItRefusesCurrentRecords(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _module()
+
+    def _write(self, record, directory):
+        path = Path(directory) / "AI_READI_claudecode_agent_evaluation.json"
+        path.write_text(json.dumps(record))
+        return path
+
+    #: Named here rather than read from the module. An earlier version iterated
+    #: over `module.CURRENT_SHAPE_MARKERS`, so narrowing that tuple to one entry
+    #: made the test pass vacuously — it derived its expectation from the code it
+    #: was checking. Caught by mutation.
+    MARKERS = ("normalized_percentage", "adjusted_max_points", "excluded_max_points")
+
+    def test_each_marker_of_the_current_shape_triggers_a_refusal(self):
+        """Any one of the three is enough. A record carrying only
+        `adjusted_max_points` is still one this tool would miscompute."""
+        for marker in self.MARKERS:
+            with self.subTest(marker=marker), tempfile.TemporaryDirectory() as tmp:
+                path = self._write(_current_record(marker), tmp)
+                with self.assertRaises(self.module.CurrentShapeRecord):
+                    self.module.fix_evaluation_scores(path)
+
+    def test_the_module_recognises_exactly_those_markers(self):
+        """The complement: if the N/A vocabulary grows a fourth key, this fails
+        rather than the guard silently missing it."""
+        self.assertEqual(tuple(self.module.CURRENT_SHAPE_MARKERS), self.MARKERS)
+
+    def test_the_refusal_names_the_file_and_the_marker(self):
+        """It has to be actionable without reading the source."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(_current_record(), tmp)
+            with self.assertRaises(self.module.CurrentShapeRecord) as caught:
+                self.module.fix_evaluation_scores(path)
+        message = str(caught.exception)
+        self.assertIn("AI_READI_claudecode_agent_evaluation.json", message)
+        self.assertIn("normalized_percentage", message)
+
+    def test_a_refused_record_is_not_modified(self):
+        """The point of the guard. `dry_run` defaults to False, so a refusal
+        that happened *after* the rewrite would be no guard at all."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(_current_record(), tmp)
+            before = path.read_bytes()
+            with self.assertRaises(self.module.CurrentShapeRecord):
+                self.module.fix_evaluation_scores(path, dry_run=False)
+            self.assertEqual(path.read_bytes(), before)
+
+    def test_it_refuses_before_deciding_the_rubric_type(self):
+        """A current record with an unrecognisable rubric must still refuse
+        rather than return the softer "unknown rubric type" skip, which reads
+        as "nothing to do here"."""
+        with tempfile.TemporaryDirectory() as tmp:
+            record = _current_record()
+            record.pop("rubric")
+            record.pop("categories")
+            path = self._write(record, tmp)
+            with self.assertRaises(self.module.CurrentShapeRecord):
+                self.module.fix_evaluation_scores(path)
+
+
+@unittest.skipUnless(SCRIPT.exists(), "repair script not present")
+class TestItStillHandlesWhatItWasWrittenFor(unittest.TestCase):
+    """The guard must not refuse everything — that would be indistinguishable
+    from deleting the tool, and the pre-2026 corpus is what it exists for."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.module = _module()
+
+    def test_a_legacy_record_is_accepted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "AI_READI_claudecode_agent_evaluation.json"
+            path.write_text(json.dumps(_legacy_record()))
+            modified, message = self.module.fix_evaluation_scores(path, dry_run=True)
+        self.assertIsInstance(message, str)
+
+    def test_a_record_with_no_overall_score_is_not_refused(self):
+        """The pre-2026 rubric10 shape reports `summary_scores`, and has no
+        `overall_score` at all."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "AI_READI_claudecode_agent_evaluation.json"
+            path.write_text(json.dumps({
+                "rubric": "rubric10-semantic",
+                "summary_scores": {"total_score": 40, "total_max_score": 50,
+                                   "overall_percentage": 80.0},
+                "element_scores": []}))
+            self.module.fix_evaluation_scores(path, dry_run=True)  # must not raise
+
+
+@unittest.skipUnless(SCRIPT.exists(), "repair script not present")
+class TestTheLiveCorpus(unittest.TestCase):
+    """Every recorded semantic evaluation is either legacy or refused."""
+
+    def test_no_current_record_would_be_rewritten(self):
+        module = _module()
+        current = REPO / "data" / "evaluation_llm"
+        checked = refused = 0
+        for path in sorted(current.glob("*_semantic/concatenated/*_evaluation.json")):
+            record = json.loads(path.read_text())
+            checked += 1
+            try:
+                module.refuse_current_shape(record, path)
+            except module.CurrentShapeRecord:
+                refused += 1
+        self.assertGreater(checked, 0, "no recorded evaluations found")
+        self.assertEqual(
+            refused,
+            sum(1 for p in sorted(current.glob("*_semantic/concatenated/*_evaluation.json"))
+                if "overall_score" in json.loads(p.read_text())),
+            "every record in the current shape must be refused, and no other")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #328. Closes #325.

Two small pieces of evaluation-reporting hygiene before the rerun, on one branch
because each is a few lines and both concern the same corpus.

## #328 — the repair tool now refuses the current shape

`scripts/fix_evaluation_scores.py` recomputes a percentage as `total / max` and
writes `overall_score.percentage`. Both halves are wrong for a record written
after the N/A convention:

- the reported figure is `normalized_percentage` over `adjusted_max_points` —
  the maximum *after* exclusions — so `total / max_points` is a different number
  whenever anything is excluded;
- `percentage` is not declared by either semantic schema (#323), so writing it
  turns a conformant record non-conformant.

Nothing in the pipeline invokes it, and everything it could still legitimately
repair — the 12 superseded and 8 invalid records — is being regenerated. So it
refuses rather than being migrated: that would be work spent on a corpus about to
be replaced. The guard runs *before* the rubric-type check and before any
rewrite, and `dry_run` defaults to `False`, so a refusal placed after the rewrite
would be no guard at all — there is a test for exactly that.

Against the live corpus: **8 refused, 0 modified.**

A refusal is reported separately from a fault. A traceback here would read as a
problem with the corpus rather than a tool that is out of date.

## #325 — the saturation, measured, and a correction

I reported "11 points across five questions". It is **six questions and 20
points** — the count omitted Q9, and the arithmetic did not add up either way.

| | question | score | of |
|---|---|---|---|
| Q2 | Entry Length Adequacy | 5 | 5 |
| Q6 | Dataset Identification Metadata | 1 | 1 |
| Q7 | Funding and Acknowledgements | 5 | 5 |
| **Q9** | **Access Requirements and Governance** | **3** | **5** |
| Q12 | Collection Protocol Clarity | 5 | 5 |
| Q16 | Findability (Persistent Links) | 1 | 1 |

Q9 differs in kind. The other five saturate at their maximum — the corpus
answers them uniformly well. Q9 is pinned at 3 because its top band needs a
confidentiality classification and a governance contact, and **0 of 25** records
populate those fields; until #329 the digest never named them.

**Why this confounds nothing, stated precisely rather than asserted:**

```
full 88-point score      mean 68.9   sd 11.0413
66-point subscore        mean 48.9   sd 11.0413
```

Identical to four decimal places, by construction. Every point of between-record
variation comes from the 14 discriminating questions. What saturation costs is
the absolute percentage: 22.7 of 78.3 points are awarded before a datasheet is
read.

`notes/rubric20_saturation_2026-08-04.md` carries the numbers, the recommended
manuscript wording, and the argument **against** dropping the questions —
rubric20 is the published instrument, a 66-point variant would not be comparable
to anything already scored, and saturation is a property of a four-project corpus
rather than of the questions. A fifth project omitting its funders would
un-saturate Q7 immediately.

## Testing

8 tests, mutation-checked with 7 reintroductions. One survivor first time round,
**in the test rather than the code**: it iterated over
`module.CURRENT_SHAPE_MARKERS`, so narrowing that tuple to one entry made it pass
vacuously — a test deriving its expectation from the code it checks. The markers
are now named independently, with a complementary test that the module
recognises exactly those three.

`1210 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)