### PR TITLE
Repair invalid records from the validator's findings before failing the run (#356)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -165,8 +165,8 @@ PHASE_MAX_TOKENS = {
     # AI-READI full attempts died at 64000 with the record truncated. The value
     # is clamped per route by `output_limit()`, so on a 64k route (the
     # `google/…` rebroadcasts) the request still asks for exactly 64000.
-    "full": 96000, "reconcile_full": 96000,
-    "core": 56000, "reconcile_core": 56000,
+    "full": 96000, "reconcile_full": 96000, "repair_full": 96000,
+    "core": 56000, "reconcile_core": 56000, "repair_core": 56000,
     # 24000, not 12000. The original was derived from records generated before
     # the v2 rules existed, and two AI-READI runs truncated mid-audit — a phase
     # that fails at its ceiling costs the whole run, since the phases before it
@@ -1029,6 +1029,29 @@ def validation_block(spec: RunSpec, problems: list[dict[str, str]],
     return block
 
 
+def _validator_lines(path: Path, schema: str,
+                     cls: str) -> tuple[list[str] | None, str | None]:
+    """(findings, failure): every validator finding, one per line.
+
+    `findings` is None exactly when `failure` says why the validator itself
+    could not run — the two outcomes must stay distinguishable, because a
+    record that could not be checked is not a record that passed, and a
+    repair attempted against a broken validator would be flying blind.
+    """
+    try:
+        r = subprocess.run(
+            ["poetry", "run", "linkml-validate", "-s", schema, "-C", cls,
+             str(path)],
+            capture_output=True, text=True, timeout=180)
+    except Exception as exc:                           # noqa: BLE001
+        return None, str(exc)
+    if r.returncode == 0:
+        return [], None
+    lines = [l for l in (r.stdout + r.stderr).strip().splitlines()
+             if l.strip()]
+    return lines, None
+
+
 def validate_outputs(spec: RunSpec) -> list[dict[str, str]]:
     """LinkML-validate both records, returning problems rather than raising.
 
@@ -1042,20 +1065,137 @@ def validate_outputs(spec: RunSpec) -> list[dict[str, str]]:
         if not path.exists():
             problems.append({"artifact": str(path), "error": "missing"})
             continue
-        try:
-            r = subprocess.run(
-                ["poetry", "run", "linkml-validate", "-s", schema, "-C", cls,
-                 str(path)],
-                capture_output=True, text=True, timeout=180)
-        except Exception as exc:                       # noqa: BLE001
+        lines, failure = _validator_lines(path, schema, cls)
+        if failure is not None:
             problems.append({"artifact": str(path),
-                             "error": f"validator did not run: {exc}"})
+                             "error": f"validator did not run: {failure}"})
             continue
-        if r.returncode != 0:
-            detail = (r.stdout + r.stderr).strip().splitlines()
+        if lines:
             problems.append({"artifact": str(path), "class": cls,
-                             "error": " | ".join(detail[:4])})
+                             "error": " | ".join(lines[:4])})
     return problems
+
+
+REPAIR_SYSTEM = (
+    "You repair the shape of Datasheets-for-Datasets records. The schema "
+    "digest defines the required structure. The validator findings are the "
+    "complete work order: correct what they name and nothing else. Never add, "
+    "remove or reword dataset facts; a fact whose required structure the "
+    "record cannot supply moves to the nearest slot that accepts it, or is "
+    "omitted as a last resort.")
+
+REPAIR_INSTRUCTION = (
+    "Shape repair. The record above failed LinkML validation; each finding "
+    "names the failing path and the shape the schema requires. Emit the "
+    "record in its entirety with only those failures corrected. Output only "
+    "YAML.")
+
+# Two, not one: reconciliation once introduced a shape error while repairing
+# an audited omission, so a first repair can conceivably do the same. Two, not
+# more: a repair that has not converged in two rounds is not converging, and
+# every further round bills the whole record again.
+REPAIR_ROUNDS = 2
+
+
+def build_repair(artifact: str, body: str, errors: list[str]) -> PhaseRequest:
+    """A shape-repair request: digest, failing record, validator findings.
+
+    Deliberately excludes the input bundle. The validator names shapes, not
+    facts; a repair with the corpus in view is an invitation to fix content,
+    and the evidence boundary belongs to the six generation phases. Excluding
+    it also makes a repair call an order of magnitude cheaper than a phase.
+    """
+    cls = "CoreDataset" if artifact == "core" else "Dataset"
+    digest = schema_digest.digest_text(cls)
+    cached = [{"type": "text", "text": digest,
+               "cache_control": {"type": "ephemeral"}}]
+    parts: list[dict[str, Any]] = list(cached)
+    parts.append({"type": "text",
+                  "text": f"# Record that failed validation\n\n{body}"})
+    parts.append({"type": "text",
+                  "text": "# Validator findings\n\n" + "\n".join(errors)})
+    parts.append({"type": "text", "text": REPAIR_INSTRUCTION})
+    return PhaseRequest(phase=f"repair_{artifact}", system=REPAIR_SYSTEM,
+                        cached_blocks=cached,
+                        messages=[{"role": "user", "content": parts}])
+
+
+def _repair_invalid(spec: RunSpec, client, settings: dict[str, Any],
+                    usage: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Validator-driven shape repair of whichever artifacts fail (#356).
+
+    The six phases audit evidence; none of them reliably checks values
+    against the digest even when asked (#360: the shape-instructed audit
+    discussed `external_resources` without noticing its `restrictions` type).
+    The LinkML validator does exactly that, precisely — so its findings drive
+    a bounded repair pass instead of failing the fully billed run outright.
+
+    Every failure mode leaves the last-written bytes on disk and is recorded
+    in the returned log; the caller re-validates afterwards, so a repair that
+    made things worse is caught by the same gate that caught the original.
+    """
+    log: list[dict[str, Any]] = []
+    for artifact, schema, cls in (("full", FULL_SCHEMA_PATH, "Dataset"),
+                                  ("core", CORE_SCHEMA_PATH, "CoreDataset")):
+        path = _artifact_path(spec, artifact)
+        if not path.exists():
+            continue
+        ph = f"repair_{artifact}"
+        for rnd in range(1, REPAIR_ROUNDS + 1):
+            errors, failure = _validator_lines(path, schema, cls)
+            if failure is not None:
+                log.append({"phase": ph, "round": rnd,
+                            "outcome": f"validator did not run: {failure}"})
+                break
+            if not errors:
+                break
+            req = build_repair(artifact, path.read_text(encoding="utf-8"),
+                               errors)
+            try:
+                resp = _call_with_retry(
+                    client, model=settings["name"],
+                    max_tokens=PHASE_MAX_TOKENS.get(ph, DEFAULT_MAX_TOKENS),
+                    temperature=settings["temperature"],
+                    system=req.system, messages=req.messages)
+            except Exception as exc:                   # noqa: BLE001
+                # A dead repair call must not take down a run that would
+                # otherwise report invalid-but-complete, as before repair
+                # existed.
+                log.append({"phase": ph, "round": rnd,
+                            "outcome": f"call failed: {exc}"})
+                break
+            cap = reasoning.capture(resp)
+            reasoning.append(_reasoning_path(spec),
+                             {"phase": ph, "label": spec.label,
+                              "project": spec.project,
+                              "model": settings["name"],
+                              "attempt": rnd, **cap.to_dict()})
+            usage.append({
+                "phase": ph, "attempt": rnd,
+                "input_tokens": getattr(resp.usage, "input_tokens", None),
+                "output_tokens": getattr(resp.usage, "output_tokens", None),
+                "cache_read": getattr(resp.usage, "cache_read_input_tokens", None),
+                "cache_write": getattr(resp.usage, "cache_creation_input_tokens", None),
+                "max_tokens": PHASE_MAX_TOKENS.get(ph, DEFAULT_MAX_TOKENS),
+                "stop_reason": getattr(resp, "stop_reason", None),
+            })
+            if getattr(resp, "stop_reason", None) == "max_tokens":
+                log.append({"phase": ph, "round": rnd,
+                            "outcome": "truncated; record left as it was"})
+                continue
+            text = "".join(b.text for b in resp.content
+                           if getattr(b, "type", "") == "text")
+            try:
+                body = _extract(text, "yaml", schema, cls)
+            except RuntimeError as exc:
+                log.append({"phase": ph, "round": rnd,
+                            "outcome": f"unusable response: {exc}"})
+                continue
+            path.write_text(normalise_enum_aliases(normalise_temporal(body)),
+                            encoding="utf-8")
+            log.append({"phase": ph, "round": rnd, "outcome": "applied",
+                        "findings": len(errors)})
+    return log
 
 
 # Server-side conditions that clear on their own. `overloaded_error` is the one
@@ -1455,6 +1595,16 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     # because it only checks that files exist. An invalid record that looks
     # finished is worse than a failed run.
     problems = validate_outputs(spec)
+    if problems:
+        # Validator-driven shape repair (#356): the validator's findings are
+        # precise and the run is already fully billed, so a bounded repair is
+        # cheaper than discarding the run. Hashing happens in
+        # validation_block() below, *after* repair — integrity pins the final
+        # bytes, never an intermediate state.
+        rec.data["repair"] = _repair_invalid(spec, client, settings, usage)
+        problems = validate_outputs(spec)
+    else:
+        rec.data["repair"] = None
     rec.data["validation"] = validation_block(spec, problems)
 
     rec.write(spec.provenance_path)

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -7,6 +7,7 @@ anything is billed, so the tests exercise exactly what a real run would send.
 
 import json
 import unittest
+import unittest.mock
 from pathlib import Path
 
 from data_sheets_schema import schema_digest
@@ -686,6 +687,34 @@ class TestValidatorDrivenRepair(unittest.TestCase):
                       "a failed repair must never overwrite the record")
         self.assertEqual(len(log), self.api.REPAIR_ROUNDS)
         self.assertTrue(all(x["outcome"].startswith("unusable") for x in log))
