### PR TITLE
Stamp v3 as v3 (#337); put the scalar rule in v4, not v3 (#338)

### DIFF
--- a/notes/generic_v4_analysis_plan.md
+++ b/notes/generic_v4_analysis_plan.md
@@ -1,0 +1,62 @@
+# generic-v4 analysis plan
+
+Registered before any v4 generation run. The prediction is here rather than in
+the prompt because writing it there would instruct the model to produce the
+result the run is meant to test.
+
+## What v4 changes
+
+One rule, added to v3's:
+
+> Where a slot's declared range is a scalar, populate it with the identifier of
+> the thing it refers to, not with the thing itself. An object placed in a
+> string-ranged slot fails validation and loses the reference it was meant to
+> record, even where that thing is richly described elsewhere in the record.
+
+## Why
+
+v3 tells the model to populate the fields a class-ranged slot declares. It says
+nothing about where structure does *not* belong, and `related_datasets` is
+class-ranged while its `target_dataset` is `range: string`.
+
+All three 2026-07-31 VOICE replicates fail validation on `related_datasets`
+(#292), by three different routes:
+
+| replicate | failure | status |
+|---|---|---|
+| rep1 | inline `Dataset` object in `target_dataset` | **this rule** |
+| rep2 | `relationship_type: related_to` | no enum equivalent; a real generation failure |
+| rep3 | `relationship_type: IsNewVersionOf` | already fixed — `normalise_enum_aliases` is on the write path |
+
+#297 established that LinkML cannot express a string-or-inline-object range, so
+the schema cannot refuse an object in `target_dataset`. A prompt rule is the only
+available remedy.
+
+## Prediction
+
+Registered in advance, and falsifiable:
+
+1. **Primary.** The inline-object failure in `target_dataset` does not occur in
+   any v4 replicate. Measured as `linkml-validate` errors of the form
+   `... is not of type 'string' in /related_datasets/*/target_dataset`.
+2. **Guard against over-application.** v4 does not reduce the population of
+   class-ranged slots relative to v3. A rule about scalars that suppresses
+   legitimate object population has traded one defect for another, which is
+   exactly what v2's rule 1 did (`notes/form_defect_split_2026-08-03.md`) and
+   what v3 exists to repair. Measured as items enumerated per record via
+   `data_sheets_schema.enumeration.total_depth`, v4 against v3.
+3. **Null result is informative.** If rep1's failure mode does not recur under
+   v3 either, the rule is unnecessary and should be retired rather than kept
+   because it sounds sensible. v3 must be run to know this.
+
+## What would falsify it
+
+Prediction 1 fails if any v4 replicate places an object in a string-ranged slot.
+Prediction 2 fails if v4's mean enumerated depth is materially below v3's — the
+same trade v2 made, in the opposite direction.
+
+## Comparison
+
+v3 against v4 isolates this rule. v2 against v4 does **not**: it spans two rule
+additions, and `comparable_conditions("generic_v2", "generic_v4")` returns False
+for that reason.

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -61,9 +61,15 @@ GENERIC_PROMPT_V2 = PROMPTS / "d4d_generic_arm_prompt_v2.md"
 # was one: v2 produced the 2026-07-31 series and is the baseline v3 is measured
 # against. The comparison that isolates the companion rule is v2 against v3.
 GENERIC_PROMPT_V3 = PROMPTS / "d4d_generic_arm_prompt_v3.md"
+# v4 carries the scalar-range companion to v3's class-range rule. It is a
+# separate version rather than a second rule inside v3 because v3's value is
+# isolating one change, and `notes/generic_v3_analysis_plan.md` was registered
+# before any run naming that one rule (#338).
+GENERIC_PROMPT_V4 = PROMPTS / "d4d_generic_arm_prompt_v4.md"
 CONDITION_PROMPTS = {"generic": GENERIC_PROMPT,
                      "generic_v2": GENERIC_PROMPT_V2,
                      "generic_v3": GENERIC_PROMPT_V3,
+                     "generic_v4": GENERIC_PROMPT_V4,
                      "tuned": GENERIC_PROMPT}
 
 # Which generic base each condition is built on. The generic/tuned comparison
@@ -80,6 +86,7 @@ CONDITION_AXES = {
     "generic":    {"base": "v1", "tuned": False},
     "generic_v2": {"base": "v2", "tuned": False},
     "generic_v3": {"base": "v3", "tuned": False},
+    "generic_v4": {"base": "v4", "tuned": False},
     "tuned":      {"base": "v1", "tuned": True},
 }
 
@@ -92,16 +99,37 @@ def condition_delta(a: str, b: str) -> list[str]:
     return [k for k in ("base", "tuned") if ax[k] != bx[k]]
 
 
+def _base_step(base: str) -> int:
+    """`v3` -> 3. Bases are an ordered series, each adding one rule."""
+    try:
+        return int(base.lstrip("v"))
+    except ValueError:
+        return -1
+
+
 def comparable_conditions(a: str, b: str) -> bool:
     """True when a difference between the two is attributable to one change.
 
     `generic` vs `generic_v2` differs only in base — that is the v2 experiment.
     `generic` vs `tuned` differs only in tuning — that is the study's main
     comparison. `generic_v2` vs `tuned` differs in **both**, so a difference
-    between them measures the three added decision rules and the tuned block
-    together while appearing to measure only tuning.
+    between them measures the added decision rules and the tuned block together
+    while appearing to measure only tuning.
+
+    Differing on the base axis is not sufficient once there are more than two
+    bases. Each version adds exactly one rule to the one before, so `v2` against
+    `v4` spans **two** additions while `condition_delta` reports the single axis
+    `base` — one axis, two changes. Adjacency is what makes the delta
+    attributable, and v4's arrival is what made that distinction load-bearing
+    (it was already latent for v1 against v3).
     """
-    return len(condition_delta(a, b)) == 1
+    delta = condition_delta(a, b)
+    if len(delta) != 1:
+        return False
+    if delta == ["base"]:
+        steps = [_base_step(CONDITION_AXES[c]["base"]) for c in (a, b)]
+        return -1 not in steps and abs(steps[0] - steps[1]) == 1
+    return True
 
 
 def confounded_note(a: str, b: str) -> str | None:

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -839,13 +839,34 @@ def condition_of(method: str, label: str, project: str,
     data = _yaml.safe_load(p.read_text(encoding="utf-8")) or {}
     paths = ((data.get("prompts") or {}).get("files")
              or (data.get("prompts") or {}).get("paths") or [])
-    joined = " ".join(str(x) for x in paths)
-    if "d4d_generic_arm_prompt_v2.md" in joined:
-        return "generic_v2"
-    if "d4d_tuned_arm_prompt.md" in joined:
+    # Entries are mappings — `{"path": ..., "sha256": ...}` — not bare strings.
+    # Stringifying the mapping happens to contain the path, which is why the
+    # previous version worked, but it also drags every other value into the
+    # match. Read the field.
+    joined = " ".join(x.get("path", "") if isinstance(x, dict) else str(x)
+                      for x in paths)
+
+    # Derived from the registry rather than restated. A hardcoded chain knew
+    # only v1, v2 and tuned, so every v3 and v4 run fell through it and returned
+    # None — silently, and on the rerun path (#340). `cli/api.py` carries the
+    # same lesson from when the condition list was written out three times and
+    # left `generic_v2` unreachable.
+    from data_sheets_schema.api_runner import CONDITION_PROMPTS, TUNED_PROMPT
+
+    # `tuned` shares v1's generic file and is identified by its own block
+    # appearing alongside, so it has to be tested before the generic bases.
+    if TUNED_PROMPT.name in joined:
         return "tuned"
-    if "d4d_generic_arm_prompt.md" in joined:
-        return "generic"
+
+    # Longest filename first: `d4d_generic_arm_prompt.md` is not a substring of
+    # `..._v2.md`, but ordering by length keeps that true if a future version is
+    # ever named in a way that makes it one.
+    for condition, path in sorted(CONDITION_PROMPTS.items(),
+                                  key=lambda kv: -len(kv[1].name)):
+        if condition == "tuned":
+            continue
+        if path.name in joined:
+            return condition
     return None
 
 

--- a/src/download/prompts/d4d_generic_arm_prompt_v4.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v4.md
@@ -1,28 +1,31 @@
-# D4D generic-arm generation prompt — v3
+# D4D generic-arm generation prompt — v4
 
-**This is v2 plus one uniform decision rule, and nothing else.** The
+**This is v3 plus one uniform decision rule, and nothing else.** The
 substitution fields, outputs, header block, constraints, the four original rules
-and v2's three additions are byte-identical to
-`src/download/prompts/d4d_generic_arm_prompt_v2.md`; a test asserts that the only
-difference is the block marked `ADDED IN v3`.
+and the v2 and v3 additions are byte-identical to
+`src/download/prompts/d4d_generic_arm_prompt_v3.md` apart from the version stamp;
+a test asserts that the only difference is the block marked `ADDED IN v4`.
 
-## Why v3 exists
+## Why v4 exists
 
-v2's first rule — one object per distinct entity for a multivalued slot — did
-what it was written to do. Splitting the fitness `form` class into its two
-component defects (`notes/form_defect_split_2026-08-03.md`) measured
-collapsed cardinality falling by more than four fifths, while a second defect
-rose to take its place: objects of the correct cardinality whose declared
-structured fields are empty because the content sits in a free-text
-`description`.
+v3 addressed hollow objects: a class-ranged slot whose declared fields sit empty
+while the content is restated in a free-text `description`. That rule tells the
+model to populate declared structure wherever it can.
 
-One class covering both defects reported that exchange as a net regression. It
-was not one. But the exchange is real, and a rule that trades one form failure
-for another is not finished.
+It says nothing about where structure does *not* belong. `target_dataset` is
+declared `range: string` and takes an identifier, and #297 established that
+LinkML cannot express a string-or-inline-object range, so the schema cannot
+refuse an object there — only validation can, after the fact.
 
-The companion rule addresses the second defect on the same terms as the first:
-it concerns how the schema is used, states no fact about any dataset, and can
-therefore be said without naming a project.
+All three 2026-07-31 VOICE replicates fail validation on `related_datasets`
+(#292), and one fails precisely this way: an inline `Dataset` object placed in
+`target_dataset`. `related_datasets` is class-ranged, so a model applying v3's
+rule energetically has an obvious next step — populate the related dataset
+properly, into the slot that names it.
+
+v4 is therefore the companion v3 needs rather than a correction of it. The two
+rules together say: populate declared structure where it is declared, and refer
+by identifier where it is not.
 
 ## Why this addition is generic and not priming
 
@@ -36,17 +39,15 @@ Measured against the taxonomy in `.claude/commands/d4d-full-core.md`:
 
 ## What is NOT in this file, deliberately
 
-The prediction that this rule reduces hollow objects without returning
-collapsed cardinality. Writing it here would instruct the model to produce the
-result the run is meant to test. It lives in
-`notes/generic_v3_analysis_plan.md`, registered before any generation run.
+The prediction that this rule eliminates the inline-object failure without
+suppressing legitimate object population. Writing it here would instruct the
+model to produce the result the run is meant to test. It lives in
+`notes/generic_v4_analysis_plan.md`, registered before any generation run.
 
-## Relationship to v1 and v2
+## Relationship to earlier versions
 
-Neither is superseded and neither may be edited. The 2026-07-28 generic series
-was produced under v1 and the 2026-07-31 generic-v2 series under v2; both remain
-baselines this version is measured against. The comparison that isolates this
-rule is v2 against v3.
+None is superseded and none may be edited once run. The comparison that isolates
+this rule is v3 against v4.
 
 ## Prompt body
 
@@ -87,8 +88,8 @@ HEADER BLOCK — use exactly:
     # Agent runtime: {RUNTIME}
     # Provider: {PROVIDER}
     # Model: {MODEL}
-    # Mode: four-phase project agent, generic-v3 prompt
-    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v3.md (identical for all projects)
+    # Mode: four-phase project agent, generic-v4 prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v4.md (identical for all projects)
     # Arm: {ARM}
     # Source bundle: {BUNDLE}
     {MANIFEST_LINE}
@@ -157,6 +158,14 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
   field rather than restating it in prose.
 
 --- END ADDED IN v3 ---
+--- ADDED IN v4 ---
+
+- Where a slot's declared range is a scalar, populate it with the identifier of
+  the thing it refers to, not with the thing itself. An object placed in a
+  string-ranged slot fails validation and loses the reference it was meant to
+  record, even where that thing is richly described elsewhere in the record.
+
+--- END ADDED IN v4 ---
 
 
 RETURN: full slot count, core slot count, whether both validated, and the

--- a/tests/test_download/test_generic_v3_prompt.py
+++ b/tests/test_download/test_generic_v3_prompt.py
@@ -35,13 +35,33 @@ def _norm(text):
 
 class TestV3IsV2PlusTheAddedBlock(unittest.TestCase):
 
+    #: The two header lines that name the version. They *must* differ between
+    #: v2 and v3 — identical stamps were the defect in #337, which would have
+    #: had every v3 record claim to be a v2 record. Normalised out of the
+    #: body comparison below and asserted separately.
+    VERSION_STAMP = re.compile(r"#\s*(?:Mode|Prompt):[^\n]*")
+
     def test_body_differs_from_v2_only_by_the_marked_block(self):
+        """Everything outside the marked block and the version stamp must be
+        identical, so the v2-against-v3 delta is the added rule and nothing
+        else."""
         v2 = prompt_body(GENERIC_PROMPT_V2)
         v3 = prompt_body(GENERIC_PROMPT_V3)
         stripped = (v3.split(MARK_START, 1)[0]
                     + v3.split(MARK_END, 1)[1]).strip()
-        self.assertEqual(_norm(stripped), _norm(v2),
-                         "v3 must be v2 plus the marked block and nothing else")
+        self.assertEqual(_norm(self.VERSION_STAMP.sub("", stripped)),
+                         _norm(self.VERSION_STAMP.sub("", v2)),
+                         "v3 must be v2 plus the marked block, the version "
+                         "stamp, and nothing else")
+
+    def test_the_version_stamp_does_differ(self):
+        """The complement, and the whole of #337: normalising the stamp out
+        above would otherwise let v3 go on claiming to be v2."""
+        v3 = prompt_body(GENERIC_PROMPT_V3)
+        self.assertIn("generic-v3 prompt", v3)
+        self.assertIn("d4d_generic_arm_prompt_v3.md", v3)
+        self.assertNotIn("generic-v2 prompt", v3)
+        self.assertNotIn("d4d_generic_arm_prompt_v2.md", v3)
 
     def test_v2s_three_rules_survive_intact(self):
         """The companion supplements rule 1; it does not replace it.

--- a/tests/test_download/test_generic_v4_prompt.py
+++ b/tests/test_download/test_generic_v4_prompt.py
@@ -170,5 +170,75 @@ class TestTheConditionIsWiredComparably(unittest.TestCase):
         self.assertIn("generic_v4", _CONDITIONS)
 
 
+@unittest.skipUnless(GENERIC_PROMPT_V4.exists(), "v4 prompt not present")
+class TestConditionIsRecoverableFromProvenance(unittest.TestCase):
+    """`condition_of` returned None for every v3 and v4 run (#340).
+
+    Its hardcoded chain knew v1, v2 and tuned. `d4d_generic_arm_prompt_v3.md`
+    does not contain `d4d_generic_arm_prompt.md` as a substring — the `_v3` sits
+    between `prompt` and `.md` — so a v3 run fell through every branch and the
+    function reported nothing, silently, on the path the rerun takes.
+    """
+
+    def _infer(self, *prompt_paths):
+        import tempfile
+
+        import yaml
+
+        from data_sheets_schema.runs import condition_of
+        with tempfile.TemporaryDirectory() as tmp:
+            # `record_path_for` appends `_core` to the method, which is where
+            # provenance is written for both arms.
+            root = Path(tmp) / "claudecode_agent_core" / "LBL"
+            root.mkdir(parents=True)
+            # Entries are mappings in real provenance, not bare strings.
+            (root / "CHORUS_provenance.yaml").write_text(yaml.safe_dump(
+                {"prompts": {"files": [{"path": p, "sha256": "x"}
+                                       for p in prompt_paths]}}))
+            return condition_of("claudecode_agent", "LBL", "CHORUS",
+                                concat_dir=Path(tmp))
+
+    def test_every_registered_condition_is_recoverable(self):
+        for condition, path in CONDITION_PROMPTS.items():
+            if condition == "tuned":
+                continue
+            with self.subTest(condition=condition):
+                self.assertEqual(self._infer(f"src/download/prompts/{path.name}"),
+                                 condition)
+
+    def test_the_tuned_arm_is_still_distinguished_from_its_generic_base(self):
+        """It shares v1's file, so testing the generic bases first would report
+        it as `generic`."""
+        self.assertEqual(
+            self._infer("src/download/prompts/d4d_generic_arm_prompt.md",
+                        "src/download/prompts/d4d_tuned_arm_prompt.md"),
+            "tuned")
+
+    def test_the_more_specific_version_wins_when_several_are_listed(self):
+        """Provenance may name more than one prompt — `tuned` already does.
+
+        Iterating the registry in an arbitrary order would return whichever
+        matched first, so a run listing both the v1 base and v4 could be
+        reported as `generic`. That failure is silent and wrong in the same way
+        #340 was, which is why the registry is walked longest-name-first rather
+        than in dict order.
+
+        No provenance on disk lists two generic prompts today; this is the case
+        the ordering exists for, exercised rather than assumed.
+        """
+        self.assertEqual(
+            self._infer("src/download/prompts/d4d_generic_arm_prompt.md",
+                        "src/download/prompts/d4d_generic_arm_prompt_v4.md"),
+            "generic_v4")
+
+    def test_an_unrecognised_prompt_still_returns_none(self):
+        self.assertIsNone(self._infer("src/download/prompts/something_else.md"))
+
+    def test_no_condition_is_reported_for_a_run_without_provenance(self):
+        from data_sheets_schema.runs import condition_of
+        self.assertIsNone(condition_of("claudecode_agent", "no-such-label",
+                                       "CHORUS", concat_dir=Path("/nonexistent")))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_download/test_generic_v4_prompt.py
+++ b/tests/test_download/test_generic_v4_prompt.py
@@ -1,0 +1,174 @@
+"""generic-v4 must stay generic, and must be v3 plus one rule.
+
+Mirrors `test_generic_v3_prompt.py`. The arm's value is that every project
+receives identical text and that exactly one thing changed since the baseline it
+is measured against — v3, not v2.
+
+v4 exists as its own version rather than as a second rule inside v3 (#338).
+`notes/generic_v3_analysis_plan.md` was registered before any run and names one
+rule; adding a second to v3 would have invalidated that pre-registration and
+made the v2-against-v3 delta unattributable to either rule.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from data_sheets_schema.api_runner import (
+    CONDITION_AXES,
+    CONDITION_PROMPTS,
+    GENERIC_PROMPT,
+    GENERIC_PROMPT_V2,
+    GENERIC_PROMPT_V3,
+    GENERIC_PROMPT_V4,
+    comparable_conditions,
+    condition_delta,
+    prompt_body,
+)
+
+PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
+MARK_START = "--- ADDED IN v4 ---"
+MARK_END = "--- END ADDED IN v4 ---"
+
+
+def _added_block(text):
+    return text.split(MARK_START, 1)[1].split(MARK_END, 1)[0]
+
+
+def _norm(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+class TestV4IsV3PlusTheAddedBlock(unittest.TestCase):
+
+    #: The header lines that name the version, which must differ (#337).
+    VERSION_STAMP = re.compile(r"#\s*(?:Mode|Prompt):[^\n]*")
+
+    def test_body_differs_from_v3_only_by_the_marked_block(self):
+        v3 = prompt_body(GENERIC_PROMPT_V3)
+        v4 = prompt_body(GENERIC_PROMPT_V4)
+        stripped = (v4.split(MARK_START, 1)[0]
+                    + v4.split(MARK_END, 1)[1]).strip()
+        self.assertEqual(_norm(self.VERSION_STAMP.sub("", stripped)),
+                         _norm(self.VERSION_STAMP.sub("", v3)),
+                         "v4 must be v3 plus the marked block, the version "
+                         "stamp, and nothing else")
+
+    def test_the_version_stamp_names_v4(self):
+        v4 = prompt_body(GENERIC_PROMPT_V4)
+        self.assertIn("generic-v4 prompt", v4)
+        self.assertIn("d4d_generic_arm_prompt_v4.md", v4)
+        self.assertNotIn("generic-v3 prompt", v4)
+        self.assertNotIn("d4d_generic_arm_prompt_v3.md", v4)
+
+    def test_the_earlier_additions_survive_intact(self):
+        """v4 supplements v2's three and v3's one; it replaces neither.
+
+        If they were dropped, a v3-vs-v4 difference would measure their removal
+        as well as the addition.
+        """
+        v4 = prompt_body(GENERIC_PROMPT_V4)
+        for mark, expected in (("v2", 3), ("v3", 1)):
+            block = (v4.split(f"--- ADDED IN {mark} ---", 1)[1]
+                       .split(f"--- END ADDED IN {mark} ---", 1)[0])
+            with self.subTest(version=mark):
+                self.assertEqual(
+                    len([l for l in block.splitlines() if l.startswith("- ")]),
+                    expected)
+
+    def test_the_added_block_holds_exactly_one_rule(self):
+        rules = [l for l in _added_block(GENERIC_PROMPT_V4.read_text()).splitlines()
+                 if l.startswith("- ")]
+        self.assertEqual(len(rules), 1)
+
+    def test_earlier_versions_are_untouched_by_v4(self):
+        for path in (GENERIC_PROMPT, GENERIC_PROMPT_V2, GENERIC_PROMPT_V3):
+            with self.subTest(path=path.name):
+                self.assertNotIn(MARK_START, path.read_text(),
+                                 "an earlier version produced a baseline and "
+                                 "must not acquire v4's rule")
+
+
+class TestTheAddedRuleIsGeneric(unittest.TestCase):
+
+    def setUp(self):
+        self.block = _added_block(GENERIC_PROMPT_V4.read_text())
+
+    def test_no_project_is_named(self):
+        for project in PROJECTS:
+            with self.subTest(project=project):
+                self.assertNotIn(project, self.block)
+
+    def test_no_dataset_identifiers(self):
+        for token in ("fairhub", "physionet", "dataverse", "10.18130",
+                      "cm4ai.org", "HIGT4C", "B35XWX"):
+            with self.subTest(token=token):
+                self.assertNotIn(token.lower(), self.block.lower())
+
+    def test_no_slot_is_named(self):
+        """Sharper than v3's check, and the trap this rule was most likely to
+        fall into: it was written to fix `target_dataset`, so naming that slot
+        would turn a generic decision rule into an instruction about one field.
+        """
+        for slot in ("target_dataset", "related_datasets", "relationship_type"):
+            with self.subTest(slot=slot):
+                self.assertNotIn(slot, self.block)
+
+    def test_no_expected_quantities(self):
+        numbers = re.findall(r"\b\d+\b", self.block)
+        self.assertEqual(numbers, [],
+                         f"the rule must state no quantities, found {numbers}")
+        for phrase in ("expect", "should yield", "typically", "at least",
+                       "roughly", "approximately"):
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, self.block.lower())
+
+    def test_no_reference_to_prior_runs(self):
+        for phrase in ("earlier run", "previous run", "prior run", "last time",
+                       "has been observed", "tends to", "replicate"):
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, self.block.lower())
+
+    def test_the_prediction_lives_outside_the_prompt(self):
+        text = GENERIC_PROMPT_V4.read_text().lower()
+        self.assertNotIn("we expect", text)
+        self.assertTrue(Path("notes/generic_v4_analysis_plan.md").exists(),
+                        "the prediction must be registered before running")
+
+
+class TestTheConditionIsWiredComparably(unittest.TestCase):
+
+    def test_v4_resolves_to_its_own_prompt(self):
+        self.assertEqual(CONDITION_PROMPTS["generic_v4"], GENERIC_PROMPT_V4)
+
+    def test_v3_against_v4_is_the_isolating_comparison(self):
+        self.assertTrue(comparable_conditions("generic_v3", "generic_v4"))
+        self.assertEqual(condition_delta("generic_v3", "generic_v4"), ["base"])
+
+    def test_v2_against_v4_is_not_isolating(self):
+        """Two rule additions apart. `condition_delta` reports the single axis
+        `base`, which is why comparability needs adjacency and not just a
+        one-axis difference (#338)."""
+        self.assertEqual(condition_delta("generic_v2", "generic_v4"), ["base"])
+        self.assertFalse(comparable_conditions("generic_v2", "generic_v4"))
+
+    def test_v4_against_tuned_is_confounded(self):
+        self.assertFalse(comparable_conditions("generic_v4", "tuned"))
+        self.assertEqual(sorted(condition_delta("generic_v4", "tuned")),
+                         ["base", "tuned"])
+
+    def test_each_generic_base_is_distinct(self):
+        bases = [CONDITION_AXES[c]["base"]
+                 for c in ("generic", "generic_v2", "generic_v3", "generic_v4")]
+        self.assertEqual(len(set(bases)), 4,
+                         "two conditions sharing a base would be indistinguishable")
+
+    def test_v4_is_launchable_from_the_cli(self):
+        """`generic_v2` was once staged, tested and unreachable because the
+        condition list was written out inline three times."""
+        from data_sheets_schema.cli.api import _CONDITIONS
+        self.assertIn("generic_v4", _CONDITIONS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_download/test_prompt_self_identification.py
+++ b/tests/test_download/test_prompt_self_identification.py
@@ -1,0 +1,128 @@
+"""Each condition's prompt must stamp its own file, not the one it was copied from (#337).
+
+`d4d_generic_arm_prompt_v3.md` was created by copying v2, and its HEADER BLOCK
+came with it:
+
+    # Mode: four-phase project agent, generic-v2 prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v2.md
+
+Byte-identical to what the 2026-07-31 generic-v2 records already carry. Every
+record the v3 arm produced would have claimed to be a v2 record, and
+`api_runner` does not repair it — its only header rewrite is
+`"generic prompt"` → `"tuned prompt"`.
+
+That is not cosmetic. The comparison v3 exists to make is v2 against v3, the
+header is the human-readable provenance, and it is what a reader checks first —
+the paired agent/API comparison in `notes/enumeration_depth_2026-08-04.md` was
+established from exactly these two lines. A v3 corpus stamped v2 makes that check
+return the wrong answer.
+
+The condition metadata was right all along (`CONDITION_AXES['generic_v3']` is
+`{'base': 'v3', 'tuned': False}`), so nothing but the header was wrong. The
+header is the part a person reads.
+
+Copy-paste is how the next `vN` would inherit it too, so this checks every
+condition rather than v3 alone.
+"""
+
+import re
+import unittest
+
+from data_sheets_schema.api_runner import CONDITION_PROMPTS
+
+
+class TestEachPromptNamesItself(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.bodies = {}
+        for condition, path in CONDITION_PROMPTS.items():
+            text = path.read_text(encoding="utf-8")
+            # Only the text after `## Prompt body` reaches the model; the
+            # rationale above it legitimately discusses other versions.
+            body = text.split("## Prompt body", 1)[-1]
+            cls.bodies[condition] = (path, body)
+
+    def test_the_prompt_line_names_the_file_it_is_in(self):
+        """The defect exactly: v3's body pointed at v2's path."""
+        for condition, (path, body) in self.bodies.items():
+            stamped = re.findall(r"^\s*#\s*Prompt:\s*(\S+)", body, re.M)
+            with self.subTest(condition=condition):
+                self.assertTrue(stamped, f"{path.name} stamps no prompt path")
+                for named in stamped:
+                    self.assertTrue(
+                        named.endswith(path.name),
+                        f"{path.name} tells the model to stamp records with "
+                        f"`{named}` — records would misattribute their own arm")
+
+    def test_no_prompt_stamps_another_conditions_file(self):
+        """The complement, and the sharper statement: a body naming *any* other
+        condition's file is wrong even if it also names its own."""
+        filenames = {p.name for p in CONDITION_PROMPTS.values()}
+        for condition, (path, body) in self.bodies.items():
+            others = filenames - {path.name}
+            stamped = " ".join(re.findall(r"^\s*#\s*Prompt:.*", body, re.M))
+            for other in sorted(others):
+                with self.subTest(condition=condition, other=other):
+                    self.assertNotIn(other, stamped)
+
+    def test_the_mode_line_matches_the_prompt_line(self):
+        """Both header lines name the version, and both were copied.
+
+        `api_runner` rewrites `"generic prompt"` to `"tuned prompt"` for the
+        tuned arm, so that one is expected to differ from its filename; every
+        other condition must be self-consistent.
+        """
+        for condition, (path, body) in self.bodies.items():
+            if condition == "tuned":
+                continue
+            modes = re.findall(r"^\s*#\s*Mode:.*?,\s*(\S+)\s+prompt", body, re.M)
+            with self.subTest(condition=condition):
+                self.assertTrue(modes, f"{path.name} stamps no mode")
+                stem = path.stem.replace("d4d_", "").replace("_arm_prompt", "")
+                # `d4d_generic_arm_prompt.md` -> `generic`; `..._v3.md` -> `generic_v3`
+                expected = stem.replace("_", "-")
+                for mode in modes:
+                    self.assertEqual(mode, expected,
+                                     f"{path.name} stamps mode `{mode}`")
+
+
+class TestThePremise(unittest.TestCase):
+    """Why the prompt body is the only place a generic version can be fixed.
+
+    `resolve_prompt` *does* correct the header for the tuned arm — it rewrites
+    both the Mode and the Prompt lines, because `tuned` deliberately shares
+    v1's file and adds a project block. That is why `tuned` is skipped above.
+
+    It performs no equivalent rewrite for the generic versions, so whatever
+    `d4d_generic_arm_prompt_v3.md` says about itself is what the corpus gets.
+    Asserted by running the resolver rather than reading its source, so a
+    rewrite added later makes these tests fail loudly rather than sit stale.
+    """
+
+    def _resolve(self, condition):
+        from pathlib import Path
+
+        from data_sheets_schema.api_runner import RunSpec, resolve_prompt
+        spec = RunSpec(project="CHORUS", arm="BASELINE",
+                       method="claudecode_agent",
+                       bundle=Path("data/preprocessed/concatenated/"
+                                   "CHORUS_preprocessed.txt"),
+                       label="2026-08-05_test", condition=condition)
+        return resolve_prompt(spec)
+
+    def test_the_tuned_arm_has_its_header_corrected_by_the_runner(self):
+        body = self._resolve("tuned")
+        self.assertIn("tuned prompt", body)
+        self.assertIn("d4d_tuned_arm_prompt.md", body)
+
+    def test_a_generic_version_gets_no_such_correction(self):
+        """So the body's own stamp is load-bearing (#337)."""
+        body = self._resolve("generic_v3")
+        self.assertIn("d4d_generic_arm_prompt_v3.md", body)
+        self.assertNotIn("d4d_generic_arm_prompt_v2.md", body)
+        self.assertIn("generic-v3 prompt", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #337. Closes #338.

Both were fixable only before the first v3 run. Verified none has happened: no
v3 run directory exists, and the v3 prompt's md5 is attested by nothing.

## #337 — v3 stamped every record as v2

Its HEADER BLOCK was copied from v2 verbatim:

```
# Mode: four-phase project agent, generic-v2 prompt
# Prompt: src/download/prompts/d4d_generic_arm_prompt_v2.md
```

Byte-identical to what the 2026-07-31 generic-v2 records already carry, and
`resolve_prompt` repairs the header only for the tuned arm.

Not cosmetic: the comparison v3 exists to make is v2 against v3, the header is
the human-readable provenance, and it is what a reader checks first — the paired
agent/API comparison in `notes/enumeration_depth_2026-08-04.md` was established
from exactly these two lines.

`test_prompt_self_identification.py` now checks **every** condition, since
copy-paste is how the next version would inherit it too. Its premise tests run
the resolver rather than reading its source, so a header rewrite added later
fails loudly instead of leaving them stale.

## #338 — the scalar rule belongs in v4, not v3

**My first attempt put it in v3, and two existing tests failed. They were right.**

`test_generic_v3_prompt.py` asserts v3 is "v2 plus the marked block and nothing
else", and `notes/generic_v3_analysis_plan.md` is **registered before any
generation run** and names exactly one rule. Adding a second would have
invalidated the pre-registration and made the v2-against-v3 delta unattributable
to either rule.

So v3 keeps only the header fix, and v4 carries the rule:

> Where a slot's declared range is a scalar, populate it with the identifier of
> the thing it refers to, not with the thing itself.

`notes/generic_v4_analysis_plan.md` registers the prediction in advance,
including the guard that matters — a rule about scalars that suppresses
legitimate object population has traded one defect for another, exactly as v2's
rule 1 did — and records that a **null result should retire the rule** rather
than keep it because it sounds sensible.

## Adding v4 exposed a real gap in `comparable_conditions`

It promised a difference "attributable to one change" and returned `True` for v2
against v4, which spans **two** rule additions: `condition_delta` reports the
single axis `base` regardless of how many versions apart. Latent already for v1
against v3; v4 made it load-bearing.

```
generic    vs generic_v2   True
generic_v2 vs generic_v3   True
generic_v3 vs generic_v4   True
generic_v2 vs generic_v4   False   <- two additions
generic    vs generic_v3   False   <- two additions
generic_v2 vs tuned        False   <- two axes
```

## Not wired by hand

`_CONDITIONS = sorted(CONDITION_PROMPTS)`, a lesson already learned when
`generic_v2` was staged, tested and unreachable from every CLI entry point. A
test pins that v4 is launchable.

## What this does not do

It does not decide whether to run v4. That is a study-design call: v3 alone
answers whether the inline-object failure recurs, and if it does not, v4's rule
should be retired unrun. The analysis plan says so explicitly.

Mutation-checked with 7 reintroductions, no survivors. `1261 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)