### PR TITLE
Derive the evaluation count instead of restating it (#315)

### DIFF
--- a/src/data_sheets_schema/cli/evaluate.py
+++ b/src/data_sheets_schema/cli/evaluate.py
@@ -190,10 +190,18 @@ def plan_cmd(config, paths_only):
     """
     from data_sheets_schema.evaluation_plan import (NothingSelected, plan,
                                                     summarise)
+    from data_sheets_schema.runs import AmbiguousCanonical
     try:
         evaluations = plan(config=config)
     except NothingSelected as exc:
         raise click.ClickException(str(exc))
+    except AmbiguousCanonical as exc:
+        # The state the rerun creates: marks under both the old and the new
+        # config until re-selection settles. `plan` is right to propagate rather
+        # than choose one (#308); rendering it is this boundary's job (#342).
+        raise click.ClickException(
+            f"{exc} Pass --config to say which configuration you mean, or "
+            "re-run `d4d runs select --execute` to settle the mark.")
 
     if paths_only:
         for path in dict.fromkeys(str(e.path) for e in evaluations):

--- a/src/data_sheets_schema/cli/evaluate.py
+++ b/src/data_sheets_schema/cli/evaluate.py
@@ -172,3 +172,36 @@ def llm(file, project, method, rubric, output_dir):
         sys.exit(1)
     finally:
         sys.argv = old_argv
+
+
+@evaluate.command("plan")
+@click.option("--config", default=None,
+              help="Restrict to one run config (label prefix).")
+@click.option("--paths-only", is_flag=True,
+              help="One record path per line, for piping into a sweep.")
+def plan_cmd(config, paths_only):
+    """What a semantic evaluation sweep would cover, derived from the canonical set.
+
+    The count has been stated four times and been wrong three of them (#315),
+    because it depends on how many projects end up with a canonical record —
+    which is not known until `d4d runs select --execute` has run. This derives
+    it rather than restating it, and prints the derivation alongside the number
+    so a bare count is harder to quote onward.
+    """
+    from data_sheets_schema.evaluation_plan import (NothingSelected, plan,
+                                                    summarise)
+    try:
+        evaluations = plan(config=config)
+    except NothingSelected as exc:
+        raise click.ClickException(str(exc))
+
+    if paths_only:
+        for path in dict.fromkeys(str(e.path) for e in evaluations):
+            click.echo(path)
+        return
+
+    for evaluation in evaluations:
+        click.echo(f"{evaluation.label}\t{evaluation.path}")
+    click.echo("")
+    click.echo(summarise(evaluations))
+

--- a/src/data_sheets_schema/evaluation_plan.py
+++ b/src/data_sheets_schema/evaluation_plan.py
@@ -1,0 +1,113 @@
+"""What to evaluate, derived from the canonical set rather than restated (#315).
+
+The semantic evaluation count has been written down four times and been wrong
+three of them, in both directions:
+
+    8   4 projects x 2 rubrics          full records only, unstated
+    6   3 projects x 2 rubrics          after VOICE failed selection; still full-only
+    12  3 projects x 2 variants x 2     correct only while VOICE and VOICE_PEDIATRIC
+                                        have no canonical record
+    20  5 projects x 2 variants x 2     correct only after a successful rerun
+
+Every one was a number typed into a note and then quoted from that note. The
+count is a function of how many projects end up with a canonical record, which
+is not knowable until `d4d runs select --execute` has run — and for VOICE it is
+genuinely uncertain, because `related_to` may recur (#292).
+
+So this module does not know a count. It enumerates the canonical records, pairs
+each with the rubrics, and reports what falls out. Nothing here should ever be
+quoted as a constant.
+
+`plan()` **raises** on an empty canonical set rather than returning an empty
+plan. Zero evaluations and "selection has not been run yet" are different
+states, and a plan of length zero reads as the first while usually meaning the
+second.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+#: The semantic rubrics an evaluation sweep runs. Both apply to every record;
+#: rubric10 and rubric20 measure different things and neither subsumes the other.
+SEMANTIC_RUBRICS = ("rubric10_semantic", "rubric20_semantic")
+
+#: Which record variant each path represents. `canonical_runs` reports both, and
+#: they are separate evaluations — a core record is scored against the same
+#: rubric as its full counterpart, and the two scores are the core/full contrast.
+VARIANTS = ("full", "core")
+
+
+class NothingSelected(RuntimeError):
+    """No project has a canonical record, so there is nothing to evaluate.
+
+    Distinguished from an empty plan on purpose. `d4d runs select --execute`
+    not having been run is the usual cause, and reporting "0 evaluations" would
+    read as a finished scoping exercise rather than an unstarted one.
+    """
+
+    def __init__(self, concat_dir: Path | None):
+        super().__init__(
+            f"no canonical record found under {concat_dir or 'the default '
+            'concatenated directory'}. Run `d4d runs select --execute` first; "
+            "`d4d runs canonical --missing` names the projects without one.")
+
+
+@dataclass(frozen=True)
+class Evaluation:
+    """One record, one rubric — the unit an evaluation sweep bills for."""
+
+    project: str
+    variant: str
+    rubric: str
+    path: Path
+
+    @property
+    def label(self) -> str:
+        return f"{self.project}/{self.variant}/{self.rubric}"
+
+
+def plan(concat_dir: Path | None = None, config: str | None = None,
+         rubrics: tuple[str, ...] = SEMANTIC_RUBRICS) -> list[Evaluation]:
+    """Every evaluation the canonical set implies, in a stable order.
+
+    Reads the canonical marks rather than any project list: a project without a
+    canonical record contributes nothing, which is the whole reason the count
+    cannot be stated in advance.
+    """
+    from data_sheets_schema.runs import canonical_runs
+
+    found = canonical_runs(concat_dir=concat_dir, config=config)
+    out: list[Evaluation] = []
+    for project in sorted(found):
+        record = found[project]
+        for variant in VARIANTS:
+            # `canonical_runs` reports the two record paths as top-level keys
+            # named for the variant, alongside `label`, `method` and
+            # `provenance`. A variant missing from a marked run is skipped
+            # rather than guessed at — the same discipline as a project with no
+            # mark at all.
+            path = record.get(variant)
+            if not path:
+                continue
+            for rubric in rubrics:
+                out.append(Evaluation(project=project, variant=variant,
+                                      rubric=rubric, path=Path(path)))
+    if not out:
+        raise NothingSelected(concat_dir)
+    return out
+
+
+def summarise(evaluations: list[Evaluation]) -> str:
+    """A line stating how the count was arrived at, not just the count.
+
+    The failure this module exists for is a bare number being quoted onward, so
+    the derivation travels with it.
+    """
+    projects = sorted({e.project for e in evaluations})
+    variants = sorted({e.variant for e in evaluations})
+    rubrics = sorted({e.rubric for e in evaluations})
+    return (f"{len(evaluations)} evaluations = {len(projects)} projects "
+            f"({', '.join(projects)}) x {len(variants)} variants "
+            f"({', '.join(variants)}) x {len(rubrics)} rubrics")

--- a/src/data_sheets_schema/evaluation_plan.py
+++ b/src/data_sheets_schema/evaluation_plan.py
@@ -48,9 +48,14 @@ class NothingSelected(RuntimeError):
     """
 
     def __init__(self, concat_dir: Path | None):
+        # The location is built outside the f-string: a multi-line expression
+        # inside a replacement field is PEP 701, valid on 3.12+ and a
+        # SyntaxError on the 3.10 and 3.11 this project still supports. It
+        # parsed fine locally on 3.13 and broke all three CI matrix entries.
+        where = concat_dir or "the default concatenated directory"
         super().__init__(
-            f"no canonical record found under {concat_dir or 'the default '
-            'concatenated directory'}. Run `d4d runs select --execute` first; "
+            f"no canonical record found under {where}. "
+            "Run `d4d runs select --execute` first; "
             "`d4d runs canonical --missing` names the projects without one.")
 
 

--- a/tests/test_evaluation/test_evaluation_plan.py
+++ b/tests/test_evaluation/test_evaluation_plan.py
@@ -1,0 +1,181 @@
+"""The evaluation count must be derived, never restated (#315).
+
+It has been written down four times and been wrong three of them, in both
+directions:
+
+    8   4 projects x 2 rubrics      full records only, unstated
+    6   3 projects x 2 rubrics      after VOICE failed selection; still full-only
+    12  3 projects x 2 variants x 2 correct only while VOICE and VOICE_PEDIATRIC
+                                    have no canonical record
+    20  5 projects x 2 variants x 2 correct only after a successful rerun
+
+Every one was typed into a note and then quoted from that note. So the tests
+here deliberately do **not** assert a number against the live corpus — doing so
+would recreate the defect inside the test suite, and would break on the day the
+rerun succeeds, which is the day it should quietly become 20.
+
+What they assert is that the plan is a function of the canonical marks: change
+the marks, the plan changes with them.
+"""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from data_sheets_schema.evaluation_plan import (SEMANTIC_RUBRICS, VARIANTS,
+                                                Evaluation, NothingSelected,
+                                                plan, summarise)
+
+
+def _corpus(root: Path, projects, config="2026-08-05_cfg", variants=VARIANTS):
+    """A concatenated directory with `canonical` marks for the named projects.
+
+    Shaped as `canonical_runs` reads it: a `canonical` block, `run.project`,
+    `run.label`, and `outputs.<variant>.path`. Writing a looser fixture made
+    every assertion here pass vacuously against an empty plan.
+    """
+    label = f"{config}_rep1"
+    for project in projects:
+        outputs = {}
+        for variant in variants:
+            sub = "claudecode_agent" if variant == "full" else "claudecode_agent_core"
+            suffix = "_d4d.yaml" if variant == "full" else "_d4d_core.yaml"
+            path = root / sub / label / f"{project}{suffix}"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("id: x\n")
+            outputs[variant] = {"path": str(path)}
+        prov_dir = root / "claudecode_agent_core" / label
+        prov_dir.mkdir(parents=True, exist_ok=True)
+        (prov_dir / f"{project}_provenance.yaml").write_text(yaml.safe_dump({
+            "run": {"project": project, "label": label,
+                    "method": "claudecode_agent"},
+            "outputs": outputs,
+            "canonical": {"criterion": "test", "selected_from": ["a"]},
+        }))
+    return root
+
+
+class TestThePlanFollowsTheMarks(unittest.TestCase):
+    """Not a number. A function of what is marked."""
+
+    def test_one_project_yields_variants_times_rubrics(self):
+        with TemporaryDirectory() as tmp:
+            root = _corpus(Path(tmp), ["CHORUS"])
+            got = plan(concat_dir=root)
+        self.assertEqual(len(got), len(VARIANTS) * len(SEMANTIC_RUBRICS))
+        self.assertEqual({e.project for e in got}, {"CHORUS"})
+
+    def test_adding_a_project_adds_its_evaluations(self):
+        """The rerun's effect, in miniature: mark more projects, get more
+        evaluations, with no number edited anywhere."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _corpus(root, ["CHORUS"])
+            before = len(plan(concat_dir=root))
+            _corpus(root, ["AI_READI", "CM4AI"])
+            after = len(plan(concat_dir=root))
+        self.assertEqual(after - before, 2 * len(VARIANTS) * len(SEMANTIC_RUBRICS))
+
+    def test_a_project_with_no_mark_contributes_nothing(self):
+        """The reason the count cannot be stated in advance: VOICE has no
+        canonical record while no replicate validates (#292)."""
+        with TemporaryDirectory() as tmp:
+            root = _corpus(Path(tmp), ["CHORUS", "CM4AI"])
+            got = plan(concat_dir=root)
+        self.assertNotIn("VOICE", {e.project for e in got})
+
+    def test_a_missing_variant_is_skipped_not_guessed(self):
+        with TemporaryDirectory() as tmp:
+            root = _corpus(Path(tmp), ["CHORUS"], variants=("full",))
+            got = plan(concat_dir=root)
+        self.assertEqual({e.variant for e in got}, {"full"})
+        self.assertEqual(len(got), len(SEMANTIC_RUBRICS))
+
+    def test_every_record_is_paired_with_every_rubric(self):
+        with TemporaryDirectory() as tmp:
+            root = _corpus(Path(tmp), ["CHORUS", "CM4AI"])
+            got = plan(concat_dir=root)
+        for project in ("CHORUS", "CM4AI"):
+            for variant in VARIANTS:
+                rubrics = {e.rubric for e in got
+                           if e.project == project and e.variant == variant}
+                with self.subTest(project=project, variant=variant):
+                    self.assertEqual(rubrics, set(SEMANTIC_RUBRICS))
+
+    def test_the_order_does_not_depend_on_the_resolver(self):
+        """`canonical_runs` happens to return a sorted dict, which masked
+        whether `plan` sorts at all — mutation showed removing its `sorted()`
+        changed nothing. Feed an unsorted mapping so `plan` owns its ordering
+        rather than inheriting it.
+        """
+        import data_sheets_schema.evaluation_plan as module
+        from unittest.mock import patch
+        unsorted = {
+            "VOICE": {"full": "v.yaml", "core": "vc.yaml"},
+            "AI_READI": {"full": "a.yaml", "core": "ac.yaml"},
+        }
+        with patch("data_sheets_schema.runs.canonical_runs",
+                   return_value=unsorted):
+            projects = [e.project for e in module.plan()]
+        self.assertEqual(projects[0], "AI_READI",
+                         "plan must sort projects itself")
+
+    def test_the_order_is_stable(self):
+        with TemporaryDirectory() as tmp:
+            root = _corpus(Path(tmp), ["CM4AI", "AI_READI"])
+            first = [e.label for e in plan(concat_dir=root)]
+            second = [e.label for e in plan(concat_dir=root)]
+        self.assertEqual(first, second)
+        self.assertEqual(first, sorted(first, key=lambda s: s.split("/")[0]))
+
+
+class TestNothingSelected(unittest.TestCase):
+    """An unstarted scoping and a finished one are different states."""
+
+    def test_an_empty_corpus_raises_rather_than_returning_an_empty_plan(self):
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(NothingSelected):
+                plan(concat_dir=Path(tmp))
+
+    def test_the_message_says_what_to_do(self):
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(NothingSelected) as caught:
+                plan(concat_dir=Path(tmp))
+        message = str(caught.exception)
+        self.assertIn("d4d runs select --execute", message)
+        self.assertIn("--missing", message)
+
+
+class TestSummarise(unittest.TestCase):
+    """The derivation travels with the number, so a bare count is harder to
+    quote onward — which is how this went wrong four times."""
+
+    def test_it_states_the_factors_not_just_the_total(self):
+        with TemporaryDirectory() as tmp:
+            root = _corpus(Path(tmp), ["CHORUS", "CM4AI"])
+            line = summarise(plan(concat_dir=root))
+        self.assertIn("8 evaluations", line)
+        self.assertIn("2 projects", line)
+        self.assertIn("CHORUS", line)
+        self.assertIn("2 variants", line)
+        self.assertIn("2 rubrics", line)
+
+
+class TestTheLiveCorpus(unittest.TestCase):
+    """Properties of the real plan — deliberately not its size."""
+
+    def test_the_plan_is_derivable_and_self_consistent(self):
+        try:
+            got = plan()
+        except NothingSelected:
+            self.skipTest("no canonical record on disk")
+        self.assertEqual(
+            len(got),
+            len({(e.project, e.variant) for e in got}) * len(SEMANTIC_RUBRICS),
+            "every canonical record must pair with every rubric exactly once")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation/test_evaluation_plan.py
+++ b/tests/test_evaluation/test_evaluation_plan.py
@@ -163,6 +163,47 @@ class TestSummarise(unittest.TestCase):
         self.assertIn("2 rubrics", line)
 
 
+class TestTheCliRendersFailures(unittest.TestCase):
+    """Every way this can fail must arrive as a message, not a traceback.
+
+    `AmbiguousCanonical` is the state the rerun creates — marks under the old
+    and new config until re-selection settles — and it reached the user as a
+    bare traceback with no mention of `--config` (#342).
+    """
+
+    def _invoke(self, side_effect=None, return_value=None):
+        from unittest.mock import patch
+
+        from click.testing import CliRunner
+
+        from data_sheets_schema.cli.evaluate import evaluate
+        kwargs = ({"side_effect": side_effect} if side_effect
+                  else {"return_value": return_value})
+        with patch("data_sheets_schema.runs.canonical_runs", **kwargs):
+            return CliRunner().invoke(evaluate, ["plan"])
+
+    def test_two_marks_are_reported_with_the_remedy(self):
+        from data_sheets_schema.runs import AmbiguousCanonical
+        result = self._invoke(
+            side_effect=AmbiguousCanonical("CHORUS: v2_rep1, v3_rep1"))
+        self.assertIsNone(result.exception if result.exit_code == 0 else None)
+        self.assertNotIsInstance(result.exception, AmbiguousCanonical)
+        self.assertIn("--config", result.output)
+        self.assertIn("CHORUS", result.output)
+
+    def test_nothing_selected_is_reported_with_the_remedy(self):
+        result = self._invoke(return_value={})
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("d4d runs select --execute", result.output)
+
+    def test_a_resolvable_corpus_exits_zero(self):
+        """The guard must not turn every invocation into an error."""
+        result = self._invoke(return_value={
+            "CHORUS": {"full": "c.yaml", "core": "cc.yaml"}})
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("evaluations =", result.output)
+
+
 class TestTheLiveCorpus(unittest.TestCase):
     """Properties of the real plan — deliberately not its size."""
 


### PR DESCRIPTION
Closes #315.

## The count has been wrong three times out of four

| stated | assumed | actually |
|---|---|---|
| **8** | 4 projects × 2 rubrics | full records only — unstated |
| **6** | 3 projects × 2 rubrics | still full-only |
| **12** | 3 × 2 variants × 2 rubrics | correct *only* while VOICE and VOICE_PEDIATRIC have no canonical record |
| **20** | 5 × 2 variants × 2 rubrics | correct *only* after a successful rerun |

Every one was typed into a note and then quoted from that note. The count is a
function of how many projects end up with a canonical record — not knowable
until `d4d runs select --execute` has run, and for VOICE genuinely uncertain
because `related_to` may recur (#292).

## The fix

`evaluation_plan.plan()` enumerates the canonical set and pairs each record with
each rubric; `d4d evaluate plan` prints it.

```
$ d4d evaluate plan
AI_READI/full/rubric10_semantic   data/.../AI_READI_d4d.yaml
...
12 evaluations = 3 projects (AI_READI, CHORUS, CM4AI) x 2 variants (core, full) x 2 rubrics
```

Today 12; after a successful rerun, 20 — with no number edited anywhere.
`summarise()` prints the derivation beside the total, because a bare count being
quoted onward is the failure mode itself.

`plan()` **raises** `NothingSelected` rather than returning an empty list.
"Zero evaluations" and "selection has not been run yet" are different states,
and a plan of length zero reads as the first while usually meaning the second.

## The tests do not assert a number

Asserting `len(plan()) == 12` would pass today, recreate this exact defect inside
the suite, and break on the day the rerun succeeds — which is the day it should
quietly become 20. They assert instead that the plan *follows the marks*: mark
another project, get its evaluations.

## Three faults found while writing them

- The first fixture wrote a bare `canonical` key, which `canonical_runs` does
  not recognise, so **every assertion passed against an empty plan**. It now has
  the shape the resolver reads.
- A guard asserting "no test here asserts the live count" listed the forbidden
  patterns in its own source, so it could never pass. Removed rather than
  contorted.
- Mutation showed `plan`'s `sorted()` was **inert** — `canonical_runs` already
  returns a sorted dict. Ordering is now tested against an unsorted mapping, so
  `plan` owns it rather than inheriting an implementation detail.

11 tests, mutation-checked with 6 reintroductions, no survivors.
`1277 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)