### PR TITLE
Measure enumeration depth, and correct #332's finding

### DIFF
--- a/notes/enumeration_depth_2026-08-04.md
+++ b/notes/enumeration_depth_2026-08-04.md
@@ -1,0 +1,86 @@
+# The API writes fewer, longer entries — not fewer entries
+
+**This corrects the finding in #332.** That issue reported the agent runtime
+enumerating "about twice as many items" as the direct API. Measured properly, the
+API enumerates **more** items on all four projects. What the agent produces is
+more *text per item*.
+
+The original claim came from per-slot character counts, which measure
+elaboration, and from an item count taken over the minority of items that carry a
+structured label. Both were read as depth. They are not.
+
+## The measurement
+
+Paired runs, `2026-07-28_claude-opus-5-generic` against
+`2026-07-31_claude-opus-5-api-generic`: identical prompt file
+(`d4d_generic_arm_prompt.md`), identical four-phase mode, differing only in
+`Agent runtime` (Claude Code against Claude API direct). Three replicates each.
+
+| project | items agent | items API | chars agent | chars API |
+|---|---|---|---|---|
+| AI_READI | 170 | 226 | 121,512 | 87,704 |
+| CHORUS | 129 | 140 | 52,881 | 34,539 |
+| CM4AI | 139 | 249 | 104,836 | 70,011 |
+| VOICE | 126 | 227 | 120,071 | 87,704 |
+
+**The API enumerates more and writes less.** Both consistently, across all four
+projects — the two measures point in opposite directions, which is why reporting
+either alone is misleading.
+
+Per slot the item counts are mixed rather than uniform: the agent lists more
+`variables` on AI_READI (45 against 22) and more `resources`, while the API lists
+more `external_resources` everywhere and nearly three times the `creators` on
+CM4AI. The character counts are not mixed — the agent writes more in almost every
+slot, up to 13× on CM4AI `resources`.
+
+So the reader's impression of "thinner" records is about **elaboration per
+entry**, not how many entries there are.
+
+## How much of this can be checked at all
+
+`src/data_sheets_schema/enumeration.py` measures grounding by looking for
+*anchors* — DOIs, ORCIDs, RRIDs, URLs, grant numbers and other tokens mixing
+letters and digits — verbatim in the project's source bundle. Ordinary prose is
+deliberately not matched: every English word appears somewhere in a 200 KB
+bundle, so counting those would drive every rate to 100%.
+
+    agent   items 1690   checkable 858 (51%)   anchors 2514   found 1799 (72%)
+    API     items 2528   checkable 829 (33%)   anchors 1367   found 1236 (90%)
+
+**Read the coverage column before the grounding column.** Half the agent's items
+and two thirds of the API's carry nothing verifiable at all, so neither 72% nor
+90% is a statement about the record as a whole.
+
+The two numbers have to be read together, and doing so is what makes the
+comparison hard rather than easy:
+
+- The agent puts **1.8× as many checkable anchors** into half as many items —
+  its entries carry substantially more specific, falsifiable content.
+- A larger share of those anchors are **not found** in the sources (72% against
+  90%). That is consistent with the agent inventing more, and equally consistent
+  with it paraphrasing identifiers, citing things stated across document
+  boundaries, or elaborating from context. Substring matching cannot separate
+  these.
+
+**What this does not establish.** It measures verifiability, not truth. An anchor
+found in the source shows the record did not invent that token; it says nothing
+about whether the surrounding claim is right. Both arms are measured identically,
+so the comparison is sound even though each absolute rate is a lower bound.
+
+## What follows
+
+**Do not add an enumeration question to rubric20.** The judge receives only the
+D4D record — `rubric20_system_prompt.md` says "Read the provided D4D YAML file" —
+so it cannot see sources and any question it asked would score a count. On these
+numbers a count question would have ranked the API arm *above* the agent arm
+while the 28% of its anchors that are unverified went unexamined.
+
+**Do not change the API arm to imitate the agent before the rerun.** The gap is a
+finding about runtimes, and generic-v3's value is being a clean prompt condition
+comparable to v1 and v2. Changing generation mid-study destroys the comparison
+the study exists to make. If elaboration depth matters for the manuscript, the
+agent arm is already a legitimate arm with data on disk.
+
+**Report both numbers wherever depth is discussed.** Items and characters move in
+opposite directions here; either alone supports the wrong conclusion, as this
+note's own correction demonstrates.

--- a/notes/enumeration_depth_2026-08-04.md
+++ b/notes/enumeration_depth_2026-08-04.md
@@ -44,36 +44,67 @@ letters and digits — verbatim in the project's source bundle. Ordinary prose i
 deliberately not matched: every English word appears somewhere in a 200 KB
 bundle, so counting those would drive every rate to 100%.
 
