### PR TITLE
Move API runs to the unprefixed claude-opus-5 route; size phase ceilings for v3's thinking spend

### DIFF
--- a/.github/workflows/d4d_assistant_deterministic.config
+++ b/.github/workflows/d4d_assistant_deterministic.config
@@ -19,7 +19,12 @@ model:
   # 1M input / 128k output; CBORG offers no opus-5 effort ladder on it, so
   # reasoning effort is the provider default rather than "high".
   temperature: 0.0                  # Maximum determinism
-  max_tokens: 16000                 # Sufficient for comprehensive D4D generation
+  # Fallback only (#350): six-phase API runs take their ceilings from
+  # PHASE_MAX_TOKENS in api_runner.py, which covers every phase. 16000 is NOT
+  # sufficient for a full record once thinking shares the budget — see the
+  # route-switch note above. The value is kept for the GitHub assistant path,
+  # this config's original consumer.
+  max_tokens: 16000
 
 # Prompt Configuration
 prompts:

--- a/.github/workflows/d4d_assistant_deterministic.config
+++ b/.github/workflows/d4d_assistant_deterministic.config
@@ -8,11 +8,16 @@
 # Model Configuration
 model:
   provider: anthropic
-  name: google/claude-opus-5-high    # Pinned for reproducibility (CBORG)
+  name: claude-opus-5    # Pinned for reproducibility (CBORG, unprefixed route)
   # CBORG exposes effort as a model-name suffix, not a parameter, because
   # this family rejects `temperature` outright (400: deprecated).
-  # Limits differ from the unprefixed claude-opus-5 (1M/128k):
-  # google/claude-opus-5-high is 200k input / 64k output.
+  # Switched from google/claude-opus-5-high on 2026-08-05: the v3 prompt
+  # roughly doubled full-phase thinking spend (35.7k-48.7k tokens observed on
+  # AI-READI vs 14.7k-29.3k under v1/v2), and that route's 64k output ceiling
+  # left too little room for thinking plus the record — two of three AI-READI
+  # full attempts truncated at the cap. The unprefixed claude-opus-5 route is
+  # 1M input / 128k output; CBORG offers no opus-5 effort ladder on it, so
+  # reasoning effort is the provider default rather than "high".
   temperature: 0.0                  # Maximum determinism
   max_tokens: 16000                 # Sufficient for comprehensive D4D generation
 

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -159,13 +159,23 @@ PHASES = ("full", "core", "audit", "reconcile_full", "reconcile_core", "report")
 # 97 report records already generated, plus ~40% headroom. A guessed ceiling is
 # how the previous design truncated five of six projects mid-YAML.
 PHASE_MAX_TOKENS = {
-    "full": 64000, "reconcile_full": 64000,
+    # 96000, not 64000. The v3 prompt roughly doubled full-phase thinking spend
+    # (35.7k-48.7k tokens observed on AI-READI, vs 14.7k-29.3k under v1/v2),
+    # and thinking and record share this budget — two of three 2026-08-05
+    # AI-READI full attempts died at 64000 with the record truncated. The value
+    # is clamped per route by `output_limit()`, so on a 64k route (the
+    # `google/…` rebroadcasts) the request still asks for exactly 64000.
+    "full": 96000, "reconcile_full": 96000,
     "core": 56000, "reconcile_core": 56000,
     # 24000, not 12000. The original was derived from records generated before
     # the v2 rules existed, and two AI-READI runs truncated mid-audit — a phase
     # that fails at its ceiling costs the whole run, since the phases before it
     # are already billed.
-    "audit": 24000, "report": 12000,
+    # Report raised for the same reason as full: under v3 the report phase
+    # spent 6.6k-6.8k tokens thinking and hit 12000 twice on 2026-08-05 before
+    # a third sample fit at 10.5k. The ceiling was derived from pre-v2 records
+    # and left no room for the thinking share.
+    "audit": 24000, "report": 24000,
 }
 DEFAULT_MAX_TOKENS = 64000
 

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -544,8 +544,12 @@ def build_record(project: str, method: str, label: str, *, mode: str,
             "temperature": declared.get("temperature"),
             "max_tokens": declared.get("max_tokens"),
         }
+        # Exact inequality, not substring (#349). The pin `claude-opus-5` is a
+        # substring of every family variant — `claude-opus-5[1m]`,
+        # `google/claude-opus-5-high` — so a containment test can never fire
+        # for route drift, which is precisely what this note exists to record.
         if declared.get("name") and model.get("model") and \
-                str(declared["name"]) not in str(model["model"]):
+                str(declared["name"]) != str(model["model"]):
             notes.append(
                 f"Model mismatch: this run used {model['model']!r} while "
                 f"{DETERMINISTIC_CONFIG} pins {declared['name']!r}. The two "


### PR DESCRIPTION
## Why

The v3 condition roughly doubled full-phase thinking spend on AI-READI (35.7k–48.7k tokens across three samples, vs 14.7k–29.3k across eight v1/v2 samples — the ranges do not overlap). Thinking and the visible record share one `max_tokens` budget, and the `google/claude-opus-5-high` CBORG route caps output at 64k, so the cap started binding: on 2026-08-05, two of three AI-READI full attempts truncated at 64000, and the report phase hit its 12000 ceiling twice before a third sample fit at 10.5k. The 13:57 full record cleared the cap by only ~7k tokens — sample luck, not fit.

## What

- **Config pin** (`d4d_assistant_deterministic.config`): `google/claude-opus-5-high` → unprefixed `claude-opus-5` (CBORG: 1M input / 128k output). CBORG offers no opus-5 effort ladder on the unprefixed route (only fable-5 has one), so reasoning effort becomes the provider default rather than "high" — accepted trade-off.
- **`PHASE_MAX_TOKENS`**: `full`/`reconcile_full` 64000 → 96000; `report` 12000 → 24000 (the same correction the audit ceiling received earlier for the same failure shape). `_call_with_retry` clamps via `output_limit()`, so on any 64k route the request still asks for exactly 64000 — the raise only takes effect where the route allows it.

## Evidence

Attempt history from `data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_reasoning.jsonl`:

| phase | attempt | output tokens | thinking est. | stop |
|---|---|---|---|---|
| full | 1 | 64000 | ~39.9k | max_tokens |
| full | 2 | 64000 | ~48.7k | max_tokens |
| full | 3 | 56030 | ~37.1k | end_turn |
| report | 1 | 12000 | ~6.6k | max_tokens |
| report | 2 | 12000 | ~6.8k | max_tokens |
| report | 3 | 10482 | ~3.8k | end_turn |

## Sweep-comparability note

CHORUS v3 rep1 (2026-08-05) was generated on `google/claude-opus-5-high`; runs after this PR use `claude-opus-5`. If route uniformity within the v3 sweep matters, CHORUS (and AI-READI) should be re-run on the new route — deliberately **not** done here; no generations are launched by this change.

## Testing

- `tests.test_download.test_api_runner`: 117 tests, OK (before and after each edit)
- `d4d api plan --project VOICE --condition generic_v3` resolves `claude-opus-5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)