+
+    def test_execute_repairs_through_the_real_call_path(self):
+        """The repair branch in execute() must be exercised end to end: it
+        names client/settings/usage from enclosing scope, and a wrong name
+        there survives every test that validates cleanly — the exact failure
+        class the TestExecuteOffline docstring records."""
+        import yaml as _yaml
+        from data_sheets_schema import api_runner
+        s = spec(out_dir=self.out)
+        keep = api_runner._client
+        api_runner._client = lambda: FakeClient()
+        self.addCleanup(lambda: setattr(api_runner, "_client", keep))
+        # Seven validator calls: validate#1 (full fails, core clean); repair
+        # full round 1 (fails, rewrite) and round 2 (clean); repair checks
+        # core (clean); validate#2 (both clean).
+        verdicts = iter([(["[ERROR] x"], None), ([], None),
+                         (["[ERROR] x"], None), ([], None), ([], None),
+                         ([], None), ([], None)])
+        with unittest.mock.patch.object(
+                self.api, "_validator_lines", lambda *a: next(verdicts)):
+            res = self.api.execute(s)
+        self.assertEqual(res["validation_problems"], [])
+        self.assertIn("repaired", s.full_path.read_text())
+        d = _yaml.safe_load((self.out / "CHORUS_provenance.yaml").read_text())
+        self.assertEqual([x["outcome"] for x in d["repair"]], ["applied"])
+        self.assertEqual([u["phase"] for u in d["api_usage"]][-1],
+                         "repair_full")
+        self.assertEqual(len(d["api_usage"]), 7)
 
     def test_execute_records_no_repair_when_records_validate(self):
         import yaml as _yaml

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -491,6 +491,11 @@ class FakeMessages:
         phase = next((ph for ph, instr in PHASE_INSTRUCTIONS.items()
                       if instr in blob), None)
         if phase is None:
+            from data_sheets_schema.api_runner import REPAIR_INSTRUCTION
+            if REPAIR_INSTRUCTION in blob:
+                return FakeResponse(
+                    "```yaml\nid: x\ntitle: T\nname: n\ndescription: d\n"
+                    "keywords: [repaired]\n```")
             raise AssertionError("could not identify the phase from the request")
         if self.fail_on == phase:
             raise self.exc or RuntimeError("boom")
@@ -599,6 +604,101 @@ class TestExecuteOffline(unittest.TestCase):
                                  "the route allows")
             # every phase must be given a limit large enough for its artifact
             self.assertGreaterEqual(kw["max_tokens"], 12000)
+
+
+class TestValidatorDrivenRepair(unittest.TestCase):
+    """#356 option 1: the validator's findings drive a bounded shape repair.
+
+    The shape-instructed audit still missed every type violation on the #347
+    canary (#360), so the only reliable shape check is the validator — and a
+    fully billed run should get a cheap repair before being declared invalid.
+    """
+
+    def setUp(self):
+        import tempfile
+        from data_sheets_schema import api_runner
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.out = Path(self.tmp.name) / "out"
+        self.api = api_runner
+        self.settings = {"name": "claude-opus-5", "temperature": 0.0}
+
+    def _spec_with_artifacts(self):
+        s = spec(out_dir=self.out)
+        self.out.mkdir(parents=True, exist_ok=True)
+        for p in (s.full_path, s.core_path):
+            p.write_text("id: x\ntitle: T\nname: n\ndescription: d\n"
+                         "keywords: [original]\n", encoding="utf-8")
+        return s
+
+    def test_build_repair_puts_instruction_last_and_omits_bundle(self):
+        from data_sheets_schema.api_runner import (
+            REPAIR_INSTRUCTION, build_repair)
+        req = build_repair("full", "id: x\n", ["[ERROR] bad shape"])
+        texts = [p["text"] for p in req.messages[0]["content"]]
+        self.assertEqual(texts[-1], REPAIR_INSTRUCTION)
+        # No bundle: the validator names shapes, not facts, and the evidence
+        # boundary belongs to the six generation phases.
+        self.assertFalse(any("Declared input bundle" in t for t in texts))
+        self.assertEqual(len(req.cached_blocks), 1)
+        self.assertIn("[ERROR] bad shape", texts[-2])
+        core = build_repair("core", "id: x\n", ["e"])
+        self.assertIn("CoreDataset", core.cached_blocks[0]["text"])
+
+    def test_repair_rewrites_the_failing_artifact_and_stops_when_clean(self):
+        s = self._spec_with_artifacts()
+        # full fails round 1, is clean after the rewrite; core is clean.
+        verdicts = iter([(["[ERROR] x"], None), ([], None), ([], None)])
+        with unittest.mock.patch.object(
+                self.api, "_validator_lines", lambda *a: next(verdicts)):
+            usage = []
+            log = self.api._repair_invalid(s, FakeClient(), self.settings,
+                                           usage)
+        self.assertIn("repaired", s.full_path.read_text())
+        self.assertIn("original", s.core_path.read_text())
+        self.assertEqual([x["outcome"] for x in log], ["applied"])
+        self.assertEqual([u["phase"] for u in usage], ["repair_full"])
+
+    def test_unusable_repair_leaves_the_record_untouched(self):
+        s = self._spec_with_artifacts()
+
+        class ProseClient:
+            class messages:
+                @staticmethod
+                def stream(**kw):
+                    class _S:
+                        def __enter__(self):
+                            return self
+
+                        def __exit__(self, *a):
+                            return False
+
+                        def get_final_message(self):
+                            return FakeResponse("I cannot repair this record.")
+                    return _S()
+
+        with unittest.mock.patch.object(
+                self.api, "_validator_lines",
+                lambda path, schema, cls: (["[ERROR] x"], None)
+                if "core" not in str(path) else ([], None)):
+            log = self.api._repair_invalid(s, ProseClient(), self.settings, [])
+        self.assertIn("original", s.full_path.read_text(),
+                      "a failed repair must never overwrite the record")
+        self.assertEqual(len(log), self.api.REPAIR_ROUNDS)
+        self.assertTrue(all(x["outcome"].startswith("unusable") for x in log))
+
+    def test_execute_records_no_repair_when_records_validate(self):
+        import yaml as _yaml
+        from data_sheets_schema import api_runner
+        s = spec(out_dir=self.out)
+        keep = api_runner._client
+        api_runner._client = lambda: FakeClient()
+        self.addCleanup(lambda: setattr(api_runner, "_client", keep))
+        self.api.execute(s)
+        d = _yaml.safe_load((self.out / "CHORUS_provenance.yaml").read_text())
+        self.assertIn("repair", d)
+        self.assertIsNone(d["repair"])
+        self.assertEqual(len(d["api_usage"]), 6)
 
 
 class TestResumeAndRetry(unittest.TestCase):