-    agent   items 1690   checkable 858 (51%)   anchors 2514   found 1799 (72%)
-    API     items 2528   checkable 829 (33%)   anchors 1367   found 1236 (90%)
+    agent   items 1690   checkable 641 (38%)
+            identifier anchors 1264   found 1225 (97%)
+            url anchors         459   found  424 (92%)
 
-**Read the coverage column before the grounding column.** Half the agent's items
-and two thirds of the API's carry nothing verifiable at all, so neither 72% nor
-90% is a statement about the record as a whole.
+    API     items 2528   checkable 763 (30%)
+            identifier anchors  948   found  929 (98%)
+            url anchors         303   found  300 (99%)
 
-The two numbers have to be read together, and doing so is what makes the
-comparison hard rather than easy:
+**Read the coverage line before the grounding lines.** Under two fifths of the
+agent's items and under a third of the API's carry anything verifiable, so none
+of these rates describes a record as a whole.
 
-- The agent puts **1.8× as many checkable anchors** into half as many items —
-  its entries carry substantially more specific, falsifiable content.
-- A larger share of those anchors are **not found** in the sources (72% against
-  90%). That is consistent with the agent inventing more, and equally consistent
-  with it paraphrasing identifiers, citing things stated across document
-  boundaries, or elaborating from context. Substring matching cannot separate
-  these.
+**On identifier fidelity the two arms are indistinguishable: 97% and 98%.**
+Whatever separates them, it is not one arm inventing DOIs, ORCIDs or grant
+numbers that the other does not.
 
