### PR TITLE
Say six phases where there are six (#354)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -22,7 +22,7 @@ Settings come from the GitHub assistant's deterministic config, so the two
 paths cannot drift into different procedures claiming to be the same one.
 
 Cost: the schema digest replaces the merged schema (254 KB -> 18 KB), and the
-bundle plus digest form a cached prefix reused across all four phases.
+bundle plus digest form a cached prefix reused across all six phases.
 """
 
 from __future__ import annotations
@@ -179,7 +179,8 @@ PHASE_MAX_TOKENS = {
 }
 DEFAULT_MAX_TOKENS = 64000
 
-# The API is called four to six times per run over minutes; transient 429s and
+# The API is called at least six times per run (one per phase, plus
+# phase-level retries) over minutes; transient 429s and
 # 5xx are expected rather than exceptional.
 MAX_ATTEMPTS = 5
 BACKOFF_BASE_SECONDS = 2
@@ -449,7 +450,7 @@ def build_phase(spec: RunSpec, phase: str, *, carry: dict[str, str]) -> PhaseReq
     """Assemble one phase's request.
 
     The bundle and schema digest are the cached prefix: identical across all
-    four phases of a run, and by far the largest inputs.
+    six phases of a run, and by far the largest inputs.
     """
     if phase not in PHASES:
         raise ValueError(f"unknown phase {phase!r}")

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -1,4 +1,4 @@
-"""API generation commands — four-phase D4D runs over the Anthropic API."""
+"""API generation commands — six-phase D4D runs over the Anthropic API."""
 
 import json
 import sys
@@ -62,7 +62,7 @@ def _require_bundle(spec, project, bundle):
 
 @click.group()
 def api():
-    """Generate D4D records via the Anthropic API (four-phase)."""
+    """Generate D4D records via the Anthropic API (six-phase)."""
 
 
 @api.command("plan")
@@ -117,7 +117,7 @@ def plan_cmd(project, arm, label, condition, bundle, out_dir, as_json):
               help="flat output directory (the assistant layout)")
 @click.option("--yes", is_flag=True, help="skip the cost confirmation")
 def run_cmd(project, arm, label, condition, bundle, out_dir, yes):
-    """Execute all four phases and write outputs plus a live provenance record."""
+    """Execute all six phases and write outputs plus a live provenance record."""
     from data_sheets_schema.api_runner import execute, plan
     spec = _spec(project, arm, label, condition, bundle, out_dir)
     _require_bundle(spec, project, bundle)
@@ -126,7 +126,7 @@ def run_cmd(project, arm, label, condition, bundle, out_dir, yes):
             f"{spec.full_path} already exists; a run label is never reused")
 
     p = plan(spec)
-    click.echo(f"~{p['approx_total_input_tokens']:,} input tokens across 4 phases "
+    click.echo(f"~{p['approx_total_input_tokens']:,} input tokens across 6 phases "
                f"on {p['model']['name']}")
     if not yes and not click.confirm("Proceed with billed API calls?"):
         click.echo("aborted")


### PR DESCRIPTION
Fixes #354.

Docstrings, CLI group/command help, and the `run` cost line still said four phases; the pipeline has been six since the reconcile split. User-facing help undercounted what a run bills.

Deliberately untouched: the two `# Mode: four-phase project agent` strings in `resolve_prompt()` — they are match targets against pinned bytes inside the v1 prompt files, not our own description; changing them would silently break the tuned-condition substitution.

Also reworded the retry comment: the API is called at least six times per run (one per phase, plus phase-level retries), not "four to six".

Testing: `tests.test_download.test_api_runner`, 120 tests OK; no test asserts the old wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)