### PR TITLE
Ask the audit for schema-shape findings; forbid reconciliation from breaking shape (#356)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -399,16 +399,25 @@ PHASE_INSTRUCTIONS = {
         "evidence boundary. Report, as a JSON object with keys `findings` (a "
         "list of {severity, record, slot, issue}) and `summary`: any slot whose "
         "value the bundle does not support, any omission the bundle clearly "
-        "supports, and any internal inconsistency. Output only JSON."),
+        "supports, any internal inconsistency, and any value whose shape does "
+        "not conform to the schema digest supplied above — prose where the "
+        "schema requires a list, enum values the schema does not define, or "
+        "source commentary embedded inside a name, identifier or affiliation "
+        "value. Output only JSON."),
     "reconcile_full": (
         "Phase 4a. Apply the audit findings that concern the FULL record and "
         "emit the corrected full record in its entirety, header block included. "
-        "If no finding requires a change, emit it unchanged. Output only YAML."),
+        "Every value you write or change must conform to the schema digest "
+        "supplied above — a repair that fixes evidence but breaks shape is "
+        "still a defect. If no finding requires a change, emit it unchanged. "
+        "Output only YAML."),
     "reconcile_core": (
         "Phase 4b. Apply the audit findings that concern the CORE record and "
         "emit the corrected core record in its entirety, header block included. "
         "It must remain consistent with the reconciled full record supplied "
-        "above and assert nothing the full record does not support. If no "
+        "above and assert nothing the full record does not support. Every "
+        "value you write or change must conform to the schema digest supplied "
+        "above. If no "
         "finding requires a change, emit it unchanged. Output only YAML."),
     "report": (
         "Phase 4c. Write the reconciliation report as Markdown: what the audit "

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -154,6 +154,17 @@ class TestPhaseAssembly(unittest.TestCase):
             self.assertEqual(req.messages[0]["content"][-1]["text"],
                              PHASE_INSTRUCTIONS[ph], ph)
 
+    def test_audit_and_reconcile_demand_schema_shape_conformance(self):
+        # #356: the AI-READI v3 audit saw evidence problems but no phase saw
+        # shape problems, and reconciliation introduced one while repairing an
+        # audited omission. The audit must ask for shape findings, and both
+        # reconcile phases must be told a repair may not break shape.
+        self.assertIn("shape", PHASE_INSTRUCTIONS["audit"])
+        self.assertIn("schema digest", PHASE_INSTRUCTIONS["audit"])
+        for ph in ("reconcile_full", "reconcile_core"):
+            self.assertIn("conform to the schema digest",
+                          PHASE_INSTRUCTIONS[ph], ph)
+
     def test_carry_instructions_say_above_not_below(self):
         # The instruction follows the carry, so any instruction describing a
         # carried artifact's position must say "above". "Below" would point at


### PR DESCRIPTION
Implements option 2 (and the reconcile half of option 3) from #356.

## Why

The `2026-08-05` AI-READI v3 run showed the audit catches evidence problems but no phase checks values against the schema digest sitting in the same request: annotated free-string affiliations passed every phase; a prose `future_guarantees` was never seen; and reconciliation *introduced* `collection_type: 'metadata'` while correctly repairing an audited omission. The run was billed in full before `validate_outputs` said anything.

## What

- Audit instruction now asks for shape findings alongside evidence findings: prose where the schema requires a list, enum values the schema does not define, source commentary embedded inside name/identifier/affiliation values.
- Both reconcile instructions state that every written or changed value must conform to the digest — "a repair that fixes evidence but breaks shape is still a defect."
- Regression test pinning both requirements.

Instruction-text-only change, landed between sweeps per #352's precedent (the v3 sweep restarts on the new route with this assembly from its first record). Option 1 from #356 (validator-driven repair micro-phase) remains open — it catches what the model still misses.

## Testing

`tests.test_download.test_api_runner`: 120 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)