### PR TITLE
Record an assembly fingerprint in provenance (#353)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -269,6 +269,28 @@ def prompt_body(path: Path = GENERIC_PROMPT) -> str:
     return text.split("## Prompt body", 1)[1].strip()
 
 
+# Updated by hand when build_phase() reorders its parts; the instruction texts
+# are hashed mechanically below, so wording changes cannot go unrecorded, but
+# nothing derives this ordering from the code — keep it true.
+ASSEMBLY_LAYOUT = ("schema digest, input bundle, arm prompt, "
+                   "carried artifacts, phase instruction")
+
+
+def assembly_digest() -> dict[str, Any]:
+    """Fingerprint of how requests are assembled, for provenance (#353).
+
+    The prompt-file and resolved-text hashes witness the arm prompt only. #352
+    moved the phase instruction after the carried artifacts and reworded two
+    instructions — a change that materially altered every request — yet a
+    record made the day before and the day after carried byte-identical prompt
+    evidence. This digest covers what those hashes do not: the phase
+    instruction texts and the order the parts are assembled in.
+    """
+    basis = json.dumps([ASSEMBLY_LAYOUT, PHASE_INSTRUCTIONS], sort_keys=True)
+    return {"sha256": hashlib.sha256(basis.encode("utf-8")).hexdigest(),
+            "layout": ASSEMBLY_LAYOUT}
+
+
 def resolved_prompt_digest(spec: RunSpec) -> dict[str, Any]:
     """A hash of the text the model is actually sent.
 
@@ -1395,6 +1417,7 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     # both: the file for provenance of the source, the resolution for the
     # request actually sent.
     rec.data["prompts"]["resolved"] = resolved_prompt_digest(spec)
+    rec.data["prompts"]["assembly"] = assembly_digest()
     ident = provider_identity()
     rec.data["model"] = {
         "generation_method": "schema-grounded API, six phases",

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -419,6 +419,19 @@ class TestTheRunDateIsFrozenPerRun(unittest.TestCase):
         sent = hashlib.sha256(resolve_prompt(spec).encode("utf-8")).hexdigest()
         self.assertEqual(sent, resolved_prompt_digest(spec)["sha256"])
 
+    def test_assembly_digest_moves_when_an_instruction_moves(self):
+        """#353: the prompt hashes witness the arm prompt only; #352 changed
+        every request without moving them. The assembly digest must move with
+        the instruction texts, and be stable when nothing changed."""
+        from data_sheets_schema.api_runner import (
+            PHASE_INSTRUCTIONS, assembly_digest)
+        before = assembly_digest()
+        self.assertEqual(before, assembly_digest())
+        with unittest.mock.patch.dict(PHASE_INSTRUCTIONS,
+                                      {"core": "reworded"}):
+            self.assertNotEqual(before["sha256"], assembly_digest()["sha256"])
+        self.assertEqual(before, assembly_digest())
+
     def test_the_date_can_be_pinned_explicitly(self):
         """Frozen on the spec, so a rerun can reproduce an earlier run's text."""
         from data_sheets_schema.api_runner import resolve_prompt


### PR DESCRIPTION
Fixes #353.

`prompts.assembly = {sha256, layout}` is now written beside `prompts.resolved` in every live provenance record: a digest over the `PHASE_INSTRUCTIONS` texts plus an `ASSEMBLY_LAYOUT` constant naming the part order. Instruction wording changes move the hash mechanically; part-order changes require updating the layout constant, which sits directly beside `build_phase()`'s contract with a comment saying to keep it true.

Records generated before this PR carry no `assembly` key — absence itself dates them to the pre-#352 era or the one day between #352 and this PR.

Test: digest is stable across calls, moves when an instruction is patched, and reverts when the patch lifts.

Testing: `tests.test_download.test_api_runner`, 121 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)