### PR TITLE
Count nested hollows in record stats (schema v1.2.0)

### DIFF
--- a/data/run_telemetry/2026-08-05_claude-opus-5-1m-generic-v3.yaml
+++ b/data/run_telemetry/2026-08-05_claude-opus-5-1m-generic-v3.yaml
@@ -1,7 +1,7 @@
 label: 2026-08-05_claude-opus-5-1m-generic-v3
 method: claudecode_agent
-generated_at: '2026-08-06T07:02:48+00:00'
-schema_version: 1.1.0
+generated_at: '2026-08-06T07:10:53+00:00'
+schema_version: 1.2.0
 runs:
 - project: AI_READI
   label: 2026-08-05_claude-opus-5-1m-generic-v3_rep1
@@ -217,6 +217,7 @@ runs:
     lines: 1701
     root_slot_count: 70
     populated_root_slot_count: 70
+    hollow_value_count: 0
   - artifact: core
     path: data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/AI_READI_d4d_core.yaml
     sha256: c3f7c4944b0278dd1765607d8797396e485f5e5d031644979f38892d7f7ddfbf
@@ -224,6 +225,7 @@ runs:
     lines: 1305
     root_slot_count: 58
     populated_root_slot_count: 58
+    hollow_value_count: 0
   - artifact: report
     path: data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/AI_READI_reconciliation.md
     sha256: aa7a377ddd75f06cef8dd96c3898ba9cf57f2ace171c94047569c7599bbd92ea
@@ -399,6 +401,7 @@ runs:
     lines: 763
     root_slot_count: 53
     populated_root_slot_count: 53
+    hollow_value_count: 0
   - artifact: core
     path: data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/CHORUS_d4d_core.yaml
     sha256: 810488e1961311245c7f4df3fc4567149f5c79b42837d6a9dadfa5efb55ccfcc
@@ -406,6 +409,7 @@ runs:
     lines: 718
     root_slot_count: 48
     populated_root_slot_count: 48
+    hollow_value_count: 0
   - artifact: report
     path: data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/CHORUS_reconciliation.md
     sha256: a77bfccba9fe1dfeef0c41b0d9efe3825f3369996dd5c99dd74a7b3fbea49b02
@@ -603,6 +607,7 @@ runs:
     lines: 1476
     root_slot_count: 76
     populated_root_slot_count: 76
+    hollow_value_count: 0
   - artifact: core
     path: data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep2/AI_READI_d4d_core.yaml
     sha256: 1a8db435e1636240011ac7ea8ec00df6fcb4d37a03cc191e9974e2636197efb6
@@ -610,6 +615,7 @@ runs:
     lines: 1254
     root_slot_count: 62
     populated_root_slot_count: 62
+    hollow_value_count: 0
   - artifact: report
     path: data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep2/AI_READI_reconciliation.md
     sha256: d1dbe5302d26a0d60b2cc419d955c1259dc8355d45bb68b885670652ae535505
@@ -717,6 +723,24 @@ comparisons:
     value: 48.0
   - subject: AI_READI rep2
     value: 62.0
+- metric: full_hollow_value_count
+  unit: hollows
+  values:
+  - subject: AI_READI rep1
+    value: 0.0
+  - subject: CHORUS rep1
+    value: 0.0
+  - subject: AI_READI rep2
+    value: 0.0
+- metric: core_hollow_value_count
+  unit: hollows
+  values:
+  - subject: AI_READI rep1
+    value: 0.0
+  - subject: CHORUS rep1
+    value: 0.0
+  - subject: AI_READI rep2
+    value: 0.0
 - metric: validation_problem_count
   unit: artifacts
   values:
@@ -791,3 +815,14 @@ findings:
     issue #286 documents the stale-baseline problem.'
   relates_to:
   - '#286'
