### PR TITLE
Repair while findings strictly decrease, up to four rounds (#364)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1090,11 +1090,13 @@ REPAIR_INSTRUCTION = (
     "record in its entirety with only those failures corrected. Output only "
     "YAML.")
 
-# Two, not one: reconciliation once introduced a shape error while repairing
-# an audited omission, so a first repair can conceivably do the same. Two, not
-# more: a repair that has not converged in two rounds is not converging, and
-# every further round bills the whole record again.
-REPAIR_ROUNDS = 2
+# The loop runs while the finding count strictly decreases, up to this
+# ceiling. A fixed budget of 2 was cut short by the live canary (#364): the
+# core record converged 76 -> 9 -> 4 and was stopped mid-repair. Strict
+# decrease is the real convergence test — a round that leaves the count equal
+# or higher IS non-convergence and stops immediately — and the ceiling bounds
+# what a stubborn record can bill.
+REPAIR_ROUNDS = 4
 
 
 def build_repair(artifact: str, body: str, errors: list[str]) -> PhaseRequest:
@@ -1141,6 +1143,11 @@ def _repair_invalid(spec: RunSpec, client, settings: dict[str, Any],
         if not path.exists():
             continue
         ph = f"repair_{artifact}"
+        # The count the last APPLIED repair was working from. Compared only
+        # against applied rounds: a truncated or unusable round rewrote
+        # nothing, so its unchanged count says nothing about convergence and
+        # must not cancel the retry the round ceiling allows for.
+        applied_from: int | None = None
         for rnd in range(1, REPAIR_ROUNDS + 1):
             errors, failure = _validator_lines(path, schema, cls)
             if failure is not None:
@@ -1148,6 +1155,11 @@ def _repair_invalid(spec: RunSpec, client, settings: dict[str, Any],
                             "outcome": f"validator did not run: {failure}"})
                 break
             if not errors:
+                break
+            if applied_from is not None and len(errors) >= applied_from:
+                log.append({"phase": ph, "round": rnd,
+                            "outcome": (f"not converging: {applied_from} -> "
+                                        f"{len(errors)} findings; stopped")})
                 break
             req = build_repair(artifact, path.read_text(encoding="utf-8"),
                                errors)
@@ -1193,6 +1205,7 @@ def _repair_invalid(spec: RunSpec, client, settings: dict[str, Any],
                 continue
             path.write_text(normalise_enum_aliases(normalise_temporal(body)),
                             encoding="utf-8")
+            applied_from = len(errors)
             log.append({"phase": ph, "round": rnd, "outcome": "applied",
                         "findings": len(errors)})
     return log

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -688,6 +688,20 @@ class TestValidatorDrivenRepair(unittest.TestCase):
         self.assertEqual(len(log), self.api.REPAIR_ROUNDS)
         self.assertTrue(all(x["outcome"].startswith("unusable") for x in log))
 
+    def test_repair_stops_when_an_applied_round_makes_no_progress(self):
+        """#364: strict decrease is the convergence test, but only across
+        APPLIED rounds — a dud round rewrote nothing and must not cancel the
+        retry the ceiling allows."""
+        s = self._spec_with_artifacts()
+        with unittest.mock.patch.object(
+                self.api, "_validator_lines",
+                lambda path, schema, cls: (["[ERROR] a", "[ERROR] b"], None)
+                if "core" not in str(path) else ([], None)):
+            log = self.api._repair_invalid(s, FakeClient(), self.settings, [])
+        self.assertEqual([x["outcome"] for x in log][:1], ["applied"])
+        self.assertEqual(len(log), 2, log)
+        self.assertIn("not converging", log[1]["outcome"])
+
     def test_execute_repairs_through_the_real_call_path(self):
         """The repair branch in execute() must be exercised end to end: it
         names client/settings/usage from enclosing scope, and a wrong name


### PR DESCRIPTION
Fixes #364.

The live canary contradicted the "two rounds or it isn't converging" heuristic: the core record went 76 → 9 → 4 findings and was cut off with 4 left. The loop now continues while the finding count strictly decreases, ceiling 4. The comparison runs only against **applied** rounds — a truncated or unusable round rewrote nothing, so its unchanged count says nothing about convergence and must not cancel the retry the ceiling allows. An applied round that fails to reduce the count stops immediately with a `not converging` log entry.

Tests: new non-convergence test (applied round with no decrease → stop, logged); the dud-response test scales with the constant (4 unusable rounds, record untouched). 128 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)