### PR TITLE
Snapshot every intermediate phase record; list them hashed in provenance (#369)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1122,6 +1122,54 @@ def build_repair(artifact: str, body: str, errors: list[str]) -> PhaseRequest:
                         messages=[{"role": "user", "content": parts}])
 
 
+def _intermediate_dir(spec: RunSpec) -> Path:
+    """Where a run's phase snapshots live, beside its provenance."""
+    return spec.provenance_path.parent / "intermediate"
+
+
+def _snapshot(spec: RunSpec, name: str, body: str) -> Path:
+    """Preserve one phase's output before a later phase overwrites it (#369).
+
+    Never overwrites: repair round numbers restart on a resumed invocation,
+    so a colliding name gets a numeric suffix — losing the earlier round's
+    state to the later one would defeat the point.
+    """
+    d = _intermediate_dir(spec)
+    d.mkdir(parents=True, exist_ok=True)
+    stem, dot, ext = name.rpartition(".")
+    path = d / name
+    n = 2
+    while path.exists():
+        path = d / f"{stem}_{n}.{ext}"
+        n += 1
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _intermediates_block(spec: RunSpec) -> list[dict[str, Any]] | None:
+    """Every snapshot on disk for this run's project, pinned by hash.
+
+    Globbed at record-build time rather than accumulated in memory, so a
+    resumed invocation lists the earlier invocations' snapshots too.
+    """
+    d = _intermediate_dir(spec)
+    if not d.is_dir():
+        return None
+    out = []
+    for p in sorted(d.glob(f"{spec.project}_*")):
+        # The remainder after the project name must be a phase token:
+        # VOICE and VOICE_PEDIATRIC share label directories, and a bare
+        # prefix glob would claim the other project's snapshots.
+        rest = p.name[len(spec.project) + 1:]
+        if not rest.startswith(("full", "core", "audit", "reconcile",
+                                "repair", "report")):
+            continue
+        out.append({"path": str(p),
+                    "sha256": hashlib.sha256(
+                        p.read_bytes()).hexdigest()})
+    return out or None
+
+
 def _repair_invalid(spec: RunSpec, client, settings: dict[str, Any],
                     usage: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Validator-driven shape repair of whichever artifacts fail (#356).
@@ -1208,8 +1256,9 @@ def _repair_invalid(spec: RunSpec, client, settings: dict[str, Any],
                 log.append({"phase": ph, "round": rnd,
                             "outcome": f"unusable response: {exc}"})
                 continue
-            path.write_text(normalise_enum_aliases(normalise_temporal(body)),
-                            encoding="utf-8")
+            body = normalise_enum_aliases(normalise_temporal(body))
+            path.write_text(body, encoding="utf-8")
+            _snapshot(spec, f"{spec.project}_{ph}_r{rnd}.yaml", body)
             applied_from = len(errors)
             log.append({"phase": ph, "round": rnd, "outcome": "applied",
                         "findings": len(errors)})
@@ -1559,11 +1608,20 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             time.sleep(BACKOFF_BASE_SECONDS ** attempt)
         if ph == "audit":
             carry["Audit findings"] = body
+            # The progress file that carries the findings is deleted on
+            # success, so without this the run's richest intermediate
+            # survives only as the report's prose summary (#369).
+            _snapshot(spec, f"{spec.project}_audit.json", body)
         elif artifact:
             target.parent.mkdir(parents=True, exist_ok=True)
             if artifact in ("full", "core"):
                 body = normalise_enum_aliases(normalise_temporal(body))
             target.write_text(body, encoding="utf-8")
+            # Reconcile (and later repair) overwrite the artifact in place;
+            # the snapshot is the only record of what this phase produced.
+            _snapshot(spec, f"{spec.project}_{ph}.yaml"
+                      if artifact != "report" else f"{spec.project}_{ph}.md",
+                      body)
             label = {"full": "Completed full record",
                      "core": "Completed core record",
                      "report": "Reconciliation report"}[artifact]
@@ -1647,6 +1705,7 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     else:
         rec.data["repair"] = None
     rec.data["validation"] = validation_block(spec, problems)
+    rec.data["intermediates"] = _intermediates_block(spec)
 
     rec.write(spec.provenance_path)
 

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -761,6 +761,48 @@ class TestValidatorDrivenRepair(unittest.TestCase):
         self.assertEqual(phases[:6], [u["phase"] for u in first["api_usage"]])
         self.assertEqual(phases[-1], "repair_full")
 
+    def test_execute_snapshots_every_intermediate(self):
+        """#369: reconcile and repair overwrite artifacts in place, and the
+        audit findings die with the progress file on success. The snapshots
+        are the only phase-evolution record the manuscript can analyze."""
+        import yaml as _yaml
+        from data_sheets_schema import api_runner
+        s = spec(out_dir=self.out)
+        keep = api_runner._client
+        api_runner._client = lambda: FakeClient()
+        self.addCleanup(lambda: setattr(api_runner, "_client", keep))
+        self.api.execute(s)
+        inter = s.provenance_path.parent / "intermediate"
+        names = sorted(p.name for p in inter.iterdir())
+        for expected in ("CHORUS_full.yaml", "CHORUS_core.yaml",
+                         "CHORUS_audit.json", "CHORUS_reconcile_full.yaml",
+                         "CHORUS_reconcile_core.yaml", "CHORUS_report.md"):
+            self.assertIn(expected, names)
+        d = _yaml.safe_load((self.out / "CHORUS_provenance.yaml").read_text())
+        listed = {Path(i["path"]).name for i in d["intermediates"]}
+        self.assertEqual(listed, set(names))
+        for i in d["intermediates"]:
+            self.assertEqual(len(i["sha256"]), 64)
+
+    def test_snapshot_never_overwrites_a_colliding_name(self):
+        s = spec(out_dir=self.out)
+        self.out.mkdir(parents=True, exist_ok=True)
+        first = self.api._snapshot(s, "CHORUS_repair_full_r1.yaml", "one\n")
+        second = self.api._snapshot(s, "CHORUS_repair_full_r1.yaml", "two\n")
+        self.assertNotEqual(first, second)
+        self.assertEqual(first.read_text(), "one\n")
+        self.assertEqual(second.read_text(), "two\n")
+        self.assertEqual(second.name, "CHORUS_repair_full_r1_2.yaml")
+
+    def test_intermediates_do_not_claim_a_prefix_sibling_project(self):
+        s = spec(out_dir=self.out)
+        self.out.mkdir(parents=True, exist_ok=True)
+        self.api._snapshot(s, "CHORUS_full.yaml", "id: x\n")
+        self.api._snapshot(s, "CHORUS_EXTENDED_full.yaml", "id: y\n")
+        block = self.api._intermediates_block(s)
+        self.assertEqual([Path(i["path"]).name for i in block],
+                         ["CHORUS_full.yaml"])
+
     def test_execute_records_no_repair_when_records_validate(self):
         import yaml as _yaml
         from data_sheets_schema import api_runner


### PR DESCRIPTION
Fixes #369.

## Why

For the manuscript we want to analyze record evolution across the process — what the audit caught, what reconciliation changed, what each repair round fixed. Today that data is destroyed as it is produced: reconcile and repair overwrite artifacts in place, and the audit findings JSON lives only in the progress file, which is deleted on success.

## What

- `_snapshot()`: every artifact-writing step also writes an immutable copy under `{method}_core/{label}/intermediate/` — `{PROJECT}_full.yaml`, `_core.yaml`, `_audit.json`, `_reconcile_full.yaml`, `_reconcile_core.yaml`, `_report.md`, `_repair_{full|core}_rN.yaml`. Names deliberately avoid the `*_d4d.yaml` / `*_d4d_core.yaml` patterns downstream globs use, and live in a subdirectory no existing tooling descends into.
- Collisions never overwrite: repair round numbers restart on a resumed invocation, so `_rN` gets a numeric suffix — the convergence sequence keeps every state.
- Provenance gains an `intermediates` block (path + sha256 per snapshot), globbed at record-build time so a resumed invocation lists earlier invocations' snapshots too, filtered by phase token so `VOICE` never claims `VOICE_PEDIATRIC`'s files (the #313 prefix-collision class).
- Storage cost: ~0.5–1 MB per run.

## Known limitation

Intermediates for all past runs — including the in-flight rep2/rep3, whose process predates this code — are unrecoverable; their per-phase output *sizes* survive in telemetry (`visible_text_chars`). Noted in #369.

## Testing

3 new tests: all six phase snapshots + hashed provenance listing through `execute()`; collision suffixing preserves both states; prefix-sibling filtering. 131 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)