### PR DESCRIPTION
Implements option 1 from #356, motivated by #360: the shape-instructed audit (#357) produced 29 genuinely digest-engaged findings on the #347 canary and still missed all three mechanical type violations. Exhaustive type-checking is what the model does not do reliably — and what `linkml-validate` does precisely.

## What

When `validate_outputs` fails after the six phases:
- `_repair_invalid()` runs per failing artifact: at most **2 rounds** (reconciliation once introduced a shape error while fixing another, so one round can too; a repair that hasn't converged in two isn't converging), each round re-running the validator and sending `[class digest, failing record, validator findings, instruction]`.
- **No bundle in the request** — the validator names shapes, not facts; the evidence boundary stays with the six generation phases, and a repair call costs an order of magnitude less than a phase (~30k tokens vs ~200k).
- `REPAIR_SYSTEM` forbids adding/removing/rewording facts; a fact whose required structure the record can't supply moves to the nearest accepting slot or is omitted as a last resort.
- Every failure mode (dead call, truncation, unusable response, validator failure) leaves the last-written bytes on disk, logs an outcome, and the run then reports exactly as it would have before this PR.
- Provenance: `repair` block (rounds + outcomes, `null` when nothing needed repair), repair calls in `api_usage` and the reasoning log. Artifact hashes were already computed in `validation_block` *after* this point, so integrity pins the final bytes — no race.
- `validate_outputs` internals refactored into `_validator_lines()` so repair sees every finding while the summary keeps its 4-line cap; "validator did not run" stays distinguishable (a repair against a broken validator would fly blind — it refuses instead).

## Tests (4 new; 125 total, OK)

- `build_repair`: instruction last, digest-only cache, no bundle, findings included, core digest for core.
- Repair rewrites the failing artifact, stops when clean, logs usage under `repair_full`.
- An unusable repair response **never overwrites the record** (both rounds logged, file untouched).
- A fully valid run records `repair: null` and exactly 6 usage entries — repair costs nothing when nothing is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)