### PR TITLE
Reproduce published artifacts on the recorded instrument, not the live config pin (#351)

### DIFF
--- a/src/data_sheets_schema/agreement.py
+++ b/src/data_sheets_schema/agreement.py
@@ -575,12 +575,20 @@ def build_matrix(*, root: Path = DEFAULT_ROOT, method: str = DEFAULT_METHOD,
                  reps: int = 3, cache_dir: Path = DEFAULT_CACHE,
                  embed: bool = False, offline: bool = False,
                  embed_online: bool = False,
+                 judge_model: str | None = None,
                  ) -> tuple[dict[str, dict[str, Any]], dict[str, list[SlotAgreement]]]:
     """The whole matrix, plus the per-slot rows behind every cell.
 
     `embed_online` is separate from `offline` so that re-judging a handful of
     slots cannot quietly buy ~1400 embeddings on the way past. The embedder
     reads its cache and stops there unless asked otherwise.
+
+    `judge_model` pins the instrument. Left as None the judge inherits the
+    live config pin — right for a fresh measurement, wrong for reproducing a
+    published one: when #345 switched the pin, every model-scoped cached
+    verdict silently fell out of scope and the offline rebuild of an already
+    frozen artifact failed (#351). A reproduction passes the judge_model the
+    publication records.
     """
     configs = configs or DEFAULT_CONFIGS
     embedder = (Embedder(cache_path=cache_dir / "embeddings.jsonl",
@@ -596,6 +604,7 @@ def build_matrix(*, root: Path = DEFAULT_ROOT, method: str = DEFAULT_METHOD,
                       file=sys.stderr)
                 continue
             judge = EquivalenceJudge(
+                model=judge_model,
                 cache_path=cache_dir / f"{project}_equivalence.jsonl",
                 offline=offline)
             result = compare_records(records, embedder=embedder, judge=judge)

--- a/src/data_sheets_schema/form_defects.py
+++ b/src/data_sheets_schema/form_defects.py
@@ -175,6 +175,31 @@ def attribute(failures: list[FormFailure], *, root: Path = DEFAULT_ROOT,
     return failures
 
 
+def recorded_model(cache_path: Path) -> str:
+    """The one model the cached subtype judgements were made under.
+
+    A reproduction must run on the instrument the cache records, not on the
+    live config pin: the pin is free to move (#345 moved it), and the moment it
+    does, every model-scoped entry falls out of scope and an offline rebuild of
+    a frozen artifact fails (#351). Requires exactly one recorded model for the
+    current rubric — zero means there is nothing to reproduce, two means two
+    instruments are pooled and neither table can be trusted (#277).
+    """
+    models: set[str] = set()
+    for line in Path(cache_path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        if entry.get("rubric") == _digest(FORM_SUBTYPE_SYSTEM):
+            models.add(entry.get("model", ""))
+    models.discard("")
+    if len(models) != 1:
+        raise ValueError(
+            f"{cache_path} records {len(models)} models for the current "
+            f"rubric ({sorted(models)}); a reproduction needs exactly one.")
+    return models.pop()
+
+
 class FormSubtypeClassifier:
     """Which form failure is this? Cached, model-scoped, offline-capable."""
 

--- a/tests/test_agreement.py
+++ b/tests/test_agreement.py
@@ -482,8 +482,18 @@ class TestPublishedMatrixReproduces(unittest.TestCase):
 
     def test_matrix_rebuilds_offline_and_matches(self):
         published = json.loads((CACHE / "matrix.json").read_text())
-        matrix, _ = build_matrix(root=REPO / "data" / "d4d_concatenated",
-                                 cache_dir=CACHE, offline=True)
+        # Rebuild on the instrument the publication records, not the live
+        # config pin (#351): the pin moved once (#345) and every model-scoped
+        # cached verdict fell out of scope. The mock proves the pin is not
+        # even consulted — a reproduction must not depend on mutable config.
+        models = {c["judge_model"] for c in published.values()}
+        self.assertEqual(len(models), 1, "published matrix spans judge models")
+        with unittest.mock.patch(
+                "data_sheets_schema.api_runner._model_settings",
+                side_effect=AssertionError("reproduction consulted the config pin")):
+            matrix, _ = build_matrix(root=REPO / "data" / "d4d_concatenated",
+                                     cache_dir=CACHE, offline=True,
+                                     judge_model=models.pop())
         self.assertEqual(len(matrix), 8)
         for key, cell in published.items():
             self.assertIn(key, matrix)

--- a/tests/test_form_defects.py
+++ b/tests/test_form_defects.py
@@ -18,6 +18,7 @@ from data_sheets_schema.form_defects import (
     _parse_subtype,
     attribute,
     load_form_failures,
+    recorded_model,
     table,
 )
 
@@ -193,8 +194,12 @@ class TestTheSplitResult(unittest.TestCase):
 
     def _classified(self):
         failures = attribute(load_form_failures(JUDGEMENTS))
+        # The recorded instrument, not the live config pin (#351): the pin
+        # moved once (#345) and every model-scoped cached subtype fell out of
+        # scope, failing this offline rebuild of a frozen finding.
+        cache = SUBTYPE_CACHE / "form_subtypes.jsonl"
         classifier = FormSubtypeClassifier(
-            cache_path=SUBTYPE_CACHE / "form_subtypes.jsonl", offline=True)
+            model=recorded_model(cache), cache_path=cache, offline=True)
         return [(f, *classifier(f)) for f in failures]
 
     def test_collapsed_cardinality_all_but_disappears_under_v2(self):


### PR DESCRIPTION
Fixes #351.

## Root cause (corrects the issue's original framing)

The four offline reproducibility tests (`test_agreement.TestPublishedMatrixReproduces`, `test_form_defects.TestTheSplitResult`) began failing with `OfflineCacheMiss` after #345 — not because the 2026-08-05 regeneration entered the corpus (discovery was label-pinned all along), but because `EquivalenceJudge.model` and `FormSubtypeClassifier.model` default to `_model_settings()["name"]`, the **live config pin**. Cached verdicts are model-scoped (correctly), so moving the pin from `google/claude-opus-5-high` to `claude-opus-5` silently dropped every model-scoped cache entry out of scope. Verified both directions: pinning the judge to the recorded model rebuilds all 8 matrix cells with zero misses.

## What

- `build_matrix(judge_model=...)` threads the instrument to `EquivalenceJudge`; `None` keeps today's behavior for fresh measurements.
- The matrix test reads `judge_model` from the published `matrix.json` cells (asserting exactly one), and mocks `_model_settings` to *raise* — proving the reproduction path never consults mutable config.
- `form_defects.recorded_model(cache_path)` returns the one model the subtype cache records for the current rubric (raising on zero or two — two instruments pooled is #277's error); the split tests use it.

## Testing

- `tests.test_agreement` + `tests.test_form_defects`: 73 tests, OK (previously 4 errors)
- Full suite: 1249 tests, OK (skipped=5) — first fully green run since the pin switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)