### PR TITLE
Keep prior accounting when resuming a completed run (#362)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1365,6 +1365,21 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     skipped: list[str] = []
     carry: dict[str, str] = {}
 
+    # Seed the accounting from a prior pass (#362). A completed-but-invalid
+    # run keeps its resume state so a re-run can repair it (#361) — but this
+    # invocation rebuilds the provenance record, and starting `usage` empty
+    # would replace six phases of real token accounting with only the calls
+    # this invocation makes. Every billed call stays on the record. Gated on
+    # the progress file too: without resume state this is a from-scratch
+    # regeneration, and a dead run's accounting does not belong on it.
+    if spec.provenance_path.exists() and _progress_path(spec).exists():
+        try:
+            prior = yaml.safe_load(
+                spec.provenance_path.read_text(encoding="utf-8")) or {}
+            usage.extend(prior.get("api_usage") or [])
+        except yaml.YAMLError:
+            pass
+
     # Resume from an explicit progress file rather than inferring from
     # artifacts. A `full` record on disk may be pre- or post-reconciliation and
     # nothing in the file distinguishes them, so guessing would silently skip

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -716,6 +716,37 @@ class TestValidatorDrivenRepair(unittest.TestCase):
                          "repair_full")
         self.assertEqual(len(d["api_usage"]), 7)
 
+    def test_resume_of_a_completed_run_keeps_the_prior_accounting(self):
+        """#362: re-running an invalid-but-complete run is how repair is
+        triggered (#361), and that invocation rebuilds provenance. The six
+        phases' real token accounting must survive into the new record, not
+        be replaced by only the resumed calls."""
+        import yaml as _yaml
+        from data_sheets_schema import api_runner
+        s = spec(out_dir=self.out)
+        keep = api_runner._client
+        api_runner._client = lambda: FakeClient()
+        self.addCleanup(lambda: setattr(api_runner, "_client", keep))
+        self.api.execute(s)                      # full pass: 6 usage rows
+        prov = self.out / "CHORUS_provenance.yaml"
+        first = _yaml.safe_load(prov.read_text())
+        self.assertEqual(len(first["api_usage"]), 6)
+        # Keep resume state, as a validation failure would have.
+        self.api._save_progress(s, list(self.api.PHASES), None)
+        # Re-run: all phases skip, repair runs once on the full record.
+        verdicts = iter([(["[ERROR] x"], None), ([], None),
+                         (["[ERROR] x"], None), ([], None), ([], None),
+                         ([], None), ([], None)])
+        with unittest.mock.patch.object(
+                self.api, "_validator_lines", lambda *a: next(verdicts)):
+            res = self.api.execute(s)
+        self.assertEqual(len(res["skipped"]), 6)
+        second = _yaml.safe_load(prov.read_text())
+        phases = [u["phase"] for u in second["api_usage"]]
+        self.assertEqual(len(phases), 7, phases)
+        self.assertEqual(phases[:6], [u["phase"] for u in first["api_usage"]])
+        self.assertEqual(phases[-1], "repair_full")
+
     def test_execute_records_no_repair_when_records_validate(self):
         import yaml as _yaml
         from data_sheets_schema import api_runner


### PR DESCRIPTION
Fixes #362.

The `already_complete` guard protects accounting only for runs with no resume state; a completed-but-invalid run keeps its progress file by design, and re-running it (now the designed way to trigger #361's repair) rebuilt provenance with `usage` starting empty — six phases of real token accounting replaced by only the resumed calls.

`usage` is now seeded from the prior record's `api_usage`, gated on **both** the provenance record and the progress file existing: with resume state it's a continuation (cumulative accounting, every billed call kept); without it it's a from-scratch regeneration and inherits nothing.

Test: full pass → force-keep resume state → re-run with a failing validator; the new record carries the original 6 phase rows followed by `repair_full`, in order.

Testing: `tests.test_download.test_api_runner`, 127 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)