+- topic: nested hollow values
+  kind: observation
+  claim: Every record in this sweep counts zero mechanical hollows at any depth (null,
+    blank, empty, or containers of only those) — but so does every v2-sweep AI_READI
+    record. The hollow_object defect class the form-defects analysis found under v2
+    is therefore semantic hollowness inside structurally populated objects, visible
+    only to the LLM judge; a mechanical zero here does not clear a record of it.
+  evidence: hollow_value_count 0 for all six current-sweep artifacts and for all six
+    2026-07-31 v2 AI_READI artifacts, measured with the same counter.
+  relates_to:
+  - '#369'

--- a/data/run_telemetry/findings/2026-08-05_claude-opus-5-1m-generic-v3_findings.yaml
+++ b/data/run_telemetry/findings/2026-08-05_claude-opus-5-1m-generic-v3_findings.yaml
@@ -77,3 +77,17 @@
     data/evaluation/scores.json file_path values lack label directories;
     issue #286 documents the stale-baseline problem.
   relates_to: ["#286"]
+
+- topic: nested hollow values
+  kind: observation
+  claim: >-
+    Every record in this sweep counts zero mechanical hollows at any depth
+    (null, blank, empty, or containers of only those) — but so does every
+    v2-sweep AI_READI record. The hollow_object defect class the form-defects
+    analysis found under v2 is therefore semantic hollowness inside
+    structurally populated objects, visible only to the LLM judge; a
+    mechanical zero here does not clear a record of it.
+  evidence: >-
+    hollow_value_count 0 for all six current-sweep artifacts and for all six
+    2026-07-31 v2 AI_READI artifacts, measured with the same counter.
+  relates_to: ["#369"]

--- a/src/data_sheets_schema/run_telemetry.py
+++ b/src/data_sheets_schema/run_telemetry.py
@@ -36,7 +36,7 @@ import yaml
 from data_sheets_schema.api_runner import CONCAT_DIR
 
 SCHEMA_PATH = Path("src/data_sheets_schema/schema/d4d_run_telemetry.yaml")
-SCHEMA_VERSION = "1.1.0"
+SCHEMA_VERSION = "1.2.0"
 
 # CBORG-posted opus-5 rates (2026-08-05, /model/info): $ per token. Cache
 # writes bill at 1.25x input, cache reads at 0.1x. No premium tier above 200k.
@@ -122,6 +122,41 @@ def _invocations(rows: list[dict[str, Any]]) -> int | None:
     return 1 + gaps
 
 
