### PR TITLE
Put the phase instruction last, after the carried artifacts (#346)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -391,7 +391,7 @@ PHASE_INSTRUCTIONS = {
         "commentary before or after."),
     "core": (
         "Phase 2. Produce the CORE D4D record for class `CoreDataset`, using "
-        "the declared bundle and the completed full record supplied below. The "
+        "the declared bundle and the completed full record supplied above. The "
         "core record must not assert anything the full record does not support. "
         "Output only the YAML."),
     "audit": (
@@ -408,7 +408,7 @@ PHASE_INSTRUCTIONS = {
         "Phase 4b. Apply the audit findings that concern the CORE record and "
         "emit the corrected core record in its entirety, header block included. "
         "It must remain consistent with the reconciled full record supplied "
-        "below and assert nothing the full record does not support. If no "
+        "above and assert nothing the full record does not support. If no "
         "finding requires a change, emit it unchanged. Output only YAML."),
     "report": (
         "Phase 4c. Write the reconciliation report as Markdown: what the audit "
@@ -461,12 +461,18 @@ def build_phase(spec: RunSpec, phase: str, *, carry: dict[str, str]) -> PhaseReq
          "cache_control": {"type": "ephemeral"}},
     ]
 
+    # Carried artifacts go BEFORE the phase instruction, so the instruction is
+    # the last thing in the message (#346). With the old order the message
+    # ended with the carried full record — for AI-READI an 83KB YAML document
+    # sitting 21k tokens after "Output only the YAML" — and the model continued
+    # that document instead of answering: ten consecutive core-phase attempts
+    # produced a mid-record fragment growing an `extension_mechanism` slot.
     parts: list[dict[str, Any]] = list(cached)
     parts.append({"type": "text", "text": resolve_prompt(spec)})
-    parts.append({"type": "text", "text": PHASE_INSTRUCTIONS[phase]})
     for name, text in carry.items():
         parts.append({"type": "text",
                       "text": f"# {name}\n\n{text}"})
+    parts.append({"type": "text", "text": PHASE_INSTRUCTIONS[phase]})
 
     return PhaseRequest(
         phase=phase,

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -139,6 +139,28 @@ class TestPhaseAssembly(unittest.TestCase):
         blob = " ".join(p["text"] for p in req.messages[0]["content"])
         self.assertIn("Completed full record", blob)
 
+    def test_instruction_is_the_last_part_so_carry_never_trails(self):
+        # #346: when the carried full record was the final content block, the
+        # message ended with a large YAML document and the model continued it
+        # instead of answering — ten consecutive core attempts on AI-READI
+        # returned a mid-record fragment. The instruction must come last.
+        for ph, carry in (
+                ("core", {"Completed full record": "id: x\n"}),
+                ("reconcile_core", {"Reconciled full record": "id: x\n",
+                                    "Completed core record": "id: y\n",
+                                    "Audit findings": "{}"}),
+                ("report", {"Audit findings": "{}"})):
+            req = build_phase(spec(), ph, carry=carry)
+            self.assertEqual(req.messages[0]["content"][-1]["text"],
+                             PHASE_INSTRUCTIONS[ph], ph)
+
+    def test_carry_instructions_say_above_not_below(self):
+        # The instruction follows the carry, so any instruction describing a
+        # carried artifact's position must say "above". "Below" would point at
+        # nothing and invite exactly the confusion #346 documents.
+        for ph, instr in PHASE_INSTRUCTIONS.items():
+            self.assertNotIn("supplied below", instr, ph)
+
     def test_unknown_phase_rejected(self):
         with self.assertRaises(ValueError):
             build_phase(spec(), "nonsense", carry={})


### PR DESCRIPTION
Fixes #346.

## Why

`build_phase()` assembled messages as `[schema, bundle, prompt, instruction, carry]`, so the carried full record was the final content block. For AI-READI that meant the message ended with an 83 KB YAML document sitting ~21k tokens after "Output only the YAML" — and the model continued the trailing document instead of answering: ten consecutive core-phase attempts (2026-08-05, two bursts hours apart) returned a ~1k-token mid-record fragment growing an `extension_mechanism` slot. The core phase emits no thinking, so sampling is near-greedy and the failure reproduced on every retry. Quarantining that full record and regenerating it made core pass first-attempt — confirming the carry was the trigger.

## What

- Carried artifacts now precede the phase instruction; the instruction is the last thing the model reads.
- `core` and `reconcile_core` instructions that located their artifact "supplied below" now say "supplied above".
- Two regression tests: the instruction is the final content part for every carrying phase, and no instruction says "supplied below".

## Sweep note

This changes request assembly for **every condition**, so it lands now, between sweeps — the v3 sweep restarts on the `claude-opus-5` route (#347) with this assembly from its first record.

## Testing

`tests.test_download.test_api_runner`: 119 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)