### PR TITLE
Schema-backed run telemetry across the D4D generation phases

### DIFF
--- a/data/run_telemetry/2026-08-05_claude-opus-5-1m-generic-v3.yaml
+++ b/data/run_telemetry/2026-08-05_claude-opus-5-1m-generic-v3.yaml
@@ -1,0 +1,384 @@
+label: 2026-08-05_claude-opus-5-1m-generic-v3
+method: claudecode_agent
+generated_at: '2026-08-06T05:54:03+00:00'
+schema_version: 1.0.0
+runs:
+- project: AI_READI
+  label: 2026-08-05_claude-opus-5-1m-generic-v3_rep1
+  validation_state: valid
+  timing_basis: file_mtime
+  phases:
+  - phase: full
+    attempts:
+    - attempt: 1
+      input_tokens: 2215
+      output_tokens: 74274
+      cache_read_tokens: 0
+      cache_write_tokens: 152657
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 50130
+      visible_text_chars: 96576
+      reasoning_present: true
+      reasoning_available: false
+  - phase: core
+    attempts:
+    - attempt: 1
+      input_tokens: 34488
+      output_tokens: 22993
+      cache_read_tokens: 0
+      cache_write_tokens: 149662
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 5354
+      visible_text_chars: 70556
+      reasoning_present: false
+      reasoning_available: false
+  - phase: audit
+    attempts:
+    - attempt: 1
+      input_tokens: 57591
+      output_tokens: 6335
+      cache_read_tokens: 0
+      cache_write_tokens: 152657
+      max_tokens: 24000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 1775
+      visible_text_chars: 18241
+      reasoning_present: false
+      reasoning_available: false
+    - attempt: 2
+      input_tokens: 57591
+      output_tokens: 4332
+      cache_read_tokens: 152657
+      cache_write_tokens: 0
+      max_tokens: 24000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 1173
+      visible_text_chars: 12637
+      reasoning_present: false
+      reasoning_available: false
+    - attempt: 3
+      input_tokens: 57591
+      output_tokens: 8290
+      cache_read_tokens: 152657
+      cache_write_tokens: 0
+      max_tokens: 24000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 2201
+      visible_text_chars: 24359
+      reasoning_present: false
+      reasoning_available: false
+  - phase: reconcile_full
+    attempts:
+    - attempt: 1
+      input_tokens: 42822
+      output_tokens: 44221
+      cache_read_tokens: 152657
+      cache_write_tokens: 0
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 21224
+      visible_text_chars: 91988
+      reasoning_present: true
+      reasoning_available: false
+  - phase: reconcile_core
+    attempts:
+    - attempt: 1
+      input_tokens: 64250
+      output_tokens: 24712
+      cache_read_tokens: 0
+      cache_write_tokens: 149662
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 6020
+      visible_text_chars: 74770
+      reasoning_present: false
+      reasoning_available: false
+  - phase: report
+    attempts:
+    - attempt: 1
+      input_tokens: 10522
+      output_tokens: 9491
+      cache_read_tokens: 0
+      cache_write_tokens: 152657
+      max_tokens: 24000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 2715
+      visible_text_chars: 27104
+      reasoning_present: false
+      reasoning_available: false
+    artifact_written_at: '2026-08-06T03:37:27+00:00'
+  - phase: repair_full
+    attempts:
+    - attempt: 1
+      input_tokens: 59602
+      output_tokens: 34463
+      cache_read_tokens: 0
+      cache_write_tokens: 10512
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 10901
+      visible_text_chars: 94248
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 2
+      input_tokens: 34871
+      output_tokens: 33917
+      cache_read_tokens: 0
+      cache_write_tokens: 10512
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 10485
+      visible_text_chars: 93728
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 3
+      input_tokens: 33600
+      output_tokens: 33116
+      cache_read_tokens: 0
+      cache_write_tokens: 10512
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 9647
+      visible_text_chars: 93876
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 4
+      input_tokens: 33501
+      output_tokens: 31139
+      cache_read_tokens: 10512
+      cache_write_tokens: 0
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 7702
+      visible_text_chars: 93750
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 1
+      input_tokens: 33354
+      output_tokens: 33387
+      cache_read_tokens: 0
+      cache_write_tokens: 10512
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 9523
+      visible_text_chars: 95458
+      reasoning_present: true
+      reasoning_available: false
+    artifact_written_at: '2026-08-06T04:20:07+00:00'
+  - phase: repair_core
+    attempts:
+    - attempt: 1
+      input_tokens: 47340
+      output_tokens: 27024
+      cache_read_tokens: 0
+      cache_write_tokens: 7517
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 7903
+      visible_text_chars: 76486
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 2
+      input_tokens: 29000
+      output_tokens: 27436
+      cache_read_tokens: 7517
+      cache_write_tokens: 0
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 8446
+      visible_text_chars: 75960
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 3
+      input_tokens: 27702
+      output_tokens: 29825
+      cache_read_tokens: 7517
+      cache_write_tokens: 0
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 10572
+      visible_text_chars: 77014
+      reasoning_present: true
+      reasoning_available: false
+    artifact_written_at: '2026-08-06T04:11:51+00:00'
+  replicate: 1
+  model: claude-opus-5
+  provider: LBL CBORG (proxy to Anthropic)
+  arm: baseline
+  finished_at: '2026-08-06T04:14:51+00:00'
+  validation_problem_count: 0
+  total_input_tokens: 626040
+  total_output_tokens: 444955
+  total_cache_read_tokens: 483517
+  total_cache_write_tokens: 806860
+  total_reasoning_tokens_estimate: 165771
+  approx_cost_usd: 19.54
+  repair_rounds:
+  - artifact: full
+    round: 1
+    outcome: applied
+    findings: 21
+- project: CHORUS
+  label: 2026-08-05_claude-opus-5-1m-generic-v3_rep1
+  validation_state: valid
+  timing_basis: file_mtime
+  phases:
+  - phase: full
+    attempts:
+    - attempt: 1
+      input_tokens: 2215
+      output_tokens: 26564
+      cache_read_tokens: 0
+      cache_write_tokens: 24247
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 17434
+      visible_text_chars: 36521
+      reasoning_present: true
+      reasoning_available: false
+  - phase: core
+    attempts:
+    - attempt: 1
+      input_tokens: 14646
+      output_tokens: 13880
+      cache_read_tokens: 0
+      cache_write_tokens: 21252
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 5023
+      visible_text_chars: 35431
+      reasoning_present: true
+      reasoning_available: false
+  - phase: audit
+    attempts:
+    - attempt: 1
+      input_tokens: 26828
+      output_tokens: 5234
+      cache_read_tokens: 0
+      cache_write_tokens: 24247
+      max_tokens: 24000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 1348
+      visible_text_chars: 15544
+      reasoning_present: false
+      reasoning_available: false
+  - phase: reconcile_full
+    attempts:
+    - attempt: 1
+      input_tokens: 19924
+      output_tokens: 16668
+      cache_read_tokens: 24247
+      cache_write_tokens: 0
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 7577
+      visible_text_chars: 36365
+      reasoning_present: true
+      reasoning_available: false
+  - phase: reconcile_core
+    attempts:
+    - attempt: 1
+      input_tokens: 31971
+      output_tokens: 14254
+      cache_read_tokens: 0
+      cache_write_tokens: 21252
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 5425
+      visible_text_chars: 35316
+      reasoning_present: true
+      reasoning_available: false
+  - phase: report
+    attempts:
+    - attempt: 1
+      input_tokens: 7466
+      output_tokens: 8373
+      cache_read_tokens: 24247
+      cache_write_tokens: 0
+      max_tokens: 24000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 4528
+      visible_text_chars: 15383
+      reasoning_present: true
+      reasoning_available: false
+    artifact_written_at: '2026-08-06T02:20:14+00:00'
+  - phase: repair_full
+    attempts:
+    - attempt: 1
+      input_tokens: 24382
+      output_tokens: 15840
+      cache_read_tokens: 0
+      cache_write_tokens: 10512
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 6520
+      visible_text_chars: 37283
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 2
+      input_tokens: 13682
+      output_tokens: 16609
+      cache_read_tokens: 10512
+      cache_write_tokens: 0
+      max_tokens: 96000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 7231
+      visible_text_chars: 37513
+      reasoning_present: true
+      reasoning_available: false
+    artifact_written_at: '2026-08-06T02:49:00+00:00'
+  - phase: repair_core
+    attempts:
+    - attempt: 1
+      input_tokens: 23800
+      output_tokens: 14473
+      cache_read_tokens: 0
+      cache_write_tokens: 7517
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 5425
+      visible_text_chars: 36195
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 2
+      input_tokens: 13386
+      output_tokens: 13159
+      cache_read_tokens: 7517
+      cache_write_tokens: 0
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 4120
+      visible_text_chars: 36157
+      reasoning_present: true
+      reasoning_available: false
+    - attempt: 1
+      input_tokens: 12998
+      output_tokens: 13326
+      cache_read_tokens: 0
+      cache_write_tokens: 7517
+      max_tokens: 56000
+      stop_reason: end_turn
+      reasoning_tokens_estimate: 4294
+      visible_text_chars: 36130
+      reasoning_present: true
+      reasoning_available: false
+    artifact_written_at: '2026-08-06T02:59:46+00:00'
+  replicate: 1
+  model: claude-opus-5
+  provider: LBL CBORG (proxy to Anthropic)
+  arm: baseline
+  finished_at: '2026-08-06T02:57:34+00:00'
+  validation_problem_count: 0
+  total_input_tokens: 191298
+  total_output_tokens: 158380
+  total_cache_read_tokens: 66523
+  total_cache_write_tokens: 116544
+  total_reasoning_tokens_estimate: 68925
+  approx_cost_usd: 5.68
+  repair_rounds:
+  - artifact: core
+    round: 1
+    outcome: applied
+    findings: 6

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1163,6 +1163,9 @@ def _repair_invalid(spec: RunSpec, client, settings: dict[str, Any],
                 break
             req = build_repair(artifact, path.read_text(encoding="utf-8"),
                                errors)
+            attempt_started = datetime.now(timezone.utc).isoformat(
+                timespec="seconds")
+            attempt_t0 = time.monotonic()
             try:
                 resp = _call_with_retry(
                     client, model=settings["name"],
@@ -1184,6 +1187,8 @@ def _repair_invalid(spec: RunSpec, client, settings: dict[str, Any],
                               "attempt": rnd, **cap.to_dict()})
             usage.append({
                 "phase": ph, "attempt": rnd,
+                "started_at": attempt_started,
+                "seconds": round(time.monotonic() - attempt_t0, 3),
                 "input_tokens": getattr(resp.usage, "input_tokens", None),
                 "output_tokens": getattr(resp.usage, "output_tokens", None),
                 "cache_read": getattr(resp.usage, "cache_read_input_tokens", None),
@@ -1490,6 +1495,12 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         # the body is retried here, on the same budget, and only a phase that
         # fails every attempt takes the run down with it.
         for attempt in range(1, MAX_ATTEMPTS + 1):
+            # Stamped per attempt so telemetry can reconstruct wall time; file
+            # mtimes only date the artifact a phase wrote, not the attempts
+            # that failed on the way there.
+            attempt_started = datetime.now(timezone.utc).isoformat(
+                timespec="seconds")
+            attempt_t0 = time.monotonic()
             resp = _call_with_retry(
                 client,
                 model=settings["name"],
@@ -1513,6 +1524,8 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             usage.append({
                 "phase": ph,
                 "attempt": attempt,
+                "started_at": attempt_started,
+                "seconds": round(time.monotonic() - attempt_t0, 3),
                 "input_tokens": getattr(resp.usage, "input_tokens", None),
                 "output_tokens": getattr(resp.usage, "output_tokens", None),
                 "cache_read": getattr(resp.usage, "cache_read_input_tokens", None),

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -12,6 +12,54 @@ def runs():
     pass
 
 
+@runs.command("telemetry")
+@click.option("--label-prefix", required=True,
+              help="run label or prefix, e.g. 2026-08-05_claude-opus-5-1m-generic-v3")
+@click.option("--method", default="claudecode_agent", show_default=True)
+@click.option("-o", "--output", type=click.Path(), default=None,
+              help="output path; defaults to data/run_telemetry/{label_prefix}.yaml")
+@click.option("--validate", "do_validate", is_flag=True,
+              help="linkml-validate the report against the telemetry schema")
+def telemetry_cmd(label_prefix, method, output, do_validate):
+    """Collect per-phase process telemetry into a schema-backed report.
+
+    Harvests provenance api_usage, the reasoning log, repair rounds,
+    validation outcomes and what timing evidence exists (see the schema's
+    timing_basis for how honest each figure is).
+    """
+    import subprocess
+    import yaml as _yaml
+
+    from data_sheets_schema.run_telemetry import SCHEMA_PATH, collect_report
+
+    report = collect_report(label_prefix, method=method)
+    if not report["runs"]:
+        raise click.ClickException(
+            f"no runs with provenance found for prefix {label_prefix!r} "
+            f"under method {method!r}")
+    out = Path(output) if output else (
+        Path("data/run_telemetry") / f"{label_prefix}.yaml")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(_yaml.safe_dump(report, sort_keys=False,
+                                   allow_unicode=True), encoding="utf-8")
+    click.echo(f"✓ {len(report['runs'])} run(s) -> {out}")
+    for r in report["runs"]:
+        click.echo(f"   {r['project']:9} rep{r.get('replicate', '?')} "
+                   f"{r['validation_state']:9} in={r['total_input_tokens']:,} "
+                   f"out={r['total_output_tokens']:,} "
+                   f"~${r['approx_cost_usd']:.2f} timing={r['timing_basis']}")
+    if do_validate:
+        res = subprocess.run(
+            ["poetry", "run", "linkml-validate", "-s", str(SCHEMA_PATH),
+             "-C", "RunTelemetryReport", str(out)],
+            capture_output=True, text=True, timeout=180)
+        if res.returncode != 0:
+            raise click.ClickException(
+                f"telemetry report failed schema validation:\n"
+                f"{(res.stdout + res.stderr).strip()[:800]}")
+        click.echo("✓ report validates against d4d_run_telemetry.yaml")
+
+
 @runs.command()
 @click.option('--label', 'labels', multiple=True,
               help='Run label(s) to archive; repeatable.')

--- a/src/data_sheets_schema/run_telemetry.py
+++ b/src/data_sheets_schema/run_telemetry.py
@@ -1,0 +1,259 @@
+"""Collect process telemetry for six-phase D4D generation runs.
+
+Harvests what the runs already record — provenance ``api_usage`` rows, the
+reasoning log, the repair log, validation outcome, artifact mtimes — into a
+report conforming to ``schema/d4d_run_telemetry.yaml``. Nothing here calls an
+API or mutates a run directory.
+
+Evidence honesty rules, mirrored in the schema:
+
+* ``timing_basis`` says where time figures come from. Runs made before
+  per-attempt timestamps existed (#367) can only be dated by artifact mtimes
+  and the provenance stamp; ``wall_seconds_estimate`` is then absent rather
+  than guessed, because an artifact mtime is the *last* write (a repaired
+  record's mtime dates the repair, not the phase).
+* ``invocations`` is derived from gaps between recorded timestamps and is
+  absent for legacy runs — repair-round numbering alone cannot distinguish a
+  resumed invocation from a second artifact's rounds.
+* Attempts join to reasoning entries by (phase, order of appearance), not by
+  attempt number: both files accumulate across invocations, so numbers repeat
+  while order is preserved.
+* The ``repair_rounds`` outcomes come from the provenance repair block, which
+  records only the latest invocation until #366 is fixed; every repair *call*
+  still appears under ``phases`` from the cumulative usage rows.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from data_sheets_schema.api_runner import CONCAT_DIR
+
+SCHEMA_PATH = Path("src/data_sheets_schema/schema/d4d_run_telemetry.yaml")
+SCHEMA_VERSION = "1.0.0"
+
+# CBORG-posted opus-5 rates (2026-08-05, /model/info): $ per token. Cache
+# writes bill at 1.25x input, cache reads at 0.1x. No premium tier above 200k.
+RATE_INPUT = 5e-6
+RATE_CACHE_WRITE = 6.25e-6
+RATE_CACHE_READ = 0.5e-6
+RATE_OUTPUT = 25e-6
+
+# Which artifact each phase writes, for attaching the one mtime evidence
+# point to the phase that actually left it behind (the last writer).
+_ARTIFACT_WRITERS = {
+    "full": ("full", "reconcile_full", "repair_full"),
+    "core": ("core", "reconcile_core", "repair_core"),
+    "report": ("report",),
+}
+
+_STOP_REASONS = {"end_turn", "max_tokens", "stop_sequence"}
+# 6 minutes: longer than any observed inter-phase gap within one invocation
+# (validator runs included), far shorter than any operator round trip.
+_INVOCATION_GAP_SECONDS = 360
+
+
+def _mtime_iso(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    return datetime.fromtimestamp(path.stat().st_mtime,
+                                  tz=timezone.utc).isoformat(timespec="seconds")
+
+
+def _reasoning_entries(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            out.append(json.loads(line))
+    return out
+
+
+def _attempt(row: dict[str, Any],
+             reasoning_entry: dict[str, Any] | None) -> dict[str, Any]:
+    a: dict[str, Any] = {"attempt": int(row.get("attempt") or 0)}
+    for src, dst in (("started_at", "started_at"), ("seconds", "seconds"),
+                     ("input_tokens", "input_tokens"),
+                     ("output_tokens", "output_tokens"),
+                     ("cache_read", "cache_read_tokens"),
+                     ("cache_write", "cache_write_tokens"),
+                     ("max_tokens", "max_tokens")):
+        if row.get(src) is not None:
+            a[dst] = row[src]
+    stop = row.get("stop_reason")
+    if stop is not None:
+        a["stop_reason"] = stop if stop in _STOP_REASONS else "other"
+    if reasoning_entry:
+        for src, dst in (("reasoning_tokens_estimate",
+                          "reasoning_tokens_estimate"),
+                         ("visible_text_chars", "visible_text_chars"),
+                         ("reasoning_present", "reasoning_present"),
+                         ("reasoning_available", "reasoning_available")):
+            if reasoning_entry.get(src) is not None:
+                a[dst] = reasoning_entry[src]
+    return a
+
+
+def _invocations(rows: list[dict[str, Any]]) -> int | None:
+    """1 + the number of recorded-timestamp gaps longer than an invocation gap.
+
+    None without timestamps: repair-round numbering alone cannot tell a
+    resumed invocation from a second artifact's rounds, and a wrong count is
+    worse than no count.
+    """
+    stamps = []
+    for r in rows:
+        if r.get("started_at"):
+            try:
+                stamps.append(datetime.fromisoformat(r["started_at"]))
+            except ValueError:
+                return None
+    if len(stamps) != len(rows) or not stamps:
+        return None
+    gaps = sum(1 for a, b in zip(stamps, stamps[1:])
+               if (b - a).total_seconds() > _INVOCATION_GAP_SECONDS)
+    return 1 + gaps
+
+
+def run_telemetry(run_dir: Path, project: str) -> dict[str, Any] | None:
+    """One RunTelemetry object, or None when no provenance exists yet."""
+    prov_path = run_dir / f"{project}_provenance.yaml"
+    if not prov_path.exists():
+        return None
+    prov = yaml.safe_load(prov_path.read_text(encoding="utf-8")) or {}
+    rows = prov.get("api_usage") or []
+    reasoning = _reasoning_entries(run_dir / f"{project}_reasoning.jsonl")
+
+    # Join by (phase, occurrence index): both logs accumulate across
+    # invocations in the same order, so numbers repeat while order holds.
+    by_phase_reasoning: dict[str, list[dict[str, Any]]] = {}
+    for e in reasoning:
+        by_phase_reasoning.setdefault(e.get("phase", ""), []).append(e)
+    seen_per_phase: dict[str, int] = {}
+
+    phases: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        ph = row.get("phase") or "other"
+        idx = seen_per_phase.get(ph, 0)
+        seen_per_phase[ph] = idx + 1
+        entries = by_phase_reasoning.get(ph, [])
+        entry = entries[idx] if idx < len(entries) else None
+        phases.setdefault(ph, {"phase": ph, "attempts": []})
+        phases[ph]["attempts"].append(_attempt(row, entry))
+
+    # The single mtime evidence point goes to the artifact's last writer.
+    method_dir = run_dir.parent.parent
+    label = run_dir.name
+    artifact_paths = {
+        "full": method_dir / (prov.get("run", {}).get("method")
+                              or "claudecode_agent") / label
+                / f"{project}_d4d.yaml",
+        "core": run_dir / f"{project}_d4d_core.yaml",
+        "report": run_dir / f"{project}_reconciliation.md",
+    }
+    for artifact, writers in _ARTIFACT_WRITERS.items():
+        last = next((w for w in reversed(writers) if w in phases), None)
+        if last:
+            stamp = _mtime_iso(artifact_paths[artifact])
+            if stamp:
+                phases[last]["artifact_written_at"] = stamp
+
+    validation = prov.get("validation")
+    if isinstance(validation, dict):
+        probs = validation.get("problems") or []
+        state = "valid" if not probs else "invalid"
+        prob_count = len(probs)
+    else:
+        state, prob_count = "unchecked", None
+
+    total = {k: sum(r.get(k) or 0 for r in rows)
+             for k in ("input_tokens", "output_tokens",
+                       "cache_read", "cache_write")}
+    reasoning_total = sum(e.get("reasoning_tokens_estimate") or 0
+                          for e in reasoning)
+    cost = (total["input_tokens"] * RATE_INPUT
+            + total["cache_write"] * RATE_CACHE_WRITE
+            + total["cache_read"] * RATE_CACHE_READ
+            + total["output_tokens"] * RATE_OUTPUT)
+
+    timed = [r for r in rows if r.get("seconds") is not None]
+    if timed and len(timed) == len(rows):
+        basis = "recorded"
+        wall = round(sum(r["seconds"] for r in rows), 1)
+    elif any(p.get("artifact_written_at") for p in phases.values()):
+        basis, wall = "file_mtime", None
+    else:
+        basis, wall = "absent", None
+
+    run_block = prov.get("run") or {}
+    model_block = prov.get("model") or {}
+    out: dict[str, Any] = {
+        "project": project,
+        "label": run_block.get("label") or label,
+        "validation_state": state,
+        "timing_basis": basis,
+        "phases": list(phases.values()),
+    }
+    if run_block.get("replicate") is not None:
+        out["replicate"] = run_block["replicate"]
+    # No condition: provenance does not record it as a field — the pinned
+    # prompt file is its witness, and inferring a name from a filename here
+    # would put an unrecorded claim into the report.
+    for k, v in (("model", model_block.get("model")),
+                 ("provider", model_block.get("provider")),
+                 ("arm", run_block.get("arm"))):
+        if v:
+            out[k] = v
+    if prov.get("record_generated_at"):
+        out["finished_at"] = prov["record_generated_at"]
+    if wall is not None:
+        out["wall_seconds_estimate"] = wall
+    if prob_count is not None:
+        out["validation_problem_count"] = prob_count
+    out["total_input_tokens"] = total["input_tokens"]
+    out["total_output_tokens"] = total["output_tokens"]
+    out["total_cache_read_tokens"] = total["cache_read"]
+    out["total_cache_write_tokens"] = total["cache_write"]
+    out["total_reasoning_tokens_estimate"] = reasoning_total
+    out["approx_cost_usd"] = round(cost, 2)
+    inv = _invocations(rows)
+    if inv is not None:
+        out["invocations"] = inv
+    repair = prov.get("repair") or []
+    if repair:
+        out["repair_rounds"] = [
+            {"artifact": r["phase"].replace("repair_", ""),
+             "round": r["round"], "outcome": r["outcome"],
+             **({"findings": r["findings"]} if r.get("findings") is not None
+                else {})}
+            for r in repair]
+    return out
+
+
+def collect_report(label_prefix: str,
+                   method: str = "claudecode_agent",
+                   root: Path | None = None) -> dict[str, Any]:
+    """A RunTelemetryReport over every run dir matching the label prefix."""
+    base = (root or CONCAT_DIR) / f"{method}_core"
+    runs: list[dict[str, Any]] = []
+    dirs = sorted(p for p in base.glob(f"{label_prefix}*") if p.is_dir())
+    for d in dirs:
+        for prov in sorted(d.glob("*_provenance.yaml")):
+            project = prov.name.replace("_provenance.yaml", "")
+            t = run_telemetry(d, project)
+            if t:
+                runs.append(t)
+    return {
+        "label": label_prefix,
+        "method": method,
+        "generated_at": datetime.now(timezone.utc).isoformat(
+            timespec="seconds"),
+        "schema_version": SCHEMA_VERSION,
+        "runs": runs,
+    }

--- a/src/data_sheets_schema/schema/d4d_run_telemetry.yaml
+++ b/src/data_sheets_schema/schema/d4d_run_telemetry.yaml
@@ -1,0 +1,266 @@
+id: https://w3id.org/bridge2ai/data-sheets-schema/d4d-run-telemetry
+name: d4d-run-telemetry
+title: D4D Generation Run Telemetry
+description: >-
+  Process telemetry for six-phase D4D generation runs: per-attempt token
+  accounting, reasoning spend, repair convergence, validation outcome and
+  what timing evidence exists. Standalone — deliberately NOT imported by the
+  main D4D schema; this describes the machinery, not a dataset. Named outside
+  the D4D_*.yaml convention so the module build and lint globs never sweep
+  it in.
+license: MIT
+prefixes:
+  linkml: https://w3id.org/linkml/
+  d4drt: https://w3id.org/bridge2ai/data-sheets-schema/d4d-run-telemetry/
+default_prefix: d4drt
+default_range: string
+imports:
+  - linkml:types
+
+enums:
+  PhaseEnum:
+    description: >-
+      The six generation phases, plus the validator-driven repair phases
+      (#361) that run only when a completed record fails validation.
+    permissible_values:
+      full:
+        description: Generate the full Dataset record.
+      core:
+        description: Generate the CoreDataset record from the full record.
+      audit:
+        description: Audit both records against bundle, boundary and shape.
+      reconcile_full:
+        description: Apply audit findings to the full record.
+      reconcile_core:
+        description: Apply audit findings to the core record.
+      report:
+        description: Write the reconciliation report.
+      repair_full:
+        description: Validator-driven shape repair of the full record.
+      repair_core:
+        description: Validator-driven shape repair of the core record.
+  StopReasonEnum:
+    description: >-
+      Why the model stopped. max_tokens marks an attempt whose output was
+      truncated and discarded; the guard never writes those.
+    permissible_values:
+      end_turn:
+        description: The model finished of its own accord.
+      max_tokens:
+        description: The ceiling cut the response off.
+      stop_sequence:
+        description: A configured stop sequence fired.
+      other:
+        description: Any stop reason this schema does not name.
+  ValidationStateEnum:
+    description: Whether the run's records pass LinkML validation.
+    permissible_values:
+      valid:
+        description: Both records pass linkml-validate.
+      invalid:
+        description: At least one record fails; the run is not shippable.
+      unchecked:
+        description: >-
+          Validation evidence is absent — distinct from valid, exactly as a
+          record that could not be checked is not a record that passed.
+  TimingBasisEnum:
+    description: >-
+      Where the timing figures come from. Runs made before per-attempt
+      timestamps existed can only be dated by artifact mtimes and the
+      provenance stamp, and a reader must be able to tell.
+    permissible_values:
+      recorded:
+        description: Per-attempt timestamps and durations from the run itself.
+      file_mtime:
+        description: >-
+          Approximated from artifact modification times; per-attempt
+          durations are not available.
+      absent:
+        description: No timing evidence of any kind survives.
+
+classes:
+  RunTelemetryReport:
+    tree_root: true
+    description: One report per collection pass, covering every run it found.
+    attributes:
+      label:
+        description: The run label the report covers, e.g. 2026-08-05_claude-opus-5-1m-generic-v3.
+        required: true
+      method:
+        description: Generation method, e.g. claudecode_agent.
+        required: true
+      generated_at:
+        description: When this report was collected (UTC).
+        range: datetime
+        required: true
+      schema_version:
+        description: Version of this telemetry schema the report conforms to.
+        required: true
+      runs:
+        description: Every run found under the label, one entry per project.
+        range: RunTelemetry
+        multivalued: true
+        inlined_as_list: true
+
+  RunTelemetry:
+    description: One project's run under the label, with every billed attempt.
+    attributes:
+      project:
+        description: Project the run documents, e.g. AI_READI.
+        required: true
+      replicate:
+        description: Replicate number parsed from the run label.
+        range: integer
+      label:
+        description: Full run label including the replicate suffix.
+        required: true
+      model:
+        description: Model route the run was billed against, as recorded.
+      provider:
+        description: API provider, e.g. LBL CBORG (proxy to Anthropic).
+      arm:
+        description: Experimental arm, e.g. BASELINE (input documents only).
+      validation_state:
+        description: Final validation outcome of both records.
+        range: ValidationStateEnum
+        required: true
+      validation_problem_count:
+        description: How many artifacts still carry validation problems.
+        range: integer
+      timing_basis:
+        description: Where every time figure in this run comes from.
+        range: TimingBasisEnum
+        required: true
+      finished_at:
+        range: datetime
+        description: The provenance record_generated_at, when present.
+      wall_seconds_estimate:
+        range: float
+        description: >-
+          Coarse whole-run estimate; basis given by timing_basis. Absent when
+          no two time points exist to subtract.
+      total_input_tokens:
+        description: Sum of uncached input tokens across every billed call.
+        range: integer
+      total_output_tokens:
+        description: Sum of output tokens (thinking and visible text together).
+        range: integer
+      total_cache_read_tokens:
+        description: Sum of prompt-cache read tokens across every billed call.
+        range: integer
+      total_cache_write_tokens:
+        description: Sum of prompt-cache write tokens across every billed call.
+        range: integer
+      total_reasoning_tokens_estimate:
+        range: integer
+        description: >-
+          Sum of per-attempt estimates (output tokens minus a chars/4 estimate
+          of visible text). Sound for comparison, not cost attribution — the
+          proxy withholds reasoning text, so the estimate is the only measure.
+      approx_cost_usd:
+        range: float
+        description: >-
+          input*$5/M + cache_write*$6.25/M + cache_read*$0.50/M + output*$25/M
+          at the CBORG-posted opus-5 rates; an estimate, not an invoice.
+      invocations:
+        range: integer
+        description: >-
+          How many batch invocations the run took. Completed-but-invalid runs
+          keep resume state so a re-run can continue repair (#361, #362), so
+          more than one is routine for large records.
+      phases:
+        description: Per-phase attempt history, in first-appearance order.
+        range: PhaseTelemetry
+        multivalued: true
+        inlined_as_list: true
+      repair_rounds:
+        description: Validator-driven repair rounds with their outcomes.
+        range: RepairRound
+        multivalued: true
+        inlined_as_list: true
+
+  PhaseTelemetry:
+    description: All attempts of one phase, in order.
+    attributes:
+      phase:
+        description: Which phase these attempts belong to.
+        range: PhaseEnum
+        required: true
+      attempts:
+        description: Every billed attempt of this phase, in call order.
+        range: AttemptTelemetry
+        multivalued: true
+        inlined_as_list: true
+        required: true
+      artifact_written_at:
+        range: datetime
+        description: >-
+          Modification time of the artifact this phase writes, when the file
+          still exists. The only per-phase time point for runs predating
+          recorded timing.
+
+  AttemptTelemetry:
+    description: One billed API call.
+    attributes:
+      attempt:
+        description: >-
+          Attempt number as recorded; numbers repeat across invocations while
+          list order is chronological.
+        range: integer
+        required: true
+      started_at:
+        range: datetime
+        description: Present only for runs made after timing was recorded.
+      seconds:
+        range: float
+        description: Wall time of the call, retries at the transport layer included.
+      input_tokens:
+        description: Uncached input tokens billed for this call.
+        range: integer
+      output_tokens:
+        description: Output tokens billed, thinking included.
+        range: integer
+      cache_read_tokens:
+        description: Prompt-cache tokens read by this call.
+        range: integer
+      cache_write_tokens:
+        description: Prompt-cache tokens written by this call.
+        range: integer
+      max_tokens:
+        range: integer
+        description: The ceiling requested, after the per-route clamp.
+      stop_reason:
+        description: Why the model stopped on this attempt.
+        range: StopReasonEnum
+      reasoning_tokens_estimate:
+        description: Output tokens minus a chars/4 estimate of visible text.
+        range: integer
+      visible_text_chars:
+        description: Characters of visible (non-thinking) response text.
+        range: integer
+      reasoning_present:
+        range: boolean
+        description: A thinking block came back, possibly with its text stripped.
+      reasoning_available:
+        range: boolean
+        description: The thinking text itself was capturable, not just attested.
+
+  RepairRound:
+    description: >-
+      One round of validator-driven repair (#361/#365). findings is the
+      validator line count the round started from; the trajectory across
+      rounds is the convergence record (e.g. 165 -> 27 -> 22 -> 21).
+    attributes:
+      artifact:
+        required: true
+        description: full or core.
+      round:
+        description: Repair round number within one invocation.
+        range: integer
+        required: true
+      outcome:
+        required: true
+        description: applied, truncated, unusable response, not converging, or validator did not run.
+      findings:
+        description: Validator finding lines this round started from.
+        range: integer

--- a/tests/test_run_telemetry.py
+++ b/tests/test_run_telemetry.py
@@ -1,0 +1,135 @@
+"""Tests for the run-telemetry collector and its schema."""
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.run_telemetry import (
+    SCHEMA_PATH,
+    SCHEMA_VERSION,
+    collect_report,
+    run_telemetry,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _seed_run(root: Path, label: str, project: str) -> Path:
+    """A synthetic run: two invocations, an audit retry, one repair round."""
+    core_dir = root / "claudecode_agent_core" / label
+    full_dir = root / "claudecode_agent" / label
+    core_dir.mkdir(parents=True)
+    full_dir.mkdir(parents=True)
+    (full_dir / f"{project}_d4d.yaml").write_text("id: x\n")
+    (core_dir / f"{project}_d4d_core.yaml").write_text("id: x\n")
+    (core_dir / f"{project}_reconciliation.md").write_text("# ok\n")
+
+    def row(phase, attempt, started, out_tok=100, stop="end_turn"):
+        return {"phase": phase, "attempt": attempt, "started_at": started,
+                "seconds": 10.0, "input_tokens": 50, "output_tokens": out_tok,
+                "cache_read": 5, "cache_write": 7, "max_tokens": 96000,
+                "stop_reason": stop}
+
+    # Two invocations: a >6 min gap sits between the report row and the
+    # repair row. The audit needed two attempts.
+    usage = [
+        row("full", 1, "2026-08-05T20:00:00+00:00"),
+        row("core", 1, "2026-08-05T20:05:00+00:00"),
+        row("audit", 1, "2026-08-05T20:10:00+00:00", stop="max_tokens"),
+        row("audit", 2, "2026-08-05T20:12:00+00:00"),
+        row("report", 1, "2026-08-05T20:15:00+00:00"),
+        row("repair_full", 1, "2026-08-05T21:00:00+00:00"),
+    ]
+    prov = {
+        "record_generated_at": "2026-08-05T21:10:00+00:00",
+        "run": {"label": label, "project": project,
+                "method": "claudecode_agent", "arm": "BASELINE",
+                "replicate": 1},
+        "model": {"model": "claude-opus-5", "provider": "LBL CBORG"},
+        "api_usage": usage,
+        "repair": [{"phase": "repair_full", "round": 1,
+                    "outcome": "applied", "findings": 12}],
+        "validation": {"problems": []},
+    }
+    (core_dir / f"{project}_provenance.yaml").write_text(
+        yaml.safe_dump(prov), encoding="utf-8")
+    reasoning = [
+        {"phase": "full", "attempt": 1, "reasoning_tokens_estimate": 40,
+         "visible_text_chars": 240, "reasoning_present": True,
+         "reasoning_available": False},
+        {"phase": "core", "attempt": 1, "reasoning_tokens_estimate": 10,
+         "visible_text_chars": 360},
+        {"phase": "audit", "attempt": 1, "reasoning_tokens_estimate": 5,
+         "visible_text_chars": 100},
+        {"phase": "audit", "attempt": 2, "reasoning_tokens_estimate": 6,
+         "visible_text_chars": 120},
+        {"phase": "report", "attempt": 1, "reasoning_tokens_estimate": 3,
+         "visible_text_chars": 90},
+        {"phase": "repair_full", "attempt": 1,
+         "reasoning_tokens_estimate": 2, "visible_text_chars": 80},
+    ]
+    (core_dir / f"{project}_reasoning.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in reasoning) + "\n", encoding="utf-8")
+    return core_dir
+
+
+class TestRunTelemetry(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.run_dir = _seed_run(self.root, "2026-08-05_test_rep1", "CHORUS")
+
+    def test_recorded_timing_and_invocations(self):
+        t = run_telemetry(self.run_dir, "CHORUS")
+        self.assertEqual(t["timing_basis"], "recorded")
+        self.assertEqual(t["wall_seconds_estimate"], 60.0)
+        # The >6 min gap before the repair row marks a second invocation.
+        self.assertEqual(t["invocations"], 2)
+
+    def test_attempts_join_reasoning_by_occurrence(self):
+        t = run_telemetry(self.run_dir, "CHORUS")
+        audit = next(p for p in t["phases"] if p["phase"] == "audit")
+        self.assertEqual(len(audit["attempts"]), 2)
+        self.assertEqual(audit["attempts"][0]["stop_reason"], "max_tokens")
+        self.assertEqual(audit["attempts"][0]["reasoning_tokens_estimate"], 5)
+        self.assertEqual(audit["attempts"][1]["reasoning_tokens_estimate"], 6)
+        full = next(p for p in t["phases"] if p["phase"] == "full")
+        self.assertIs(full["attempts"][0]["reasoning_present"], True)
+        self.assertIs(full["attempts"][0]["reasoning_available"], False)
+
+    def test_totals_repair_and_validation_state(self):
+        t = run_telemetry(self.run_dir, "CHORUS")
+        self.assertEqual(t["validation_state"], "valid")
+        self.assertEqual(t["validation_problem_count"], 0)
+        self.assertEqual(t["total_output_tokens"], 600)
+        self.assertEqual(t["total_reasoning_tokens_estimate"], 66)
+        self.assertEqual(t["repair_rounds"],
+                         [{"artifact": "full", "round": 1,
+                           "outcome": "applied", "findings": 12}])
+
+    def test_missing_provenance_returns_none(self):
+        self.assertIsNone(run_telemetry(self.run_dir, "NOPE"))
+
+    def test_report_validates_against_the_schema(self):
+        report = collect_report("2026-08-05_test", root=self.root)
+        self.assertEqual(len(report["runs"]), 1)
+        self.assertEqual(report["schema_version"], SCHEMA_VERSION)
+        out = self.root / "report.yaml"
+        out.write_text(yaml.safe_dump(report, sort_keys=False),
+                       encoding="utf-8")
+        res = subprocess.run(
+            ["poetry", "run", "linkml-validate",
+             "-s", str(REPO / SCHEMA_PATH), "-C", "RunTelemetryReport",
+             str(out)],
+            capture_output=True, text=True, timeout=180, cwd=REPO)
+        self.assertEqual(res.returncode, 0,
+                         (res.stdout + res.stderr)[:800])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds structured, LinkML-validated process telemetry for six-phase runs.

## What

- **`schema/d4d_run_telemetry.yaml`** — standalone LinkML schema (deliberately outside the `D4D_*.yaml` module glob and never imported by the dataset schema): `RunTelemetryReport → RunTelemetry → PhaseTelemetry → AttemptTelemetry`, plus `RepairRound` convergence records. Lints clean.
- **`run_telemetry.py` collector + `d4d runs telemetry`** — harvests provenance `api_usage`, the reasoning log (joined to attempts by phase + occurrence order, since attempt numbers repeat across invocations), repair rounds, validation outcome, artifact mtimes; writes to `data/run_telemetry/{label}.yaml`; `--validate` runs `linkml-validate` against the schema.
- **`api_runner.py`**: usage rows now carry `started_at` + `seconds`, stamped per attempt in both the phase loop and the repair loop — file mtimes only date an artifact's *last* write, so failed attempts and per-phase durations were previously unrecoverable.

## Evidence-honesty rules (in the schema, not just prose)

- `timing_basis ∈ {recorded, file_mtime, absent}` — existing runs predate the stamps and are marked `file_mtime` with no fabricated wall time.
- `invocations` derives from >6-minute gaps between recorded timestamps only; repair-round numbering cannot distinguish a resumed invocation from a second artifact's rounds, so legacy runs get no guess.
- `repair_rounds` outcomes come from the provenance repair block, latest-invocation-only until #366; every repair *call* still appears under `phases` via the cumulative usage rows (#362).

## Deliverable included

`data/run_telemetry/2026-08-05_claude-opus-5-1m-generic-v3.yaml` — validated report over the two valid sweep runs (AI-READI: 16 attempts across 8 phases, repair convergence, ~$19.54; CHORUS: ~$5.68). Re-collect once reps 2–3 finish.

## Testing

- `tests/test_run_telemetry.py` (5 tests): recorded-basis timing + invocation derivation, occurrence-order reasoning join, totals/repair/validation mapping, missing-provenance None, and end-to-end schema validation of a generated report.
- `tests.test_download.test_api_runner`: 128 tests OK with the timestamp additions.
- `linkml-lint` on the schema: no problems.
- Live canary: the committed report was generated and validated against the real sweep.

The running rep2/rep3 batch is unaffected (its process holds the old module; these runs will report `timing_basis: file_mtime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)