+def _is_hollow(v: Any) -> bool:
+    """Null, blank, empty — or a container whose every member is.
+
+    False and 0 are values, not hollows. A whitespace-only string is hollow:
+    it renders as content and carries none, which is the defect's whole
+    shape.
+    """
+    if v is None:
+        return True
+    if isinstance(v, str):
+        return not v.strip()
+    if isinstance(v, dict):
+        return all(_is_hollow(x) for x in v.values())
+    if isinstance(v, list):
+        return all(_is_hollow(x) for x in v)
+    return False
+
+
+def count_hollows(v: Any) -> int:
+    """Maximal hollow subtrees at any depth.
+
+    A hollow object counts once, not once per empty member — the question is
+    "how many hollows does a reader meet", not "how many empty cells exist".
+    Mechanical kin of the form-defects `hollow_object` class, which is
+    LLM-judged; this one is structural and free.
+    """
+    if _is_hollow(v):
+        return 1
+    if isinstance(v, dict):
+        return sum(count_hollows(x) for x in v.values())
+    if isinstance(v, list):
+        return sum(count_hollows(x) for x in v)
+    return 0
+
+
 def _record_stats(artifact: str, path: Path) -> dict[str, Any] | None:
     """File and content statistics for one final artifact.
 
@@ -147,8 +182,8 @@ def _record_stats(artifact: str, path: Path) -> dict[str, Any] | None:
         if isinstance(parsed, dict):
             out["root_slot_count"] = len(parsed)
             out["populated_root_slot_count"] = sum(
-                1 for v in parsed.values()
-                if v is not None and v != "" and v != [] and v != {})
+                1 for v in parsed.values() if not _is_hollow(v))
+            out["hollow_value_count"] = count_hollows(parsed)
     return out
 
 
@@ -176,6 +211,14 @@ _COMPARISON_METRICS = (
                      if s["artifact"] == "full"), None)),
     ("core_root_slot_count", "slots",
      lambda r: next((s.get("root_slot_count")
+                     for s in r.get("records", [])
+                     if s["artifact"] == "core"), None)),
+    ("full_hollow_value_count", "hollows",
+     lambda r: next((s.get("hollow_value_count")
+                     for s in r.get("records", [])
+                     if s["artifact"] == "full"), None)),
+    ("core_hollow_value_count", "hollows",
+     lambda r: next((s.get("hollow_value_count")
                      for s in r.get("records", [])
                      if s["artifact"] == "core"), None)),
     ("validation_problem_count", "artifacts",

--- a/src/data_sheets_schema/schema/d4d_run_telemetry.yaml
+++ b/src/data_sheets_schema/schema/d4d_run_telemetry.yaml
@@ -325,8 +325,15 @@ classes:
         range: integer
       populated_root_slot_count:
         description: >-
-          Top-level keys whose value is neither null nor an empty string,
-          list or mapping.
+          Top-level keys whose value is not hollow — hollow being null, a
+          blank string, an empty container, or a container whose every
+          member is hollow, recursively.
+        range: integer
+      hollow_value_count:
+        description: >-
+          Maximal hollow subtrees at any depth: a hollow object counts once,
+          not once per empty member. The mechanical, structural kin of the
+          form-defects hollow_object class, which is LLM-judged.
         range: integer
 
   Comparison:

--- a/tests/test_run_telemetry.py
+++ b/tests/test_run_telemetry.py
@@ -156,6 +156,31 @@ class TestRunTelemetry(unittest.TestCase):
         self.assertEqual(got[0]["artifact"], "core")
         self.assertEqual(got[0]["evaluation_type"], "presence")
 
+    def test_hollow_counting_is_maximal_and_keeps_falsy_values(self):
+        from data_sheets_schema.run_telemetry import count_hollows
+        record = {
+            "a": "text",
+            "b": None,                          # hollow
+            "c": {"x": None, "y": "", "z": []},  # one hollow object, not 3
+            "d": [{"name": "real"}, {"name": "  "}],  # one hollow member
+            "e": 0,                             # a value, not a hollow
+            "f": False,                         # a value, not a hollow
+            "g": ["", None],                    # hollow list, counts once
+        }
+        self.assertEqual(count_hollows(record), 4)
+        self.assertEqual(count_hollows({"a": 1}), 0)
+        self.assertEqual(count_hollows({}), 1)
+
+    def test_record_stats_report_nested_hollows(self):
+        (self.run_dir.parent.parent / "claudecode_agent" /
+         "2026-08-05_test_rep1" / "CHORUS_d4d.yaml").write_text(
+            "id: x\nok: v\nempty: null\nobj:\n  a: null\n  b: ''\n")
+        t = run_telemetry(self.run_dir, "CHORUS")
+        full = next(s for s in t["records"] if s["artifact"] == "full")
+        self.assertEqual(full["root_slot_count"], 4)
+        self.assertEqual(full["populated_root_slot_count"], 2)
+        self.assertEqual(full["hollow_value_count"], 2)
+
     def test_findings_pass_through_to_the_report(self):
         finding = {"topic": "test", "kind": "observation",
                    "claim": "the fixture ran", "evidence": "this test"}


### PR DESCRIPTION
Adds `hollow_value_count` to `RecordStats`: maximal hollow subtrees at any depth (null, blank string, empty container, or a container whose every member is hollow — `False` and `0` are values). Included in the mechanical comparisons; schema lints clean; 11 tests OK.

**Measured result, with a correction:** every current-sweep artifact counts **zero** mechanical hollows — but so does every 2026-07-31 v2 AI-READI record. So the `hollow_object` defect class the form-defects split found under v2 is *semantic* hollowness inside structurally populated objects (LLM-judged), not structural emptiness; a mechanical zero does not clear a record of it. This corrects the reading offered in conversation earlier today and is recorded as a typed finding in the report itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)