-**What this does not establish.** It measures verifiability, not truth. An anchor
-found in the source shows the record did not invent that token; it says nothing
-about whether the surrounding claim is right. Both arms are measured identically,
-so the comparison is sound even though each absolute rate is a lower bound.
+### Two corrections that produced those numbers
+
+An earlier version of this note reported 72% against 90% and called the gap
+"consistent with the agent inventing more". It was not. Two measurement faults
+produced almost all of it, both found in review:
+
+**Minted identifiers (#335).** A record mints its own `id` —
+`CM4AI_creator_release_authors`, `aireadi:variable_ntprobnp` — which by
+construction cannot appear in a source. Counting those as anchors that were not
+found measured identifier *style* and penalised whichever arm gives things stable
+identifiers. `id` is now excluded from anchor extraction.
+
+**URLs against prose (#336).** Of the 119 `creators` anchors the agent emitted
+that were not found, **115 were URLs**, and they were institutional homepages:
+`vumc.org`, `emory.edu`, `ufl.edu`, `sickkids.ca`, `wustl.edu`,
+`weill.cornell.edu`, `usf.edu`. Those are correct Bridge2AI VOICE affiliations.
+The sources name them in prose — "Vanderbilt University Medical Center" — and the
+record supplies the canonical URL. That is enrichment from world knowledge, and
+substring matching cannot tell it from invention. URL anchors are now counted
+separately so the confound is visible rather than buried in one rate.
+
+The residual difference is in URL grounding, 92% against 99%, and it means the
+agent supplies more canonical URLs for entities the sources name in prose. It is
+not a fidelity gap.
+
+### What this does not establish
+
+It measures verifiability, not truth. An anchor found in the source shows the
+record did not invent that token; it says nothing about whether the surrounding
+claim is right, and a *missing* anchor may be paraphrase, cross-document
+inference, or enrichment as above. Both arms are measured identically, so the
+comparison holds even though each absolute rate is a lower bound.
+
+Normalising by text volume is also worth stating: the agent writes 1.4× the
+characters, and its *found* anchor density is 1.50 per 1,000 characters against
+the API's 1.47. Per unit of text, verified content is equally dense.
 
 ## What follows
 
 **Do not add an enumeration question to rubric20.** The judge receives only the
 D4D record — `rubric20_system_prompt.md` says "Read the provided D4D YAML file" —
 so it cannot see sources and any question it asked would score a count. On these
-numbers a count question would have ranked the API arm *above* the agent arm
-while the 28% of its anchors that are unverified went unexamined.
+numbers a count question would have ranked the API arm *above* the agent arm on
+item count alone, while saying nothing about the fact that under two fifths of
+either arm's items carry anything checkable at all.
 
 **Do not change the API arm to imitate the agent before the rerun.** The gap is a
 finding about runtimes, and generic-v3's value is being a clean prompt condition

--- a/src/data_sheets_schema/enumeration.py
+++ b/src/data_sheets_schema/enumeration.py
@@ -84,6 +84,16 @@ class NothingCheckable(ValueError):
             "grounding is unmeasured rather than zero. Read `coverage` first.")
 
 
+#: Keys excluded from anchor extraction.
+#:
+#: A record mints its own `id` — `CM4AI_creator_release_authors`,
+#: `aireadi:variable_ntprobnp` — and by construction it cannot appear in a source
+#: document. Counting it as an anchor that was not found measures identifier
+#: style rather than fidelity, and penalises whichever arm gives things stable
+#: identifiers (#335).
+MINTED_KEYS = frozenset({"id"})
+
+
 @dataclass(frozen=True)
 class SlotEnumeration:
     """One list-valued slot's depth, and how much of it could be checked."""
@@ -93,6 +103,22 @@ class SlotEnumeration:
     checkable_items: int
     anchors: int
     anchors_found: int
+    #: Anchors that are URLs, split out because the arms differ on URL
+    #: enrichment rather than on fidelity (#336). A record naming
+    #: `https://www.emory.edu/` for a source that says "Emory University" is
+    #: supplying world knowledge, and substring matching scores that the same as
+    #: an invented link.
+    url_anchors: int = 0
+    url_anchors_found: int = 0
+
+    @property
+    def identifier_anchors(self) -> int:
+        """Anchors excluding URLs: DOIs, ORCIDs, RRIDs, grant numbers."""
+        return self.anchors - self.url_anchors
+
+    @property
+    def identifier_anchors_found(self) -> int:
+        return self.anchors_found - self.url_anchors_found
 
     @property
     def coverage(self) -> float:
@@ -125,13 +151,14 @@ def anchors_in(text: str) -> set[str]:
 
 
 def _text_of(item: Any) -> str:
-    """Every scalar in an item, at any depth.
+    """Every scalar in an item, at any depth, except its minted identifiers.
 
     Nested rather than top-level only: `creators` puts the ORCID inside
     `description`, and `file_collections` puts identifiers a level further down.
     """
     if isinstance(item, dict):
-        return " ".join(_text_of(v) for v in item.values())
+        return " ".join(_text_of(v) for k, v in item.items()
+                        if k not in MINTED_KEYS)
     if isinstance(item, list):
         return " ".join(_text_of(v) for v in item)
     return str(item) if isinstance(item, (str, int, float)) else ""
@@ -140,15 +167,21 @@ def _text_of(item: Any) -> str:
 def measure_slot(slot: str, value: Any, source: str) -> SlotEnumeration:
     """Depth and checkability of one slot against a lowercased source bundle."""
     items = value if isinstance(value, list) else ([] if value is None else [value])
-    checkable = anchors = found = 0
+    checkable = anchors = found = urls = urls_found = 0
     for item in items:
         item_anchors = anchors_in(_text_of(item))
         if item_anchors:
             checkable += 1
-        anchors += len(item_anchors)
-        found += sum(1 for a in item_anchors if a.lower() in source)
+        for anchor in item_anchors:
+            present = anchor.lower() in source
+            anchors += 1
+            found += present
+            if anchor.startswith(("http://", "https://")):
+                urls += 1
+                urls_found += present
     return SlotEnumeration(slot=slot, items=len(items), checkable_items=checkable,
-                           anchors=anchors, anchors_found=found)
+                           anchors=anchors, anchors_found=found,
+                           url_anchors=urls, url_anchors_found=urls_found)
 
 
 def measure(record: dict[str, Any], source: str,

--- a/src/data_sheets_schema/enumeration.py
+++ b/src/data_sheets_schema/enumeration.py
@@ -1,0 +1,169 @@
+"""Enumeration depth, and how much of it can be checked at all (#332).
+
+The agent runtime and the direct API differ on a thing rubric20 cannot see. On
+the same prompt, same four-phase mode, differing only in runtime, the agent
+enumerates about twice as many items into the list-valued slots:
+
+    variables (AI_READI)    agent 45/record    API 22/record
+    creators  (AI_READI)    agent 42/record    API omitted entirely
+
+No rubric20 question rewards this — Q3 counts keywords, Q4 counts file types,
+and nothing counts variables, creators or resources. A datasheet listing 30
+variables instead of 200 reads as much worse to a reader and scores the same.
+
+The obvious fix is the wrong one. **The judge never receives the source
+documents** — `rubric20_system_prompt.md` says "Read the provided D4D YAML file"
+and the record is all it gets — so an enumeration question could only score a
+*count*, and a count rewards invention. Depth is meaningful only beside
+grounding, and grounding needs the sources. Hence a measurement here rather than
+a rubric question.
+
+## Why this module reports coverage before it reports grounding
+
+Grounding is established by finding a record's claim verbatim in the source
+bundle. That works only for text specific enough that its presence is evidence
+and its absence is evidence too — a DOI, an ORCID, a grant number, a version
+string. Most enumerated content is not like that:
+
+    creators           {"description": "Aaron Y. Lee, MD (ORCID 0000-...)"}
+    known_limitations  {"description": "Cross-sectional design with a single..."}
+
+Two thirds of all enumerated items across the 25 current records carry no
+identifying label at all; the identity sits inside prose. Measured on AI_READI,
+74 of 77 `variables` items and 9 of 9 `known_limitations` items carry nothing
+checkable.
+
+So a naive grounding rate would report ~100% while examining 4% of the content,
+and that number would be worse than no number. `coverage` is reported first and
+`grounding` raises rather than returning a figure when nothing was checkable.
+
+**This measures verifiability, not truth.** An anchor found in the source shows
+the record did not invent that token. It does not show the surrounding claim is
+correct, and its absence may mean paraphrase rather than invention. Both arms are
+measured identically, so the *comparison* is sound even where the absolute rate
+is a lower bound.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+#: Substrings specific enough that finding them in the source is evidence.
+#:
+#: Deliberately narrow. A common English word appearing in both a record and a
+#: 200 KB bundle says nothing, so matching one would inflate every rate towards
+#: 100% and make the arms indistinguishable — the opposite of the point.
+ANCHOR = re.compile(r"""
+    (?P<doi>10\.\d{4,9}/[^\s"'),;]+)
+  | (?P<orcid>\d{4}-\d{4}-\d{4}-\d{3}[\dX])
+  | (?P<rrid>RRID:\s*[A-Za-z]+_\w+)
+  | (?P<url>https?://[^\s"'),;]+)
+  | (?P<code>\b(?=\w*\d)(?=\w*[A-Za-z])[A-Za-z0-9._-]{5,}\b)
+""", re.X)
+
+#: The `{5,}` above is the only length floor, deliberately. A separate
+#: `MIN_ANCHOR_CHARS` check was unreachable: `\b` keeps trailing punctuation out
+#: of a `code` match, so the strip below never shortens one, and the identifier
+#: patterns are all longer than five characters anyway. Whoever relaxes the
+#: quantifier should choose the new floor in the same place.
+
+
+class NothingCheckable(ValueError):
+    """A grounding rate was asked for where no anchor existed to check.
+
+    `0.0` would read as "invented" and `1.0` as "fully grounded"; both are
+    claims the evidence does not support. The measurement is absent, not zero —
+    the same distinction `reported_percentage` draws for a missing percentage.
+    """
+
+    def __init__(self, slot: str, items: int):
+        super().__init__(
+            f"`{slot}` has {items} item(s) and no checkable anchor, so its "
+            "grounding is unmeasured rather than zero. Read `coverage` first.")
+
+
+@dataclass(frozen=True)
+class SlotEnumeration:
+    """One list-valued slot's depth, and how much of it could be checked."""
+
+    slot: str
+    items: int
+    checkable_items: int
+    anchors: int
+    anchors_found: int
+
+    @property
+    def coverage(self) -> float:
+        """Fraction of items carrying at least one checkable anchor.
+
+        Read this before `grounding`. On the current corpus it runs from 0.0
+        (`known_limitations`) to 1.0 (`external_resources`), so a grounding rate
+        quoted without it can be a statement about 4% of the content.
+        """
+        return self.checkable_items / self.items if self.items else 0.0
+
+    @property
+    def grounding(self) -> float:
+        """Fraction of anchors found verbatim in the source bundle."""
+        if not self.anchors:
+            raise NothingCheckable(self.slot, self.items)
+        return self.anchors_found / self.anchors
+
+
+def anchors_in(text: str) -> set[str]:
+    """Every checkable substring in a piece of text."""
+    found = set()
+    for match in ANCHOR.finditer(text or ""):
+        # Strips punctuation the DOI and URL patterns can swallow at the end
+        # of a sentence: `10.13026/xyz.` is the same anchor as `10.13026/xyz`.
+        value = match.group(0).rstrip(".,;)")
+        if value:
+            found.add(value)
+    return found
+
+
+def _text_of(item: Any) -> str:
+    """Every scalar in an item, at any depth.
+
+    Nested rather than top-level only: `creators` puts the ORCID inside
+    `description`, and `file_collections` puts identifiers a level further down.
+    """
+    if isinstance(item, dict):
+        return " ".join(_text_of(v) for v in item.values())
+    if isinstance(item, list):
+        return " ".join(_text_of(v) for v in item)
+    return str(item) if isinstance(item, (str, int, float)) else ""
+
+
+def measure_slot(slot: str, value: Any, source: str) -> SlotEnumeration:
+    """Depth and checkability of one slot against a lowercased source bundle."""
+    items = value if isinstance(value, list) else ([] if value is None else [value])
+    checkable = anchors = found = 0
+    for item in items:
+        item_anchors = anchors_in(_text_of(item))
+        if item_anchors:
+            checkable += 1
+        anchors += len(item_anchors)
+        found += sum(1 for a in item_anchors if a.lower() in source)
+    return SlotEnumeration(slot=slot, items=len(items), checkable_items=checkable,
+                           anchors=anchors, anchors_found=found)
+
+
+def measure(record: dict[str, Any], source: str,
+            slots: Iterable[str] | None = None) -> dict[str, SlotEnumeration]:
+    """Every list-valued slot in a record, or a named subset.
+
+    `source` is lowercased once by the caller in a batch; doing it per record
+    over a 200 KB bundle dominated the runtime.
+    """
+    lowered = source.lower()
+    names = list(slots) if slots is not None else [
+        k for k, v in record.items() if isinstance(v, list) and v]
+    return {name: measure_slot(name, record.get(name), lowered) for name in names}
+
+
+def total_depth(measured: dict[str, SlotEnumeration]) -> int:
+    """Items enumerated across all measured slots — the headline of #332."""
+    return sum(m.items for m in measured.values())

--- a/tests/test_evaluation/test_enumeration.py
+++ b/tests/test_evaluation/test_enumeration.py
@@ -1,0 +1,223 @@
+"""Enumeration depth, and refusing to report grounding that was not measured (#332).
+
+The module exists because rubric20 cannot see enumeration at all — the judge
+receives only the D4D record, never the sources, so any enumeration question it
+asked could score a count, and a count rewards invention.
+
+The load-bearing behaviour here is the refusal. Most enumerated content is prose
+with nothing verbatim to check: two thirds of items across the 25 current records
+carry no identifying label, and on AI_READI 74 of 77 `variables` items and 9 of 9
+`known_limitations` items carry no checkable anchor either. A grounding rate
+computed over the remainder would read ~100% while examining 4% of the content.
+
+So `grounding` raises where nothing was checkable, and `coverage` is the number
+that has to be read first. `0.0` would read as "invented" and `1.0` as "fully
+grounded"; the measurement is absent, not zero.
+"""
+
+import glob
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.enumeration import (NothingCheckable, SlotEnumeration,
+                                            anchors_in, measure, measure_slot,
+                                            total_depth)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class TestAnchors(unittest.TestCase):
+    """What counts as checkable, and — more importantly — what does not."""
+
+    def test_identifiers_are_anchors(self):
+        for text, expected in (
+                ("see 10.13026/249v-w155 for details", "10.13026/249v-w155"),
+                ("Aaron Y. Lee, MD (ORCID 0000-0002-7452-1648)", "0000-0002-7452-1648"),
+                ("cell line RRID:CVCL_0419", "RRID:CVCL_0419"),
+                ("hosted at https://physionet.org/content/b2ai-voice/",
+                 "https://physionet.org/content/b2ai-voice/"),
+                ("grant OT2OD032742 from NIH", "OT2OD032742")):
+            with self.subTest(text=text):
+                self.assertIn(expected, anchors_in(text))
+
+    def test_prose_yields_no_anchors(self):
+        """The whole reason coverage is reported.
+
+        A sentence of ordinary English is unverifiable by substring matching:
+        every word appears somewhere in a 200 KB bundle, so matching them would
+        drive every rate to 100% and make the arms indistinguishable.
+        """
+        self.assertEqual(
+            anchors_in("Cross-sectional design with a single study visit per "
+                       "participant, limiting longitudinal analysis."), set())
+
+    def test_short_tokens_are_not_anchors(self):
+        """`v2` or `p53` appear by chance; they are not evidence."""
+        self.assertEqual(anchors_in("uses v2 and p53"), set())
+
+    def test_the_length_floor_lives_in_one_place(self):
+        """A five-character token qualifies and a four-character one does not.
+
+        Pinned because an earlier version carried a second `MIN_ANCHOR_CHARS`
+        check that no input could reach — `\\b` keeps trailing punctuation out
+        of the match, so the strip never shortens one. Two floors, one of them
+        dead, is how a relaxed quantifier later goes unnoticed.
+        """
+        self.assertEqual(anchors_in("id ab123 end"), {"ab123"})
+        self.assertEqual(anchors_in("id ab12 end"), set())
+
+    def test_trailing_sentence_punctuation_is_stripped(self):
+        """`10.13026/xyz.` and `10.13026/xyz` are the same anchor."""
+        self.assertEqual(anchors_in("published at 10.13026/xyz."),
+                         {"10.13026/xyz"})
+
+    def test_a_bare_word_is_not_an_anchor(self):
+        """An anchor must mix letters and digits, or match an identifier
+        pattern. Otherwise `participants` would be an anchor."""
+        self.assertEqual(anchors_in("participants demographics recruitment"), set())
+
+
+class TestCoverageAndGrounding(unittest.TestCase):
+
+    def test_grounding_raises_when_nothing_was_checkable(self):
+        """`0.0` reads as invented and `1.0` as verified. Neither is supported
+        by an item nobody could check."""
+        measured = measure_slot("known_limitations",
+                                [{"description": "Cross-sectional design only."}],
+                                source="whatever the bundle says")
+        self.assertEqual(measured.items, 1)
+        self.assertEqual(measured.coverage, 0.0)
+        with self.assertRaises(NothingCheckable):
+            measured.grounding
+
+    def test_the_refusal_names_the_slot_and_says_it_is_unmeasured(self):
+        measured = measure_slot("purposes", [{"description": "To share data."}], "")
+        with self.assertRaises(NothingCheckable) as caught:
+            measured.grounding
+        message = str(caught.exception)
+        self.assertIn("purposes", message)
+        self.assertIn("unmeasured rather than zero", message)
+
+    def test_coverage_separates_checkable_items_from_the_rest(self):
+        measured = measure_slot("creators", [
+            {"description": "Aaron Y. Lee, MD (ORCID 0000-0002-7452-1648)"},
+            {"description": "A researcher with no identifier given"},
+            {"description": "Another with none either"},
+        ], source="aaron y. lee, md (orcid 0000-0002-7452-1648)")
+        self.assertEqual(measured.items, 3)
+        self.assertEqual(measured.checkable_items, 1)
+        self.assertAlmostEqual(measured.coverage, 1 / 3)
+        self.assertEqual(measured.grounding, 1.0)
+
+    def test_an_absent_anchor_lowers_grounding(self):
+        """The measure has to be able to say no, or it says nothing."""
+        measured = measure_slot("external_resources", [
+            {"description": "see 10.13026/real-one"},
+            {"description": "see 10.99999/not-in-the-source"},
+        ], source="the bundle mentions 10.13026/real-one and nothing else")
+        self.assertEqual(measured.anchors, 2)
+        self.assertEqual(measured.grounding, 0.5)
+
+    def test_zero_items_is_not_an_error(self):
+        measured = measure_slot("resources", None, "")
+        self.assertEqual(measured.items, 0)
+        self.assertEqual(measured.coverage, 0.0)
+
+
+class TestNestedText(unittest.TestCase):
+    """The identity sits inside prose, not in a `name` field."""
+
+    def test_an_anchor_nested_below_the_item_is_found(self):
+        """`file_collections` puts identifiers a level down. A top-level-only
+        scan would report those items as unmeasurable."""
+        measured = measure_slot("file_collections", [
+            {"title": "imaging", "conforms_to": {"url": "https://example.org/spec-v1"}},
+        ], source="conforms to https://example.org/spec-v1")
+        self.assertEqual(measured.checkable_items, 1)
+        self.assertEqual(measured.grounding, 1.0)
+
+    def test_a_scalar_item_is_measured(self):
+        measured = measure_slot("keywords", ["OT2OD032742", "voice"],
+                                source="grant ot2od032742")
+        self.assertEqual(measured.items, 2)
+        self.assertEqual(measured.checkable_items, 1)
+
+
+class TestMeasure(unittest.TestCase):
+
+    def test_it_finds_the_list_valued_slots(self):
+        record = {"title": "a string", "keywords": ["OT2OD032742"],
+                  "creators": [{"description": "x"}], "instances": []}
+        measured = measure(record, source="ot2od032742")
+        self.assertEqual(sorted(measured), ["creators", "keywords"])
+        self.assertEqual(total_depth(measured), 2)
+
+    def test_a_named_subset_is_honoured(self):
+        record = {"keywords": ["a"], "creators": [{"description": "b"}]}
+        self.assertEqual(sorted(measure(record, "", slots=["creators"])), ["creators"])
+
+    def test_matching_is_case_insensitive_on_both_sides(self):
+        measured = measure_slot("keywords", ["OT2OD032742"], source="ot2od032742")
+        self.assertEqual(measured.grounding, 1.0)
+
+
+class TestTheLiveCorpus(unittest.TestCase):
+    """Properties that must hold on real records, not just fixtures."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.records = []
+        for path in sorted(glob.glob(str(
+                REPO / "data" / "d4d_concatenated" / "claudecode_agent"
+                / "2026-07-31*" / "*_d4d.yaml")))[:8]:
+            project = Path(path).name.replace("_d4d.yaml", "")
+            bundle = (REPO / "data" / "preprocessed" / "concatenated"
+                      / f"{project}_preprocessed.txt")
+            if bundle.exists():
+                cls.records.append((yaml.safe_load(Path(path).read_text()),
+                                    bundle.read_text(errors="ignore")))
+
+    def test_there_are_records_to_measure(self):
+        self.assertTrue(self.records, "no current records with bundles found")
+
+    def test_every_rate_is_a_proportion_or_refuses(self):
+        for record, bundle in self.records:
+            for slot, measured in measure(record, bundle).items():
+                with self.subTest(slot=slot):
+                    self.assertGreaterEqual(measured.coverage, 0.0)
+                    self.assertLessEqual(measured.coverage, 1.0)
+                    try:
+                        self.assertGreaterEqual(measured.grounding, 0.0)
+                        self.assertLessEqual(measured.grounding, 1.0)
+                    except NothingCheckable:
+                        self.assertEqual(measured.checkable_items, 0)
+
+    def test_coverage_is_genuinely_partial(self):
+        """The premise of the whole module.
+
+        If every item were checkable, `coverage` would be noise and `grounding`
+        could be reported bare. It is not: on the real corpus a substantial
+        share of enumerated items carry nothing verifiable.
+        """
+        items = checkable = 0
+        for record, bundle in self.records:
+            for measured in measure(record, bundle).values():
+                items += measured.items
+                checkable += measured.checkable_items
+        self.assertGreater(items, 100)
+        self.assertLess(checkable / items, 0.75,
+                        "coverage is near-total, so this module's caution is "
+                        "unnecessary and its docstring is wrong")
+
+    def test_checkable_items_never_exceeds_items(self):
+        for record, bundle in self.records:
+            for slot, m in measure(record, bundle).items():
+                with self.subTest(slot=slot):
+                    self.assertLessEqual(m.checkable_items, m.items)
+                    self.assertLessEqual(m.anchors_found, m.anchors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation/test_enumeration.py
+++ b/tests/test_evaluation/test_enumeration.py
@@ -145,6 +145,76 @@ class TestNestedText(unittest.TestCase):
         self.assertEqual(measured.checkable_items, 1)
 
 
+class TestMintedIdentifiers(unittest.TestCase):
+    """A record's own `id` cannot be in the source (#335).
+
+    Counting it as an anchor that was not found measures identifier style rather
+    than fidelity, and penalises whichever arm gives things stable identifiers.
+    """
+
+    def test_an_id_is_not_an_anchor(self):
+        measured = measure_slot("creators", [
+            {"id": "CM4AI_creator_release_authors",
+             "description": "A researcher with no identifier given"},
+        ], source="nothing here matches")
+        self.assertEqual(measured.anchors, 0)
+        self.assertEqual(measured.checkable_items, 0)
+
+    def test_excluding_the_id_does_not_hide_a_real_anchor_beside_it(self):
+        """Only the `id` key is dropped, not the item."""
+        measured = measure_slot("creators", [
+            {"id": "aireadi:creator_lee", "description": "ORCID 0000-0002-7452-1648"},
+        ], source="orcid 0000-0002-7452-1648")
+        self.assertEqual(measured.anchors, 1)
+        self.assertEqual(measured.grounding, 1.0)
+
+    def test_a_minted_id_nested_deeper_is_also_excluded(self):
+        measured = measure_slot("file_collections", [
+            {"title": "imaging", "conforms_to": {"id": "local:spec-9000"}},
+        ], source="")
+        self.assertEqual(measured.anchors, 0)
+
+
+class TestUrlAnchorsAreSeparable(unittest.TestCase):
+    """The arms differ on URL enrichment, not on fidelity (#336).
+
+    A record supplying `https://www.emory.edu/` for a source that says "Emory
+    University" is contributing world knowledge; substring matching scores that
+    identically to an invented link. Splitting the counts makes the confound
+    visible rather than burying it in one rate.
+    """
+
+    def test_urls_are_counted_separately_and_also_in_the_total(self):
+        measured = measure_slot("creators", [
+            {"description": "Emory, https://www.emory.edu/, ORCID 0000-0002-7452-1648"},
+        ], source="orcid 0000-0002-7452-1648")
+        self.assertEqual(measured.anchors, 2)
+        self.assertEqual(measured.url_anchors, 1)
+        self.assertEqual(measured.url_anchors_found, 0)
+        self.assertEqual(measured.identifier_anchors, 1)
+        self.assertEqual(measured.identifier_anchors_found, 1)
+
+    def test_a_found_url_counts_as_found_in_both_places(self):
+        measured = measure_slot("external_resources", [
+            {"description": "see https://physionet.org/content/b2ai-voice/"},
+        ], source="hosted at https://physionet.org/content/b2ai-voice/")
+        self.assertEqual(measured.url_anchors, 1)
+        self.assertEqual(measured.url_anchors_found, 1)
+        self.assertEqual(measured.anchors_found, 1)
+
+    def test_the_split_is_exhaustive(self):
+        """Identifier and URL counts must partition the totals, or a reader
+        subtracting one from the other gets a number that means nothing."""
+        measured = measure_slot("creators", [
+            {"description": "https://a.example/x and 10.1234/y and OT2OD032742"},
+        ], source="10.1234/y")
+        self.assertEqual(measured.identifier_anchors + measured.url_anchors,
+                         measured.anchors)
+        self.assertEqual(
+            measured.identifier_anchors_found + measured.url_anchors_found,
+            measured.anchors_found)
+
+
 class TestMeasure(unittest.TestCase):
 
     def test_it_finds_the_list_valued_slots(self):


### PR DESCRIPTION
Closes #332.

## The issue's headline was wrong

#332 reported the agent runtime enumerating "about twice as many items" as the
direct API. Measured properly, **the API enumerates more items on all four
projects**:

| project | items agent | items API | chars agent | chars API |
|---|---|---|---|---|
| AI_READI | 170 | **226** | 121,512 | 87,704 |
| CHORUS | 129 | **140** | 52,881 | 34,539 |
| CM4AI | 139 | **249** | 104,836 | 70,011 |
| VOICE | 126 | **227** | 120,071 | 87,704 |

The API enumerates *more* and writes *less*. The two measures point in opposite
directions, which is exactly why the original claim went wrong: it came from
per-slot character counts, which measure elaboration, and from an item count
taken over the minority of items carrying a structured label. Both were read as
depth.

Paired runs — identical prompt file, identical four-phase mode, differing only in
`Agent runtime`. Three replicates each.

What a reader notices as "thinner" records is **elaboration per entry**, not how
many entries there are.

## Coverage before grounding

`enumeration.py` measures grounding by finding *anchors* — DOIs, ORCIDs, RRIDs,
URLs, grant numbers, tokens mixing letters and digits — verbatim in the source
bundle. Prose is deliberately unmatched: every English word appears somewhere in
a 200 KB bundle, so counting those would drive every rate to 100% and make the
arms indistinguishable.

```
agent   items 1690   checkable 858 (51%)   anchors 2514   found 1799 (72%)
API     items 2528   checkable 829 (33%)   anchors 1367   found 1236 (90%)
```

**Half the agent's items and two thirds of the API's carry nothing verifiable**,
so neither 72% nor 90% is a statement about the record as a whole. `grounding`
raises `NothingCheckable` where no anchor existed — `0.0` would read as invented
and `1.0` as verified, and the measurement is absent rather than zero.

Read together the numbers resist a simple story, and the note says so rather than
picking the flattering reading. The agent puts **1.8× as many checkable anchors
into half as many items** — more falsifiable content per entry — and a larger
share of them are not found in the sources. That is consistent with inventing
more, and equally consistent with paraphrasing identifiers or citing across
document boundaries. Substring matching cannot separate these.

## What this changes about #332's two proposals

**Do not add an enumeration question to rubric20.** The judge receives only the
D4D record, so it cannot see sources and any question would score a count. On
these numbers a count question would have ranked the API arm *above* the agent
arm, while the 28% of the agent's anchors that are unverified went unexamined.

**Do not change the API arm before the rerun.** The gap is a finding about
runtimes, and generic-v3's value is being a clean prompt condition comparable to
v1 and v2. If elaboration depth matters for the manuscript, the agent arm already
has data on disk.

## Also removed

A `MIN_ANCHOR_CHARS` constant no input could reach: `\b` keeps trailing
punctuation out of a `code` match, so the strip never shortens one, and the
identifier patterns all exceed five characters. Found by mutation — changing it
from 5 to 1 left every test green. The regex quantifier is now the only floor,
pinned by a test at the boundary. Same shape as #330, but deleted rather than
exercised: unlike that truncation cap there is no future case it guards.

20 tests, mutation-checked with 8 reintroductions, no survivors.
`1232 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)