### PR TITLE
Defuse the trap slots: scalarize the narrative family, id-optional Organization/Grant, string references (schema 2.0.0)

### DIFF
--- a/data/run_telemetry/trap_slot_inventory_v2_schema.yaml
+++ b/data/run_telemetry/trap_slot_inventory_v2_schema.yaml
@@ -1,0 +1,2319 @@
+generated_at: '2026-08-06T19:27:27+00:00'
+schema_version: 1.3.0
+corpus_note: All *_d4d.yaml and *_d4d_core.yaml under data/d4d_concatenated excluding
+  ATTIC and quarantined .failed-* files. Valid records contribute zero rows.
+records_scanned: 299
+records_with_errors: 213
+traps:
+- slot_path: /collection_mechanisms/*/mechanism_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 682
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Hardware devices and sensors (retinal imaging, ECG, wearables, environmental
+    monitors)'', ''Clinical procedures (monofilament and cognitive function testing)'', '
+  - '[''CRISPRi gene knockdown system with perturb-seq readout'', ''Size exclusion
+    chromatography coupled with mass spectrometry'', ''Confocal microscopy with DAPI,
+    calre'
+  record_count: 178
+- slot_path: /raw_data_sources/*/source_type
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 510
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Human research participants''] is not of type ''string'', ''null'''
+  - '[''Instrument and sensor exports''] is not of type ''string'', ''null'''
+  record_count: 169
+- slot_path: /preprocessing_strategies/*/preprocessing_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 499
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''File formats, data standards, metadata, and example outputs provided per domain'',
+    ''Harmonization across three collection sites''] is not of type ''string'', ''nul'
+  - '[''RO-Crate packaging with provenance metadata'', ''FAIRSCAPE framework for AI-ready
+    data formatting'', ''Rich metadata including ontology annotations''] is not of
+    ty'
+  record_count: 180
+- slot_path: /data_collectors/*/collector_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 438
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Multi-site data collection across 3 harmonized sites''] is not of type ''string'',
+    ''null'''
+  - '[''University of California San Diego (Ideker Lab, Mali Lab, Sali Lab)'', ''University
+    of California San Francisco (Krogan Lab)'', ''Stanford University (Lundberg La'
+  record_count: 178
+- slot_path: /maintainers/*/maintainer_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 408
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''See Documentation site Contact Us and GitHub references''] is not of type
+    ''string'', ''null'''
+  - '[''Point of contact Trey Ideker (University of California San Diego)'', ''Data
+    depositor Justin Niestroy (University of Virginia)''] is not of type ''string'',
+    ''null'''
+  record_count: 182
+- slot_path: /raw_data_sources/*/raw_data_format
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 386
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''REDCap survey and form responses'', ''Coordinator-entered clinical measurements'']
+    is not of type ''string'', ''null'''
+  - '[''ECG in .xml'', ''MoCA Duo application output in .csv, comprising total score,
+    section subscores, Memory Index Score, and task completion times'', ''Topcon retinal'
+  record_count: 143
+- slot_path: /anomalies/*/anomaly_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 350
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Early releases may exhibit unbalanced distributions across diabetes severity
+    groups''] is not of type ''string'', ''null'''
+  - '[''In cases of survey data, skipped questions or incomplete responses are expected'']
+    is not of type ''string'', ''null'''
+  record_count: 145
+- slot_path: /ethical_reviews/*/review_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 322
+  projects:
+  - VOICE
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''IRB approval from University of South Florida''] is not of type ''string'',
+    ''null'''
+  - '[''AI-READI was approved by the Institutional Review Board of the University
+    of Washington under approval number STUDY00016228, including reliance agreements
+    wit'
+  record_count: 176
+- slot_path: /prohibited_uses/*/prohibition_reason
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 255
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Licensee shall not make clinical treatment decisions based on the Data, as
+    it is intended solely as a research resource.''] is not of type ''string'', ''null'''
+  - '[''Licensee shall not use or attempt to use the Data, alone or in concert with
+    other information, to compromise or otherwise infringe the confidentiality of
+    info'
+  record_count: 148
+- slot_path: /collection_timeframes/*/timeframe_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 250
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Pilot phase data included in initial release'', ''Enrollment ongoing with
+    periodic updates''] is not of type ''string'', ''null'''
+  - '[''Data creation date 2025-02-27'', ''Publication date 2025-03-03'', ''Ongoing
+    data augmentation planned''] is not of type ''string'', ''null'''
+  record_count: 166
+- slot_path: /raw_sources/*/raw_data_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 239
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''The raw data is saved and expected to be preserved by the AI-READI project
+    at least for the duration of the project.'', ''Raw data are not anticipated to
+    be sha'
+  - '[''"Clinical notes - stored locally except tokens": raw note text is retained
+    at contributing sites, and only tokenized content is held centrally.'', ''The
+    current'
+  record_count: 165
+- slot_path: /sensitive_elements/*/sensitivity_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 213
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Sex, race, ethnicity held under controlled access'', ''Genetic sequencing
+    data'', ''Past health records and medications'', ''Traffic and accident reports'']
+    is not o'
+  - '[''The public dataset does not contain data that is considered sensitive.'',
+    ''The controlled access dataset contains data regarding racial and ethnic origins,
+    loc'
+  record_count: 178
+- slot_path: /cleaning_strategies/*/cleaning_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 212
+  projects:
+  - AI_READI
+  - VOICE
+  - CHORUS
+  - CM4AI
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Cross-site harmonization procedures'', ''Domain-specific data cleaning as
+    documented''] is not of type ''string'', ''null'''
+  - '[''HIPAA Safe Harbor identifiers removed'', ''State and province removed (country
+    retained)'', ''Free speech transcripts removed'', ''Raw audio waveforms omitted'']
+    is '
+  record_count: 153
+- slot_path: /future_use_impacts/*/impact_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 207
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Potential bias from unbalanced early releases'', ''Privacy considerations
+    for controlled-access data''] is not of type ''string'', ''null'''
+  - '[''Cell line-specific phenotypes may not generalize across all cell types'',
+    ''Chemotherapy treatment conditions specific to paclitaxel and vorinostat''] is
+    not of '
+  record_count: 164
+- slot_path: /acquisition_methods/*/acquisition_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 204
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Physical and clinical measurements directly observed'', ''Survey data reported
+    by subjects'', ''Imaging data (retinal) directly captured'', ''Wearable device
+    data p'
+  - '[''CRISPRi perturbation sequencing for transcriptional and fitness phenotypes'',
+    ''SEC-MS for protein-protein interaction mapping'', ''ICC-IF and confocal microscopy'
+  record_count: 178
+- slot_path: /subpopulations/*/identification
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 191
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''The dataset does not identify demographic sub-populations by age, gender,
+    sex, or ethnicity in the public release.'', ''No regulation prevents demographic
+    data '
+  - '[''Intensive care unit (ICU) admissions'', ''Pediatric intensive care unit (PICU)
+    admissions'', ''Neonatal intensive care unit (NICU) admissions'', ''Demographics
+    capt'
+  record_count: 149
+- slot_path: /intended_uses/*/use_category
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 185
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Research'', ''Artificial intelligence and machine learning method development'',
+    ''Standards and data stewardship exemplar''] is not of type ''string'', ''null'''
+  - '[''clinical AI/ML model development'', ''external model validation'', ''AI/ML
+    training and education''] is not of type ''string'', ''null'''
+  record_count: 155
+- slot_path: /license_and_use_terms/license_terms
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 182
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Public data under license with defined permitted uses'', ''Full dataset requires
+    Data Use Agreement''] is not of type ''string'', ''null'''
+  - '[''CC BY-NC-SA 4.0'', ''Attribution required to copyright holders and authors'',
+    ''Non-commercial use only''] is not of type ''string'', ''null'''
+  record_count: 182
+- slot_path: /updates/update_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 182
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Periodic data releases as enrollment continues'', ''Documentation versioned
+    with dataset (e.g., v1.0.0, v2.0.0)''] is not of type ''string'', ''null'''
+  - '[''Regular data augmentation planned'', ''Version 1.4 as of March 2025 publication'']
+    is not of type ''string'', ''null'''
+  record_count: 182
+- slot_path: /confidential_elements/*/confidentiality_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 181
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''5-digit zip code held under controlled access'', ''Genetic sequencing data
+    held under controlled access'', ''Past health records and medications held under
+    contro'
+  - '[''The dataset does not contain data that might be considered confidential. No
+    personally identifiable information is included in the dataset.'', ''The data
+    in thi'
+  record_count: 174
+- slot_path: /discouraged_uses/*/discouragement_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 179
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Uses not permitted by license terms'', ''Uses that would violate participant
+    privacy protections''] is not of type ''string'', ''null'''
+  - '[''Commercial use not permitted under license terms'', ''Attribution and share-alike
+    requirements must be followed''] is not of type ''string'', ''null'''
+  record_count: 145
+- slot_path: /missing_data_documentation/*/missing_data_patterns
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 175
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Not all modalities are available for all participants'', ''Skipped questions
+    or incomplete responses in survey data'', ''Missing device-derived data for some
+    at-h'
+  - '[''Full-text clinical notes are not held centrally; only tokens are available
+    in the enclave.'', ''Imaging is limited to 1000 available images as of August/Septemb'
+  record_count: 173
+- slot_path: /is_deidentified/deidentification_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 173
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''The data in this dataset contain no protected health information. No personally
+    identifiable information is included in the dataset.'', ''Information related
+    to'
+  - '[''Clinical notes are stored locally at contributing sites; only tokens are held
+    centrally.'', ''The chorus-ai GitHub organization maintains a privacy scan tool
+    fo'
+  record_count: 173
+- slot_path: /missing_data_documentation/*/missing_data_causes
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 171
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Some participants elected not to participate in some study elements'', ''In
+    a few cases the data collection device did not have any stored results or was
+    return'
+  - '[''De-identification of imaging for a larger cohort was in process at the time
+    of the source capture.'', ''Clinical notes are retained locally at contributing
+    site'
+  record_count: 171
+- slot_path: /version_access/version_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 169
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Version dropdown available in documentation'', ''Each dataset version has
+    corresponding documentation version''] is not of type ''string'', ''null'''
+  - '[''DOI doi:10.18130/V3/B35XWX for persistent access'', ''Dataverse versioning
+    system tracks updates''] is not of type ''string'', ''null'''
+  record_count: 169
+- slot_path: /sampling_strategies/*/source_data
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 168
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''The study base is all patients aged 40 years or older who had a medical encounter
+    within each health system site (University of Alabama at Birmingham, Univers'
+  - '[''Clinical records of patients with acute or critical illness at 14 data contributing
+    hospitals.''] is not of type ''string'', ''null'''
+  record_count: 161
+- slot_path: /subpopulations/*/distribution
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 162
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Recruitment targets approximately 1,000 participants in each of four self-reported
+    racial and ethnic groups (White, Asian, Hispanic, Black) and approximately '
+  - '[''Current released dataset: 50,000 patient admissions from ICU, PICU, and NICU.
+    The current source bundle does not break these counts out by unit, and gives no '
+  record_count: 131
+- slot_path: /labeling_strategies/*/labeling_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 151
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Clinical test outputs annotated per domain protocols'', ''Imaging outputs
+    labeled according to clinical standards''] is not of type ''string'', ''null'''
+  - '[''No explicit label or target is associated with each data instance; no labels
+    are provided.'', ''No specific labeling was performed in the dataset, as the datase'
+  record_count: 147
+- slot_path: /retention_limit/retention_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 148
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''There are no limits on the retention of the data associated with the instances.'',
+    ''The raw data is saved and expected to be preserved by the AI-READI project '
+  - '[''Long term preservation in the University of Virginia Dataverse, supported
+    by committed institutional funds.'', "LibraData is the University of Virginia''s
+    insta'
+  record_count: 148
+- slot_path: /sampling_strategies/*/why_not_representative
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 146
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''The design deliberately departs from the demographic distribution of the US
+    population in order to build a balanced training dataset, because building balance'
+  - '[''Data in this release was derived from commercially available de-identified
+    human cell lines and does not represent all biological variants which may be seen
+    i'
+  record_count: 146
+- slot_path: /human_subject_research/ethics_review_board
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 144
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_assistant
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''University of Washington Institutional Review Board (Human Subjects Division)'',
+    ''University of Alabama at Birmingham IRB (via reliance)'', ''University of Calif'
+  - '[''CM4AI Ethics Module, with review contacts Vardit Ravitsky (The Hastings Center)
+    and Jean-Christophe Belisle-Pipon (Simon Fraser University).'', ''CM4AI Data Gov'
+  record_count: 144
+- slot_path: /data_protection_impacts/*/impact_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 138
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''No, a data protection impact analysis has not been conducted.''] is not of
+    type ''string'', ''null'''
+  - '[''CM4AI data are non-clinical, derived from tissue cultures, and are considered
+    to be de-identified as they cannot be matched, with current knowledge, to a huma'
+  record_count: 138
+- slot_path: /regulatory_restrictions/other_compliance
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 133
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''NIH Genomic Data Sharing policy security and privacy standards, per the NIH
+    Best Practices for Controlled-Access Data Subject to the NIH GDS Policy.'', ''Univer'
+  - '[''The Ethics team developed a plan for ethical preparation, licensing, dissemination
+    and Data Access supervision of CM4AI datasets, balancing openness of the da'
+  record_count: 133
+- slot_path: /other_tasks/*/task_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 132
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Reconstruction of a temporal atlas of T2DM development and reversal towards
+    health through pseudotime manifold analysis.'', ''Multimodal model development
+    acros'
+  - '[''The CHoRUS GitHub overview invites people "interested in getting involved
+    in downstream analytics on the mapped and assembled dataset" to make contact.'',
+    ''Tra'
+  record_count: 117
+- slot_path: /informed_consent/*/consent_documentation
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 128
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''The approved consent form for the principal project site, the University of
+    Washington, is published at https://docs.aireadi.org/v3/AI-READI%20Consent_Form_St'
+  - '[''No participant consent documentation is reported; the Dataverse release records
+    state Human Subjects - No and De-identified Samples - Yes.''] is not of type ''s'
+  record_count: 126
+- slot_path: /extension_mechanism/extension_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 123
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''There is currently no mechanism for others to extend or augment the AI-READI
+    dataset outside of those who are involved in the project.''] is not of type ''strin'
+  - '[''"We have established a chorus-mapping repository with documentation and pooled
+    tabular mappings along with an associated clinical validation SOP for contribut'
+  record_count: 123
+- slot_path: /informed_consent/*/consent_scope
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 112
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''The public version of the dataset can only be used for type 2 diabetes related
+    research; a private version will allow for more generic use. The FAIRhub datase'
+  - '[''The distributed data derive from the commercially available MDA-MB-468 breast
+    cancer cell line and the KOLF2.1J induced pluripotent stem cell line, both of
+    wh'
+  record_count: 110
+- slot_path: /informed_consent/*/consent_type
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 103
+  projects:
+  - VOICE
+  - AI_READI
+  - CM4AI
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Written consent for data collection'', ''Consent for research data sharing'']
+    is not of type ''string'', ''null'''
+  - '[''Written informed consent'', ''Electronic consent (e-consent) via REDCap'',
+    ''In-person written consent''] is not of type ''string'', ''null'''
+  record_count: 101
+- slot_path: /external_resources/*/future_guarantees
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 101
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Documentation versions correspond to dataset versions''] is not of type ''string'',
+    ''null'''
+  - '[''The source documentation does not state any commitment that the external resources
+    listed here will remain available and stable over time. The dataset itself '
+  record_count: 91
+- slot_path: /labeling_strategies/*/data_annotation_protocol
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 91
+  projects:
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  examples:
+  - '[''Cell maps are annotated in a two-pronged approach - first, maps are aligned
+    to known protein function and pathway resources including the Gene Ontology and
+    Re'
+  - '[''Diagnostic labels are the result of a clinical assessment of the participant.
+    At each site, a local clinician provided the diagnosis based on a clinical inter'
+  record_count: 89
+- slot_path: /variables/*/quality_notes
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 87
+  projects:
+  - AI_READI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  examples:
+  - '[''Professionals require training to score the test'', "A person''s level of
+    education may affect the test", ''Socioeconomic factors may affect the test'',
+    ''People l'
+  - '[''Because participants may have repeated visits, there may be more than one
+    row per participant in the phenotype data files.''] is not of type ''string'',
+    ''null'''
+  record_count: 16
+- slot_path: /relationships/*/relationship_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 85
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''All instances are part of the same prospective data generation project (AI-READI).'',
+    ''There is currently only one visit per participant.'', "Within a participa'
+  - '[''The three measurement modalities are matched by protein and gene identity
+    across a shared target list, so a protein may appear as an AP-MS or SEC-MS interacti'
+  record_count: 81
+- slot_path: /direct_collection/*/collection_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 85
+  projects:
+  - AI_READI
+  - CHORUS
+  - CM4AI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''The data was collected directly from participants across the three recruiting
+    sites.'', "Recruitment pools were identified by screening electronic health recor'
+  - '[''Data collection is retrospective and proceeds through data contributing sites,
+    which extract, curate, and upload clinical data extracts under CHoRUS SOPs, rat'
+  record_count: 85
+- slot_path: /informed_consent/*/withdrawal_mechanism
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 82
+  projects:
+  - AI_READI
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  - claudecode_agent_healthsheet_core
+  examples:
+  - '[''Participants were permitted to withdraw consent at any time and cease study
+    participation; any data that had been shared or used up to that point would stay
+    i'
+  - '[''Participants may withdraw at any point. Data provided before or during voice
+    data collection is not included in the database if the participant withdraws at
+    t'
+  record_count: 80
+- slot_path: /splits/*/split_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 71
+  projects:
+  - AI_READI
+  - CHORUS
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''The current version of the dataset comes with recommended data splits into
+    proportions of 70% training, 15% validation, and 15% testing.'', ''Because sex,
+    race,'
+  - '[''"The dataset will also provision a holdout test set, accessible for model
+    external validation to aid marketplace adoption of AI-developed models for implement'
+  record_count: 71
+- slot_path: /participant_privacy/*/anonymization_method
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 71
+  projects:
+  - AI_READI
+  - CHORUS
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''The public set is stripped of Protected Health Information, as defined by
+    the HIPAA Privacy Rule via the Safe Harbor method, as well as information related
+    to'
+  - '[''Extraction and tokenization of unstructured clinical notes using the OHNLP
+    toolkit, with raw notes retained locally at contributing sites.'', ''De-identificatio'
+  record_count: 71
+- slot_path: /participant_privacy/*/reidentification_risk
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 71
+  projects:
+  - AI_READI
+  - VOICE
+  - CHORUS
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''AI algorithms can infer individual patient characteristics and could facilitate
+    individual-level identification. To prevent re-identification attempts, the pr'
+  - '[''All raw voice data was removed from the released dataset because it has the
+    potential to cause individual re-identification or to be used for illicit or unaut'
+  record_count: 71
+- slot_path: /labeling_strategies/*/data_annotation_platform
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 69
+  projects:
+  - CHORUS
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_merged
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  examples:
+  - '[''CHoRUS visualization and annotation environment''] is not of type ''string'',
+    ''null'''
+  - '[''REDCap, used to record clinical validation and diagnosis forms as part of
+    the case report form.'', ''The Bridge2AI-Voice application and reproschema-ui,
+    used to'
+  record_count: 69
+- slot_path: /collection_consents/*/consent_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 61
+  projects:
+  - AI_READI
+  - CM4AI
+  - VOICE
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''Informed consent to participate was required before participation in any part
+    of the protocol, including questionnaires. Written informed consent is provided '
+  - '[''CM4AI has elected to use the cancer cell line MDA-MB-468 (with and without
+    treatment with paclitaxel and vorinostat) and the iPSC line KOLF2.1J (with and
+    with'
+  record_count: 61
+- slot_path: /participant_privacy/*/data_linkage
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 51
+  projects:
+  - AI_READI
+  - CHORUS
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '["Within the dataset, modalities are linked by the participant''s study identifier
+    used as the participant-level directory name and as the person key in the OMOP'
+  - '[''OMOP Location entities are geocoded via DeGauss (UF-Geocoding), and data elements
+    are enriched with contextual factors such as geographic distance to the near'
+  record_count: 51
+- slot_path: /creators/*
+  error_class: undeclared_slot
+  observed_shapes:
+  - unknown
+  occurrence_count: 47
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - Additional properties are not allowed ('affiliation' was unexpected)
+  - Additional properties are not allowed ('affiliation' was unexpected)
+  record_count: 1
+- slot_path: /creators/*/affiliations/*
+  error_class: union_mismatch
+  observed_shapes:
+  - string
+  occurrence_count: 46
+  projects:
+  - AI_READI
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - '''Washington University in St. Louis (https://ror.org/01yc7t268), as recorded
+    in the FAIRhub study metadata for v3.0.0; the NIH RePORTER record for award OT2OD03'
+  - '''Washington University in St. Louis (https://ror.org/01yc7t268), as recorded
+    in the FAIRhub study metadata; the Nature Metabolism comment gives the University
+    o'
+  record_count: 4
+- slot_path: /collection_notifications/*/notification_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 42
+  projects:
+  - AI_READI
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''Each individual was aware of the data collection, as this was not passive
+    data collection or secondary use of existing data, but rather active data collection'
+  - '[''Yes; participants went through an IRB-approved consent process. Participants
+    were explicitly informed about the data being collected, the methods used to secu'
+  record_count: 42
+- slot_path: /consent_revocations/*/revocation_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 42
+  projects:
+  - AI_READI
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''Participants were permitted to withdraw consent at any time and cease study
+    participation.'', ''Any data that had been shared or used up to that point would
+    sta'
+  - '[''Consenting participants are informed that they may withdraw from the study
+    at any point. If a participant chooses to withdraw during or before the voice
+    data '
+  record_count: 42
+- slot_path: /participant_compensation/*/compensation_type
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 37
+  projects:
+  - AI_READI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''Monetary stipend'', ''Reimbursement of travel costs'', ''Return of individual
+    results''] is not of type ''string'', ''null'''
+  - '[''Electronic gift cards.''] is not of type ''string'', ''null'''
+  record_count: 37
+- slot_path: /participant_compensation/*/compensation_amount
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 37
+  projects:
+  - AI_READI
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''Study subjects received a compensation of USD 200 for the study visit, paid
+    through the grant funding.'', ''The stipend is provided when the final data from
+    par'
+  - '[''Participants receive 40 US dollars for a data collection session that takes
+    less than 90 minutes and 80 US dollars for a session that takes over 90 minutes,
+    f'
+  record_count: 37
+- slot_path: /participant_compensation/*/compensation_rationale
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 35
+  projects:
+  - AI_READI
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_healthsheet
+  - claudecode_agent_merged
+  examples:
+  - '[''Compensation recognises the substantial participant burden of a 2.5 to 4 hour
+    visit plus a ten-day at-home monitoring period with three devices that must be
+    r'
+  - '[''Participants are compensated for their time.'', ''Compensation is provided
+    to the adult population only; the pediatric cohort is not compensated.'', ''In
+    the sepa'
+  record_count: 35
+- slot_path: /resources/*
+  error_class: union_mismatch
+  observed_shapes:
+  - object
+  occurrence_count: 31
+  projects:
+  - VOICE
+  - CM4AI
+  - CHORUS
+  - AI_READI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate_only
+  - claudecode_agent_merged
+  - gpt5
+  examples:
+  - '{''id'': ''d4d:VOICE_adult'', ''name'': ''b2ai-voice'', ''title'': ''Bridge2AI-Voice:
+    An ethically-sourced, diverse voice dataset linked to health information'', ''descripti'
+  - '{''id'': ''d4d:VOICE_pediatric'', ''name'': ''b2ai-voice-pediatric'', ''title'':
+    ''Bridge2AI-Voice Pediatric Dataset'', ''description'': ''The Bridge2AI-Voice
+    pediatric datase'
+  record_count: 13
+- slot_path: /related_datasets/*/relationship_type
+  error_class: invalid_enum_value
+  expected: '[''derives_from'', ''is_source_of'', ''supplements'', ''is_supplemented_by'',
+    ''is_version_of'', ''has_version'', ''is_new_version_of'
+  observed_shapes:
+  - string
+  occurrence_count: 23
+  projects:
+  - AI_READI
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  examples:
+  - '''IsNewVersionOf'' is not one of [''derives_from'', ''is_source_of'', ''supplements'',
+    ''is_supplemented_by'', ''is_version_of'', ''has_version'', ''is_new_version_of'',
+    ''is_pr'
+  - '''IsNewVersionOf'' is not one of [''derives_from'', ''is_source_of'', ''supplements'',
+    ''is_supplemented_by'', ''is_version_of'', ''has_version'', ''is_new_version_of'',
+    ''is_pr'
+  record_count: 6
+- slot_path: /instances/*/sampling_strategies/*/source_data
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 14
+  projects:
+  - VOICE
+  - AI_READI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  examples:
+  - '[''Patients presenting at specialty clinics and institutions ("high volume expert
+    clinics") who were screened for inclusion and exclusion criteria prior to their'
+  - '[''All participants enrolled during the data collection period covered by the
+    release.''] is not of type ''string'', ''null'''
+  record_count: 12
+- slot_path: /resources/*/license_and_use_terms/license_terms
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 13
+  projects:
+  - VOICE
+  - CM4AI
+  - CHORUS
+  methods:
+  - claudecode_agent_core
+  - claudecode_agent_crate_only_core
+  examples:
+  - '[''Access policy for v3.0.0 and v3.1.0: only credentialed users who sign the
+    DUA can access the files. No training required.'', ''Access policy for v1.1: only
+    regi'
+  - '[''Access policy: only credentialed users who sign the DUA can access the files.
+    No training required.'', ''License for files: Bridge2AI Voice Registered Access
+    Li'
+  record_count: 3
+- slot_path: /issued
+  error_class: other
+  observed_shapes:
+  - string
+  occurrence_count: 12
+  projects:
+  - AI_READI
+  - CHORUS
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_crate_only
+  - gpt5
+  - claudecode_agent_crate_core
+  - claudecode_agent_crate_only_core
+  examples:
+  - '''2025-11-17'' is not a ''date-time'''
+  - '''2026-04-03T00:00:00'' is not a ''date-time'''
+  record_count: 12
+- slot_path: /resources/*/version_access/version_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 12
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent_core
+  examples:
+  - '[''Each PhysioNet version of the adult dataset carries its own DOI, and a version-independent
+    "latest version" DOI (https://doi.org/10.13026/37yb-1t42) resolves '
+  - '[''The pediatric release line is versioned independently of the adult release
+    line and has its own version-independent "latest version" DOI (https://doi.org/10.1'
+  record_count: 6
+- slot_path: /distributions/*
+  error_class: undeclared_slot
+  observed_shapes:
+  - unknown
+  occurrence_count: 11
+  projects:
+  - VOICE
+  - CM4AI
+  methods:
+  - claudecode_agent_core
+  examples:
+  - Additional properties are not allowed ('download_url' was unexpected)
+  - Additional properties are not allowed ('checksum' was unexpected)
+  record_count: 2
+- slot_path: /instances/*/sampling_strategies/*/why_not_representative
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 10
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_crate
+  - claudecode_agent_core
+  - claudecode_agent_crate_core
+  examples:
+  - '[''The data is not representative because it was collected at a limited number
+    of geographic locations. The team hopes to make it more representative by shifting'
+  - '[''The data is not representative because it was collected at a limited number
+    of geographic locations. The project hopes to make it more representative by shift'
+  record_count: 10
+- slot_path: /funders/*/grants/*
+  error_class: wrong_type
+  expected: '''object'''
+  observed_shapes:
+  - string
+  occurrence_count: 10
+  projects:
+  - AI_READI
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - '''OT2OD032644 - Bridge2AI: Salutogenesis Data Generation Project (application
+    10471118, award amount 5,026,499 USD, project period 2022-09-01 to 2025-08-31)''
+    is '
+  - '''P30DK035816'' is not of type ''object'''
+  record_count: 4
+- slot_path: /subsets/*/subpopulations/*/identification
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 9
+  projects:
+  - AI_READI
+  methods:
+  - claudecode_agent
+  examples:
+  - '[''Self-reported race and ethnicity''] is not of type ''string'', ''null'''
+  - '[''Sex''] is not of type ''string'', ''null'''
+  record_count: 1
+- slot_path: /subsets/*/subpopulations/*/distribution
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 9
+  projects:
+  - AI_READI
+  methods:
+  - claudecode_agent
+  examples:
+  - '[''Hispanic 204, Asian 369, Black 343, White 660''] is not of type ''string'',
+    ''null'''
+  - '[''Male 599, Female 977''] is not of type ''string'', ''null'''
+  record_count: 1
+- slot_path: /resources/*/collection_timeframes/*/timeframe_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 9
+  projects:
+  - CM4AI
+  methods:
+  - claudecode_agent_crate_only_core
+  examples:
+  - '[''Crate field rai:dataCollectionTimeframe on this component: "9/1/2022" to "1/31/2026".'']
+    is not of type ''string'', ''null'''
+  - '[''Crate field rai:dataCollectionTimeframe on this component: "9/1/2022" to "1/31/2026".'']
+    is not of type ''string'', ''null'''
+  record_count: 1
+- slot_path: /file_collections/*/collection_type
+  error_class: wrong_type
+  expected: '''array'', ''null'''
+  observed_shapes:
+  - string
+  occurrence_count: 6
+  projects:
+  - AI_READI
+  - CHORUS
+  methods:
+  - claudecode_agent
+  examples:
+  - '''metadata'' is not of type ''array'', ''null'''
+  - '''processed_data'' is not of type ''array'', ''null'''
+  record_count: 2
+- slot_path: /subsets/*
+  error_class: undeclared_slot
+  observed_shapes:
+  - unknown
+  occurrence_count: 6
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - Additional properties are not allowed ('format', 'md5', 'media_type' were unexpected)
+  - Additional properties are not allowed ('format', 'md5', 'media_type' were unexpected)
+  record_count: 1
+- slot_path: /subsets/*/funders/*
+  error_class: undeclared_slot
+  observed_shapes:
+  - unknown
+  occurrence_count: 6
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - Additional properties are not allowed ('grant' was unexpected)
+  - Additional properties are not allowed ('grant' was unexpected)
+  record_count: 1
+- slot_path: /subsets/*/funders/*/grantor
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - object
+  occurrence_count: 6
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '{''id'': ''https://reporter.nih.gov/'', ''name'': ''National Institutes of Health''}
+    is not of type ''string'', ''null'''
+  - '{''id'': ''https://reporter.nih.gov/'', ''name'': ''National Institutes of Health''}
+    is not of type ''string'', ''null'''
+  record_count: 1
+- slot_path: /subsets/*/instances/*
+  error_class: undeclared_slot
+  observed_shapes:
+  - unknown
+  occurrence_count: 6
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - Additional properties are not allowed ('data_type', 'representation' were unexpected)
+  - Additional properties are not allowed ('data_type', 'representation' were unexpected)
+  record_count: 1
+- slot_path: /subsets/*/license_and_use_terms/description
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 6
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '[''Attribution required; cite related publication(s) and this data collection.'',
+    ''Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International.'']
+    is n'
+  - '[''Attribution required; cite related publication(s) and this data collection.'',
+    ''Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International.'']
+    is n'
+  record_count: 1
+- slot_path: /subsets/*/ip_restrictions/description
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 6
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '[''Copyright (c) 2025 The Regents of the University of California.''] is not
+    of type ''string'', ''null'''
+  - '[''Copyright (c) 2025 The Regents of the University of California.''] is not
+    of type ''string'', ''null'''
+  record_count: 1
+- slot_path: /subsets/*/maintainers/*/description
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 6
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '[''Hosted by University of Virginia Dataverse; contact via dataset page.'', {''Point
+    of Contact'': ''Trey Ideker (University of California San Diego).''}] is not of
+    t'
+  - '[''Hosted by University of Virginia Dataverse; contact via dataset page.'', {''Point
+    of Contact'': ''Trey Ideker (University of California San Diego).''}] is not of
+    t'
+  record_count: 1
+- slot_path: /instances/*/missing_information
+  error_class: wrong_type
+  expected: '''array'', ''null'''
+  observed_shapes:
+  - string
+  occurrence_count: 4
+  projects:
+  - AI_READI
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - '''Not all modalities are available for all participants. Some participants elected
+    not to participate in some study elements; in a few cases the data collection '
+  - '''Coverage varies by modality. As of August 2025, clinical notes were stored
+    locally at contributing sites with only tokens available, approximately 1,000
+    images'
+  record_count: 4
+- slot_path: /resources/*/raw_sources/*/raw_data_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 4
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent_core
+  examples:
+  - '[''Raw audio data access for the Bridge2AI Voice adult cohort is via Synapse;
+    the PhysioNet project does not contain raw audio.'', ''Accessing raw audio is
+    a more '
+  - '[''Raw audio data access for the Bridge2AI Voice pediatric cohort is via Synapse;
+    the pediatric PhysioNet project does not contain raw audio.'', ''Accessing raw
+    au'
+  record_count: 2
+- slot_path: /resources/*/ethical_reviews/*/review_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 4
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent_core
+  examples:
+  - '[''Data collection and sharing was approved by the University of South Florida
+    Institutional Review Board.''] is not of type ''string'', ''null'''
+  - '[''Data collection and sharing was approved by the Research Ethics Board at the
+    Hospital for Sick Children.''] is not of type ''string'', ''null'''
+  record_count: 2
+- slot_path: /subsets/*/compression
+  error_class: invalid_enum_value
+  expected: '[''gzip'', ''bzip2'', ''zip'', ''tar'', ''xz'', ''lzma'', ''compress'']'
+  observed_shapes:
+  - string
+  occurrence_count: 3
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '''ZIP'' is not one of [''gzip'', ''bzip2'', ''zip'', ''tar'', ''xz'', ''lzma'',
+    ''compress'']'
+  - '''ZIP'' is not one of [''gzip'', ''bzip2'', ''zip'', ''tar'', ''xz'', ''lzma'',
+    ''compress'']'
+  record_count: 1
+- slot_path: /issued
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - unknown
+  occurrence_count: 2
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - datetime.datetime(2026, 5, 1, 0, 0, tzinfo=datetime.timezone.utc) is not of type
+    'string', 'null'
+  - datetime.datetime(2026, 5, 1, 0, 0, tzinfo=datetime.timezone.utc) is not of type
+    'string', 'null'
+  record_count: 2
+- slot_path: /human_subject_research/irb_approval
+  error_class: wrong_type
+  expected: '''array'', ''null'''
+  observed_shapes:
+  - string
+  occurrence_count: 2
+  projects:
+  - AI_READI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - '''University of Washington IRB approval number STUDY00016228, initial approval
+    20 December 2022, with annual continuing review; ClinicalTrials.gov registration
+    N'
+  - '''University of Washington IRB approval number STUDY00016228, initial approval
+    20 December 2022, with annual continuing review; ClinicalTrials.gov registration
+    N'
+  record_count: 2
+- slot_path: /license_and_use_terms/data_use_permission
+  error_class: wrong_type
+  expected: '''array'', ''null'''
+  observed_shapes:
+  - string
+  occurrence_count: 2
+  projects:
+  - AI_READI
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - '''disease_specific_research'' is not of type ''array'', ''null'''
+  - '''disease_specific_research'' is not of type ''array'', ''null'''
+  record_count: 2
+- slot_path: /creators/*/principal_investigator
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - boolean
+  occurrence_count: 2
+  projects:
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - True is not of type 'string', 'null'
+  - True is not of type 'string', 'null'
+  record_count: 2
+- slot_path: /human_subject_research/special_populations
+  error_class: wrong_type
+  expected: '''array'', ''null'''
+  observed_shapes:
+  - string
+  occurrence_count: 2
+  projects:
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - '''The dataset includes admissions to pediatric intensive care units (PICU) and
+    neonatal intensive care units (NICU), and therefore data concerning children and
+    n'
+  - '''The dataset includes admissions to pediatric intensive care units (PICU) and
+    neonatal intensive care units (NICU), and therefore data concerning children and
+    n'
+  record_count: 2
+- slot_path: /at_risk_populations/at_risk_groups_included
+  error_class: wrong_type
+  expected: '''boolean'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 2
+  projects:
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - '[''Critically ill and acutely ill patients'', ''Children (pediatric intensive
+    care unit admissions)'', ''Neonates (neonatal intensive care unit admissions)'']
+    is not '
+  - '[''Critically ill and acutely ill patients'', ''Children (pediatric intensive
+    care unit admissions)'', ''Neonates (neonatal intensive care unit admissions)'']
+    is not '
+  record_count: 2
+- slot_path: /regulatory_restrictions/regulatory_restrictions
+  error_class: wrong_type
+  expected: '''array'', ''null'''
+  observed_shapes:
+  - string
+  occurrence_count: 2
+  projects:
+  - CHORUS
+  methods:
+  - claudecode_agent
+  - claudecode_agent_core
+  examples:
+  - '''Every data type in the dataset is designated controlled access. Users complete
+    a registration form recording name, email and institution, sign a licensing agre'
+  - '''Every data type in the dataset is designated controlled access. Users complete
+    a registration form recording name, email and institution, sign a licensing agre'
+  record_count: 2
+- slot_path: /resources/*/preprocessing_strategies/*/preprocessing_details
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 2
+  projects:
+  - CM4AI
+  methods:
+  - claudecode_agent_crate_only_core
+  examples:
+  - '[''Data was acquired on a Bruker timsTOF platform, and quantitative analysis
+    was performed using Spectronaut.'', ''Raw data was processed using Spectronaut;
+    downst'
+  - '[''The component records a computation entity (computation-perturbation-cell-atlas-data-processing)
+    taking 90 per-channel molecule datasets as inputs and produci'
+  record_count: 1
+- slot_path: /at_risk_populations
+  error_class: union_mismatch
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - AI_READI
+  methods:
+  - claudecode_agent
+  examples:
+  - '[{''description'': ''The study enrolls only adults aged 40 years and older (study
+    metadata state a maximum age of 85 years); no minors are enrolled, so no parental'
+  record_count: 1
+- slot_path: /related_datasets/*/target_dataset
+  error_class: wrong_type
+  expected: '''string'''
+  observed_shapes:
+  - object
+  occurrence_count: 1
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent
+  examples:
+  - '{''id'': ''https://doi.org/10.13026/h995-bt35'', ''name'': ''Bridge2AI-Voice
+    Pediatric Dataset'', ''title'': ''Bridge2AI-Voice Pediatric Dataset'', ''description'':
+    ''A compan'
+  record_count: 1
+- slot_path: /license_and_use_terms
+  error_class: union_mismatch
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent_crate
+  examples:
+  - '[{''description'': ''The dataset is released under the Bridge2AI Voice Registered
+    Access License with an accompanying Bridge2AI Voice Registered Access Agreement
+    ('
+  record_count: 1
+- slot_path: /ip_restrictions
+  error_class: union_mismatch
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent_crate
+  examples:
+  - '[{''description'': ''The registered access agreement states that the data may
+    be protected by copyright and other intellectual property rights; duplication
+    as reas'
+  record_count: 1
+- slot_path: /regulatory_restrictions
+  error_class: union_mismatch
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent_crate
+  examples:
+  - '[{''description'': ''No export controls or other regulatory restrictions apply
+    to the dataset.''}, {''description'': ''HIPAA de-identification rules were applied
+    and H'
+  record_count: 1
+- slot_path: /
+  error_class: undeclared_slot
+  observed_shapes:
+  - unknown
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - Additional properties are not allowed ('same_as' was unexpected)
+  record_count: 1
+- slot_path: /funders/*
+  error_class: undeclared_slot
+  observed_shapes:
+  - unknown
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - Additional properties are not allowed ('grant' was unexpected)
+  record_count: 1
+- slot_path: /funders/*/grantor
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - object
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '{''id'': ''https://reporter.nih.gov/'', ''name'': ''National Institutes of Health''}
+    is not of type ''string'', ''null'''
+  record_count: 1
+- slot_path: /subsets/*/external_resources/*/external_resources
+  error_class: wrong_type
+  expected: '''array'', ''null'''
+  observed_shapes:
+  - string
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '''PRIDE repository (planned upload when available).'' is not of type ''array'',
+    ''null'''
+  record_count: 1
+- slot_path: /license_and_use_terms/description
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '[''Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International. Attribution
+    required to copyright holders and authors.'', ''Cite related publication(s)'
+  record_count: 1
+- slot_path: /ip_restrictions/description
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '[''Copyright (c) 2025 The Regents of the University of California except where
+    otherwise noted.'', ''Spatial proteomics raw image data Copyright (c) 2025 The
+    Board'
+  record_count: 1
+- slot_path: /maintainers/*/description
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '[''Hosted/maintained by University of Virginia Dataverse (LibraData); contact
+    via dataset page.'', {''Point of Contact'': ''Trey Ideker (University of California
+    San'
+  record_count: 1
+- slot_path: /updates/description
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '[''Data will be augmented regularly through the end of the project.''] is not
+    of type ''string'', ''null'''
+  record_count: 1
+- slot_path: /created_on
+  error_class: other
+  observed_shapes:
+  - string
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - gpt5
+  examples:
+  - '''2025-02-27'' is not a ''date-time'''
+  record_count: 1
+- slot_path: /
+  error_class: missing_required
+  observed_shapes:
+  - string
+  occurrence_count: 1
+  projects:
+  - VOICE
+  methods:
+  - gpt5
+  examples:
+  - '''id'' is a required property'
+  record_count: 1
+- slot_path: /resources/*/missing_data_documentation/*/missing_data_patterns
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - claudecode_agent_core
+  examples:
+  - '[''Some datasets are under temporary pre-publication embargo'', ''Protein-protein
+    interaction (SEC-MS), protein localization (IF imaging), and CRISPRi perturbSeq
+    d'
+  record_count: 1
+- slot_path: /resources/*/missing_data_documentation/*/missing_data_causes
+  error_class: wrong_type
+  expected: '''string'', ''null'''
+  observed_shapes:
+  - array
+  occurrence_count: 1
+  projects:
+  - CM4AI
+  methods:
+  - claudecode_agent_core
+  examples:
+  - '[''Pre-publication embargo on perturb-seq data in KOLF2.1J iPSCs and in MDA-MB-468
+    breast cancer cells, recorded as "Embargoed" in the release\''s external data
+    l'
+  record_count: 1
+- slot_path: /resources/*/issued
+  error_class: other
+  observed_shapes:
+  - string
+  occurrence_count: 1
+  projects:
+  - CHORUS
+  methods:
+  - claudecode_agent_crate_core
+  examples:
+  - '''2026-04-03T00:00:00'' is not a ''date-time'''
+  record_count: 1
+- slot_path: /dialect
+  error_class: undeclared_slot
+  observed_shapes:
+  - unknown
+  occurrence_count: 1
+  projects:
+  - VOICE
+  methods:
+  - claudecode_agent_crate_only_core
+  examples:
+  - Additional properties are not allowed ('description' was unexpected)
+  record_count: 1

--- a/project/jsonld/data_sheets_schema.jsonld
+++ b/project/jsonld/data_sheets_schema.jsonld
@@ -6,7 +6,7 @@
     "https://bridge2ai.github.io/data-sheets-schema"
   ],
   "id": "https://w3id.org/bridge2ai/data-sheets-schema",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "imports": [
     "linkml:types",
     "D4D_Base_import",
@@ -4068,6 +4068,69 @@
       "@type": "SlotDefinition"
     },
     {
+      "name": "organization__id",
+      "annotations": [
+        {
+          "tag": "d4d:docExample",
+          "value": "https://ror.org/01yc7t268",
+          "@type": "Annotation"
+        }
+      ],
+      "description": "An identifier for the organization (for example a ROR), when the source material supplies one. A name alone is a valid organization.",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
+      "mappings": [
+        "http://schema.org/identifier"
+      ],
+      "slot_uri": "http://schema.org/identifier",
+      "alias": "id",
+      "owner": "Organization",
+      "domain_of": [
+        "Organization"
+      ],
+      "range": "uriorcurie",
+      "recommended": true,
+      "@type": "SlotDefinition"
+    },
+    {
+      "name": "organization__name",
+      "annotations": [
+        {
+          "tag": "d4d:docExample",
+          "value": "University of Washington",
+          "@type": "Annotation"
+        }
+      ],
+      "description": "A human-readable name for the organization.",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
+      "mappings": [
+        "http://schema.org/name"
+      ],
+      "slot_uri": "http://schema.org/name",
+      "alias": "name",
+      "owner": "Organization",
+      "domain_of": [
+        "Organization"
+      ],
+      "range": "string",
+      "@type": "SlotDefinition"
+    },
+    {
+      "name": "organization__description",
+      "description": "A human-readable description for the organization.",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
+      "mappings": [
+        "http://schema.org/description"
+      ],
+      "slot_uri": "http://schema.org/description",
+      "alias": "description",
+      "owner": "Organization",
+      "domain_of": [
+        "Organization"
+      ],
+      "range": "string",
+      "@type": "SlotDefinition"
+    },
+    {
       "name": "datasetProperty__id",
       "annotations": [
         {
@@ -4225,6 +4288,7 @@
       ],
       "range": "Organization",
       "multivalued": true,
+      "inlined": true,
       "@type": "SlotDefinition"
     },
     {
@@ -4422,7 +4486,7 @@
     },
     {
       "name": "creator__principal_investigator",
-      "description": "A key individual (Principal Investigator) responsible for or overseeing dataset creation.",
+      "description": "The name of the key individual (Principal Investigator) responsible for or overseeing dataset creation \u2014 a person's name such as 'Aaron Lee', never a yes/no flag. The slot name reads like a boolean; the value is not one (#360).",
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/motivation",
       "mappings": [
         "https://w3id.org/bridge2ai/data-sheets-schema/principalInvestigator"
@@ -4495,7 +4559,7 @@
       "domain_of": [
         "FundingMechanism"
       ],
-      "range": "Grantor",
+      "range": "string",
       "@type": "SlotDefinition"
     },
     {
@@ -4515,6 +4579,55 @@
       "multivalued": true,
       "inlined": true,
       "inlined_as_list": true,
+      "@type": "SlotDefinition"
+    },
+    {
+      "name": "grant__id",
+      "description": "An identifier for the grant, when the source material supplies one. The grant_number alone is a valid grant reference.",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/motivation",
+      "mappings": [
+        "http://schema.org/identifier"
+      ],
+      "slot_uri": "http://schema.org/identifier",
+      "alias": "id",
+      "owner": "Grant",
+      "domain_of": [
+        "Grant"
+      ],
+      "range": "uriorcurie",
+      "recommended": true,
+      "@type": "SlotDefinition"
+    },
+    {
+      "name": "grant__name",
+      "description": "A human-readable name for the grant or funding mechanism.",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/motivation",
+      "mappings": [
+        "http://schema.org/name"
+      ],
+      "slot_uri": "http://schema.org/name",
+      "alias": "name",
+      "owner": "Grant",
+      "domain_of": [
+        "Grant"
+      ],
+      "range": "string",
+      "@type": "SlotDefinition"
+    },
+    {
+      "name": "grant__description",
+      "description": "A human-readable description of the grant.",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/motivation",
+      "mappings": [
+        "http://schema.org/description"
+      ],
+      "slot_uri": "http://schema.org/description",
+      "alias": "description",
+      "owner": "Grant",
+      "domain_of": [
+        "Grant"
+      ],
+      "range": "string",
       "@type": "SlotDefinition"
     },
     {
@@ -4761,7 +4874,6 @@
         "SamplingStrategy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -4821,7 +4933,6 @@
         "SamplingStrategy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -4923,7 +5034,6 @@
         "Relationships"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -4947,7 +5057,6 @@
         "Splits"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -4974,7 +5083,6 @@
         "DataAnomaly"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5165,7 +5273,6 @@
         "ExternalResource"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5241,7 +5348,6 @@
         "Confidentiality"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5317,7 +5423,6 @@
         "Subpopulation"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5344,7 +5449,6 @@
         "Subpopulation"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5414,7 +5518,6 @@
         "Deidentification"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5454,12 +5557,15 @@
         "SensitiveElement"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
       "name": "datasetRelationship__target_dataset",
-      "description": "The dataset that this relationship points to. Can be specified by identifier, URL, or Dataset object.",
+      "description": "The identifier or URL of the dataset this relationship points to.",
+      "comments": [
+        "A reference, not an inline dataset. The description used to promise \"identifier, URL, or Dataset object\" while the range permitted only the first, and LinkML cannot express the union: its JSON Schema generator always emits a top-level type or $ref from the slot's range, which ANDs with `any_of`, so whichever branch the range names the other one fails. Verified both ways on VOICE (#297).",
+        "A related dataset with its own DOI, protocol and approval is its own datasheet and is referenced from here by identifier. That is the resolution of #292 for VOICE, whose pediatric companion has all three."
+      ],
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/composition",
       "mappings": [
         "http://purl.org/dc/terms/relation"
@@ -5589,7 +5695,6 @@
         "InstanceAcquisition"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5613,7 +5718,6 @@
         "CollectionMechanism"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5660,7 +5764,6 @@
         "DataCollector"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5730,7 +5833,6 @@
         "CollectionTimeframe"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5770,7 +5872,6 @@
         "DirectCollection"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5794,7 +5895,6 @@
         "MissingDataDocumentation"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5818,7 +5918,6 @@
         "MissingDataDocumentation"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5892,7 +5991,6 @@
         "RawDataSource"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5939,7 +6037,6 @@
         "RawDataSource"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5963,7 +6060,6 @@
         "PreprocessingStrategy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5987,7 +6083,6 @@
         "CleaningStrategy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6011,7 +6106,6 @@
         "LabelingStrategy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6031,7 +6125,6 @@
         "LabelingStrategy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6124,7 +6217,6 @@
         "LabelingStrategy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6164,7 +6256,6 @@
         "RawData"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6494,7 +6585,6 @@
         "OtherTask"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6518,7 +6608,6 @@
         "FutureUseImpact"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6542,7 +6631,6 @@
         "DiscouragedUse"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6607,7 +6695,6 @@
         "IntendedUse"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6631,7 +6718,6 @@
         "ProhibitedUse"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6735,7 +6821,6 @@
         "Maintainer"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6829,7 +6914,6 @@
         "UpdatePlan"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6876,7 +6960,6 @@
         "RetentionLimits"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6940,7 +7023,6 @@
         "VersionAccess"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6987,7 +7069,6 @@
         "ExtensionMechanism"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7011,7 +7092,7 @@
     },
     {
       "name": "ethicalReview__reviewing_organization",
-      "description": "Organization that conducted the ethical review (e.g., Institutional Review Board, Ethics Committee, Research Ethics Board). Provides information about the body responsible for ethical oversight.",
+      "description": "Name or identifier of the organization that conducted the ethical review (e.g., Institutional Review Board, Ethics Committee, Research Ethics Board). A plain string: every one of the 245 corpus values here was a name, ROR or curie, and Organization no longer carries the identifier that made string references expressible (#360).",
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/ethics",
       "mappings": [
         "http://schema.org/provider"
@@ -7025,7 +7106,7 @@
       "domain_of": [
         "EthicalReview"
       ],
-      "range": "Organization",
+      "range": "string",
       "@type": "SlotDefinition"
     },
     {
@@ -7049,7 +7130,6 @@
         "EthicalReview"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7073,7 +7153,6 @@
         "DataProtectionImpact"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7097,7 +7176,6 @@
         "CollectionNotification"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7121,7 +7199,6 @@
         "CollectionConsent"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7145,7 +7222,6 @@
         "ConsentRevocation"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7202,7 +7278,6 @@
         "HumanSubjectResearch"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7283,7 +7358,6 @@
         "InformedConsent"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7307,7 +7381,6 @@
         "InformedConsent"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7324,7 +7397,6 @@
         "InformedConsent"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7341,7 +7413,6 @@
         "InformedConsent"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7365,7 +7436,6 @@
         "ParticipantPrivacy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7389,7 +7459,6 @@
         "ParticipantPrivacy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7423,7 +7492,6 @@
         "ParticipantPrivacy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7463,7 +7531,6 @@
         "HumanSubjectCompensation"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7487,7 +7554,6 @@
         "HumanSubjectCompensation"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7504,7 +7570,6 @@
         "HumanSubjectCompensation"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7606,7 +7671,6 @@
         "LicenseAndUseTerms"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7749,7 +7813,6 @@
         "ExportControlRegulatoryRestrictions"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -8090,7 +8153,6 @@
         "VariableMetadata"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -9364,13 +9426,50 @@
       "mappings": [
         "schema:Organization"
       ],
-      "is_a": "NamedThing",
       "slots": [
-        "namedThing__id",
-        "namedThing__name",
-        "namedThing__description"
+        "organization__id",
+        "organization__name",
+        "organization__description"
       ],
       "slot_usage": {},
+      "attributes": [
+        {
+          "name": "id",
+          "annotations": [
+            {
+              "tag": "d4d:docExample",
+              "value": "https://ror.org/01yc7t268",
+              "@type": "Annotation"
+            }
+          ],
+          "description": "An identifier for the organization (for example a ROR), when the source material supplies one. A name alone is a valid organization.",
+          "slot_uri": "schema:identifier",
+          "range": "uriorcurie",
+          "recommended": true,
+          "@type": "SlotDefinition"
+        },
+        {
+          "name": "name",
+          "annotations": [
+            {
+              "tag": "d4d:docExample",
+              "value": "University of Washington",
+              "@type": "Annotation"
+            }
+          ],
+          "description": "A human-readable name for the organization.",
+          "slot_uri": "schema:name",
+          "range": "string",
+          "@type": "SlotDefinition"
+        },
+        {
+          "name": "description",
+          "description": "A human-readable description for the organization.",
+          "slot_uri": "schema:description",
+          "range": "string",
+          "@type": "SlotDefinition"
+        }
+      ],
       "class_uri": "http://schema.org/Organization",
       "@type": "ClassDefinition"
     },
@@ -9767,7 +9866,7 @@
       "attributes": [
         {
           "name": "principal_investigator",
-          "description": "A key individual (Principal Investigator) responsible for or overseeing dataset creation.",
+          "description": "The name of the key individual (Principal Investigator) responsible for or overseeing dataset creation \u2014 a person's name such as 'Aaron Lee', never a yes/no flag. The slot name reads like a boolean; the value is not one (#360).",
           "broad_mappings": [
             "dcterms:creator",
             "schema:creator"
@@ -9823,7 +9922,7 @@
             "schema:funder"
           ],
           "slot_uri": "d4d:grantor",
-          "range": "Grantor",
+          "range": "string",
           "@type": "SlotDefinition"
         },
         {
@@ -9846,9 +9945,9 @@
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/motivation",
       "is_a": "Organization",
       "slots": [
-        "namedThing__id",
-        "namedThing__name",
-        "namedThing__description"
+        "organization__id",
+        "organization__name",
+        "organization__description"
       ],
       "slot_usage": {},
       "class_uri": "https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grantor",
@@ -9859,15 +9958,36 @@
       "definition_uri": "https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant",
       "description": "The name and/or identifier of the specific mechanism providing monetary support or other resources supporting creation of the dataset.\n",
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/motivation",
-      "is_a": "NamedThing",
       "slots": [
-        "namedThing__id",
-        "namedThing__name",
-        "namedThing__description",
+        "grant__id",
+        "grant__name",
+        "grant__description",
         "grant__grant_number"
       ],
       "slot_usage": {},
       "attributes": [
+        {
+          "name": "id",
+          "description": "An identifier for the grant, when the source material supplies one. The grant_number alone is a valid grant reference.",
+          "slot_uri": "schema:identifier",
+          "range": "uriorcurie",
+          "recommended": true,
+          "@type": "SlotDefinition"
+        },
+        {
+          "name": "name",
+          "description": "A human-readable name for the grant or funding mechanism.",
+          "slot_uri": "schema:name",
+          "range": "string",
+          "@type": "SlotDefinition"
+        },
+        {
+          "name": "description",
+          "description": "A human-readable description of the grant.",
+          "slot_uri": "schema:description",
+          "range": "string",
+          "@type": "SlotDefinition"
+        },
         {
           "name": "grant_number",
           "annotations": [
@@ -10053,7 +10173,6 @@
           "description": "One or more descriptions of the larger sets from which the sample was drawn, if applicable.\n",
           "slot_uri": "d4d:sourceData",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -10086,7 +10205,6 @@
           "description": "One or more explanations of why the sample is not representative of the larger set, if applicable.\n",
           "slot_uri": "d4d:whyNotRepresentative",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -10191,7 +10309,6 @@
           "description": "Free-text description of how relationships between instances are represented (e.g., graph edges, ratings matrices, foreign keys), including relationship types and any associated metadata.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10225,7 +10342,6 @@
           "description": "Free-text description of the recommended data splits (e.g., 80/10/10 train/ validation/test), how they are defined, and the rationale for the split strategy.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10262,7 +10378,6 @@
           ],
           "slot_uri": "d4d:anomalyDetails",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10444,7 +10559,6 @@
           ],
           "slot_uri": "d4d:availabilityGuarantee",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -10504,7 +10618,6 @@
           "description": "Free-text description of which data elements are confidential, the basis for confidentiality (e.g., legal privilege, patient data), and how they are handled or restricted.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10585,7 +10698,6 @@
           ],
           "slot_uri": "d4d:subpopulationIdentification",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -10603,7 +10715,6 @@
           ],
           "slot_uri": "d4d:subpopulationDistribution",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10661,7 +10772,6 @@
           "description": "Details on de-identification procedures and residual risks.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10706,7 +10816,6 @@
           "description": "Details on sensitive data elements present and handling procedures.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10731,7 +10840,11 @@
       "attributes": [
         {
           "name": "target_dataset",
-          "description": "The dataset that this relationship points to. Can be specified by identifier, URL, or Dataset object.",
+          "description": "The identifier or URL of the dataset this relationship points to.",
+          "comments": [
+            "A reference, not an inline dataset. The description used to promise \"identifier, URL, or Dataset object\" while the range permitted only the first, and LinkML cannot express the union: its JSON Schema generator always emits a top-level type or $ref from the slot's range, which ANDs with `any_of`, so whichever branch the range names the other one fails. Verified both ways on VOICE (#297).",
+            "A related dataset with its own DOI, protocol and approval is its own datasheet and is referenced from here by identifier. That is the resolution of #292 for VOICE, whose pediatric companion has all three."
+          ],
           "slot_uri": "dcterms:relation",
           "range": "string",
           "required": true,
@@ -10814,7 +10927,6 @@
           "description": "Free-text description of how data was acquired for each instance, including instruments, protocols, and any manual steps involved.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10851,7 +10963,6 @@
           "description": "Free-text description of the specific mechanisms or procedures used to collect the data (e.g., hardware model, software API, manual curation process), including how those mechanisms were validated.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10900,7 +11011,6 @@
           "description": "Free-text description of who was involved in data collection (e.g., students, crowdworkers, contractors), their training or qualifications, and how they were compensated.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10967,7 +11077,6 @@
           "description": "Free-text description of the data collection period and whether this timeframe matches the creation timeframe of the underlying data (e.g., historical records, prospective collection).\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11009,7 +11118,6 @@
           "description": "Free-text description of whether data was collected directly from individuals or obtained via third parties or other indirect sources, and what those sources are.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11048,7 +11156,6 @@
           "description": "Description of patterns in missing data (e.g., missing completely at random, missing at random, missing not at random).\n",
           "slot_uri": "d4d:missingDataPatterns",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -11063,7 +11170,6 @@
           "description": "Known or suspected causes of missing data (e.g., sensor failures, participant dropout, privacy constraints).\n",
           "slot_uri": "d4d:missingDataCauses",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -11135,7 +11241,6 @@
           ],
           "slot_uri": "d4d:sourceType",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -11164,7 +11269,6 @@
           "description": "One or more formats of the raw data before any preprocessing (e.g., CSV, DICOM, JSON).\n",
           "slot_uri": "d4d:rawDataFormat",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11201,7 +11305,6 @@
           "description": "Free-text description of preprocessing steps applied to the data, including tools used, parameters, order of operations, and rationale for each step.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11238,7 +11341,6 @@
           "description": "Free-text description of data cleaning procedures applied, including criteria for removing or correcting instances, tools used, and how removed instances are accounted for.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11277,7 +11379,6 @@
           "description": "One or more platforms or tools used for annotation (e.g., Label Studio, Prodigy, Amazon Mechanical Turk, custom annotation tool).",
           "slot_uri": "rai:dataAnnotationPlatform",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -11288,7 +11389,6 @@
           ],
           "slot_uri": "d4d:dataAnnotationProtocol",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -11345,7 +11445,6 @@
           "description": "Free-text description of the labeling or annotation procedures, including annotation guidelines, task definitions, and quality control metrics.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11387,7 +11486,6 @@
           "description": "Free-text description of raw data availability, access procedures, and any conditions or restrictions on accessing the raw data.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11708,7 +11806,6 @@
           "description": "Free-text description of other potential tasks the dataset could support, including any prerequisites or limitations for those uses.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11745,7 +11842,6 @@
           "description": "Free-text description of potential future impacts or risks arising from the dataset's composition or collection (e.g., unfair treatment, privacy violations, legal or financial risks), and any recommended mitigation strategies.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11779,7 +11875,6 @@
           "description": "Free-text description of tasks or applications for which the dataset is not recommended, with explanation of why (e.g., out-of-scope, risk of harm, poor coverage).\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11845,7 +11940,6 @@
           "description": "One or more categories of intended use (e.g., research, clinical, educational, commercial, policy).",
           "slot_uri": "d4d:useCategory",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11879,7 +11973,6 @@
           "description": "One or more reasons why this use is prohibited (e.g., license restriction, ethical concern, privacy risk, legal constraint).",
           "slot_uri": "d4d:prohibitionReason",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12015,7 +12108,6 @@
           "description": "Free-text description of the organization, team, or individual responsible for maintaining the dataset, including contact information and hosting arrangements.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12116,7 +12208,6 @@
           "description": "Free-text description of planned update types (e.g., corrections, additions, deletions), responsible parties, and how updates will be communicated to users.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12165,7 +12256,6 @@
           "description": "Free-text description of applicable retention limits, legal or ethical basis for those limits, and how they will be enforced (e.g., automated deletion, anonymization after the retention period).\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12223,7 +12313,6 @@
           "description": "Free-text description of version support policies, how long older versions will be hosted, and how dataset consumers will be notified when versions become obsolete.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12272,7 +12361,6 @@
           "description": "Free-text description of how third parties can contribute to the dataset, how contributions are validated (e.g., peer review, automated tests), and how accepted contributions will be communicated to the community.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12308,12 +12396,12 @@
         },
         {
           "name": "reviewing_organization",
-          "description": "Organization that conducted the ethical review (e.g., Institutional Review Board, Ethics Committee, Research Ethics Board). Provides information about the body responsible for ethical oversight.",
+          "description": "Name or identifier of the organization that conducted the ethical review (e.g., Institutional Review Board, Ethics Committee, Research Ethics Board). A plain string: every one of the 245 corpus values here was a name, ROR or curie, and Organization no longer carries the identifier that made string references expressible (#360).",
           "exact_mappings": [
             "schema:provider"
           ],
           "slot_uri": "schema:provider",
-          "range": "Organization",
+          "range": "string",
           "@type": "SlotDefinition"
         },
         {
@@ -12328,7 +12416,6 @@
           "description": "Free-text description of the ethical review process, board decisions, outcomes, and any supporting documentation (e.g., IRB approval number, ethics committee name).\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12362,7 +12449,6 @@
           "description": "Free-text description of the data protection impact analysis, including methodology, privacy risks identified, mitigation measures taken, and any regulatory findings.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12396,7 +12482,6 @@
           "description": "Free-text description of how individuals were notified about data collection, including the notification method (e.g., email, poster, in-person), timing, and the language or text of the notification itself if available.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12430,7 +12515,6 @@
           "description": "Free-text description of how consent was requested (e.g., opt-in form, verbal agreement), provided, and documented, including the language individuals consented to.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12464,7 +12548,6 @@
           "description": "Free-text description of the mechanism provided for individuals to revoke consent (e.g., opt-out portal, written request), the scope of revocation (full withdrawal or specific uses), and what happens to their data after revocation.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12517,7 +12600,6 @@
           "description": "What ethics review board(s) reviewed this research? Include institution names and approval details.\n",
           "slot_uri": "d4d:ethicsReviewBoard",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12585,7 +12667,6 @@
           "description": "What type of consent was obtained (e.g., written, verbal, electronic, implied through participation)?\n",
           "slot_uri": "d4d:consentType",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12600,7 +12681,6 @@
           "description": "How is consent documented? Include references to consent forms or procedures used.\n",
           "slot_uri": "d4d:consentDocumentation",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12608,7 +12688,6 @@
           "description": "How can participants withdraw their consent? What procedures are in place for data deletion upon withdrawal?\n",
           "slot_uri": "d4d:withdrawalMechanism",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12616,7 +12695,6 @@
           "description": "What specific uses did participants consent to? Are there limitations on data use based on consent?\n",
           "slot_uri": "d4d:consentScope",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12653,7 +12731,6 @@
           "description": "What methods were used to anonymize or de-identify participant data? Include technical details of privacy-preserving techniques.\n",
           "slot_uri": "d4d:anonymizationMethod",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12668,7 +12745,6 @@
           "description": "What is the assessed risk of re-identification? What measures were taken to minimize this risk?\n",
           "slot_uri": "d4d:reidentificationRisk",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12684,7 +12760,6 @@
           "description": "Can this dataset be linked to other datasets in ways that might compromise participant privacy?\n",
           "slot_uri": "d4d:dataLinkage",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12728,7 +12803,6 @@
           "description": "What type of compensation was provided (e.g., monetary payment, gift cards, course credit, other incentives)?\n",
           "slot_uri": "d4d:compensationType",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12743,7 +12817,6 @@
           "description": "What was the amount or value of compensation provided? Include currency or equivalent value.\n",
           "slot_uri": "d4d:compensationAmount",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12751,7 +12824,6 @@
           "description": "What was the rationale for the compensation structure? How was the amount determined to be appropriate?\n",
           "slot_uri": "d4d:compensationRationale",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12851,7 +12923,6 @@
           ],
           "slot_uri": "d4d:licenseDescription",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -12982,7 +13053,6 @@
           "description": "Other regulatory compliance frameworks applicable to this dataset (e.g., CCPA, PIPEDA, industry-specific regulations).",
           "slot_uri": "d4d:otherCompliance",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -13217,7 +13287,6 @@
           ],
           "slot_uri": "d4d:qualityNotes",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -13388,9 +13457,9 @@
   ],
   "metamodel_version": "1.7.0",
   "source_file": "data_sheets_schema.yaml",
-  "source_file_date": "2026-08-01T19:29:40",
+  "source_file_date": "2026-08-06T11:46:39",
   "source_file_size": 32488,
-  "generation_date": "2026-08-01T20:36:28",
+  "generation_date": "2026-08-06T12:01:28",
   "@type": "SchemaDefinition",
   "@context": [
     "project/jsonld/data_sheets_schema.context.jsonld",

--- a/project/jsonschema/data_sheets_schema.schema.json
+++ b/project/jsonschema/data_sheets_schema.schema.json
@@ -255,11 +255,8 @@
             "properties": {
                 "cleaning_details": {
                     "description": "Free-text description of data cleaning procedures applied, including criteria for removing or correcting instances, tools used, and how removed instances are accounted for.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -304,11 +301,8 @@
             "properties": {
                 "consent_details": {
                     "description": "Free-text description of how consent was requested (e.g., opt-in form, verbal agreement), provided, and documented, including the language individuals consented to.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -367,11 +361,8 @@
                 },
                 "mechanism_details": {
                     "description": "Free-text description of the specific mechanisms or procedures used to collect the data (e.g., hardware model, software API, manual curation process), including how those mechanisms were validated.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -423,11 +414,8 @@
                 },
                 "notification_details": {
                     "description": "Free-text description of how individuals were notified about data collection, including the notification method (e.g., email, poster, in-person), timing, and the language or text of the notification itself if available.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -488,11 +476,8 @@
                 },
                 "timeframe_details": {
                     "description": "Free-text description of the data collection period and whether this timeframe matches the creation timeframe of the underlying data (e.g., historical records, prospective collection).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -549,11 +534,8 @@
                 },
                 "confidentiality_details": {
                     "description": "Free-text description of which data elements are confidential, the basis for confidentiality (e.g., legal privilege, patient data), and how they are handled or restricted.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -629,11 +611,8 @@
                 },
                 "revocation_details": {
                     "description": "Free-text description of the mechanism provided for individuals to revoke consent (e.g., opt-out portal, written request), the scope of revocation (full withdrawal or specific uses), and what happens to their data after revocation.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -753,7 +732,7 @@
                     ]
                 },
                 "principal_investigator": {
-                    "description": "A key individual (Principal Investigator) responsible for or overseeing dataset creation.",
+                    "description": "The name of the key individual (Principal Investigator) responsible for or overseeing dataset creation \u2014 a person's name such as 'Aaron Lee', never a yes/no flag. The slot name reads like a boolean; the value is not one (#360).",
                     "type": [
                         "string",
                         "null"
@@ -797,11 +776,8 @@
             "properties": {
                 "anomaly_details": {
                     "description": "Free-text description of errors, noise sources, or redundancies in the dataset, including their known causes and estimated prevalence.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -846,11 +822,8 @@
             "properties": {
                 "collector_details": {
                     "description": "Free-text description of who was involved in data collection (e.g., students, crowdworkers, contractors), their training or qualifications, and how they were compensated.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -916,11 +889,8 @@
                 },
                 "impact_details": {
                     "description": "Free-text description of the data protection impact analysis, including methodology, privacy risks identified, mitigation measures taken, and any regulatory findings.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3133,7 +3103,7 @@
                     "description": "The type of relationship (e.g., derives_from, supplements, is_version_of). Uses DatasetRelationshipTypeEnum for standardized relationship types."
                 },
                 "target_dataset": {
-                    "description": "The dataset that this relationship points to. Can be specified by identifier, URL, or Dataset object.",
+                    "description": "The identifier or URL of the dataset this relationship points to.",
                     "type": "string"
                 },
                 "used_software": {
@@ -3203,11 +3173,8 @@
             "properties": {
                 "deidentification_details": {
                     "description": "Details on de-identification procedures and residual risks.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3276,11 +3243,8 @@
             "properties": {
                 "collection_details": {
                     "description": "Free-text description of whether data was collected directly from individuals or obtained via third parties or other indirect sources, and what those sources are.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3339,11 +3303,8 @@
                 },
                 "discouragement_details": {
                     "description": "Free-text description of tasks or applications for which the dataset is not recommended, with explanation of why (e.g., out-of-scope, risk of harm, poor coverage).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3613,16 +3574,13 @@
                 },
                 "review_details": {
                     "description": "Free-text description of the ethical review process, board decisions, outcomes, and any supporting documentation (e.g., IRB approval number, ethics committee name).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
                 "reviewing_organization": {
-                    "description": "Organization that conducted the ethical review (e.g., Institutional Review Board, Ethics Committee, Research Ethics Board). Provides information about the body responsible for ethical oversight.",
+                    "description": "Name or identifier of the organization that conducted the ethical review (e.g., Institutional Review Board, Ethics Committee, Research Ethics Board). A plain string: every one of the 245 corpus values here was a name, ROR or curie, and Organization no longer carries the identifier that made string references expressible (#360).",
                     "type": [
                         "string",
                         "null"
@@ -3733,11 +3691,8 @@
                 },
                 "other_compliance": {
                     "description": "Other regulatory compliance frameworks applicable to this dataset (e.g., CCPA, PIPEDA, industry-specific regulations).",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3785,11 +3740,8 @@
                 },
                 "extension_details": {
                     "description": "Free-text description of how third parties can contribute to the dataset, how contributions are validated (e.g., peer review, automated tests), and how accepted contributions will be communicated to the community.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3851,11 +3803,8 @@
                 },
                 "future_guarantees": {
                     "description": "Explanation of any commitments that external resources will remain available and stable over time.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -4529,11 +4478,8 @@
                 },
                 "impact_details": {
                     "description": "Free-text description of potential future impacts or risks arising from the dataset's composition or collection (e.g., unfair treatment, privacy violations, legal or financial risks), and any recommended mitigation strategies.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -4563,7 +4509,7 @@
             "description": "The name and/or identifier of the specific mechanism providing monetary support or other resources supporting creation of the dataset.",
             "properties": {
                 "description": {
-                    "description": "A human-readable description for a thing.",
+                    "description": "A human-readable description of the grant.",
                     "type": [
                         "string",
                         "null"
@@ -4577,20 +4523,20 @@
                     ]
                 },
                 "id": {
-                    "description": "A unique identifier for a thing.",
-                    "type": "string"
+                    "description": "An identifier for the grant, when the source material supplies one. The grant_number alone is a valid grant reference.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "name": {
-                    "description": "A human-readable name for a thing.",
+                    "description": "A human-readable name for the grant or funding mechanism.",
                     "type": [
                         "string",
                         "null"
                     ]
                 }
             },
-            "required": [
-                "id"
-            ],
             "title": "Grant",
             "type": "object"
         },
@@ -4599,27 +4545,27 @@
             "description": "The name and/or identifier of the organization providing monetary support  or other resources supporting creation of the dataset.",
             "properties": {
                 "description": {
-                    "description": "A human-readable description for a thing.",
+                    "description": "A human-readable description for the organization.",
                     "type": [
                         "string",
                         "null"
                     ]
                 },
                 "id": {
-                    "description": "A unique identifier for a thing.",
-                    "type": "string"
+                    "description": "An identifier for the organization (for example a ROR), when the source material supplies one. A name alone is a valid organization.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "name": {
-                    "description": "A human-readable name for a thing.",
+                    "description": "A human-readable name for the organization.",
                     "type": [
                         "string",
                         "null"
                     ]
                 }
             },
-            "required": [
-                "id"
-            ],
             "title": "Grantor",
             "type": "object"
         },
@@ -4629,11 +4575,8 @@
             "properties": {
                 "compensation_amount": {
                     "description": "What was the amount or value of compensation provided? Include currency or equivalent value.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -4646,21 +4589,15 @@
                 },
                 "compensation_rationale": {
                     "description": "What was the rationale for the compensation structure? How was the amount determined to be appropriate?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
                 "compensation_type": {
                     "description": "What type of compensation was provided (e.g., monetary payment, gift cards, course credit, other incentives)?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -4712,11 +4649,8 @@
                 },
                 "ethics_review_board": {
                     "description": "What ethics review board(s) reviewed this research? Include institution names and approval details.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5089,11 +5023,8 @@
             "properties": {
                 "consent_documentation": {
                     "description": "How is consent documented? Include references to consent forms or procedures used.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5106,21 +5037,15 @@
                 },
                 "consent_scope": {
                     "description": "What specific uses did participants consent to? Are there limitations on data use based on consent?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
                 "consent_type": {
                     "description": "What type of consent was obtained (e.g., written, verbal, electronic, implied through participation)?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5157,11 +5082,8 @@
                 },
                 "withdrawal_mechanism": {
                     "description": "How can participants withdraw their consent? What procedures are in place for data deletion upon withdrawal?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 }
@@ -5276,11 +5198,8 @@
             "properties": {
                 "acquisition_details": {
                     "description": "Free-text description of how data was acquired for each instance, including instruments, protocols, and any manual steps involved.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5391,11 +5310,8 @@
                 },
                 "use_category": {
                     "description": "One or more categories of intended use (e.g., research, clinical, educational, commercial, policy).",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5436,21 +5352,15 @@
                 },
                 "data_annotation_platform": {
                     "description": "One or more platforms or tools used for annotation (e.g., Label Studio, Prodigy, Amazon Mechanical Turk, custom annotation tool).",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
                 "data_annotation_protocol": {
                     "description": "Annotation methodology, tasks, and protocols followed during labeling. Includes annotation guidelines, quality control procedures, and task definitions.",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5477,11 +5387,8 @@
                 },
                 "labeling_details": {
                     "description": "Free-text description of the labeling or annotation procedures, including annotation guidelines, task definitions, and quality control metrics.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5543,11 +5450,8 @@
                 },
                 "license_terms": {
                     "description": "Description of the dataset's license and terms of use, including links, costs, or usage constraints (e.g., 'CC BY 4.0', 'Apache 2.0', 'MIT', 'CC BY-NC-SA 4.0', 'proprietary - contact data@example.org for access').",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5675,11 +5579,8 @@
                 },
                 "maintainer_details": {
                     "description": "Free-text description of the organization, team, or individual responsible for maintaining the dataset, including contact information and hosting arrangements.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5761,21 +5662,15 @@
                 },
                 "missing_data_causes": {
                     "description": "Known or suspected causes of missing data (e.g., sensor failures, participant dropout, privacy constraints).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
                 "missing_data_patterns": {
                     "description": "Description of patterns in missing data (e.g., missing completely at random, missing at random, missing not at random).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5896,27 +5791,27 @@
             "description": "Represents a group or organization.",
             "properties": {
                 "description": {
-                    "description": "A human-readable description for a thing.",
+                    "description": "A human-readable description for the organization.",
                     "type": [
                         "string",
                         "null"
                     ]
                 },
                 "id": {
-                    "description": "A unique identifier for a thing.",
-                    "type": "string"
+                    "description": "An identifier for the organization (for example a ROR), when the source material supplies one. A name alone is a valid organization.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "name": {
-                    "description": "A human-readable name for a thing.",
+                    "description": "A human-readable name for the organization.",
                     "type": [
                         "string",
                         "null"
                     ]
                 }
             },
-            "required": [
-                "id"
-            ],
             "title": "Organization",
             "type": "object"
         },
@@ -5947,11 +5842,8 @@
                 },
                 "task_details": {
                     "description": "Free-text description of other potential tasks the dataset could support, including any prerequisites or limitations for those uses.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -5975,21 +5867,15 @@
             "properties": {
                 "anonymization_method": {
                     "description": "What methods were used to anonymize or de-identify participant data? Include technical details of privacy-preserving techniques.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
                 "data_linkage": {
                     "description": "Can this dataset be linked to other datasets in ways that might compromise participant privacy?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6026,11 +5912,8 @@
                 },
                 "reidentification_risk": {
                     "description": "What is the assessed risk of re-identification? What measures were taken to minimize this risk?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6055,7 +5938,7 @@
                 "affiliation": {
                     "description": "The organization(s) to which the person belongs in the context of this dataset. May vary across datasets; multivalued to support multiple affiliations.",
                     "items": {
-                        "type": "string"
+                        "$ref": "#/$defs/Organization"
                     },
                     "type": [
                         "array",
@@ -6129,11 +6012,8 @@
                 },
                 "preprocessing_details": {
                     "description": "Free-text description of preprocessing steps applied to the data, including tools used, parameters, order of operations, and rationale for each step.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6178,11 +6058,8 @@
                 },
                 "prohibition_reason": {
                     "description": "One or more reasons why this use is prohibited (e.g., license restriction, ethical concern, privacy risk, legal constraint).",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6280,11 +6157,8 @@
                 },
                 "raw_data_details": {
                     "description": "Free-text description of raw data availability, access procedures, and any conditions or restrictions on accessing the raw data.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6336,11 +6210,8 @@
                 },
                 "raw_data_format": {
                     "description": "One or more formats of the raw data before any preprocessing (e.g., CSV, DICOM, JSON).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6350,11 +6221,8 @@
                 },
                 "source_type": {
                     "description": "One or more types of raw source (e.g., sensor, database, user input, web scraping).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6402,11 +6270,8 @@
                 },
                 "relationship_details": {
                     "description": "Free-text description of how relationships between instances are represented (e.g., graph edges, ratings matrices, foreign keys), including relationship types and any associated metadata.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6451,11 +6316,8 @@
                 },
                 "retention_details": {
                     "description": "Free-text description of applicable retention limits, legal or ethical basis for those limits, and how they will be enforced (e.g., automated deletion, anonymization after the retention period).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6538,11 +6400,8 @@
                 },
                 "source_data": {
                     "description": "One or more descriptions of the larger sets from which the sample was drawn, if applicable.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6568,11 +6427,8 @@
                 },
                 "why_not_representative": {
                     "description": "One or more explanations of why the sample is not representative of the larger set, if applicable.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 }
@@ -6614,11 +6470,8 @@
                 },
                 "sensitivity_details": {
                     "description": "Details on sensitive data elements present and handling procedures.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6713,11 +6566,8 @@
                 },
                 "split_details": {
                     "description": "Free-text description of the recommended data splits (e.g., 80/10/10 train/ validation/test), how they are defined, and the rationale for the split strategy.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6748,11 +6598,8 @@
                 },
                 "distribution": {
                     "description": "The distribution of instances across identified subpopulations, including counts, percentages, or proportions for each subgroup.",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6765,11 +6612,8 @@
                 },
                 "identification": {
                     "description": "How subpopulations are identified and defined (e.g., by age groups, gender, geographic region, disease status, or other demographic/clinical characteristics).",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6927,11 +6771,8 @@
                 },
                 "update_details": {
                     "description": "Free-text description of planned update types (e.g., corrections, additions, deletions), responsible parties, and how updates will be communicated to users.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -7115,11 +6956,8 @@
                 },
                 "quality_notes": {
                     "description": "Notes about data quality, reliability, or known issues specific to this variable.",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -7215,11 +7053,8 @@
                 },
                 "version_details": {
                     "description": "Free-text description of version support policies, how long older versions will be hosted, and how dataset consumers will be notified when versions become obsolete.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -7432,5 +7267,5 @@
     ],
     "title": "data-sheets-schema",
     "type": "object",
-    "version": "1.0.0"
+    "version": "2.0.0"
 }

--- a/project/owl/data_sheets_schema.owl.ttl
+++ b/project/owl/data_sheets_schema.owl.ttl
@@ -34,34 +34,34 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FormatDialect" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:header ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:double_quote ],
+            owl:onProperty data_sheets_schema:comment_prefix ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:header ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:header ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:header ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:header ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:delimiter ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:double_quote ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:comment_prefix ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -71,15 +71,23 @@ data_sheets_schema:FormatDialect a owl:Class,
             owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
+            owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:double_quote ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:quote_char ] ;
     skos:definition "Additional format information for a file." ;
     skos:inScheme data_sheets_schema:base .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grantor> a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "Grantor" ;
+    rdfs:subClassOf data_sheets_schema:Organization ;
+    skos:definition """The name and/or identifier of the organization providing monetary support  or other resources supporting creation of the dataset.
+""" ;
+    skos:inScheme data_sheets_schema:motivation .
 
 data_sheets_schema:same_as a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -102,7 +110,7 @@ data_sheets_schema:DataSubset a owl:Class,
     rdfs:label "DataSubset" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_subpopulation ],
+            owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_data_split ],
@@ -114,7 +122,7 @@ data_sheets_schema:DataSubset a owl:Class,
             owl:onProperty data_sheets_schema:is_subpopulation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_data_split ],
+            owl:onProperty data_sheets_schema:is_subpopulation ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty data_sheets_schema:is_data_split ],
@@ -126,104 +134,104 @@ data_sheets_schema:File a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "File" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:format ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:path ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CompressionEnum ;
             owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:file_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:FormatEnum ;
             owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:hash ],
+            owl:onProperty data_sheets_schema:file_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:dialect ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:md5 ],
+            owl:allValuesFrom data_sheets_schema:FileTypeEnum ;
+            owl:onProperty data_sheets_schema:file_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:hash ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:path ],
+            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
+            owl:onProperty data_sheets_schema:media_type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:dialect ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty data_sheets_schema:bytes ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FileTypeEnum ;
-            owl:onProperty data_sheets_schema:file_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:hash ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:sha256 ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:file_type ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "file",
@@ -238,58 +246,58 @@ data_sheets_schema:FileCollection a owl:Class,
     rdfs:label "FileCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:file_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FileCollectionTypeEnum ;
+            owl:onProperty data_sheets_schema:collection_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:file_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:File ;
             owl:onProperty data_sheets_schema:resources ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:file_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:total_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:total_bytes ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
-            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:resources ],
+            owl:onProperty data_sheets_schema:file_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CompressionEnum ;
             owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FileCollectionTypeEnum ;
-            owl:onProperty data_sheets_schema:collection_type ],
         data_sheets_schema:Information ;
     skos:altLabel "data files",
         "file collection",
@@ -304,31 +312,31 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Software" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:url ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:url ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license ],
         data_sheets_schema:NamedThing ;
     skos:definition "A software program or library." ;
@@ -344,6 +352,9 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What mechanisms or procedures were used to collect the data (e.g., hardware, manual curation, software APIs)? Also covers how these mechanisms were validated.
 """ ;
@@ -354,29 +365,32 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionTimeframe" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Date ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Date ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Date ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Date ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Over what timeframe was the data collected, and does this timeframe match the creation timeframe of the underlying data?
 """ ;
@@ -387,16 +401,19 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataCollector" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -411,10 +428,10 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "DirectCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
@@ -422,8 +439,11 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Indicates whether the data was collected directly from the individuals in question or obtained via third parties/other sources.
 """ ;
@@ -434,45 +454,48 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "InstanceAcquisition" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Describes how data associated with each instance was acquired (e.g., directly observed, reported by subjects, inferred).
@@ -483,25 +506,31 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MissingDataDocumentation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documentation of missing data in the dataset, including patterns, causes, and strategies for handling missing values.
@@ -514,34 +543,40 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "RawDataSource" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Description of raw data sources before preprocessing, cleaning, or labeling. Documents where the original data comes from and how it can be accessed.
 """ ;
@@ -552,19 +587,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Confidentiality" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be confidential (e.g., protected by legal privilege, patient data, non-public communications)?
@@ -575,16 +613,16 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ContentWarning" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -601,6 +639,9 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         data_sheets_schema:DatasetProperty ;
@@ -613,37 +654,37 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "DatasetBias" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:BiasTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documents known biases present in the dataset. Biases are systematic errors or prejudices that may affect the representativeness or fairness of the data. Distinct from anomalies (data quality issues) and limitations (scope constraints).
 """ ;
@@ -654,29 +695,29 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetLimitation" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:LimitationTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
@@ -684,7 +725,7 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -699,20 +740,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
@@ -721,10 +765,7 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Typed relationship to another dataset, enabling precise specification of how datasets relate to each other (e.g., supplements, derives from, is version of). Supports RO-Crate-style dataset interlinking.
 """ ;
@@ -734,31 +775,34 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Deidentification" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -772,71 +816,71 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Instance" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What do the instances that comprise the dataset represent (e.g., documents, photos, people, countries)?
 """ ;
@@ -846,14 +890,14 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MissingInfo" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
@@ -866,10 +910,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Relationships" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are relationships between individual instances made explicit (e.g., users' movie ratings, social network links)?
@@ -880,20 +927,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SensitiveElement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be considered sensitive (e.g., race, sexual orientation, religion, biometrics)?
 """ ;
@@ -904,6 +954,9 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Splits" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         [ a owl:Restriction ;
@@ -918,22 +971,28 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Subpopulation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -947,44 +1006,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExportControlRegulatoryRestrictions" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Do any export controls or other regulatory restrictions apply to the dataset or to individual instances? Includes compliance tracking for regulations like HIPAA and other US regulations. If so, please describe these restrictions and provide a link or copy of any supporting documentation. Maps to DUO terms related to ethics approval, geographic restrictions, and institutional requirements.
 """ ;
@@ -994,10 +1056,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "IPRestrictions" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#restrictions> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#restrictions> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Have any third parties imposed IP-based or other restrictions on the data associated with the instances? If so, describe them and note any relevant fees or licensing terms. Maps to DUO terms related to commercial/non-profit use restrictions (NCU, NPU, NPUNCU).
@@ -1009,25 +1071,28 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "LicenseAndUseTerms" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+            owl:allValuesFrom data_sheets_schema:DataUsePermissionEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DataUsePermissionEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
+            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed under a copyright or other IP license, and/or under applicable terms of use? Provide a link or copy of relevant licensing terms and any fees.
 """ ;
@@ -1065,13 +1130,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ThirdPartySharing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed to third parties outside of the entity (e.g., company, institution, organization) on behalf of which the dataset was created?
@@ -1085,6 +1150,9 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
         data_sheets_schema:DatasetProperty ;
@@ -1096,10 +1164,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionNotification" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were the individuals in question notified about the data collection? If so, please describe (or show with screenshots, etc.) how notice was provided, and reproduce the language of the notification itself if possible.
@@ -1115,6 +1186,9 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If consent was obtained, were the consenting individuals provided with a mechanism to revoke their consent in the future or for certain uses? If so, please describe.
 """ ;
@@ -1129,6 +1203,9 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has an analysis of the potential impact of the dataset and its use on data subjects (e.g., a data protection impact analysis) been conducted? If so, please provide a description of this analysis, including the outcomes, and any supporting documentation.
 """ ;
@@ -1141,26 +1218,29 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Organization ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were any ethical or compliance review processes conducted (e.g., by an institutional review board)? If so, please provide a description of these review processes, including the frequency of review and documentation of outcomes, as well as a link or other access point to any supporting documentation.
 """ ;
@@ -1170,32 +1250,32 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AtRiskPopulations" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about protections for at-risk populations in human subjects research.
 """ ;
@@ -1205,32 +1285,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "HumanSubjectCompensation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about compensation or incentives provided to human research participants.
 """ ;
@@ -1241,37 +1330,40 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "HumanSubjectResearch" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about whether the dataset involves human subjects research and what regulatory or ethical review processes were followed.
 """ ;
@@ -1281,38 +1373,50 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "InformedConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Details about informed consent procedures used in human subjects research.
 """ ;
@@ -1323,27 +1427,36 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ParticipantPrivacy" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about privacy protections and anonymization procedures for human research participants.
@@ -1354,19 +1467,19 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Erratum" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there an erratum? If so, please provide a link or other access point.
@@ -1378,19 +1491,22 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ExtensionMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If others want to extend/augment/build on/contribute to the dataset, is there a mechanism for them to do so? If so, please describe how those contributions are validated and communicated.
 """ ;
@@ -1400,19 +1516,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Maintainer" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who will be supporting/hosting/maintaining the dataset?
@@ -1423,20 +1542,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "RetentionLimits" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If the dataset relates to people, are there applicable limits on the retention of their data (e.g., were individuals told their data would be deleted after a certain time)? If so, please describe these limits and how they will be enforced.
 """ ;
@@ -1446,19 +1568,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UpdatePlan" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be updated (e.g., to correct labeling errors, add new instances, delete instances)? If so, how often, by whom, and how will these updates be communicated?
@@ -1473,9 +1598,6 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
         [ a owl:Restriction ;
@@ -1484,12 +1606,18 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will older versions of the dataset continue to be supported/hosted/maintained? If so, how? If not, how will obsolescence be communicated to dataset consumers?
 """ ;
@@ -1499,13 +1627,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AddressingGap" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Was there a specific gap that needed to be filled by creation of the dataset?" ;
@@ -1515,26 +1643,26 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Creator" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CRediTRoleEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Organization ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliations> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliations> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who created the dataset (e.g., which team, research group) and on behalf of which entity (e.g., company, institution, organization)? This may also be considered a team.
 """ ;
@@ -1544,20 +1672,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FundingMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grantor> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who funded the creation of the dataset? If there is an associated grant, please provide the name of the grantor and the grant name and number.
 """ ;
@@ -1568,23 +1696,41 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "Grant" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
-        data_sheets_schema:NamedThing ;
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ] ;
     skos:definition """The name and/or identifier of the specific mechanism providing monetary support or other resources supporting creation of the dataset.
-""" ;
-    skos:inScheme data_sheets_schema:motivation .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grantor> a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "Grantor" ;
-    rdfs:subClassOf data_sheets_schema:Organization ;
-    skos:definition """The name and/or identifier of the organization providing monetary support  or other resources supporting creation of the dataset.
 """ ;
     skos:inScheme data_sheets_schema:motivation .
 
@@ -1592,13 +1738,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Purpose" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "For what purpose was the dataset created?" ;
@@ -1608,13 +1754,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Task" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Was there a specific task in mind for the dataset's application?" ;
@@ -1625,6 +1771,18 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "AnnotationAnalysis" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -1634,34 +1792,22 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Analysis of annotation quality, inter-annotator agreement metrics, and systematic patterns in annotation disagreements.
 """ ;
@@ -1673,6 +1819,9 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "CleaningStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -1694,25 +1843,25 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Description of data imputation methodology, including techniques used to handle missing values and rationale for chosen approaches.
 """ ;
@@ -1723,47 +1872,56 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "LabelingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any labeling of the data done (e.g., part-of-speech tagging)? This class documents the annotation process and quality metrics.
 """ ;
@@ -1773,8 +1931,11 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MachineAnnotationTools" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
@@ -1786,10 +1947,7 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Automated or machine-learning-based annotation tools used in dataset creation, including NLP pipelines, computer vision models, or other automated labeling systems.
 """ ;
@@ -1800,10 +1958,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "PreprocessingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any preprocessing of the data done (e.g., discretization or bucketing, tokenization, SIFT feature extraction)?
@@ -1815,9 +1976,6 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "RawData" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
         [ a owl:Restriction ;
@@ -1827,8 +1985,14 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was the "raw" data saved in addition to the preprocessed/cleaned/labeled data? If so, please provide a link or other access point to the "raw" data.
 """ ;
@@ -1838,6 +2002,9 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DiscouragedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
         [ a owl:Restriction ;
@@ -1852,10 +2019,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExistingUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has the dataset been used for any tasks already?
@@ -1866,10 +2033,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FutureUseImpact" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there anything about the dataset's composition or collection that might impact future uses or create risks/harm (e.g., unfair treatment, legal or financial risks)? If so, describe these impacts and any mitigation strategies.
@@ -1887,10 +2057,7 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -1900,7 +2067,13 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of intended uses for this dataset. Complements FutureUseImpact by focusing on positive, recommended applications rather than risks. Aligns with RO-Crate "Intended Use" field.
 """ ;
@@ -1914,6 +2087,9 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         data_sheets_schema:DatasetProperty ;
@@ -1925,10 +2101,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ProhibitedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of prohibited or forbidden uses for this dataset. Stronger than DiscouragedUse - these are uses that are explicitly not permitted by license, ethics, or policy. Aligns with RO-Crate "Prohibited Uses" field.
@@ -1939,10 +2118,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UseRepository" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
@@ -1951,8 +2130,8 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "A repository or registry of known uses of this dataset by third parties. Documents where the dataset has been applied, enabling discoverability of downstream use cases and impact tracking." ;
     skos:inScheme data_sheets_schema:uses .
@@ -1961,101 +2140,107 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VariableMetadata" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
@@ -2063,17 +2248,14 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Metadata describing an individual variable, field, or column in a dataset. Variables may represent measurements, observations, derived values, or categorical attributes." ;
     skos:exactMatch schema1:PropertyValue ;
@@ -3215,79 +3397,6 @@ data_sheets_schema:cleaning_strategies a owl:ObjectProperty,
     skos:definition "Data cleaning and quality control procedures applied to the dataset. List of CleaningStrategy objects from the Preprocessing module describing outlier removal, deduplication, and error correction steps." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "acquisition_details" ;
-    skos:definition """Free-text description of how data was acquired for each instance, including instruments, protocols, and any manual steps involved.
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "Retinal images captured with Heidelberg Spectralis OCT" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "collection_details" ;
-    skos:definition """Free-text description of whether data was collected directly from individuals or obtained via third parties or other indirect sources, and what those sources are.
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "Collected directly from consented participants at clinical sites" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "collector_details" ;
-    skos:definition """Free-text description of who was involved in data collection (e.g., students, crowdworkers, contractors), their training or qualifications, and how they were compensated.
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "Certified study coordinators at 3 collection sites" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "mechanism_details" ;
-    skos:definition """Free-text description of the specific mechanisms or procedures used to collect the data (e.g., hardware model, software API, manual curation process), including how those mechanisms were validated.
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "In-person clinical visit with standardized MOP" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "missing_data_causes" ;
-    skos:definition """Known or suspected causes of missing data (e.g., sensor failures, participant dropout, privacy constraints).
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "Device malfunction, participant non-compliance, technical failures" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "missing_data_patterns" ;
-    skos:definition """Description of patterns in missing data (e.g., missing completely at random, missing at random, missing not at random).
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "CGM data missing for 15% of participants (device errors)" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "raw_data_format" ;
-    skos:definition """One or more formats of the raw data before any preprocessing (e.g., CSV, DICOM, JSON).
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "HL7 FHIR R4" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "source_type" ;
-    skos:broadMatch dcterms:type ;
-    skos:definition """One or more types of raw source (e.g., sensor, database, user input, web scraping).
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "Electronic Health Records" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "timeframe_details" ;
-    skos:definition """Free-text description of the data collection period and whether this timeframe matches the creation timeframe of the underlying data (e.g., historical records, prospective collection).
-""" ;
-    skos:inScheme data_sheets_schema:collection ;
-    data_sheets_schema:docExample "Enrollment ongoing; data released annually" .
-
 data_sheets_schema:collection_consents a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "collection_consents" ;
@@ -3322,14 +3431,8 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
         linkml:ClassDefinition ;
     rdfs:label "ExternalResource" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:external_resources ],
@@ -3337,8 +3440,11 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
@@ -3348,6 +3454,12 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is the dataset self-contained or does it rely on external resources (e.g., websites, other datasets)? If external, are there guarantees that those resources will remain available and unchanged?
 """ ;
@@ -3357,56 +3469,62 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
         linkml:ClassDefinition ;
     rdfs:label "SamplingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain all possible instances, or is it a sample (not necessarily random) of instances from a larger set? If so, how representative is it?
 """ ;
@@ -3419,54 +3537,6 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:composition ;
     data_sheets_schema:docExample "Training split underrepresents Asian participants" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "anomaly_details" ;
-    skos:broadMatch dcterms:description ;
-    skos:definition """Free-text description of errors, noise sources, or redundancies in the dataset, including their known causes and estimated prevalence.
-""" ;
-    skos:inScheme data_sheets_schema:composition ;
-    data_sheets_schema:docExample "15% of CGM readings missing due to device malfunction" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "confidentiality_details" ;
-    skos:definition """Free-text description of which data elements are confidential, the basis for confidentiality (e.g., legal privilege, patient data), and how they are handled or restricted.
-""" ;
-    skos:inScheme data_sheets_schema:composition ;
-    data_sheets_schema:docExample "ZIP codes suppressed; race/ethnicity available only in aggregate" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "deidentification_details" ;
-    skos:definition """Details on de-identification procedures and residual risks.
-""" ;
-    skos:inScheme data_sheets_schema:composition ;
-    data_sheets_schema:docExample "HIPAA Safe Harbor method applied; expert re-identification risk assessment confirms low risk" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "distribution" ;
-    skos:broadMatch dcterms:description ;
-    skos:definition "The distribution of instances across identified subpopulations, including counts, percentages, or proportions for each subgroup." ;
-    skos:inScheme data_sheets_schema:composition ;
-    data_sheets_schema:docExample "Hispanic participants: 1,023 (25.6% of total)" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "future_guarantees" ;
-    skos:broadMatch dcterms:description ;
-    skos:definition """Explanation of any commitments that external resources will remain available and stable over time.
-""" ;
-    skos:inScheme data_sheets_schema:composition .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "identification" ;
-    skos:broadMatch dcterms:description ;
-    skos:definition "How subpopulations are identified and defined (e.g., by age groups, gender, geographic region, disease status, or other demographic/clinical characteristics)." ;
-    skos:inScheme data_sheets_schema:composition .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -3489,14 +3559,6 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
     skos:definition """References to one or more MissingInfo objects describing missing data.
 """ ;
     skos:inScheme data_sheets_schema:composition .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "relationship_details" ;
-    skos:definition """Free-text description of how relationships between instances are represented (e.g., graph edges, ratings matrices, foreign keys), including relationship types and any associated metadata.
-""" ;
-    skos:inScheme data_sheets_schema:composition ;
-    data_sheets_schema:docExample "Participants linked to multiple visits via participant_id foreign key" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -3521,29 +3583,6 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:composition .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "sensitivity_details" ;
-    skos:definition """Details on sensitive data elements present and handling procedures.
-""" ;
-    skos:inScheme data_sheets_schema:composition ;
-    data_sheets_schema:docExample "Genetic sequencing data requires additional DUA" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "source_data" ;
-    skos:definition """One or more descriptions of the larger sets from which the sample was drawn, if applicable.
-""" ;
-    skos:inScheme data_sheets_schema:composition .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "split_details" ;
-    skos:definition """Free-text description of the recommended data splits (e.g., 80/10/10 train/ validation/test), how they are defined, and the rationale for the split strategy.
-""" ;
-    skos:inScheme data_sheets_schema:composition ;
-    data_sheets_schema:docExample "70/15/15 train/validation/test split stratified by site and T2DM severity" .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "strategies" ;
@@ -3567,13 +3606,6 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:composition ;
     data_sheets_schema:docExample "Device malfunction or non-compliance during 14-day wear period" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "why_not_representative" ;
-    skos:definition """One or more explanations of why the sample is not representative of the larger set, if applicable.
-""" ;
-    skos:inScheme data_sheets_schema:composition .
 
 data_sheets_schema:confidential_elements a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -3606,21 +3638,6 @@ data_sheets_schema:creators a owl:ObjectProperty,
     skos:exactMatch <http://purl.obolibrary.org/obo/DUO_0000001> ;
     skos:inScheme data_sheets_schema:data-governance ;
     data_sheets_schema:docExample "health_medical_biomedical_research" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "license_terms" ;
-    skos:broadMatch dcterms:license,
-        dcterms:rights ;
-    skos:definition "Description of the dataset's license and terms of use, including links, costs, or usage constraints (e.g., 'CC BY 4.0', 'Apache 2.0', 'MIT', 'CC BY-NC-SA 4.0', 'proprietary - contact data@example.org for access')." ;
-    skos:inScheme data_sheets_schema:data-governance ;
-    data_sheets_schema:docExample "CC BY-NC 4.0 - Attribution-NonCommercial required" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "other_compliance" ;
-    skos:definition "Other regulatory compliance frameworks applicable to this dataset (e.g., CCPA, PIPEDA, industry-specific regulations)." ;
-    skos:inScheme data_sheets_schema:data-governance .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -3704,46 +3721,6 @@ data_sheets_schema:ethical_reviews a owl:ObjectProperty,
     skos:definition "Ethical reviews and institutional oversight for the dataset. List of EthicalReview objects from the Ethics module describing IRB approvals, ethics committee reviews, and compliance certifications." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "consent_details" ;
-    skos:definition """Free-text description of how consent was requested (e.g., opt-in form, verbal agreement), provided, and documented, including the language individuals consented to.
-""" ;
-    skos:inScheme data_sheets_schema:ethics ;
-    data_sheets_schema:docExample "Written informed consent obtained before any study procedures; available in English and Spanish" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "impact_details" ;
-    skos:definition """Free-text description of the data protection impact analysis, including methodology, privacy risks identified, mitigation measures taken, and any regulatory findings.
-""" ;
-    skos:inScheme data_sheets_schema:ethics ;
-    data_sheets_schema:docExample "DPIA conducted; minimal residual re-identification risk after de-identification" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "notification_details" ;
-    skos:definition """Free-text description of how individuals were notified about data collection, including the notification method (e.g., email, poster, in-person), timing, and the language or text of the notification itself if available.
-""" ;
-    skos:inScheme data_sheets_schema:ethics ;
-    data_sheets_schema:docExample "Participants notified in-person at clinic visit; written information sheet provided in English and Spanish" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "review_details" ;
-    skos:definition """Free-text description of the ethical review process, board decisions, outcomes, and any supporting documentation (e.g., IRB approval number, ethics committee name).
-""" ;
-    skos:inScheme data_sheets_schema:ethics ;
-    data_sheets_schema:docExample "IRB approval: UAB IRB-300010084, UCSD IRB-811480, UW IRB-STUDY00017428" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "revocation_details" ;
-    skos:definition """Free-text description of the mechanism provided for individuals to revoke consent (e.g., opt-out portal, written request), the scope of revocation (full withdrawal or specific uses), and what happens to their data after revocation.
-""" ;
-    skos:inScheme data_sheets_schema:ethics ;
-    data_sheets_schema:docExample "Participants may withdraw via written request; data retained but excluded from future analyses" .
-
 data_sheets_schema:existing_uses a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "existing_uses" ;
@@ -3769,78 +3746,10 @@ data_sheets_schema:future_use_impacts a owl:ObjectProperty,
     skos:definition "Anticipated impacts of future uses, including risks and benefits. List of FutureUseImpact objects from the Uses module describing foreseeable consequences of using this dataset in new applications." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "anonymization_method" ;
-    skos:definition """What methods were used to anonymize or de-identify participant data? Include technical details of privacy-preserving techniques.
-""" ;
-    skos:inScheme data_sheets_schema:human ;
-    data_sheets_schema:docExample "De-identified per HIPAA Safe Harbor; 5-digit ZIP replaced with region codes" .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "assent_procedures" ;
     skos:definition """For research involving minors, what assent procedures were used? How was developmentally appropriate assent obtained?
-""" ;
-    skos:inScheme data_sheets_schema:human .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "compensation_amount" ;
-    skos:definition """What was the amount or value of compensation provided? Include currency or equivalent value.
-""" ;
-    skos:inScheme data_sheets_schema:human ;
-    data_sheets_schema:docExample "$75 for initial visit; $25 for annual follow-up" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "compensation_rationale" ;
-    skos:definition """What was the rationale for the compensation structure? How was the amount determined to be appropriate?
-""" ;
-    skos:inScheme data_sheets_schema:human .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "compensation_type" ;
-    skos:definition """What type of compensation was provided (e.g., monetary payment, gift cards, course credit, other incentives)?
-""" ;
-    skos:inScheme data_sheets_schema:human ;
-    data_sheets_schema:docExample "Monetary payment via gift card" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "consent_documentation" ;
-    skos:definition """How is consent documented? Include references to consent forms or procedures used.
-""" ;
-    skos:inScheme data_sheets_schema:human ;
-    data_sheets_schema:docExample "Separate consent forms for main study, biorepository, and genetic analysis" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "consent_scope" ;
-    skos:definition """What specific uses did participants consent to? Are there limitations on data use based on consent?
-""" ;
-    skos:inScheme data_sheets_schema:human .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "consent_type" ;
-    skos:definition """What type of consent was obtained (e.g., written, verbal, electronic, implied through participation)?
-""" ;
-    skos:inScheme data_sheets_schema:human ;
-    data_sheets_schema:docExample "Written informed consent with optional consent for future use of biospecimens" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "data_linkage" ;
-    skos:definition """Can this dataset be linked to other datasets in ways that might compromise participant privacy?
-""" ;
-    skos:inScheme data_sheets_schema:human .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "ethics_review_board" ;
-    skos:definition """What ethics review board(s) reviewed this research? Include institution names and approval details.
 """ ;
     skos:inScheme data_sheets_schema:human .
 
@@ -3874,14 +3783,6 @@ data_sheets_schema:future_use_impacts a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:human ;
     data_sheets_schema:docExample "45 CFR Part 46, HIPAA Privacy Rule (45 CFR Parts 160 and 164)" .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "reidentification_risk" ;
-    skos:definition """What is the assessed risk of re-identification? What measures were taken to minimize this risk?
-""" ;
-    skos:inScheme data_sheets_schema:human ;
-    data_sheets_schema:docExample "Low risk; expert determination per 45 CFR 164.514(b)(1)" .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "special_populations" ;
@@ -3896,13 +3797,6 @@ data_sheets_schema:future_use_impacts a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:human ;
     data_sheets_schema:docExample "No participants under 18; pregnant women excluded from CGM protocol" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "withdrawal_mechanism" ;
-    skos:definition """How can participants withdraw their consent? What procedures are in place for data deletion upon withdrawal?
-""" ;
-    skos:inScheme data_sheets_schema:human .
 
 data_sheets_schema:imputation_protocols a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -3972,46 +3866,6 @@ data_sheets_schema:maintainers a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:maintenance ;
     data_sheets_schema:docExample "v1.0.1: Corrected mislabeled CGM device serial numbers for 12 participants" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "extension_details" ;
-    skos:definition """Free-text description of how third parties can contribute to the dataset, how contributions are validated (e.g., peer review, automated tests), and how accepted contributions will be communicated to the community.
-""" ;
-    skos:inScheme data_sheets_schema:maintenance ;
-    data_sheets_schema:docExample "New modalities added via versioned data releases; schema extensions via GitHub PRs" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "maintainer_details" ;
-    skos:definition """Free-text description of the organization, team, or individual responsible for maintaining the dataset, including contact information and hosting arrangements.
-""" ;
-    skos:inScheme data_sheets_schema:maintenance ;
-    data_sheets_schema:docExample "AI-READI Data Coordinating Center, University of Washington" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "retention_details" ;
-    skos:definition """Free-text description of applicable retention limits, legal or ethical basis for those limits, and how they will be enforced (e.g., automated deletion, anonymization after the retention period).
-""" ;
-    skos:inScheme data_sheets_schema:maintenance ;
-    data_sheets_schema:docExample "Data retained for minimum 10 years per NIH data sharing policy" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "update_details" ;
-    skos:definition """Free-text description of planned update types (e.g., corrections, additions, deletions), responsible parties, and how updates will be communicated to users.
-""" ;
-    skos:inScheme data_sheets_schema:maintenance ;
-    data_sheets_schema:docExample "Quarterly releases with approximately 500 new participants per release" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "version_details" ;
-    skos:definition """Free-text description of version support policies, how long older versions will be hosted, and how dataset consumers will be notified when versions become obsolete.
-""" ;
-    skos:inScheme data_sheets_schema:maintenance ;
-    data_sheets_schema:docExample "All versions available at fairhub.io; older versions archived on Zenodo" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4085,28 +3939,6 @@ data_sheets_schema:participant_privacy a owl:ObjectProperty,
     skos:exactMatch <http://mlcommons.org/croissant/RAI/annotatorDemographics> ;
     skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "cleaning_details" ;
-    skos:definition """Free-text description of data cleaning procedures applied, including criteria for removing or correcting instances, tools used, and how removed instances are accounted for.
-""" ;
-    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
-    data_sheets_schema:docExample "Outlier removal using 3-sigma rule; manual review of flagged records" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "data_annotation_platform" ;
-    skos:definition "One or more platforms or tools used for annotation (e.g., Label Studio, Prodigy, Amazon Mechanical Turk, custom annotation tool)." ;
-    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
-    data_sheets_schema:docExample "Label Studio 1.7.3" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "data_annotation_protocol" ;
-    skos:definition "Annotation methodology, tasks, and protocols followed during labeling. Includes annotation guidelines, quality control procedures, and task definitions." ;
-    skos:exactMatch <http://mlcommons.org/croissant/RAI/dataAnnotationProtocol> ;
-    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "disagreement_patterns" ;
@@ -4136,29 +3968,6 @@ data_sheets_schema:participant_privacy a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
     data_sheets_schema:docExample "cgm_mean_glucose, hba1c_percent, bmi" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "labeling_details" ;
-    skos:definition """Free-text description of the labeling or annotation procedures, including annotation guidelines, task definitions, and quality control metrics.
-""" ;
-    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
-    data_sheets_schema:docExample "Board-certified ophthalmologists graded retinal images using ETDRS scale" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "preprocessing_details" ;
-    skos:definition """Free-text description of preprocessing steps applied to the data, including tools used, parameters, order of operations, and rationale for each step.
-""" ;
-    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
-    data_sheets_schema:docExample "DICOM to NIfTI conversion using dcm2niix v1.0.20211006" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "raw_data_details" ;
-    skos:definition """Free-text description of raw data availability, access procedures, and any conditions or restrictions on accessing the raw data.
-""" ;
-    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4280,50 +4089,12 @@ data_sheets_schema:used_software a owl:ObjectProperty,
     skos:definition "What software was used as part of this dataset property?" ;
     skos:inScheme data_sheets_schema:base .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "discouragement_details" ;
-    skos:definition """Free-text description of tasks or applications for which the dataset is not recommended, with explanation of why (e.g., out-of-scope, risk of harm, poor coverage).
-""" ;
-    skos:inScheme data_sheets_schema:uses ;
-    data_sheets_schema:docExample "Not recommended for clinical diagnosis without additional validation" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "impact_details" ;
-    skos:definition """Free-text description of potential future impacts or risks arising from the dataset's composition or collection (e.g., unfair treatment, privacy violations, legal or financial risks), and any recommended mitigation strategies.
-""" ;
-    skos:inScheme data_sheets_schema:uses ;
-    data_sheets_schema:docExample "Models trained on this data may reinforce existing health disparities if deployed without fairness audits" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "prohibition_reason" ;
-    skos:definition "One or more reasons why this use is prohibited (e.g., license restriction, ethical concern, privacy risk, legal constraint)." ;
-    skos:inScheme data_sheets_schema:uses ;
-    data_sheets_schema:docExample "Re-identification of participants is strictly prohibited" .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "repository_details" ;
     skos:definition """Free-text description of the repository of known dataset uses, including how it is maintained and how to contribute new use cases.
 """ ;
     skos:inScheme data_sheets_schema:uses .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "task_details" ;
-    skos:definition """Free-text description of other potential tasks the dataset could support, including any prerequisites or limitations for those uses.
-""" ;
-    skos:inScheme data_sheets_schema:uses ;
-    data_sheets_schema:docExample "Longitudinal disease trajectory modeling" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "use_category" ;
-    skos:definition "One or more categories of intended use (e.g., research, clinical, educational, commercial, policy)." ;
-    skos:inScheme data_sheets_schema:uses ;
-    data_sheets_schema:docExample "academic research" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4344,13 +4115,6 @@ data_sheets_schema:used_software a owl:ObjectProperty,
     skos:definition "Code(s) used to represent missing values for this variable. Examples: \"NA\", \"-999\", \"null\", \"\". Multiple codes may be specified." ;
     skos:inScheme data_sheets_schema:variables ;
     data_sheets_schema:docExample "NA" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "quality_notes" ;
-    skos:broadMatch dcterms:description ;
-    skos:definition "Notes about data quality, reliability, or known issues specific to this variable." ;
-    skos:inScheme data_sheets_schema:variables .
 
 <http://purl.obolibrary.org/obo/DUO_0000021> a owl:Class,
         data_sheets_schema:DataUsePermissionEnum ;
@@ -4382,6 +4146,74 @@ schema1:DataDownload a owl:Class,
     rdfs:label "data_file" ;
     rdfs:subClassOf data_sheets_schema:FileTypeEnum .
 
+data_sheets_schema:NamedThing a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "NamedThing" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:description ] ;
+    skos:definition "A generic grouping for any identifiable entity." ;
+    skos:exactMatch schema1:Thing ;
+    skos:inScheme data_sheets_schema:base .
+
+data_sheets_schema:Organization a owl:Class,
+        linkml:ClassDefinition ;
+    rdfs:label "Organization" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:id ] ;
+    skos:definition "Represents a group or organization." ;
+    skos:exactMatch schema1:Organization ;
+    skos:inScheme data_sheets_schema:base .
+
 data_sheets_schema:at_risk_populations a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "at_risk_populations" ;
@@ -4411,6 +4243,30 @@ data_sheets_schema:citation a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:collection ;
     data_sheets_schema:docExample "Requires institutional DUA and IRB approval" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "acquisition_details" ;
+    skos:definition """Free-text description of how data was acquired for each instance, including instruments, protocols, and any manual steps involved.
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "Retinal images captured with Heidelberg Spectralis OCT" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "collection_details" ;
+    skos:definition """Free-text description of whether data was collected directly from individuals or obtained via third parties or other indirect sources, and what those sources are.
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "Collected directly from consented participants at clinical sites" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "collector_details" ;
+    skos:definition """Free-text description of who was involved in data collection (e.g., students, crowdworkers, contractors), their training or qualifications, and how they were compensated.
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "Certified study coordinators at 3 collection sites" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "end_date" ;
@@ -4432,6 +4288,38 @@ data_sheets_schema:citation a owl:ObjectProperty,
     skos:definition "Whether collection was direct from individuals." ;
     skos:inScheme data_sheets_schema:collection .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "mechanism_details" ;
+    skos:definition """Free-text description of the specific mechanisms or procedures used to collect the data (e.g., hardware model, software API, manual curation process), including how those mechanisms were validated.
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "In-person clinical visit with standardized MOP" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "missing_data_causes" ;
+    skos:definition """Known or suspected causes of missing data (e.g., sensor failures, participant dropout, privacy constraints).
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "Device malfunction, participant non-compliance, technical failures" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "missing_data_patterns" ;
+    skos:definition """Description of patterns in missing data (e.g., missing completely at random, missing at random, missing not at random).
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "CGM data missing for 15% of participants (device errors)" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "raw_data_format" ;
+    skos:definition """One or more formats of the raw data before any preprocessing (e.g., CSV, DICOM, JSON).
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "HL7 FHIR R4" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "role" ;
@@ -4447,12 +4335,29 @@ data_sheets_schema:citation a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:collection ;
     data_sheets_schema:docExample "Electronic health records from UCSF Epic system" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "source_type" ;
+    skos:broadMatch dcterms:type ;
+    skos:definition """One or more types of raw source (e.g., sensor, database, user input, web scraping).
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "Electronic Health Records" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "start_date" ;
     skos:definition "Start date of data collection." ;
     skos:inScheme data_sheets_schema:collection ;
     data_sheets_schema:docExample "2023-07-18" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "timeframe_details" ;
+    skos:definition """Free-text description of the data collection period and whether this timeframe matches the creation timeframe of the underlying data (e.g., historical records, prospective collection).
+""" ;
+    skos:inScheme data_sheets_schema:collection ;
+    data_sheets_schema:docExample "Enrollment ongoing; data released annually" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4484,6 +4389,15 @@ data_sheets_schema:comment_prefix a owl:ObjectProperty,
     skos:definition "Character(s) used to indicate comment lines (e.g., \"#\" for CSV comments)." ;
     skos:inScheme data_sheets_schema:base .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "anomaly_details" ;
+    skos:broadMatch dcterms:description ;
+    skos:definition """Free-text description of errors, noise sources, or redundancies in the dataset, including their known causes and estimated prevalence.
+""" ;
+    skos:inScheme data_sheets_schema:composition ;
+    data_sheets_schema:docExample "15% of CGM readings missing due to device malfunction" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "archival" ;
@@ -4511,6 +4425,14 @@ data_sheets_schema:comment_prefix a owl:ObjectProperty,
     rdfs:label "confidential_elements_present" ;
     skos:definition "Indicates whether any confidential data elements are present." ;
     skos:inScheme data_sheets_schema:composition .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "confidentiality_details" ;
+    skos:definition """Free-text description of which data elements are confidential, the basis for confidentiality (e.g., legal privilege, patient data), and how they are handled or restricted.
+""" ;
+    skos:inScheme data_sheets_schema:composition ;
+    data_sheets_schema:docExample "ZIP codes suppressed; race/ethnicity available only in aggregate" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4540,16 +4462,47 @@ data_sheets_schema:comment_prefix a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:composition .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "deidentification_details" ;
+    skos:definition """Details on de-identification procedures and residual risks.
+""" ;
+    skos:inScheme data_sheets_schema:composition ;
+    data_sheets_schema:docExample "HIPAA Safe Harbor method applied; expert re-identification risk assessment confirms low risk" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "description" ;
     skos:definition "Free-text description providing additional context about the relationship." ;
     skos:inScheme data_sheets_schema:composition .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "distribution" ;
+    skos:broadMatch dcterms:description ;
+    skos:definition "The distribution of instances across identified subpopulations, including counts, percentages, or proportions for each subgroup." ;
+    skos:inScheme data_sheets_schema:composition ;
+    data_sheets_schema:docExample "Hispanic participants: 1,023 (25.6% of total)" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "future_guarantees" ;
+    skos:broadMatch dcterms:description ;
+    skos:definition """Explanation of any commitments that external resources will remain available and stable over time.
+""" ;
+    skos:inScheme data_sheets_schema:composition .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "identifiable_elements_present" ;
     skos:definition "Indicates whether data subjects can be identified." ;
+    skos:inScheme data_sheets_schema:composition .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "identification" ;
+    skos:broadMatch dcterms:description ;
+    skos:definition "How subpopulations are identified and defined (e.g., by age groups, gender, geographic region, disease status, or other demographic/clinical characteristics)." ;
     skos:inScheme data_sheets_schema:composition .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> a owl:ObjectProperty,
@@ -4635,6 +4588,14 @@ data_sheets_schema:comment_prefix a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:composition ;
     data_sheets_schema:docExample "Use longitudinal follow-up cohorts for causal inference studies" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "relationship_details" ;
+    skos:definition """Free-text description of how relationships between instances are represented (e.g., graph edges, ratings matrices, foreign keys), including relationship types and any associated metadata.
+""" ;
+    skos:inScheme data_sheets_schema:composition ;
+    data_sheets_schema:docExample "Participants linked to multiple visits via participant_id foreign key" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "relationship_type" ;
@@ -4655,6 +4616,29 @@ data_sheets_schema:comment_prefix a owl:ObjectProperty,
     skos:definition "Indicates whether sensitive data elements are present." ;
     skos:inScheme data_sheets_schema:composition .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "sensitivity_details" ;
+    skos:definition """Details on sensitive data elements present and handling procedures.
+""" ;
+    skos:inScheme data_sheets_schema:composition ;
+    data_sheets_schema:docExample "Genetic sequencing data requires additional DUA" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "source_data" ;
+    skos:definition """One or more descriptions of the larger sets from which the sample was drawn, if applicable.
+""" ;
+    skos:inScheme data_sheets_schema:composition .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "split_details" ;
+    skos:definition """Free-text description of the recommended data splits (e.g., 80/10/10 train/ validation/test), how they are defined, and the rationale for the split strategy.
+""" ;
+    skos:inScheme data_sheets_schema:composition ;
+    data_sheets_schema:docExample "70/15/15 train/validation/test split stratified by site and T2DM severity" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "subpopulation_elements_present" ;
@@ -4664,7 +4648,16 @@ data_sheets_schema:comment_prefix a owl:ObjectProperty,
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "target_dataset" ;
-    skos:definition "The dataset that this relationship points to. Can be specified by identifier, URL, or Dataset object." ;
+    skos:definition "The identifier or URL of the dataset this relationship points to." ;
+    skos:inScheme data_sheets_schema:composition ;
+    skos:note "A reference, not an inline dataset. The description used to promise \"identifier, URL, or Dataset object\" while the range permitted only the first, and LinkML cannot express the union: its JSON Schema generator always emits a top-level type or $ref from the slot's range, which ANDs with `any_of`, so whichever branch the range names the other one fails. Verified both ways on VOICE (#297).",
+        "A related dataset with its own DOI, protocol and approval is its own datasheet and is referenced from here by identifier. That is the resolution of #292 for VOICE, whose pediatric companion has all three." .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "why_not_representative" ;
+    skos:definition """One or more explanations of why the sample is not representative of the larger set, if applicable.
+""" ;
     skos:inScheme data_sheets_schema:composition .
 
 data_sheets_schema:conforms_to a owl:ObjectProperty,
@@ -4732,6 +4725,21 @@ data_sheets_schema:created_on a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:data-governance ;
     data_sheets_schema:docExample "compliant" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "license_terms" ;
+    skos:broadMatch dcterms:license,
+        dcterms:rights ;
+    skos:definition "Description of the dataset's license and terms of use, including links, costs, or usage constraints (e.g., 'CC BY 4.0', 'Apache 2.0', 'MIT', 'CC BY-NC-SA 4.0', 'proprietary - contact data@example.org for access')." ;
+    skos:inScheme data_sheets_schema:data-governance ;
+    data_sheets_schema:docExample "CC BY-NC 4.0 - Attribution-NonCommercial required" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "other_compliance" ;
+    skos:definition "Other regulatory compliance frameworks applicable to this dataset (e.g., CCPA, PIPEDA, industry-specific regulations)." ;
+    skos:inScheme data_sheets_schema:data-governance .
+
 data_sheets_schema:delimiter a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "delimiter" ;
@@ -4794,6 +4802,14 @@ data_sheets_schema:encoding a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:base ;
     data_sheets_schema:docExample "UTF-8" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "consent_details" ;
+    skos:definition """Free-text description of how consent was requested (e.g., opt-in form, verbal agreement), provided, and documented, including the language individuals consented to.
+""" ;
+    skos:inScheme data_sheets_schema:ethics ;
+    data_sheets_schema:docExample "Written informed consent obtained before any study procedures; available in English and Spanish" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "contact_person" ;
@@ -4801,12 +4817,44 @@ data_sheets_schema:encoding a owl:ObjectProperty,
     skos:definition "Contact person for questions about ethical review. Provides structured contact information including name, email, affiliation, and optional ORCID." ;
     skos:inScheme data_sheets_schema:ethics .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "impact_details" ;
+    skos:definition """Free-text description of the data protection impact analysis, including methodology, privacy risks identified, mitigation measures taken, and any regulatory findings.
+""" ;
+    skos:inScheme data_sheets_schema:ethics ;
+    data_sheets_schema:docExample "DPIA conducted; minimal residual re-identification risk after de-identification" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "notification_details" ;
+    skos:definition """Free-text description of how individuals were notified about data collection, including the notification method (e.g., email, poster, in-person), timing, and the language or text of the notification itself if available.
+""" ;
+    skos:inScheme data_sheets_schema:ethics ;
+    data_sheets_schema:docExample "Participants notified in-person at clinic visit; written information sheet provided in English and Spanish" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "review_details" ;
+    skos:definition """Free-text description of the ethical review process, board decisions, outcomes, and any supporting documentation (e.g., IRB approval number, ethics committee name).
+""" ;
+    skos:inScheme data_sheets_schema:ethics ;
+    data_sheets_schema:docExample "IRB approval: UAB IRB-300010084, UCSD IRB-811480, UW IRB-STUDY00017428" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "reviewing_organization" ;
-    skos:definition "Organization that conducted the ethical review (e.g., Institutional Review Board, Ethics Committee, Research Ethics Board). Provides information about the body responsible for ethical oversight." ;
+    skos:definition "Name or identifier of the organization that conducted the ethical review (e.g., Institutional Review Board, Ethics Committee, Research Ethics Board). A plain string: every one of the 245 corpus values here was a name, ROR or curie, and Organization no longer carries the identifier that made string references expressible (#360)." ;
     skos:exactMatch schema1:provider ;
     skos:inScheme data_sheets_schema:ethics .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "revocation_details" ;
+    skos:definition """Free-text description of the mechanism provided for individuals to revoke consent (e.g., opt-out portal, written request), the scope of revocation (full withdrawal or specific uses), and what happens to their data after revocation.
+""" ;
+    skos:inScheme data_sheets_schema:ethics ;
+    data_sheets_schema:docExample "Participants may withdraw via written request; data retained but excluded from future analyses" .
 
 data_sheets_schema:extension_mechanism a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4849,6 +4897,14 @@ data_sheets_schema:header a owl:ObjectProperty,
     skos:definition "Whether the first row of the file contains column headers. Expected values: \"true\" or \"false\" (as strings per CSV dialect specification). Follows the W3C CSV-on-the-Web dialect specification." ;
     skos:inScheme data_sheets_schema:base .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "anonymization_method" ;
+    skos:definition """What methods were used to anonymize or de-identify participant data? Include technical details of privacy-preserving techniques.
+""" ;
+    skos:inScheme data_sheets_schema:human ;
+    data_sheets_schema:docExample "De-identified per HIPAA Safe Harbor; 5-digit ZIP replaced with region codes" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "at_risk_groups_included" ;
@@ -4856,11 +4912,42 @@ data_sheets_schema:header a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:human .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "compensation_amount" ;
+    skos:definition """What was the amount or value of compensation provided? Include currency or equivalent value.
+""" ;
+    skos:inScheme data_sheets_schema:human ;
+    data_sheets_schema:docExample "$75 for initial visit; $25 for annual follow-up" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "compensation_provided" ;
     skos:definition "Were participants compensated for their participation?" ;
     skos:inScheme data_sheets_schema:human .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "compensation_rationale" ;
+    skos:definition """What was the rationale for the compensation structure? How was the amount determined to be appropriate?
+""" ;
+    skos:inScheme data_sheets_schema:human .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "compensation_type" ;
+    skos:definition """What type of compensation was provided (e.g., monetary payment, gift cards, course credit, other incentives)?
+""" ;
+    skos:inScheme data_sheets_schema:human ;
+    data_sheets_schema:docExample "Monetary payment via gift card" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "consent_documentation" ;
+    skos:definition """How is consent documented? Include references to consent forms or procedures used.
+""" ;
+    skos:inScheme data_sheets_schema:human ;
+    data_sheets_schema:docExample "Separate consent forms for main study, biorepository, and genetic analysis" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4868,10 +4955,54 @@ data_sheets_schema:header a owl:ObjectProperty,
     skos:definition "Was informed consent obtained from all participants?" ;
     skos:inScheme data_sheets_schema:human .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "consent_scope" ;
+    skos:definition """What specific uses did participants consent to? Are there limitations on data use based on consent?
+""" ;
+    skos:inScheme data_sheets_schema:human .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "consent_type" ;
+    skos:definition """What type of consent was obtained (e.g., written, verbal, electronic, implied through participation)?
+""" ;
+    skos:inScheme data_sheets_schema:human ;
+    data_sheets_schema:docExample "Written informed consent with optional consent for future use of biospecimens" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "data_linkage" ;
+    skos:definition """Can this dataset be linked to other datasets in ways that might compromise participant privacy?
+""" ;
+    skos:inScheme data_sheets_schema:human .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "ethics_review_board" ;
+    skos:definition """What ethics review board(s) reviewed this research? Include institution names and approval details.
+""" ;
+    skos:inScheme data_sheets_schema:human .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "involves_human_subjects" ;
     skos:definition "Does this dataset involve human subjects research?" ;
+    skos:inScheme data_sheets_schema:human .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "reidentification_risk" ;
+    skos:definition """What is the assessed risk of re-identification? What measures were taken to minimize this risk?
+""" ;
+    skos:inScheme data_sheets_schema:human ;
+    data_sheets_schema:docExample "Low risk; expert determination per 45 CFR 164.514(b)(1)" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "withdrawal_mechanism" ;
+    skos:definition """How can participants withdraw their consent? What procedures are in place for data deletion upon withdrawal?
+""" ;
     skos:inScheme data_sheets_schema:human .
 
 data_sheets_schema:human_subject_research a owl:ObjectProperty,
@@ -4954,6 +5085,14 @@ data_sheets_schema:license_and_use_terms a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:maintenance ;
     data_sheets_schema:docExample "https://example.org/dataset/errata/2024-01-15" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "extension_details" ;
+    skos:definition """Free-text description of how third parties can contribute to the dataset, how contributions are validated (e.g., peer review, automated tests), and how accepted contributions will be communicated to the community.
+""" ;
+    skos:inScheme data_sheets_schema:maintenance ;
+    data_sheets_schema:docExample "New modalities added via versioned data releases; schema extensions via GitHub PRs" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "frequency" ;
@@ -4966,6 +5105,22 @@ data_sheets_schema:license_and_use_terms a owl:ObjectProperty,
     rdfs:label "latest_version_doi" ;
     skos:definition "DOI or URL identifying the latest version of this dataset (e.g., '10.5281/zenodo.1234567' for a DOI or 'https://doi.org/10.5281/zenodo.1234567' for a full URL). Use CURIE format for DOIs (e.g., 'doi:10.5281/zenodo.1234567')." ;
     skos:inScheme data_sheets_schema:maintenance .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "maintainer_details" ;
+    skos:definition """Free-text description of the organization, team, or individual responsible for maintaining the dataset, including contact information and hosting arrangements.
+""" ;
+    skos:inScheme data_sheets_schema:maintenance ;
+    data_sheets_schema:docExample "AI-READI Data Coordinating Center, University of Washington" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "retention_details" ;
+    skos:definition """Free-text description of applicable retention limits, legal or ethical basis for those limits, and how they will be enforced (e.g., automated deletion, anonymization after the retention period).
+""" ;
+    skos:inScheme data_sheets_schema:maintenance ;
+    data_sheets_schema:docExample "Data retained for minimum 10 years per NIH data sharing policy" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4980,6 +5135,22 @@ data_sheets_schema:license_and_use_terms a owl:ObjectProperty,
     skos:definition """Role of the maintainer (e.g., researcher, platform, organization).
 """ ;
     skos:inScheme data_sheets_schema:maintenance .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "update_details" ;
+    skos:definition """Free-text description of planned update types (e.g., corrections, additions, deletions), responsible parties, and how updates will be communicated to users.
+""" ;
+    skos:inScheme data_sheets_schema:maintenance ;
+    data_sheets_schema:docExample "Quarterly releases with approximately 500 new participants per release" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "version_details" ;
+    skos:definition """Free-text description of version support policies, how long older versions will be hosted, and how dataset consumers will be notified when versions become obsolete.
+""" ;
+    skos:inScheme data_sheets_schema:maintenance ;
+    data_sheets_schema:docExample "All versions available at fairhub.io; older versions archived on Zenodo" .
 
 data_sheets_schema:md5 a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -5005,6 +5176,12 @@ data_sheets_schema:modified_by a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:base ;
     data_sheets_schema:docExample "orcid:0000-0002-9876-5432" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "description" ;
+    skos:definition "A human-readable description of the grant." ;
+    skos:inScheme data_sheets_schema:motivation .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "grant_number" ;
@@ -5020,12 +5197,24 @@ data_sheets_schema:modified_by a owl:ObjectProperty,
     skos:definition "Name/identifier of the organization providing monetary or resource support." ;
     skos:inScheme data_sheets_schema:motivation .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "id" ;
+    skos:definition "An identifier for the grant, when the source material supplies one. The grant_number alone is a valid grant reference." ;
+    skos:inScheme data_sheets_schema:motivation .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "name" ;
+    skos:definition "A human-readable name for the grant or funding mechanism." ;
+    skos:inScheme data_sheets_schema:motivation .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "principal_investigator" ;
     skos:broadMatch dcterms:creator,
         schema1:creator ;
-    skos:definition "A key individual (Principal Investigator) responsible for or overseeing dataset creation." ;
+    skos:definition "The name of the key individual (Principal Investigator) responsible for or overseeing dataset creation — a person's name such as 'Aaron Lee', never a yes/no flag. The slot name reads like a boolean; the value is not one (#360)." ;
     skos:inScheme data_sheets_schema:motivation .
 
 data_sheets_schema:orcid a owl:ObjectProperty,
@@ -5072,6 +5261,28 @@ data_sheets_schema:page a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
     data_sheets_schema:docExample "3 (three independent annotators per item)" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "cleaning_details" ;
+    skos:definition """Free-text description of data cleaning procedures applied, including criteria for removing or correcting instances, tools used, and how removed instances are accounted for.
+""" ;
+    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
+    data_sheets_schema:docExample "Outlier removal using 3-sigma rule; manual review of flagged records" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "data_annotation_platform" ;
+    skos:definition "One or more platforms or tools used for annotation (e.g., Label Studio, Prodigy, Amazon Mechanical Turk, custom annotation tool)." ;
+    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
+    data_sheets_schema:docExample "Label Studio 1.7.3" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "data_annotation_protocol" ;
+    skos:definition "Annotation methodology, tasks, and protocols followed during labeling. Includes annotation guidelines, quality control procedures, and task definitions." ;
+    skos:exactMatch <http://mlcommons.org/croissant/RAI/dataAnnotationProtocol> ;
+    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "imputation_rationale" ;
@@ -5091,6 +5302,29 @@ data_sheets_schema:page a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "inter_annotator_agreement_score" ;
     skos:definition """Measured agreement between annotators (e.g., Cohen's kappa value, Fleiss' kappa, Krippendorff's alpha).
+""" ;
+    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "labeling_details" ;
+    skos:definition """Free-text description of the labeling or annotation procedures, including annotation guidelines, task definitions, and quality control metrics.
+""" ;
+    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
+    data_sheets_schema:docExample "Board-certified ophthalmologists graded retinal images using ETDRS scale" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "preprocessing_details" ;
+    skos:definition """Free-text description of preprocessing steps applied to the data, including tools used, parameters, order of operations, and rationale for each step.
+""" ;
+    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
+    data_sheets_schema:docExample "DICOM to NIfTI conversion using dcm2niix v1.0.20211006" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "raw_data_details" ;
+    skos:definition """Free-text description of raw data availability, access procedures, and any conditions or restrictions on accessing the raw data.
 """ ;
     skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling .
 
@@ -5176,6 +5410,29 @@ data_sheets_schema:url a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:base ;
     data_sheets_schema:docExample "https://github.com/example/tool" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "discouragement_details" ;
+    skos:definition """Free-text description of tasks or applications for which the dataset is not recommended, with explanation of why (e.g., out-of-scope, risk of harm, poor coverage).
+""" ;
+    skos:inScheme data_sheets_schema:uses ;
+    data_sheets_schema:docExample "Not recommended for clinical diagnosis without additional validation" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "impact_details" ;
+    skos:definition """Free-text description of potential future impacts or risks arising from the dataset's composition or collection (e.g., unfair treatment, privacy violations, legal or financial risks), and any recommended mitigation strategies.
+""" ;
+    skos:inScheme data_sheets_schema:uses ;
+    data_sheets_schema:docExample "Models trained on this data may reinforce existing health disparities if deployed without fairness audits" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "prohibition_reason" ;
+    skos:definition "One or more reasons why this use is prohibited (e.g., license restriction, ethical concern, privacy risk, legal constraint)." ;
+    skos:inScheme data_sheets_schema:uses ;
+    data_sheets_schema:docExample "Re-identification of participants is strictly prohibited" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "repository_url" ;
@@ -5183,12 +5440,27 @@ data_sheets_schema:url a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:uses ;
     data_sheets_schema:docExample "https://paperswithcode.com/dataset/ai-readi" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "task_details" ;
+    skos:definition """Free-text description of other potential tasks the dataset could support, including any prerequisites or limitations for those uses.
+""" ;
+    skos:inScheme data_sheets_schema:uses ;
+    data_sheets_schema:docExample "Longitudinal disease trajectory modeling" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "usage_notes" ;
     skos:definition "A note or caveat about using the dataset for its intended purposes." ;
     skos:inScheme data_sheets_schema:uses ;
     data_sheets_schema:docExample "Models should be evaluated for fairness across racial/ethnic subgroups before clinical deployment" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "use_category" ;
+    skos:definition "One or more categories of intended use (e.g., research, clinical, educational, commercial, policy)." ;
+    skos:inScheme data_sheets_schema:uses ;
+    data_sheets_schema:docExample "academic research" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -5243,6 +5515,13 @@ data_sheets_schema:url a owl:ObjectProperty,
     skos:definition "The precision or number of decimal places for numeric variables." ;
     skos:inScheme data_sheets_schema:variables ;
     data_sheets_schema:docExample "2 (two decimal places, e.g., 3.14)" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "quality_notes" ;
+    skos:broadMatch dcterms:description ;
+    skos:definition "Notes about data quality, reliability, or known issues specific to this variable." ;
+    skos:inScheme data_sheets_schema:variables .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -5304,473 +5583,473 @@ data_sheets_schema:Dataset a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#AnnotationAnalysis> ;
-            owl:onProperty data_sheets_schema:annotation_analyses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:known_biases ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:third_party_sharing ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetLimitation> ;
-            owl:onProperty data_sheets_schema:known_limitations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
-            owl:onProperty data_sheets_schema:errata ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_file_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#AtRiskPopulations> ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FileCollection ;
-            owl:onProperty data_sheets_schema:file_collections ],
+            owl:onProperty data_sheets_schema:purposes ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
             owl:onProperty data_sheets_schema:content_warnings ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:cleaning_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/MissingDataDocumentation> ;
-            owl:onProperty data_sheets_schema:missing_data_documentation ],
+            owl:onProperty data_sheets_schema:parent_datasets ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#MachineAnnotationTools> ;
-            owl:onProperty data_sheets_schema:machine_annotation_tools ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:machine_annotation_tools ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:regulatory_restrictions ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:content_warnings ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_collections ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
-            owl:onProperty data_sheets_schema:purposes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:tasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
             owl:onProperty data_sheets_schema:collection_timeframes ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:splits ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Splits> ;
-            owl:onProperty data_sheets_schema:splits ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:maintainers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:distribution_formats ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DirectCollection> ;
-            owl:onProperty data_sheets_schema:direct_collection ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
             owl:onProperty data_sheets_schema:human_subject_research ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
-            owl:onProperty data_sheets_schema:raw_sources ],
+            owl:onProperty data_sheets_schema:splits ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:funders ],
+            owl:onProperty data_sheets_schema:raw_data_sources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
+            owl:onProperty data_sheets_schema:sensitive_elements ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
-            owl:onProperty data_sheets_schema:anomalies ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
-            owl:onProperty data_sheets_schema:funders ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:missing_data_documentation ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
             owl:onProperty data_sheets_schema:instances ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:maintainers ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:resources ],
+            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
-            owl:onProperty data_sheets_schema:cleaning_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/RawDataSource> ;
-            owl:onProperty data_sheets_schema:raw_data_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#ThirdPartySharing> ;
-            owl:onProperty data_sheets_schema:third_party_sharing ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DataSubset ;
-            owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:errata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:creators ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionConsent> ;
-            owl:onProperty data_sheets_schema:collection_consents ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#AtRiskPopulations> ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_file_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:known_limitations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
+            owl:onProperty data_sheets_schema:machine_annotation_tools ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
             owl:onProperty data_sheets_schema:sensitive_elements ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:annotation_analyses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:purposes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_consents ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#ImputationProtocol> ;
-            owl:onProperty data_sheets_schema:imputation_protocols ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
-            owl:onProperty data_sheets_schema:creators ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:anomalies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
-            owl:onProperty data_sheets_schema:maintainers ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Relationships> ;
-            owl:onProperty data_sheets_schema:relationships ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:relationships ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:DataSubset ;
             owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:content_warnings ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetBias> ;
-            owl:onProperty data_sheets_schema:known_biases ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_file_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
             owl:onProperty data_sheets_schema:version_access ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
+            owl:onProperty data_sheets_schema:total_size_bytes ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionNotification> ;
-            owl:onProperty data_sheets_schema:collection_notifications ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:known_limitations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:raw_sources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FileCollection ;
+            owl:onProperty data_sheets_schema:file_collections ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
+            owl:onProperty data_sheets_schema:creators ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#ImputationProtocol> ;
+            owl:onProperty data_sheets_schema:imputation_protocols ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_consents ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
             owl:onProperty data_sheets_schema:tasks ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:consent_revocations ],
+            owl:onProperty data_sheets_schema:distribution_dates ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:imputation_protocols ],
+            owl:onProperty data_sheets_schema:extension_mechanism ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:direct_collection ],
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
+            owl:onProperty data_sheets_schema:maintainers ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/RawDataSource> ;
             owl:onProperty data_sheets_schema:raw_data_sources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
+            owl:onProperty data_sheets_schema:distribution_dates ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#MachineAnnotationTools> ;
+            owl:onProperty data_sheets_schema:machine_annotation_tools ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetLimitation> ;
+            owl:onProperty data_sheets_schema:known_limitations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionNotification> ;
+            owl:onProperty data_sheets_schema:collection_notifications ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:annotation_analyses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:relationships ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:creators ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:third_party_sharing ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Splits> ;
+            owl:onProperty data_sheets_schema:splits ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#ConsentRevocation> ;
             owl:onProperty data_sheets_schema:consent_revocations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_notifications ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:missing_data_documentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:sampling_strategies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
             owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
+            owl:onProperty data_sheets_schema:cleaning_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:other_tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_notifications ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:imputation_protocols ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetBias> ;
+            owl:onProperty data_sheets_schema:known_biases ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Relationships> ;
+            owl:onProperty data_sheets_schema:relationships ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:direct_collection ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:consent_revocations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DirectCollection> ;
+            owl:onProperty data_sheets_schema:direct_collection ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#ThirdPartySharing> ;
+            owl:onProperty data_sheets_schema:third_party_sharing ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/MissingDataDocumentation> ;
+            owl:onProperty data_sheets_schema:missing_data_documentation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:updates ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
             owl:onProperty data_sheets_schema:participant_compensation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
+            owl:onProperty data_sheets_schema:distribution_formats ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
+            owl:onProperty data_sheets_schema:raw_sources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:cleaning_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionConsent> ;
+            owl:onProperty data_sheets_schema:collection_consents ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:file_collections ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
+            owl:onProperty data_sheets_schema:other_tasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#AnnotationAnalysis> ;
+            owl:onProperty data_sheets_schema:annotation_analyses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:known_biases ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "data package",
@@ -5784,218 +6063,198 @@ data_sheets_schema:Information a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Information" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_by ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:conforms_to_class ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
+            owl:onProperty data_sheets_schema:created_on ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty data_sheets_schema:download_url ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
             owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:conforms_to_schema ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:page ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:publisher ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:page ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "10\\.\\d{4,}\\/.+" ] ) ] ;
             owl:onProperty data_sheets_schema:doi ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:was_derived_from ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:keywords ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
+            owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
+            owl:onProperty data_sheets_schema:status ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
-            owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:created_by ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:keywords ],
+            owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:language ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:doi ],
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
         data_sheets_schema:NamedThing ;
     skos:closeMatch schema1:CreativeWork ;
     skos:definition "Grouping for datasets and data files." ;
-    skos:inScheme data_sheets_schema:base .
-
-data_sheets_schema:Organization a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "Organization" ;
-    rdfs:subClassOf data_sheets_schema:NamedThing ;
-    skos:definition "Represents a group or organization." ;
-    skos:exactMatch schema1:Organization ;
     skos:inScheme data_sheets_schema:base .
 
 data_sheets_schema:Person a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:orcid ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:affiliation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Organization ;
-            owl:onProperty data_sheets_schema:affiliation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:email ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( linkml:String [ a rdfs:Datatype ;
@@ -6003,8 +6262,20 @@ data_sheets_schema:Person a owl:Class,
                                 owl:withRestrictions ( [ xsd:pattern "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$" ] ) ] ) ] ;
             owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:allValuesFrom data_sheets_schema:Organization ;
+            owl:onProperty data_sheets_schema:affiliation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:email ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:orcid ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:email ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:orcid ],
         data_sheets_schema:NamedThing ;
     skos:definition "An individual human being. This class represents a person in the context of a specific dataset. Attributes like affiliation and email represent the person's current or most relevant contact information for this dataset. For stable cross-dataset identification, use the ORCID field. Note that contributor roles (CRediT) are specified in the usage context (e.g., Creator class) rather than on the Person directly, since roles vary by dataset." ;
     skos:exactMatch schema1:Person ;
@@ -6018,40 +6289,6 @@ data_sheets_schema:Person a owl:Class,
     skos:inScheme data_sheets_schema:uses ;
     data_sheets_schema:docExample "Training fairness-aware ML models for T2DM prediction",
         "Used in NEJM 2024 paper on CGM patterns in T2DM (DOI: 10.1056/NEJMoa2404007)" .
-
-data_sheets_schema:NamedThing a owl:Class,
-        linkml:ClassDefinition ;
-    rdfs:label "NamedThing" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ] ;
-    skos:definition "A generic grouping for any identifiable entity." ;
-    skos:exactMatch schema1:Thing ;
-    skos:inScheme data_sheets_schema:base .
 
 data_sheets_schema:Boolean a owl:Class,
         linkml:EnumDefinition ;
@@ -6067,28 +6304,11 @@ data_sheets_schema:VersionTypeEnum a owl:Class,
         <https://w3id.org/bridge2ai/data-sheets-schema/VersionTypeEnum#MINOR>,
         <https://w3id.org/bridge2ai/data-sheets-schema/VersionTypeEnum#PATCH> .
 
-data_sheets_schema:description a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "description" ;
-    skos:definition "A human-readable description for a thing.",
-        "A human-readable description for this property." ;
-    skos:inScheme data_sheets_schema:base ;
-    data_sheets_schema:docExample "A multimodal dataset of 4,000 participants with Type 2 Diabetes." .
-
 data_sheets_schema:external_resources a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "external_resources" ;
     skos:definition "Links or identifiers for external resources. Can be used either as a list of ExternalResource objects (in Dataset) or as a list of URL strings (within ExternalResource class)." ;
     skos:inScheme data_sheets_schema:base .
-
-data_sheets_schema:id a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "id" ;
-    skos:definition "A unique identifier for a thing.",
-        "An optional identifier for this property." ;
-    skos:inScheme data_sheets_schema:base ;
-    data_sheets_schema:docExample "https://example.org/dataset/my-dataset-001",
-        "https://example.org/dataset/property-001" .
 
 data_sheets_schema:license a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -6098,14 +6318,6 @@ data_sheets_schema:license a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:base ;
     data_sheets_schema:docExample "CC-BY-NC-4.0",
         "MIT" .
-
-data_sheets_schema:name a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "name" ;
-    skos:definition "A human-readable name for a thing.",
-        "A human-readable name for this property." ;
-    skos:inScheme data_sheets_schema:base ;
-    data_sheets_schema:docExample "AI-READI Dataset" .
 
 data_sheets_schema:path a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -6144,6 +6356,26 @@ data_sheets_schema:compression a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:base ;
     data_sheets_schema:docExample "zip" .
 
+data_sheets_schema:description a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "description" ;
+    skos:definition "A human-readable description for a thing.",
+        "A human-readable description for the organization.",
+        "A human-readable description for this property." ;
+    skos:inScheme data_sheets_schema:base ;
+    data_sheets_schema:docExample "A multimodal dataset of 4,000 participants with Type 2 Diabetes." .
+
+data_sheets_schema:id a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "id" ;
+    skos:definition "A unique identifier for a thing.",
+        "An identifier for the organization (for example a ROR), when the source material supplies one. A name alone is a valid organization.",
+        "An optional identifier for this property." ;
+    skos:inScheme data_sheets_schema:base ;
+    data_sheets_schema:docExample "https://example.org/dataset/my-dataset-001",
+        "https://example.org/dataset/property-001",
+        "https://ror.org/01yc7t268" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "response" ;
@@ -6155,6 +6387,16 @@ data_sheets_schema:compression a owl:ObjectProperty,
     data_sheets_schema:docExample "Lack of racially diverse T2DM datasets with linked multi-modal clinical data.",
         "Multi-domain biomarker discovery for Type 2 Diabetes mellitus.",
         "Primary purpose is to support hypothesis-agnostic AI/ML analyses of T2DM salutogenesis." .
+
+data_sheets_schema:name a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "name" ;
+    skos:definition "A human-readable name for a thing.",
+        "A human-readable name for the organization.",
+        "A human-readable name for this property." ;
+    skos:inScheme data_sheets_schema:base ;
+    data_sheets_schema:docExample "AI-READI Dataset",
+        "University of Washington" .
 
 data_sheets_schema:ComplianceStatusEnum a owl:Class,
         linkml:EnumDefinition ;
@@ -6359,37 +6601,37 @@ data_sheets_schema:DatasetProperty a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetProperty" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Software ;
+            owl:onProperty data_sheets_schema:used_software ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:description ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:used_software ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:used_software ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Software ;
-            owl:onProperty data_sheets_schema:used_software ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:name ] ;
     skos:definition "Represents a single property of a dataset, or a set of related properties." ;
     skos:inScheme data_sheets_schema:base .
@@ -6438,7 +6680,7 @@ data_sheets_schema:DatasetRelationshipTypeEnum a owl:Class,
     rdfs:label "data-sheets-schema" ;
     dcterms:license "MIT" ;
     dcterms:title "data-sheets-schema" ;
-    pav:version "1.0.0" ;
+    pav:version "2.0.0" ;
     rdfs:seeAlso <https://bridge2ai.github.io/data-sheets-schema> ;
     skos:definition "A LinkML schema for Datasheets for Datasets." .
 

--- a/src/data_sheets_schema/datamodel/data_sheets_schema.py
+++ b/src/data_sheets_schema/datamodel/data_sheets_schema.py
@@ -1,5 +1,5 @@
 # Auto generated from data_sheets_schema.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-01T20:36:30
+# Generation date: 2026-08-06T12:01:30
 # Schema: data-sheets-schema
 #
 # id: https://w3id.org/bridge2ai/data-sheets-schema
@@ -60,7 +60,7 @@ from linkml_runtime.linkml_model.types import Boolean, Date, Datetime, Float, In
 from linkml_runtime.utils.metamodelcore import Bool, URI, URIorCURIE, XSDDate, XSDDateTime
 
 metamodel_version = "1.7.0"
-version = "1.0.0"
+version = "2.0.0"
 
 # Namespaces
 AIO = CurieNamespace('AIO', 'https://w3id.org/aio/')
@@ -102,10 +102,6 @@ class NamedThingId(URIorCURIE):
     pass
 
 
-class OrganizationId(NamedThingId):
-    pass
-
-
 class SoftwareId(NamedThingId):
     pass
 
@@ -127,14 +123,6 @@ class DatasetId(InformationId):
 
 
 class DataSubsetId(DatasetId):
-    pass
-
-
-class GrantorId(OrganizationId):
-    pass
-
-
-class GrantId(NamedThingId):
     pass
 
 
@@ -178,7 +166,7 @@ class NamedThing(YAMLRoot):
 
 
 @dataclass(repr=False)
-class Organization(NamedThing):
+class Organization(YAMLRoot):
     """
     Represents a group or organization.
     """
@@ -189,13 +177,19 @@ class Organization(NamedThing):
     class_name: ClassVar[str] = "Organization"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Organization
 
-    id: Union[str, OrganizationId] = None
+    id: Optional[Union[str, URIorCURIE]] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.id):
-            self.MissingRequiredField("id")
-        if not isinstance(self.id, OrganizationId):
-            self.id = OrganizationId(self.id)
+        if self.id is not None and not isinstance(self.id, URIorCURIE):
+            self.id = URIorCURIE(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         super().__post_init__(**kwargs)
 
@@ -283,7 +277,7 @@ class Person(NamedThing):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Person
 
     id: Union[str, PersonId] = None
-    affiliation: Optional[Union[Union[str, OrganizationId], list[Union[str, OrganizationId]]]] = empty_list()
+    affiliation: Optional[Union[Union[dict, Organization], list[Union[dict, Organization]]]] = empty_list()
     email: Optional[str] = None
     orcid: Optional[str] = None
 
@@ -295,7 +289,7 @@ class Person(NamedThing):
 
         if not isinstance(self.affiliation, list):
             self.affiliation = [self.affiliation] if self.affiliation is not None else []
-        self.affiliation = [v if isinstance(v, OrganizationId) else OrganizationId(v) for v in self.affiliation]
+        self.affiliation = [v if isinstance(v, Organization) else Organization(**as_dict(v)) for v in self.affiliation]
 
         if self.email is not None and not isinstance(self.email, str):
             self.email = str(self.email)
@@ -938,14 +932,16 @@ class Creator(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Creator
 
     principal_investigator: Optional[Union[str, PersonId]] = None
-    affiliations: Optional[Union[dict[Union[str, OrganizationId], Union[dict, Organization]], list[Union[dict, Organization]]]] = empty_dict()
+    affiliations: Optional[Union[Union[dict, Organization], list[Union[dict, Organization]]]] = empty_list()
     credit_roles: Optional[Union[Union[str, "CRediTRoleEnum"], list[Union[str, "CRediTRoleEnum"]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.principal_investigator is not None and not isinstance(self.principal_investigator, PersonId):
             self.principal_investigator = PersonId(self.principal_investigator)
 
-        self._normalize_inlined_as_list(slot_name="affiliations", slot_type=Organization, key_name="id", keyed=True)
+        if not isinstance(self.affiliations, list):
+            self.affiliations = [self.affiliations] if self.affiliations is not None else []
+        self.affiliations = [v if isinstance(v, Organization) else Organization(**as_dict(v)) for v in self.affiliations]
 
         if not isinstance(self.credit_roles, list):
             self.credit_roles = [self.credit_roles] if self.credit_roles is not None else []
@@ -967,19 +963,20 @@ class FundingMechanism(DatasetProperty):
     class_name: ClassVar[str] = "FundingMechanism"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.FundingMechanism
 
-    grantor: Optional[Union[str, GrantorId]] = None
-    grants: Optional[Union[dict[Union[str, GrantId], Union[dict, "Grant"]], list[Union[dict, "Grant"]]]] = empty_dict()
+    grantor: Optional[str] = None
+    grants: Optional[Union[Union[dict, "Grant"], list[Union[dict, "Grant"]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if self.grantor is not None and not isinstance(self.grantor, GrantorId):
-            self.grantor = GrantorId(self.grantor)
+        if self.grantor is not None and not isinstance(self.grantor, str):
+            self.grantor = str(self.grantor)
 
-        self._normalize_inlined_as_list(slot_name="grants", slot_type=Grant, key_name="id", keyed=True)
+        if not isinstance(self.grants, list):
+            self.grants = [self.grants] if self.grants is not None else []
+        self.grants = [v if isinstance(v, Grant) else Grant(**as_dict(v)) for v in self.grants]
 
         super().__post_init__(**kwargs)
 
 
-@dataclass(repr=False)
 class Grantor(Organization):
     """
     The name and/or identifier of the organization providing monetary support or other resources supporting creation
@@ -992,19 +989,9 @@ class Grantor(Organization):
     class_name: ClassVar[str] = "Grantor"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Grantor
 
-    id: Union[str, GrantorId] = None
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.id):
-            self.MissingRequiredField("id")
-        if not isinstance(self.id, GrantorId):
-            self.id = GrantorId(self.id)
-
-        super().__post_init__(**kwargs)
-
 
 @dataclass(repr=False)
-class Grant(NamedThing):
+class Grant(YAMLRoot):
     """
     The name and/or identifier of the specific mechanism providing monetary support or other resources supporting
     creation of the dataset.
@@ -1016,14 +1003,20 @@ class Grant(NamedThing):
     class_name: ClassVar[str] = "Grant"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Grant
 
-    id: Union[str, GrantId] = None
+    id: Optional[Union[str, URIorCURIE]] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
     grant_number: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.id):
-            self.MissingRequiredField("id")
-        if not isinstance(self.id, GrantId):
-            self.id = GrantId(self.id)
+        if self.id is not None and not isinstance(self.id, URIorCURIE):
+            self.id = URIorCURIE(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
 
         if self.grant_number is not None and not isinstance(self.grant_number, str):
             self.grant_number = str(self.grant_number)
@@ -1097,10 +1090,10 @@ class SamplingStrategy(DatasetProperty):
 
     is_sample: Optional[Union[bool, Bool]] = None
     is_random: Optional[Union[bool, Bool]] = None
-    source_data: Optional[Union[str, list[str]]] = empty_list()
+    source_data: Optional[str] = None
     is_representative: Optional[Union[bool, Bool]] = None
     representative_verification: Optional[Union[str, list[str]]] = empty_list()
-    why_not_representative: Optional[Union[str, list[str]]] = empty_list()
+    why_not_representative: Optional[str] = None
     strategies: Optional[Union[str, list[str]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -1110,9 +1103,8 @@ class SamplingStrategy(DatasetProperty):
         if self.is_random is not None and not isinstance(self.is_random, Bool):
             self.is_random = Bool(self.is_random)
 
-        if not isinstance(self.source_data, list):
-            self.source_data = [self.source_data] if self.source_data is not None else []
-        self.source_data = [v if isinstance(v, str) else str(v) for v in self.source_data]
+        if self.source_data is not None and not isinstance(self.source_data, str):
+            self.source_data = str(self.source_data)
 
         if self.is_representative is not None and not isinstance(self.is_representative, Bool):
             self.is_representative = Bool(self.is_representative)
@@ -1121,9 +1113,8 @@ class SamplingStrategy(DatasetProperty):
             self.representative_verification = [self.representative_verification] if self.representative_verification is not None else []
         self.representative_verification = [v if isinstance(v, str) else str(v) for v in self.representative_verification]
 
-        if not isinstance(self.why_not_representative, list):
-            self.why_not_representative = [self.why_not_representative] if self.why_not_representative is not None else []
-        self.why_not_representative = [v if isinstance(v, str) else str(v) for v in self.why_not_representative]
+        if self.why_not_representative is not None and not isinstance(self.why_not_representative, str):
+            self.why_not_representative = str(self.why_not_representative)
 
         if not isinstance(self.strategies, list):
             self.strategies = [self.strategies] if self.strategies is not None else []
@@ -1171,12 +1162,11 @@ class Relationships(DatasetProperty):
     class_name: ClassVar[str] = "Relationships"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Relationships
 
-    relationship_details: Optional[Union[str, list[str]]] = empty_list()
+    relationship_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.relationship_details, list):
-            self.relationship_details = [self.relationship_details] if self.relationship_details is not None else []
-        self.relationship_details = [v if isinstance(v, str) else str(v) for v in self.relationship_details]
+        if self.relationship_details is not None and not isinstance(self.relationship_details, str):
+            self.relationship_details = str(self.relationship_details)
 
         super().__post_init__(**kwargs)
 
@@ -1193,12 +1183,11 @@ class Splits(DatasetProperty):
     class_name: ClassVar[str] = "Splits"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Splits
 
-    split_details: Optional[Union[str, list[str]]] = empty_list()
+    split_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.split_details, list):
-            self.split_details = [self.split_details] if self.split_details is not None else []
-        self.split_details = [v if isinstance(v, str) else str(v) for v in self.split_details]
+        if self.split_details is not None and not isinstance(self.split_details, str):
+            self.split_details = str(self.split_details)
 
         super().__post_init__(**kwargs)
 
@@ -1215,12 +1204,11 @@ class DataAnomaly(DatasetProperty):
     class_name: ClassVar[str] = "DataAnomaly"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DataAnomaly
 
-    anomaly_details: Optional[Union[str, list[str]]] = empty_list()
+    anomaly_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.anomaly_details, list):
-            self.anomaly_details = [self.anomaly_details] if self.anomaly_details is not None else []
-        self.anomaly_details = [v if isinstance(v, str) else str(v) for v in self.anomaly_details]
+        if self.anomaly_details is not None and not isinstance(self.anomaly_details, str):
+            self.anomaly_details = str(self.anomaly_details)
 
         super().__post_init__(**kwargs)
 
@@ -1309,7 +1297,7 @@ class ExternalResource(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ExternalResource
 
     external_resources: Optional[Union[str, list[str]]] = empty_list()
-    future_guarantees: Optional[Union[str, list[str]]] = empty_list()
+    future_guarantees: Optional[str] = None
     archival: Optional[Union[bool, Bool]] = None
     restrictions: Optional[Union[str, list[str]]] = empty_list()
 
@@ -1318,9 +1306,8 @@ class ExternalResource(DatasetProperty):
             self.external_resources = [self.external_resources] if self.external_resources is not None else []
         self.external_resources = [v if isinstance(v, str) else str(v) for v in self.external_resources]
 
-        if not isinstance(self.future_guarantees, list):
-            self.future_guarantees = [self.future_guarantees] if self.future_guarantees is not None else []
-        self.future_guarantees = [v if isinstance(v, str) else str(v) for v in self.future_guarantees]
+        if self.future_guarantees is not None and not isinstance(self.future_guarantees, str):
+            self.future_guarantees = str(self.future_guarantees)
 
         if self.archival is not None and not isinstance(self.archival, Bool):
             self.archival = Bool(self.archival)
@@ -1346,15 +1333,14 @@ class Confidentiality(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Confidentiality
 
     confidential_elements_present: Optional[Union[bool, Bool]] = None
-    confidentiality_details: Optional[Union[str, list[str]]] = empty_list()
+    confidentiality_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.confidential_elements_present is not None and not isinstance(self.confidential_elements_present, Bool):
             self.confidential_elements_present = Bool(self.confidential_elements_present)
 
-        if not isinstance(self.confidentiality_details, list):
-            self.confidentiality_details = [self.confidentiality_details] if self.confidentiality_details is not None else []
-        self.confidentiality_details = [v if isinstance(v, str) else str(v) for v in self.confidentiality_details]
+        if self.confidentiality_details is not None and not isinstance(self.confidentiality_details, str):
+            self.confidentiality_details = str(self.confidentiality_details)
 
         super().__post_init__(**kwargs)
 
@@ -1400,20 +1386,18 @@ class Subpopulation(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Subpopulation
 
     subpopulation_elements_present: Optional[Union[bool, Bool]] = None
-    identification: Optional[Union[str, list[str]]] = empty_list()
-    distribution: Optional[Union[str, list[str]]] = empty_list()
+    identification: Optional[str] = None
+    distribution: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.subpopulation_elements_present is not None and not isinstance(self.subpopulation_elements_present, Bool):
             self.subpopulation_elements_present = Bool(self.subpopulation_elements_present)
 
-        if not isinstance(self.identification, list):
-            self.identification = [self.identification] if self.identification is not None else []
-        self.identification = [v if isinstance(v, str) else str(v) for v in self.identification]
+        if self.identification is not None and not isinstance(self.identification, str):
+            self.identification = str(self.identification)
 
-        if not isinstance(self.distribution, list):
-            self.distribution = [self.distribution] if self.distribution is not None else []
-        self.distribution = [v if isinstance(v, str) else str(v) for v in self.distribution]
+        if self.distribution is not None and not isinstance(self.distribution, str):
+            self.distribution = str(self.distribution)
 
         super().__post_init__(**kwargs)
 
@@ -1434,7 +1418,7 @@ class Deidentification(DatasetProperty):
     identifiable_elements_present: Optional[Union[bool, Bool]] = None
     method: Optional[str] = None
     identifiers_removed: Optional[Union[str, list[str]]] = empty_list()
-    deidentification_details: Optional[Union[str, list[str]]] = empty_list()
+    deidentification_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.identifiable_elements_present is not None and not isinstance(self.identifiable_elements_present, Bool):
@@ -1447,9 +1431,8 @@ class Deidentification(DatasetProperty):
             self.identifiers_removed = [self.identifiers_removed] if self.identifiers_removed is not None else []
         self.identifiers_removed = [v if isinstance(v, str) else str(v) for v in self.identifiers_removed]
 
-        if not isinstance(self.deidentification_details, list):
-            self.deidentification_details = [self.deidentification_details] if self.deidentification_details is not None else []
-        self.deidentification_details = [v if isinstance(v, str) else str(v) for v in self.deidentification_details]
+        if self.deidentification_details is not None and not isinstance(self.deidentification_details, str):
+            self.deidentification_details = str(self.deidentification_details)
 
         super().__post_init__(**kwargs)
 
@@ -1468,15 +1451,14 @@ class SensitiveElement(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.SensitiveElement
 
     sensitive_elements_present: Optional[Union[bool, Bool]] = None
-    sensitivity_details: Optional[Union[str, list[str]]] = empty_list()
+    sensitivity_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.sensitive_elements_present is not None and not isinstance(self.sensitive_elements_present, Bool):
             self.sensitive_elements_present = Bool(self.sensitive_elements_present)
 
-        if not isinstance(self.sensitivity_details, list):
-            self.sensitivity_details = [self.sensitivity_details] if self.sensitivity_details is not None else []
-        self.sensitivity_details = [v if isinstance(v, str) else str(v) for v in self.sensitivity_details]
+        if self.sensitivity_details is not None and not isinstance(self.sensitivity_details, str):
+            self.sensitivity_details = str(self.sensitivity_details)
 
         super().__post_init__(**kwargs)
 
@@ -1532,7 +1514,7 @@ class InstanceAcquisition(DatasetProperty):
     was_reported_by_subjects: Optional[Union[bool, Bool]] = None
     was_inferred_derived: Optional[Union[bool, Bool]] = None
     was_validated_verified: Optional[Union[bool, Bool]] = None
-    acquisition_details: Optional[Union[str, list[str]]] = empty_list()
+    acquisition_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.was_directly_observed is not None and not isinstance(self.was_directly_observed, Bool):
@@ -1547,9 +1529,8 @@ class InstanceAcquisition(DatasetProperty):
         if self.was_validated_verified is not None and not isinstance(self.was_validated_verified, Bool):
             self.was_validated_verified = Bool(self.was_validated_verified)
 
-        if not isinstance(self.acquisition_details, list):
-            self.acquisition_details = [self.acquisition_details] if self.acquisition_details is not None else []
-        self.acquisition_details = [v if isinstance(v, str) else str(v) for v in self.acquisition_details]
+        if self.acquisition_details is not None and not isinstance(self.acquisition_details, str):
+            self.acquisition_details = str(self.acquisition_details)
 
         super().__post_init__(**kwargs)
 
@@ -1567,12 +1548,11 @@ class CollectionMechanism(DatasetProperty):
     class_name: ClassVar[str] = "CollectionMechanism"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CollectionMechanism
 
-    mechanism_details: Optional[Union[str, list[str]]] = empty_list()
+    mechanism_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.mechanism_details, list):
-            self.mechanism_details = [self.mechanism_details] if self.mechanism_details is not None else []
-        self.mechanism_details = [v if isinstance(v, str) else str(v) for v in self.mechanism_details]
+        if self.mechanism_details is not None and not isinstance(self.mechanism_details, str):
+            self.mechanism_details = str(self.mechanism_details)
 
         super().__post_init__(**kwargs)
 
@@ -1590,15 +1570,14 @@ class DataCollector(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DataCollector
 
     role: Optional[str] = None
-    collector_details: Optional[Union[str, list[str]]] = empty_list()
+    collector_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.role is not None and not isinstance(self.role, str):
             self.role = str(self.role)
 
-        if not isinstance(self.collector_details, list):
-            self.collector_details = [self.collector_details] if self.collector_details is not None else []
-        self.collector_details = [v if isinstance(v, str) else str(v) for v in self.collector_details]
+        if self.collector_details is not None and not isinstance(self.collector_details, str):
+            self.collector_details = str(self.collector_details)
 
         super().__post_init__(**kwargs)
 
@@ -1618,7 +1597,7 @@ class CollectionTimeframe(DatasetProperty):
 
     start_date: Optional[Union[str, XSDDate]] = None
     end_date: Optional[Union[str, XSDDate]] = None
-    timeframe_details: Optional[Union[str, list[str]]] = empty_list()
+    timeframe_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.start_date is not None and not isinstance(self.start_date, XSDDate):
@@ -1627,9 +1606,8 @@ class CollectionTimeframe(DatasetProperty):
         if self.end_date is not None and not isinstance(self.end_date, XSDDate):
             self.end_date = XSDDate(self.end_date)
 
-        if not isinstance(self.timeframe_details, list):
-            self.timeframe_details = [self.timeframe_details] if self.timeframe_details is not None else []
-        self.timeframe_details = [v if isinstance(v, str) else str(v) for v in self.timeframe_details]
+        if self.timeframe_details is not None and not isinstance(self.timeframe_details, str):
+            self.timeframe_details = str(self.timeframe_details)
 
         super().__post_init__(**kwargs)
 
@@ -1648,15 +1626,14 @@ class DirectCollection(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DirectCollection
 
     is_direct: Optional[Union[bool, Bool]] = None
-    collection_details: Optional[Union[str, list[str]]] = empty_list()
+    collection_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.is_direct is not None and not isinstance(self.is_direct, Bool):
             self.is_direct = Bool(self.is_direct)
 
-        if not isinstance(self.collection_details, list):
-            self.collection_details = [self.collection_details] if self.collection_details is not None else []
-        self.collection_details = [v if isinstance(v, str) else str(v) for v in self.collection_details]
+        if self.collection_details is not None and not isinstance(self.collection_details, str):
+            self.collection_details = str(self.collection_details)
 
         super().__post_init__(**kwargs)
 
@@ -1674,18 +1651,16 @@ class MissingDataDocumentation(DatasetProperty):
     class_name: ClassVar[str] = "MissingDataDocumentation"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.MissingDataDocumentation
 
-    missing_data_patterns: Optional[Union[str, list[str]]] = empty_list()
-    missing_data_causes: Optional[Union[str, list[str]]] = empty_list()
+    missing_data_patterns: Optional[str] = None
+    missing_data_causes: Optional[str] = None
     handling_strategy: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.missing_data_patterns, list):
-            self.missing_data_patterns = [self.missing_data_patterns] if self.missing_data_patterns is not None else []
-        self.missing_data_patterns = [v if isinstance(v, str) else str(v) for v in self.missing_data_patterns]
+        if self.missing_data_patterns is not None and not isinstance(self.missing_data_patterns, str):
+            self.missing_data_patterns = str(self.missing_data_patterns)
 
-        if not isinstance(self.missing_data_causes, list):
-            self.missing_data_causes = [self.missing_data_causes] if self.missing_data_causes is not None else []
-        self.missing_data_causes = [v if isinstance(v, str) else str(v) for v in self.missing_data_causes]
+        if self.missing_data_causes is not None and not isinstance(self.missing_data_causes, str):
+            self.missing_data_causes = str(self.missing_data_causes)
 
         if self.handling_strategy is not None and not isinstance(self.handling_strategy, str):
             self.handling_strategy = str(self.handling_strategy)
@@ -1707,9 +1682,9 @@ class RawDataSource(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.RawDataSource
 
     source_description: str = None
-    source_type: Optional[Union[str, list[str]]] = empty_list()
+    source_type: Optional[str] = None
     access_details: Optional[str] = None
-    raw_data_format: Optional[Union[str, list[str]]] = empty_list()
+    raw_data_format: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.source_description):
@@ -1717,16 +1692,14 @@ class RawDataSource(DatasetProperty):
         if not isinstance(self.source_description, str):
             self.source_description = str(self.source_description)
 
-        if not isinstance(self.source_type, list):
-            self.source_type = [self.source_type] if self.source_type is not None else []
-        self.source_type = [v if isinstance(v, str) else str(v) for v in self.source_type]
+        if self.source_type is not None and not isinstance(self.source_type, str):
+            self.source_type = str(self.source_type)
 
         if self.access_details is not None and not isinstance(self.access_details, str):
             self.access_details = str(self.access_details)
 
-        if not isinstance(self.raw_data_format, list):
-            self.raw_data_format = [self.raw_data_format] if self.raw_data_format is not None else []
-        self.raw_data_format = [v if isinstance(v, str) else str(v) for v in self.raw_data_format]
+        if self.raw_data_format is not None and not isinstance(self.raw_data_format, str):
+            self.raw_data_format = str(self.raw_data_format)
 
         super().__post_init__(**kwargs)
 
@@ -1743,12 +1716,11 @@ class PreprocessingStrategy(DatasetProperty):
     class_name: ClassVar[str] = "PreprocessingStrategy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.PreprocessingStrategy
 
-    preprocessing_details: Optional[Union[str, list[str]]] = empty_list()
+    preprocessing_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.preprocessing_details, list):
-            self.preprocessing_details = [self.preprocessing_details] if self.preprocessing_details is not None else []
-        self.preprocessing_details = [v if isinstance(v, str) else str(v) for v in self.preprocessing_details]
+        if self.preprocessing_details is not None and not isinstance(self.preprocessing_details, str):
+            self.preprocessing_details = str(self.preprocessing_details)
 
         super().__post_init__(**kwargs)
 
@@ -1765,12 +1737,11 @@ class CleaningStrategy(DatasetProperty):
     class_name: ClassVar[str] = "CleaningStrategy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CleaningStrategy
 
-    cleaning_details: Optional[Union[str, list[str]]] = empty_list()
+    cleaning_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.cleaning_details, list):
-            self.cleaning_details = [self.cleaning_details] if self.cleaning_details is not None else []
-        self.cleaning_details = [v if isinstance(v, str) else str(v) for v in self.cleaning_details]
+        if self.cleaning_details is not None and not isinstance(self.cleaning_details, str):
+            self.cleaning_details = str(self.cleaning_details)
 
         super().__post_init__(**kwargs)
 
@@ -1788,21 +1759,19 @@ class LabelingStrategy(DatasetProperty):
     class_name: ClassVar[str] = "LabelingStrategy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.LabelingStrategy
 
-    data_annotation_platform: Optional[Union[str, list[str]]] = empty_list()
-    data_annotation_protocol: Optional[Union[str, list[str]]] = empty_list()
+    data_annotation_platform: Optional[str] = None
+    data_annotation_protocol: Optional[str] = None
     annotations_per_item: Optional[int] = None
     inter_annotator_agreement: Optional[str] = None
     annotator_demographics: Optional[Union[str, list[str]]] = empty_list()
-    labeling_details: Optional[Union[str, list[str]]] = empty_list()
+    labeling_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.data_annotation_platform, list):
-            self.data_annotation_platform = [self.data_annotation_platform] if self.data_annotation_platform is not None else []
-        self.data_annotation_platform = [v if isinstance(v, str) else str(v) for v in self.data_annotation_platform]
+        if self.data_annotation_platform is not None and not isinstance(self.data_annotation_platform, str):
+            self.data_annotation_platform = str(self.data_annotation_platform)
 
-        if not isinstance(self.data_annotation_protocol, list):
-            self.data_annotation_protocol = [self.data_annotation_protocol] if self.data_annotation_protocol is not None else []
-        self.data_annotation_protocol = [v if isinstance(v, str) else str(v) for v in self.data_annotation_protocol]
+        if self.data_annotation_protocol is not None and not isinstance(self.data_annotation_protocol, str):
+            self.data_annotation_protocol = str(self.data_annotation_protocol)
 
         if self.annotations_per_item is not None and not isinstance(self.annotations_per_item, int):
             self.annotations_per_item = int(self.annotations_per_item)
@@ -1814,9 +1783,8 @@ class LabelingStrategy(DatasetProperty):
             self.annotator_demographics = [self.annotator_demographics] if self.annotator_demographics is not None else []
         self.annotator_demographics = [v if isinstance(v, str) else str(v) for v in self.annotator_demographics]
 
-        if not isinstance(self.labeling_details, list):
-            self.labeling_details = [self.labeling_details] if self.labeling_details is not None else []
-        self.labeling_details = [v if isinstance(v, str) else str(v) for v in self.labeling_details]
+        if self.labeling_details is not None and not isinstance(self.labeling_details, str):
+            self.labeling_details = str(self.labeling_details)
 
         super().__post_init__(**kwargs)
 
@@ -1835,15 +1803,14 @@ class RawData(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.RawData
 
     access_url: Optional[Union[str, URI]] = None
-    raw_data_details: Optional[Union[str, list[str]]] = empty_list()
+    raw_data_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.access_url is not None and not isinstance(self.access_url, URI):
             self.access_url = URI(self.access_url)
 
-        if not isinstance(self.raw_data_details, list):
-            self.raw_data_details = [self.raw_data_details] if self.raw_data_details is not None else []
-        self.raw_data_details = [v if isinstance(v, str) else str(v) for v in self.raw_data_details]
+        if self.raw_data_details is not None and not isinstance(self.raw_data_details, str):
+            self.raw_data_details = str(self.raw_data_details)
 
         super().__post_init__(**kwargs)
 
@@ -2019,12 +1986,11 @@ class OtherTask(DatasetProperty):
     class_name: ClassVar[str] = "OtherTask"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.OtherTask
 
-    task_details: Optional[Union[str, list[str]]] = empty_list()
+    task_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.task_details, list):
-            self.task_details = [self.task_details] if self.task_details is not None else []
-        self.task_details = [v if isinstance(v, str) else str(v) for v in self.task_details]
+        if self.task_details is not None and not isinstance(self.task_details, str):
+            self.task_details = str(self.task_details)
 
         super().__post_init__(**kwargs)
 
@@ -2042,12 +2008,11 @@ class FutureUseImpact(DatasetProperty):
     class_name: ClassVar[str] = "FutureUseImpact"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.FutureUseImpact
 
-    impact_details: Optional[Union[str, list[str]]] = empty_list()
+    impact_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.impact_details, list):
-            self.impact_details = [self.impact_details] if self.impact_details is not None else []
-        self.impact_details = [v if isinstance(v, str) else str(v) for v in self.impact_details]
+        if self.impact_details is not None and not isinstance(self.impact_details, str):
+            self.impact_details = str(self.impact_details)
 
         super().__post_init__(**kwargs)
 
@@ -2064,12 +2029,11 @@ class DiscouragedUse(DatasetProperty):
     class_name: ClassVar[str] = "DiscouragedUse"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DiscouragedUse
 
-    discouragement_details: Optional[Union[str, list[str]]] = empty_list()
+    discouragement_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.discouragement_details, list):
-            self.discouragement_details = [self.discouragement_details] if self.discouragement_details is not None else []
-        self.discouragement_details = [v if isinstance(v, str) else str(v) for v in self.discouragement_details]
+        if self.discouragement_details is not None and not isinstance(self.discouragement_details, str):
+            self.discouragement_details = str(self.discouragement_details)
 
         super().__post_init__(**kwargs)
 
@@ -2089,7 +2053,7 @@ class IntendedUse(DatasetProperty):
 
     examples: Optional[Union[str, list[str]]] = empty_list()
     usage_notes: Optional[str] = None
-    use_category: Optional[Union[str, list[str]]] = empty_list()
+    use_category: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if not isinstance(self.examples, list):
@@ -2099,9 +2063,8 @@ class IntendedUse(DatasetProperty):
         if self.usage_notes is not None and not isinstance(self.usage_notes, str):
             self.usage_notes = str(self.usage_notes)
 
-        if not isinstance(self.use_category, list):
-            self.use_category = [self.use_category] if self.use_category is not None else []
-        self.use_category = [v if isinstance(v, str) else str(v) for v in self.use_category]
+        if self.use_category is not None and not isinstance(self.use_category, str):
+            self.use_category = str(self.use_category)
 
         super().__post_init__(**kwargs)
 
@@ -2119,12 +2082,11 @@ class ProhibitedUse(DatasetProperty):
     class_name: ClassVar[str] = "ProhibitedUse"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ProhibitedUse
 
-    prohibition_reason: Optional[Union[str, list[str]]] = empty_list()
+    prohibition_reason: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.prohibition_reason, list):
-            self.prohibition_reason = [self.prohibition_reason] if self.prohibition_reason is not None else []
-        self.prohibition_reason = [v if isinstance(v, str) else str(v) for v in self.prohibition_reason]
+        if self.prohibition_reason is not None and not isinstance(self.prohibition_reason, str):
+            self.prohibition_reason = str(self.prohibition_reason)
 
         super().__post_init__(**kwargs)
 
@@ -2208,15 +2170,14 @@ class Maintainer(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Maintainer
 
     role: Optional[Union[str, "CreatorOrMaintainerEnum"]] = None
-    maintainer_details: Optional[Union[str, list[str]]] = empty_list()
+    maintainer_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.role is not None and not isinstance(self.role, CreatorOrMaintainerEnum):
             self.role = CreatorOrMaintainerEnum(self.role)
 
-        if not isinstance(self.maintainer_details, list):
-            self.maintainer_details = [self.maintainer_details] if self.maintainer_details is not None else []
-        self.maintainer_details = [v if isinstance(v, str) else str(v) for v in self.maintainer_details]
+        if self.maintainer_details is not None and not isinstance(self.maintainer_details, str):
+            self.maintainer_details = str(self.maintainer_details)
 
         super().__post_init__(**kwargs)
 
@@ -2261,15 +2222,14 @@ class UpdatePlan(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.UpdatePlan
 
     frequency: Optional[str] = None
-    update_details: Optional[Union[str, list[str]]] = empty_list()
+    update_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.frequency is not None and not isinstance(self.frequency, str):
             self.frequency = str(self.frequency)
 
-        if not isinstance(self.update_details, list):
-            self.update_details = [self.update_details] if self.update_details is not None else []
-        self.update_details = [v if isinstance(v, str) else str(v) for v in self.update_details]
+        if self.update_details is not None and not isinstance(self.update_details, str):
+            self.update_details = str(self.update_details)
 
         super().__post_init__(**kwargs)
 
@@ -2289,15 +2249,14 @@ class RetentionLimits(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.RetentionLimits
 
     retention_period: Optional[str] = None
-    retention_details: Optional[Union[str, list[str]]] = empty_list()
+    retention_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.retention_period is not None and not isinstance(self.retention_period, str):
             self.retention_period = str(self.retention_period)
 
-        if not isinstance(self.retention_details, list):
-            self.retention_details = [self.retention_details] if self.retention_details is not None else []
-        self.retention_details = [v if isinstance(v, str) else str(v) for v in self.retention_details]
+        if self.retention_details is not None and not isinstance(self.retention_details, str):
+            self.retention_details = str(self.retention_details)
 
         super().__post_init__(**kwargs)
 
@@ -2317,7 +2276,7 @@ class VersionAccess(DatasetProperty):
 
     latest_version_doi: Optional[Union[str, URIorCURIE]] = None
     versions_available: Optional[Union[str, list[str]]] = empty_list()
-    version_details: Optional[Union[str, list[str]]] = empty_list()
+    version_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.latest_version_doi is not None and not isinstance(self.latest_version_doi, URIorCURIE):
@@ -2327,9 +2286,8 @@ class VersionAccess(DatasetProperty):
             self.versions_available = [self.versions_available] if self.versions_available is not None else []
         self.versions_available = [v if isinstance(v, str) else str(v) for v in self.versions_available]
 
-        if not isinstance(self.version_details, list):
-            self.version_details = [self.version_details] if self.version_details is not None else []
-        self.version_details = [v if isinstance(v, str) else str(v) for v in self.version_details]
+        if self.version_details is not None and not isinstance(self.version_details, str):
+            self.version_details = str(self.version_details)
 
         super().__post_init__(**kwargs)
 
@@ -2348,15 +2306,14 @@ class ExtensionMechanism(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ExtensionMechanism
 
     contribution_url: Optional[Union[str, URI]] = None
-    extension_details: Optional[Union[str, list[str]]] = empty_list()
+    extension_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.contribution_url is not None and not isinstance(self.contribution_url, URI):
             self.contribution_url = URI(self.contribution_url)
 
-        if not isinstance(self.extension_details, list):
-            self.extension_details = [self.extension_details] if self.extension_details is not None else []
-        self.extension_details = [v if isinstance(v, str) else str(v) for v in self.extension_details]
+        if self.extension_details is not None and not isinstance(self.extension_details, str):
+            self.extension_details = str(self.extension_details)
 
         super().__post_init__(**kwargs)
 
@@ -2376,19 +2333,18 @@ class EthicalReview(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.EthicalReview
 
     contact_person: Optional[Union[str, PersonId]] = None
-    reviewing_organization: Optional[Union[str, OrganizationId]] = None
-    review_details: Optional[Union[str, list[str]]] = empty_list()
+    reviewing_organization: Optional[str] = None
+    review_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.contact_person is not None and not isinstance(self.contact_person, PersonId):
             self.contact_person = PersonId(self.contact_person)
 
-        if self.reviewing_organization is not None and not isinstance(self.reviewing_organization, OrganizationId):
-            self.reviewing_organization = OrganizationId(self.reviewing_organization)
+        if self.reviewing_organization is not None and not isinstance(self.reviewing_organization, str):
+            self.reviewing_organization = str(self.reviewing_organization)
 
-        if not isinstance(self.review_details, list):
-            self.review_details = [self.review_details] if self.review_details is not None else []
-        self.review_details = [v if isinstance(v, str) else str(v) for v in self.review_details]
+        if self.review_details is not None and not isinstance(self.review_details, str):
+            self.review_details = str(self.review_details)
 
         super().__post_init__(**kwargs)
 
@@ -2407,12 +2363,11 @@ class DataProtectionImpact(DatasetProperty):
     class_name: ClassVar[str] = "DataProtectionImpact"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.DataProtectionImpact
 
-    impact_details: Optional[Union[str, list[str]]] = empty_list()
+    impact_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.impact_details, list):
-            self.impact_details = [self.impact_details] if self.impact_details is not None else []
-        self.impact_details = [v if isinstance(v, str) else str(v) for v in self.impact_details]
+        if self.impact_details is not None and not isinstance(self.impact_details, str):
+            self.impact_details = str(self.impact_details)
 
         super().__post_init__(**kwargs)
 
@@ -2430,12 +2385,11 @@ class CollectionNotification(DatasetProperty):
     class_name: ClassVar[str] = "CollectionNotification"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CollectionNotification
 
-    notification_details: Optional[Union[str, list[str]]] = empty_list()
+    notification_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.notification_details, list):
-            self.notification_details = [self.notification_details] if self.notification_details is not None else []
-        self.notification_details = [v if isinstance(v, str) else str(v) for v in self.notification_details]
+        if self.notification_details is not None and not isinstance(self.notification_details, str):
+            self.notification_details = str(self.notification_details)
 
         super().__post_init__(**kwargs)
 
@@ -2453,12 +2407,11 @@ class CollectionConsent(DatasetProperty):
     class_name: ClassVar[str] = "CollectionConsent"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.CollectionConsent
 
-    consent_details: Optional[Union[str, list[str]]] = empty_list()
+    consent_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.consent_details, list):
-            self.consent_details = [self.consent_details] if self.consent_details is not None else []
-        self.consent_details = [v if isinstance(v, str) else str(v) for v in self.consent_details]
+        if self.consent_details is not None and not isinstance(self.consent_details, str):
+            self.consent_details = str(self.consent_details)
 
         super().__post_init__(**kwargs)
 
@@ -2476,12 +2429,11 @@ class ConsentRevocation(DatasetProperty):
     class_name: ClassVar[str] = "ConsentRevocation"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ConsentRevocation
 
-    revocation_details: Optional[Union[str, list[str]]] = empty_list()
+    revocation_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.revocation_details, list):
-            self.revocation_details = [self.revocation_details] if self.revocation_details is not None else []
-        self.revocation_details = [v if isinstance(v, str) else str(v) for v in self.revocation_details]
+        if self.revocation_details is not None and not isinstance(self.revocation_details, str):
+            self.revocation_details = str(self.revocation_details)
 
         super().__post_init__(**kwargs)
 
@@ -2501,7 +2453,7 @@ class HumanSubjectResearch(DatasetProperty):
 
     involves_human_subjects: Optional[Union[bool, Bool]] = None
     irb_approval: Optional[Union[str, list[str]]] = empty_list()
-    ethics_review_board: Optional[Union[str, list[str]]] = empty_list()
+    ethics_review_board: Optional[str] = None
     special_populations: Optional[Union[str, list[str]]] = empty_list()
     regulatory_compliance: Optional[Union[str, list[str]]] = empty_list()
 
@@ -2513,9 +2465,8 @@ class HumanSubjectResearch(DatasetProperty):
             self.irb_approval = [self.irb_approval] if self.irb_approval is not None else []
         self.irb_approval = [v if isinstance(v, str) else str(v) for v in self.irb_approval]
 
-        if not isinstance(self.ethics_review_board, list):
-            self.ethics_review_board = [self.ethics_review_board] if self.ethics_review_board is not None else []
-        self.ethics_review_board = [v if isinstance(v, str) else str(v) for v in self.ethics_review_board]
+        if self.ethics_review_board is not None and not isinstance(self.ethics_review_board, str):
+            self.ethics_review_board = str(self.ethics_review_board)
 
         if not isinstance(self.special_populations, list):
             self.special_populations = [self.special_populations] if self.special_populations is not None else []
@@ -2541,30 +2492,26 @@ class InformedConsent(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.InformedConsent
 
     consent_obtained: Optional[Union[bool, Bool]] = None
-    consent_type: Optional[Union[str, list[str]]] = empty_list()
-    consent_documentation: Optional[Union[str, list[str]]] = empty_list()
-    withdrawal_mechanism: Optional[Union[str, list[str]]] = empty_list()
-    consent_scope: Optional[Union[str, list[str]]] = empty_list()
+    consent_type: Optional[str] = None
+    consent_documentation: Optional[str] = None
+    withdrawal_mechanism: Optional[str] = None
+    consent_scope: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.consent_obtained is not None and not isinstance(self.consent_obtained, Bool):
             self.consent_obtained = Bool(self.consent_obtained)
 
-        if not isinstance(self.consent_type, list):
-            self.consent_type = [self.consent_type] if self.consent_type is not None else []
-        self.consent_type = [v if isinstance(v, str) else str(v) for v in self.consent_type]
+        if self.consent_type is not None and not isinstance(self.consent_type, str):
+            self.consent_type = str(self.consent_type)
 
-        if not isinstance(self.consent_documentation, list):
-            self.consent_documentation = [self.consent_documentation] if self.consent_documentation is not None else []
-        self.consent_documentation = [v if isinstance(v, str) else str(v) for v in self.consent_documentation]
+        if self.consent_documentation is not None and not isinstance(self.consent_documentation, str):
+            self.consent_documentation = str(self.consent_documentation)
 
-        if not isinstance(self.withdrawal_mechanism, list):
-            self.withdrawal_mechanism = [self.withdrawal_mechanism] if self.withdrawal_mechanism is not None else []
-        self.withdrawal_mechanism = [v if isinstance(v, str) else str(v) for v in self.withdrawal_mechanism]
+        if self.withdrawal_mechanism is not None and not isinstance(self.withdrawal_mechanism, str):
+            self.withdrawal_mechanism = str(self.withdrawal_mechanism)
 
-        if not isinstance(self.consent_scope, list):
-            self.consent_scope = [self.consent_scope] if self.consent_scope is not None else []
-        self.consent_scope = [v if isinstance(v, str) else str(v) for v in self.consent_scope]
+        if self.consent_scope is not None and not isinstance(self.consent_scope, str):
+            self.consent_scope = str(self.consent_scope)
 
         super().__post_init__(**kwargs)
 
@@ -2581,27 +2528,24 @@ class ParticipantPrivacy(DatasetProperty):
     class_name: ClassVar[str] = "ParticipantPrivacy"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.ParticipantPrivacy
 
-    anonymization_method: Optional[Union[str, list[str]]] = empty_list()
-    reidentification_risk: Optional[Union[str, list[str]]] = empty_list()
+    anonymization_method: Optional[str] = None
+    reidentification_risk: Optional[str] = None
     privacy_techniques: Optional[Union[str, list[str]]] = empty_list()
-    data_linkage: Optional[Union[str, list[str]]] = empty_list()
+    data_linkage: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.anonymization_method, list):
-            self.anonymization_method = [self.anonymization_method] if self.anonymization_method is not None else []
-        self.anonymization_method = [v if isinstance(v, str) else str(v) for v in self.anonymization_method]
+        if self.anonymization_method is not None and not isinstance(self.anonymization_method, str):
+            self.anonymization_method = str(self.anonymization_method)
 
-        if not isinstance(self.reidentification_risk, list):
-            self.reidentification_risk = [self.reidentification_risk] if self.reidentification_risk is not None else []
-        self.reidentification_risk = [v if isinstance(v, str) else str(v) for v in self.reidentification_risk]
+        if self.reidentification_risk is not None and not isinstance(self.reidentification_risk, str):
+            self.reidentification_risk = str(self.reidentification_risk)
 
         if not isinstance(self.privacy_techniques, list):
             self.privacy_techniques = [self.privacy_techniques] if self.privacy_techniques is not None else []
         self.privacy_techniques = [v if isinstance(v, str) else str(v) for v in self.privacy_techniques]
 
-        if not isinstance(self.data_linkage, list):
-            self.data_linkage = [self.data_linkage] if self.data_linkage is not None else []
-        self.data_linkage = [v if isinstance(v, str) else str(v) for v in self.data_linkage]
+        if self.data_linkage is not None and not isinstance(self.data_linkage, str):
+            self.data_linkage = str(self.data_linkage)
 
         super().__post_init__(**kwargs)
 
@@ -2619,25 +2563,22 @@ class HumanSubjectCompensation(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.HumanSubjectCompensation
 
     compensation_provided: Optional[Union[bool, Bool]] = None
-    compensation_type: Optional[Union[str, list[str]]] = empty_list()
-    compensation_amount: Optional[Union[str, list[str]]] = empty_list()
-    compensation_rationale: Optional[Union[str, list[str]]] = empty_list()
+    compensation_type: Optional[str] = None
+    compensation_amount: Optional[str] = None
+    compensation_rationale: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.compensation_provided is not None and not isinstance(self.compensation_provided, Bool):
             self.compensation_provided = Bool(self.compensation_provided)
 
-        if not isinstance(self.compensation_type, list):
-            self.compensation_type = [self.compensation_type] if self.compensation_type is not None else []
-        self.compensation_type = [v if isinstance(v, str) else str(v) for v in self.compensation_type]
+        if self.compensation_type is not None and not isinstance(self.compensation_type, str):
+            self.compensation_type = str(self.compensation_type)
 
-        if not isinstance(self.compensation_amount, list):
-            self.compensation_amount = [self.compensation_amount] if self.compensation_amount is not None else []
-        self.compensation_amount = [v if isinstance(v, str) else str(v) for v in self.compensation_amount]
+        if self.compensation_amount is not None and not isinstance(self.compensation_amount, str):
+            self.compensation_amount = str(self.compensation_amount)
 
-        if not isinstance(self.compensation_rationale, list):
-            self.compensation_rationale = [self.compensation_rationale] if self.compensation_rationale is not None else []
-        self.compensation_rationale = [v if isinstance(v, str) else str(v) for v in self.compensation_rationale]
+        if self.compensation_rationale is not None and not isinstance(self.compensation_rationale, str):
+            self.compensation_rationale = str(self.compensation_rationale)
 
         super().__post_init__(**kwargs)
 
@@ -2691,14 +2632,13 @@ class LicenseAndUseTerms(DatasetProperty):
     class_name: ClassVar[str] = "LicenseAndUseTerms"
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.LicenseAndUseTerms
 
-    license_terms: Optional[Union[str, list[str]]] = empty_list()
+    license_terms: Optional[str] = None
     data_use_permission: Optional[Union[Union[str, "DataUsePermissionEnum"], list[Union[str, "DataUsePermissionEnum"]]]] = empty_list()
     contact_person: Optional[Union[str, PersonId]] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if not isinstance(self.license_terms, list):
-            self.license_terms = [self.license_terms] if self.license_terms is not None else []
-        self.license_terms = [v if isinstance(v, str) else str(v) for v in self.license_terms]
+        if self.license_terms is not None and not isinstance(self.license_terms, str):
+            self.license_terms = str(self.license_terms)
 
         if not isinstance(self.data_use_permission, list):
             self.data_use_permission = [self.data_use_permission] if self.data_use_permission is not None else []
@@ -2751,7 +2691,7 @@ class ExportControlRegulatoryRestrictions(DatasetProperty):
 
     regulatory_restrictions: Optional[Union[str, list[str]]] = empty_list()
     hipaa_compliant: Optional[Union[str, "ComplianceStatusEnum"]] = None
-    other_compliance: Optional[Union[str, list[str]]] = empty_list()
+    other_compliance: Optional[str] = None
     confidentiality_level: Optional[Union[str, "ConfidentialityLevelEnum"]] = None
     governance_committee_contact: Optional[Union[str, PersonId]] = None
 
@@ -2763,9 +2703,8 @@ class ExportControlRegulatoryRestrictions(DatasetProperty):
         if self.hipaa_compliant is not None and not isinstance(self.hipaa_compliant, ComplianceStatusEnum):
             self.hipaa_compliant = ComplianceStatusEnum(self.hipaa_compliant)
 
-        if not isinstance(self.other_compliance, list):
-            self.other_compliance = [self.other_compliance] if self.other_compliance is not None else []
-        self.other_compliance = [v if isinstance(v, str) else str(v) for v in self.other_compliance]
+        if self.other_compliance is not None and not isinstance(self.other_compliance, str):
+            self.other_compliance = str(self.other_compliance)
 
         if self.confidentiality_level is not None and not isinstance(self.confidentiality_level, ConfidentialityLevelEnum):
             self.confidentiality_level = ConfidentialityLevelEnum(self.confidentiality_level)
@@ -2802,7 +2741,7 @@ class VariableMetadata(DatasetProperty):
     precision: Optional[int] = None
     measurement_technique: Optional[str] = None
     derivation: Optional[str] = None
-    quality_notes: Optional[Union[str, list[str]]] = empty_list()
+    quality_notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.variable_name):
@@ -2849,9 +2788,8 @@ class VariableMetadata(DatasetProperty):
         if self.derivation is not None and not isinstance(self.derivation, str):
             self.derivation = str(self.derivation)
 
-        if not isinstance(self.quality_notes, list):
-            self.quality_notes = [self.quality_notes] if self.quality_notes is not None else []
-        self.quality_notes = [v if isinstance(v, str) else str(v) for v in self.quality_notes]
+        if self.quality_notes is not None and not isinstance(self.quality_notes, str):
+            self.quality_notes = str(self.quality_notes)
 
         super().__post_init__(**kwargs)
 
@@ -4305,6 +4243,15 @@ slots.namedThing__name = Slot(uri=SCHEMA.name, name="namedThing__name", curie=SC
 slots.namedThing__description = Slot(uri=SCHEMA.description, name="namedThing__description", curie=SCHEMA.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.namedThing__description, domain=None, range=Optional[str])
 
+slots.organization__id = Slot(uri=SCHEMA.identifier, name="organization__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.organization__id, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.organization__name = Slot(uri=SCHEMA.name, name="organization__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.organization__name, domain=None, range=Optional[str])
+
+slots.organization__description = Slot(uri=SCHEMA.description, name="organization__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.organization__description, domain=None, range=Optional[str])
+
 slots.datasetProperty__id = Slot(uri=SCHEMA.identifier, name="datasetProperty__id", curie=SCHEMA.curie('identifier'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetProperty__id, domain=None, range=Optional[Union[str, URIorCURIE]])
 
@@ -4327,7 +4274,7 @@ slots.software__url = Slot(uri=SCHEMA.url, name="software__url", curie=SCHEMA.cu
                    model_uri=DATA_SHEETS_SCHEMA.software__url, domain=None, range=Optional[Union[str, URI]])
 
 slots.person__affiliation = Slot(uri=SCHEMA.affiliation, name="person__affiliation", curie=SCHEMA.curie('affiliation'),
-                   model_uri=DATA_SHEETS_SCHEMA.person__affiliation, domain=None, range=Optional[Union[Union[str, OrganizationId], list[Union[str, OrganizationId]]]])
+                   model_uri=DATA_SHEETS_SCHEMA.person__affiliation, domain=None, range=Optional[Union[Union[dict, Organization], list[Union[dict, Organization]]]])
 
 slots.person__email = Slot(uri=SCHEMA.email, name="person__email", curie=SCHEMA.curie('email'),
                    model_uri=DATA_SHEETS_SCHEMA.person__email, domain=None, range=Optional[str])
@@ -4364,16 +4311,25 @@ slots.creator__principal_investigator = Slot(uri=D4D.principalInvestigator, name
                    model_uri=DATA_SHEETS_SCHEMA.creator__principal_investigator, domain=None, range=Optional[Union[str, PersonId]])
 
 slots.creator__affiliations = Slot(uri=D4D.teamAffiliation, name="creator__affiliations", curie=D4D.curie('teamAffiliation'),
-                   model_uri=DATA_SHEETS_SCHEMA.creator__affiliations, domain=None, range=Optional[Union[dict[Union[str, OrganizationId], Union[dict, Organization]], list[Union[dict, Organization]]]])
+                   model_uri=DATA_SHEETS_SCHEMA.creator__affiliations, domain=None, range=Optional[Union[Union[dict, Organization], list[Union[dict, Organization]]]])
 
 slots.creator__credit_roles = Slot(uri=D4D.creditRoles, name="creator__credit_roles", curie=D4D.curie('creditRoles'),
                    model_uri=DATA_SHEETS_SCHEMA.creator__credit_roles, domain=None, range=Optional[Union[Union[str, "CRediTRoleEnum"], list[Union[str, "CRediTRoleEnum"]]]])
 
 slots.fundingMechanism__grantor = Slot(uri=D4D.grantor, name="fundingMechanism__grantor", curie=D4D.curie('grantor'),
-                   model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__grantor, domain=None, range=Optional[Union[str, GrantorId]])
+                   model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__grantor, domain=None, range=Optional[str])
 
 slots.fundingMechanism__grants = Slot(uri=SCHEMA.funding, name="fundingMechanism__grants", curie=SCHEMA.curie('funding'),
-                   model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__grants, domain=None, range=Optional[Union[dict[Union[str, GrantId], Union[dict, Grant]], list[Union[dict, Grant]]]])
+                   model_uri=DATA_SHEETS_SCHEMA.fundingMechanism__grants, domain=None, range=Optional[Union[Union[dict, Grant], list[Union[dict, Grant]]]])
+
+slots.grant__id = Slot(uri=SCHEMA.identifier, name="grant__id", curie=SCHEMA.curie('identifier'),
+                   model_uri=DATA_SHEETS_SCHEMA.grant__id, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.grant__name = Slot(uri=SCHEMA.name, name="grant__name", curie=SCHEMA.curie('name'),
+                   model_uri=DATA_SHEETS_SCHEMA.grant__name, domain=None, range=Optional[str])
+
+slots.grant__description = Slot(uri=SCHEMA.description, name="grant__description", curie=SCHEMA.curie('description'),
+                   model_uri=DATA_SHEETS_SCHEMA.grant__description, domain=None, range=Optional[str])
 
 slots.grant__grant_number = Slot(uri=D4D.grantIdentifier, name="grant__grant_number", curie=D4D.curie('grantIdentifier'),
                    model_uri=DATA_SHEETS_SCHEMA.grant__grant_number, domain=None, range=Optional[str])
@@ -4409,7 +4365,7 @@ slots.samplingStrategy__is_random = Slot(uri=D4D.isRandom, name="samplingStrateg
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__is_random, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.samplingStrategy__source_data = Slot(uri=D4D.sourceData, name="samplingStrategy__source_data", curie=D4D.curie('sourceData'),
-                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__source_data, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__source_data, domain=None, range=Optional[str])
 
 slots.samplingStrategy__is_representative = Slot(uri=D4D.isRepresentative, name="samplingStrategy__is_representative", curie=D4D.curie('isRepresentative'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__is_representative, domain=None, range=Optional[Union[bool, Bool]])
@@ -4418,7 +4374,7 @@ slots.samplingStrategy__representative_verification = Slot(uri=D4D.verificationD
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__representative_verification, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.samplingStrategy__why_not_representative = Slot(uri=D4D.whyNotRepresentative, name="samplingStrategy__why_not_representative", curie=D4D.curie('whyNotRepresentative'),
-                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__why_not_representative, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__why_not_representative, domain=None, range=Optional[str])
 
 slots.samplingStrategy__strategies = Slot(uri=D4D.strategies, name="samplingStrategy__strategies", curie=D4D.curie('strategies'),
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__strategies, domain=None, range=Optional[Union[str, list[str]]])
@@ -4430,13 +4386,13 @@ slots.missingInfo__why_missing = Slot(uri=D4D.missingDataCause, name="missingInf
                    model_uri=DATA_SHEETS_SCHEMA.missingInfo__why_missing, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.relationships__relationship_details = Slot(uri=DCTERMS.description, name="relationships__relationship_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.relationships__relationship_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.relationships__relationship_details, domain=None, range=Optional[str])
 
 slots.splits__split_details = Slot(uri=DCTERMS.description, name="splits__split_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.splits__split_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.splits__split_details, domain=None, range=Optional[str])
 
 slots.dataAnomaly__anomaly_details = Slot(uri=D4D.anomalyDetails, name="dataAnomaly__anomaly_details", curie=D4D.curie('anomalyDetails'),
-                   model_uri=DATA_SHEETS_SCHEMA.dataAnomaly__anomaly_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.dataAnomaly__anomaly_details, domain=None, range=Optional[str])
 
 slots.datasetBias__bias_type = Slot(uri=D4D.biasType, name="datasetBias__bias_type", curie=D4D.curie('biasType'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetBias__bias_type, domain=None, range=Optional[Union[str, "BiasTypeEnum"]])
@@ -4463,7 +4419,7 @@ slots.datasetLimitation__recommended_mitigation = Slot(uri=D4D.recommendedMitiga
                    model_uri=DATA_SHEETS_SCHEMA.datasetLimitation__recommended_mitigation, domain=None, range=Optional[str])
 
 slots.externalResource__future_guarantees = Slot(uri=D4D.availabilityGuarantee, name="externalResource__future_guarantees", curie=D4D.curie('availabilityGuarantee'),
-                   model_uri=DATA_SHEETS_SCHEMA.externalResource__future_guarantees, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.externalResource__future_guarantees, domain=None, range=Optional[str])
 
 slots.externalResource__archival = Slot(uri=D4D.hasArchivalVersion, name="externalResource__archival", curie=D4D.curie('hasArchivalVersion'),
                    model_uri=DATA_SHEETS_SCHEMA.externalResource__archival, domain=None, range=Optional[Union[bool, Bool]])
@@ -4475,7 +4431,7 @@ slots.confidentiality__confidential_elements_present = Slot(uri=D4D.confidential
                    model_uri=DATA_SHEETS_SCHEMA.confidentiality__confidential_elements_present, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.confidentiality__confidentiality_details = Slot(uri=DCTERMS.description, name="confidentiality__confidentiality_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.confidentiality__confidentiality_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.confidentiality__confidentiality_details, domain=None, range=Optional[str])
 
 slots.contentWarning__content_warnings_present = Slot(uri=D4D.content_warnings_present, name="contentWarning__content_warnings_present", curie=D4D.curie('content_warnings_present'),
                    model_uri=DATA_SHEETS_SCHEMA.contentWarning__content_warnings_present, domain=None, range=Optional[Union[bool, Bool]])
@@ -4487,10 +4443,10 @@ slots.subpopulation__subpopulation_elements_present = Slot(uri=D4D.subpopulation
                    model_uri=DATA_SHEETS_SCHEMA.subpopulation__subpopulation_elements_present, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.subpopulation__identification = Slot(uri=D4D.subpopulationIdentification, name="subpopulation__identification", curie=D4D.curie('subpopulationIdentification'),
-                   model_uri=DATA_SHEETS_SCHEMA.subpopulation__identification, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.subpopulation__identification, domain=None, range=Optional[str])
 
 slots.subpopulation__distribution = Slot(uri=D4D.subpopulationDistribution, name="subpopulation__distribution", curie=D4D.curie('subpopulationDistribution'),
-                   model_uri=DATA_SHEETS_SCHEMA.subpopulation__distribution, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.subpopulation__distribution, domain=None, range=Optional[str])
 
 slots.deidentification__identifiable_elements_present = Slot(uri=D4D.identifiableElementsPresent, name="deidentification__identifiable_elements_present", curie=D4D.curie('identifiableElementsPresent'),
                    model_uri=DATA_SHEETS_SCHEMA.deidentification__identifiable_elements_present, domain=None, range=Optional[Union[bool, Bool]])
@@ -4502,13 +4458,13 @@ slots.deidentification__identifiers_removed = Slot(uri=D4D.removedIdentifierType
                    model_uri=DATA_SHEETS_SCHEMA.deidentification__identifiers_removed, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.deidentification__deidentification_details = Slot(uri=DCTERMS.description, name="deidentification__deidentification_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.deidentification__deidentification_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.deidentification__deidentification_details, domain=None, range=Optional[str])
 
 slots.sensitiveElement__sensitive_elements_present = Slot(uri=D4D.sensitive_elements_present, name="sensitiveElement__sensitive_elements_present", curie=D4D.curie('sensitive_elements_present'),
                    model_uri=DATA_SHEETS_SCHEMA.sensitiveElement__sensitive_elements_present, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.sensitiveElement__sensitivity_details = Slot(uri=DCTERMS.description, name="sensitiveElement__sensitivity_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.sensitiveElement__sensitivity_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.sensitiveElement__sensitivity_details, domain=None, range=Optional[str])
 
 slots.datasetRelationship__target_dataset = Slot(uri=DCTERMS.relation, name="datasetRelationship__target_dataset", curie=DCTERMS.curie('relation'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetRelationship__target_dataset, domain=None, range=str)
@@ -4532,16 +4488,16 @@ slots.instanceAcquisition__was_validated_verified = Slot(uri=D4D.wasValidated, n
                    model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__was_validated_verified, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.instanceAcquisition__acquisition_details = Slot(uri=DCTERMS.description, name="instanceAcquisition__acquisition_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__acquisition_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.instanceAcquisition__acquisition_details, domain=None, range=Optional[str])
 
 slots.collectionMechanism__mechanism_details = Slot(uri=DCTERMS.description, name="collectionMechanism__mechanism_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.collectionMechanism__mechanism_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.collectionMechanism__mechanism_details, domain=None, range=Optional[str])
 
 slots.dataCollector__role = Slot(uri=SCHEMA.roleName, name="dataCollector__role", curie=SCHEMA.curie('roleName'),
                    model_uri=DATA_SHEETS_SCHEMA.dataCollector__role, domain=None, range=Optional[str])
 
 slots.dataCollector__collector_details = Slot(uri=DCTERMS.description, name="dataCollector__collector_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.dataCollector__collector_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.dataCollector__collector_details, domain=None, range=Optional[str])
 
 slots.collectionTimeframe__start_date = Slot(uri=SCHEMA.startDate, name="collectionTimeframe__start_date", curie=SCHEMA.curie('startDate'),
                    model_uri=DATA_SHEETS_SCHEMA.collectionTimeframe__start_date, domain=None, range=Optional[Union[str, XSDDate]])
@@ -4550,19 +4506,19 @@ slots.collectionTimeframe__end_date = Slot(uri=SCHEMA.endDate, name="collectionT
                    model_uri=DATA_SHEETS_SCHEMA.collectionTimeframe__end_date, domain=None, range=Optional[Union[str, XSDDate]])
 
 slots.collectionTimeframe__timeframe_details = Slot(uri=DCTERMS.description, name="collectionTimeframe__timeframe_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.collectionTimeframe__timeframe_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.collectionTimeframe__timeframe_details, domain=None, range=Optional[str])
 
 slots.directCollection__is_direct = Slot(uri=D4D.isDirect, name="directCollection__is_direct", curie=D4D.curie('isDirect'),
                    model_uri=DATA_SHEETS_SCHEMA.directCollection__is_direct, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.directCollection__collection_details = Slot(uri=DCTERMS.description, name="directCollection__collection_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.directCollection__collection_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.directCollection__collection_details, domain=None, range=Optional[str])
 
 slots.missingDataDocumentation__missing_data_patterns = Slot(uri=D4D.missingDataPatterns, name="missingDataDocumentation__missing_data_patterns", curie=D4D.curie('missingDataPatterns'),
-                   model_uri=DATA_SHEETS_SCHEMA.missingDataDocumentation__missing_data_patterns, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.missingDataDocumentation__missing_data_patterns, domain=None, range=Optional[str])
 
 slots.missingDataDocumentation__missing_data_causes = Slot(uri=D4D.missingDataCauses, name="missingDataDocumentation__missing_data_causes", curie=D4D.curie('missingDataCauses'),
-                   model_uri=DATA_SHEETS_SCHEMA.missingDataDocumentation__missing_data_causes, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.missingDataDocumentation__missing_data_causes, domain=None, range=Optional[str])
 
 slots.missingDataDocumentation__handling_strategy = Slot(uri=D4D.handlingStrategy, name="missingDataDocumentation__handling_strategy", curie=D4D.curie('handlingStrategy'),
                    model_uri=DATA_SHEETS_SCHEMA.missingDataDocumentation__handling_strategy, domain=None, range=Optional[str])
@@ -4571,25 +4527,25 @@ slots.rawDataSource__source_description = Slot(uri=DCTERMS.description, name="ra
                    model_uri=DATA_SHEETS_SCHEMA.rawDataSource__source_description, domain=None, range=str)
 
 slots.rawDataSource__source_type = Slot(uri=D4D.sourceType, name="rawDataSource__source_type", curie=D4D.curie('sourceType'),
-                   model_uri=DATA_SHEETS_SCHEMA.rawDataSource__source_type, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.rawDataSource__source_type, domain=None, range=Optional[str])
 
 slots.rawDataSource__access_details = Slot(uri=D4D.accessDetails, name="rawDataSource__access_details", curie=D4D.curie('accessDetails'),
                    model_uri=DATA_SHEETS_SCHEMA.rawDataSource__access_details, domain=None, range=Optional[str])
 
 slots.rawDataSource__raw_data_format = Slot(uri=D4D.rawDataFormat, name="rawDataSource__raw_data_format", curie=D4D.curie('rawDataFormat'),
-                   model_uri=DATA_SHEETS_SCHEMA.rawDataSource__raw_data_format, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.rawDataSource__raw_data_format, domain=None, range=Optional[str])
 
 slots.preprocessingStrategy__preprocessing_details = Slot(uri=DCTERMS.description, name="preprocessingStrategy__preprocessing_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.preprocessingStrategy__preprocessing_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.preprocessingStrategy__preprocessing_details, domain=None, range=Optional[str])
 
 slots.cleaningStrategy__cleaning_details = Slot(uri=DCTERMS.description, name="cleaningStrategy__cleaning_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.cleaningStrategy__cleaning_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.cleaningStrategy__cleaning_details, domain=None, range=Optional[str])
 
 slots.labelingStrategy__data_annotation_platform = Slot(uri=RAI.dataAnnotationPlatform, name="labelingStrategy__data_annotation_platform", curie=RAI.curie('dataAnnotationPlatform'),
-                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__data_annotation_platform, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__data_annotation_platform, domain=None, range=Optional[str])
 
 slots.labelingStrategy__data_annotation_protocol = Slot(uri=D4D.dataAnnotationProtocol, name="labelingStrategy__data_annotation_protocol", curie=D4D.curie('dataAnnotationProtocol'),
-                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__data_annotation_protocol, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__data_annotation_protocol, domain=None, range=Optional[str])
 
 slots.labelingStrategy__annotations_per_item = Slot(uri=D4D.annotationsPerItem, name="labelingStrategy__annotations_per_item", curie=D4D.curie('annotationsPerItem'),
                    model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__annotations_per_item, domain=None, range=Optional[int])
@@ -4601,13 +4557,13 @@ slots.labelingStrategy__annotator_demographics = Slot(uri=D4D.annotatorDemograph
                    model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__annotator_demographics, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.labelingStrategy__labeling_details = Slot(uri=DCTERMS.description, name="labelingStrategy__labeling_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__labeling_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.labelingStrategy__labeling_details, domain=None, range=Optional[str])
 
 slots.rawData__access_url = Slot(uri=D4D.rawDataAccessURL, name="rawData__access_url", curie=D4D.curie('rawDataAccessURL'),
                    model_uri=DATA_SHEETS_SCHEMA.rawData__access_url, domain=None, range=Optional[Union[str, URI]])
 
 slots.rawData__raw_data_details = Slot(uri=DCTERMS.description, name="rawData__raw_data_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.rawData__raw_data_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.rawData__raw_data_details, domain=None, range=Optional[str])
 
 slots.imputationProtocol__imputation_method = Slot(uri=D4D.imputation_method, name="imputationProtocol__imputation_method", curie=D4D.curie('imputation_method'),
                    model_uri=DATA_SHEETS_SCHEMA.imputationProtocol__imputation_method, domain=None, range=Optional[Union[str, list[str]]])
@@ -4655,13 +4611,13 @@ slots.useRepository__repository_details = Slot(uri=DCTERMS.description, name="us
                    model_uri=DATA_SHEETS_SCHEMA.useRepository__repository_details, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.otherTask__task_details = Slot(uri=DCTERMS.description, name="otherTask__task_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.otherTask__task_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.otherTask__task_details, domain=None, range=Optional[str])
 
 slots.futureUseImpact__impact_details = Slot(uri=DCTERMS.description, name="futureUseImpact__impact_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.futureUseImpact__impact_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.futureUseImpact__impact_details, domain=None, range=Optional[str])
 
 slots.discouragedUse__discouragement_details = Slot(uri=DCTERMS.description, name="discouragedUse__discouragement_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.discouragedUse__discouragement_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.discouragedUse__discouragement_details, domain=None, range=Optional[str])
 
 slots.intendedUse__examples = Slot(uri=D4DUSES.examples, name="intendedUse__examples", curie=D4DUSES.curie('examples'),
                    model_uri=DATA_SHEETS_SCHEMA.intendedUse__examples, domain=None, range=Optional[Union[str, list[str]]])
@@ -4670,10 +4626,10 @@ slots.intendedUse__usage_notes = Slot(uri=D4DUSES.usage_notes, name="intendedUse
                    model_uri=DATA_SHEETS_SCHEMA.intendedUse__usage_notes, domain=None, range=Optional[str])
 
 slots.intendedUse__use_category = Slot(uri=D4D.useCategory, name="intendedUse__use_category", curie=D4D.curie('useCategory'),
-                   model_uri=DATA_SHEETS_SCHEMA.intendedUse__use_category, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.intendedUse__use_category, domain=None, range=Optional[str])
 
 slots.prohibitedUse__prohibition_reason = Slot(uri=D4D.prohibitionReason, name="prohibitedUse__prohibition_reason", curie=D4D.curie('prohibitionReason'),
-                   model_uri=DATA_SHEETS_SCHEMA.prohibitedUse__prohibition_reason, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.prohibitedUse__prohibition_reason, domain=None, range=Optional[str])
 
 slots.thirdPartySharing__is_shared = Slot(uri=D4D.isExternallyShared, name="thirdPartySharing__is_shared", curie=D4D.curie('isExternallyShared'),
                    model_uri=DATA_SHEETS_SCHEMA.thirdPartySharing__is_shared, domain=None, range=Optional[Union[bool, Bool]])
@@ -4688,7 +4644,7 @@ slots.maintainer__role = Slot(uri=SCHEMA.maintainer, name="maintainer__role", cu
                    model_uri=DATA_SHEETS_SCHEMA.maintainer__role, domain=None, range=Optional[Union[str, "CreatorOrMaintainerEnum"]])
 
 slots.maintainer__maintainer_details = Slot(uri=DCTERMS.description, name="maintainer__maintainer_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.maintainer__maintainer_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.maintainer__maintainer_details, domain=None, range=Optional[str])
 
 slots.erratum__erratum_url = Slot(uri=D4D.erratumURL, name="erratum__erratum_url", curie=D4D.curie('erratumURL'),
                    model_uri=DATA_SHEETS_SCHEMA.erratum__erratum_url, domain=None, range=Optional[Union[str, URI]])
@@ -4700,13 +4656,13 @@ slots.updatePlan__frequency = Slot(uri=D4D.frequency, name="updatePlan__frequenc
                    model_uri=DATA_SHEETS_SCHEMA.updatePlan__frequency, domain=None, range=Optional[str])
 
 slots.updatePlan__update_details = Slot(uri=DCTERMS.description, name="updatePlan__update_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.updatePlan__update_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.updatePlan__update_details, domain=None, range=Optional[str])
 
 slots.retentionLimits__retention_period = Slot(uri=D4D.retentionPeriod, name="retentionLimits__retention_period", curie=D4D.curie('retentionPeriod'),
                    model_uri=DATA_SHEETS_SCHEMA.retentionLimits__retention_period, domain=None, range=Optional[str])
 
 slots.retentionLimits__retention_details = Slot(uri=DCTERMS.description, name="retentionLimits__retention_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.retentionLimits__retention_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.retentionLimits__retention_details, domain=None, range=Optional[str])
 
 slots.versionAccess__latest_version_doi = Slot(uri=DCTERMS.hasVersion, name="versionAccess__latest_version_doi", curie=DCTERMS.curie('hasVersion'),
                    model_uri=DATA_SHEETS_SCHEMA.versionAccess__latest_version_doi, domain=None, range=Optional[Union[str, URIorCURIE]])
@@ -4715,34 +4671,34 @@ slots.versionAccess__versions_available = Slot(uri=D4D.versionsAvailable, name="
                    model_uri=DATA_SHEETS_SCHEMA.versionAccess__versions_available, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.versionAccess__version_details = Slot(uri=DCTERMS.description, name="versionAccess__version_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.versionAccess__version_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.versionAccess__version_details, domain=None, range=Optional[str])
 
 slots.extensionMechanism__contribution_url = Slot(uri=D4D.contributionURL, name="extensionMechanism__contribution_url", curie=D4D.curie('contributionURL'),
                    model_uri=DATA_SHEETS_SCHEMA.extensionMechanism__contribution_url, domain=None, range=Optional[Union[str, URI]])
 
 slots.extensionMechanism__extension_details = Slot(uri=DCTERMS.description, name="extensionMechanism__extension_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.extensionMechanism__extension_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.extensionMechanism__extension_details, domain=None, range=Optional[str])
 
 slots.ethicalReview__contact_person = Slot(uri=D4D.ethicsContactPoint, name="ethicalReview__contact_person", curie=D4D.curie('ethicsContactPoint'),
                    model_uri=DATA_SHEETS_SCHEMA.ethicalReview__contact_person, domain=None, range=Optional[Union[str, PersonId]])
 
 slots.ethicalReview__reviewing_organization = Slot(uri=SCHEMA.provider, name="ethicalReview__reviewing_organization", curie=SCHEMA.curie('provider'),
-                   model_uri=DATA_SHEETS_SCHEMA.ethicalReview__reviewing_organization, domain=None, range=Optional[Union[str, OrganizationId]])
+                   model_uri=DATA_SHEETS_SCHEMA.ethicalReview__reviewing_organization, domain=None, range=Optional[str])
 
 slots.ethicalReview__review_details = Slot(uri=DCTERMS.description, name="ethicalReview__review_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.ethicalReview__review_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.ethicalReview__review_details, domain=None, range=Optional[str])
 
 slots.dataProtectionImpact__impact_details = Slot(uri=DCTERMS.description, name="dataProtectionImpact__impact_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.dataProtectionImpact__impact_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.dataProtectionImpact__impact_details, domain=None, range=Optional[str])
 
 slots.collectionNotification__notification_details = Slot(uri=DCTERMS.description, name="collectionNotification__notification_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.collectionNotification__notification_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.collectionNotification__notification_details, domain=None, range=Optional[str])
 
 slots.collectionConsent__consent_details = Slot(uri=DCTERMS.description, name="collectionConsent__consent_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.collectionConsent__consent_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.collectionConsent__consent_details, domain=None, range=Optional[str])
 
 slots.consentRevocation__revocation_details = Slot(uri=DCTERMS.description, name="consentRevocation__revocation_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.consentRevocation__revocation_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.consentRevocation__revocation_details, domain=None, range=Optional[str])
 
 slots.humanSubjectResearch__involves_human_subjects = Slot(uri=D4D.involvesHumanSubjects, name="humanSubjectResearch__involves_human_subjects", curie=D4D.curie('involvesHumanSubjects'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__involves_human_subjects, domain=None, range=Optional[Union[bool, Bool]])
@@ -4751,7 +4707,7 @@ slots.humanSubjectResearch__irb_approval = Slot(uri=D4D.irbApproval, name="human
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__irb_approval, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.humanSubjectResearch__ethics_review_board = Slot(uri=D4D.ethicsReviewBoard, name="humanSubjectResearch__ethics_review_board", curie=D4D.curie('ethicsReviewBoard'),
-                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__ethics_review_board, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__ethics_review_board, domain=None, range=Optional[str])
 
 slots.humanSubjectResearch__special_populations = Slot(uri=D4D.specialPopulations, name="humanSubjectResearch__special_populations", curie=D4D.curie('specialPopulations'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectResearch__special_populations, domain=None, range=Optional[Union[str, list[str]]])
@@ -4763,40 +4719,40 @@ slots.informedConsent__consent_obtained = Slot(uri=D4D.consentObtained, name="in
                    model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_obtained, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.informedConsent__consent_type = Slot(uri=D4D.consentType, name="informedConsent__consent_type", curie=D4D.curie('consentType'),
-                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_type, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_type, domain=None, range=Optional[str])
 
 slots.informedConsent__consent_documentation = Slot(uri=D4D.consentDocumentation, name="informedConsent__consent_documentation", curie=D4D.curie('consentDocumentation'),
-                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_documentation, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_documentation, domain=None, range=Optional[str])
 
 slots.informedConsent__withdrawal_mechanism = Slot(uri=D4D.withdrawalMechanism, name="informedConsent__withdrawal_mechanism", curie=D4D.curie('withdrawalMechanism'),
-                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__withdrawal_mechanism, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__withdrawal_mechanism, domain=None, range=Optional[str])
 
 slots.informedConsent__consent_scope = Slot(uri=D4D.consentScope, name="informedConsent__consent_scope", curie=D4D.curie('consentScope'),
-                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_scope, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.informedConsent__consent_scope, domain=None, range=Optional[str])
 
 slots.participantPrivacy__anonymization_method = Slot(uri=D4D.anonymizationMethod, name="participantPrivacy__anonymization_method", curie=D4D.curie('anonymizationMethod'),
-                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__anonymization_method, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__anonymization_method, domain=None, range=Optional[str])
 
 slots.participantPrivacy__reidentification_risk = Slot(uri=D4D.reidentificationRisk, name="participantPrivacy__reidentification_risk", curie=D4D.curie('reidentificationRisk'),
-                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__reidentification_risk, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__reidentification_risk, domain=None, range=Optional[str])
 
 slots.participantPrivacy__privacy_techniques = Slot(uri=D4D.privacyTechniques, name="participantPrivacy__privacy_techniques", curie=D4D.curie('privacyTechniques'),
                    model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__privacy_techniques, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.participantPrivacy__data_linkage = Slot(uri=D4D.dataLinkage, name="participantPrivacy__data_linkage", curie=D4D.curie('dataLinkage'),
-                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__data_linkage, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__data_linkage, domain=None, range=Optional[str])
 
 slots.humanSubjectCompensation__compensation_provided = Slot(uri=D4D.compensationProvided, name="humanSubjectCompensation__compensation_provided", curie=D4D.curie('compensationProvided'),
                    model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_provided, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.humanSubjectCompensation__compensation_type = Slot(uri=D4D.compensationType, name="humanSubjectCompensation__compensation_type", curie=D4D.curie('compensationType'),
-                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_type, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_type, domain=None, range=Optional[str])
 
 slots.humanSubjectCompensation__compensation_amount = Slot(uri=D4D.compensationAmount, name="humanSubjectCompensation__compensation_amount", curie=D4D.curie('compensationAmount'),
-                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_amount, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_amount, domain=None, range=Optional[str])
 
 slots.humanSubjectCompensation__compensation_rationale = Slot(uri=D4D.compensationRationale, name="humanSubjectCompensation__compensation_rationale", curie=D4D.curie('compensationRationale'),
-                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_rationale, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.humanSubjectCompensation__compensation_rationale, domain=None, range=Optional[str])
 
 slots.atRiskPopulations__at_risk_groups_included = Slot(uri=D4D.atRiskGroupsIncluded, name="atRiskPopulations__at_risk_groups_included", curie=D4D.curie('atRiskGroupsIncluded'),
                    model_uri=DATA_SHEETS_SCHEMA.atRiskPopulations__at_risk_groups_included, domain=None, range=Optional[Union[bool, Bool]])
@@ -4811,7 +4767,7 @@ slots.atRiskPopulations__guardian_consent = Slot(uri=D4D.guardianConsent, name="
                    model_uri=DATA_SHEETS_SCHEMA.atRiskPopulations__guardian_consent, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.licenseAndUseTerms__license_terms = Slot(uri=D4D.licenseDescription, name="licenseAndUseTerms__license_terms", curie=D4D.curie('licenseDescription'),
-                   model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__license_terms, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__license_terms, domain=None, range=Optional[str])
 
 slots.licenseAndUseTerms__data_use_permission = Slot(uri=DUO['0000001'], name="licenseAndUseTerms__data_use_permission", curie=DUO.curie('0000001'),
                    model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__data_use_permission, domain=None, range=Optional[Union[Union[str, "DataUsePermissionEnum"], list[Union[str, "DataUsePermissionEnum"]]]])
@@ -4829,7 +4785,7 @@ slots.exportControlRegulatoryRestrictions__hipaa_compliant = Slot(uri=D4D.hipaaC
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__hipaa_compliant, domain=None, range=Optional[Union[str, "ComplianceStatusEnum"]])
 
 slots.exportControlRegulatoryRestrictions__other_compliance = Slot(uri=D4D.otherCompliance, name="exportControlRegulatoryRestrictions__other_compliance", curie=D4D.curie('otherCompliance'),
-                   model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__other_compliance, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__other_compliance, domain=None, range=Optional[str])
 
 slots.exportControlRegulatoryRestrictions__confidentiality_level = Slot(uri=D4D.confidentialityLevel, name="exportControlRegulatoryRestrictions__confidentiality_level", curie=D4D.curie('confidentialityLevel'),
                    model_uri=DATA_SHEETS_SCHEMA.exportControlRegulatoryRestrictions__confidentiality_level, domain=None, range=Optional[Union[str, "ConfidentialityLevelEnum"]])
@@ -4877,7 +4833,7 @@ slots.variableMetadata__derivation = Slot(uri=DCTERMS.provenance, name="variable
                    model_uri=DATA_SHEETS_SCHEMA.variableMetadata__derivation, domain=None, range=Optional[str])
 
 slots.variableMetadata__quality_notes = Slot(uri=D4D.qualityNotes, name="variableMetadata__quality_notes", curie=D4D.curie('qualityNotes'),
-                   model_uri=DATA_SHEETS_SCHEMA.variableMetadata__quality_notes, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.variableMetadata__quality_notes, domain=None, range=Optional[str])
 
 slots.file__file_type = Slot(uri=D4D.fileType, name="file__file_type", curie=D4D.curie('fileType'),
                    model_uri=DATA_SHEETS_SCHEMA.file__file_type, domain=None, range=Optional[Union[str, "FileTypeEnum"]])

--- a/src/data_sheets_schema/schema/D4D_Base_import.yaml
+++ b/src/data_sheets_schema/schema/D4D_Base_import.yaml
@@ -112,11 +112,38 @@ classes:
           "d4d:docExample": "A multimodal dataset of 4,000 participants with Type 2 Diabetes."
     class_uri: schema:Thing
 
+  # Not a NamedThing, like DatasetProperty below and for the same reason:
+  # NamedThing's required id turned every bare-name affiliation into a
+  # validation failure (46 of the corpus's 55 union mismatches, #360) —
+  # bundles name organizations far more often than they identify them.
+  # Without an identifier the class always inlines; the two slots that used
+  # to hold string *references* to organizations (grantor,
+  # reviewing_organization) are now plain strings, which is what 573
+  # corpus values already were.
   Organization:
-    is_a: NamedThing
     class_uri: schema:Organization
     description: >-
       Represents a group or organization.
+    attributes:
+      id:
+        slot_uri: schema:identifier
+        range: uriorcurie
+        recommended: true
+        description: >-
+          An identifier for the organization (for example a ROR), when the
+          source material supplies one. A name alone is a valid organization.
+        annotations:
+          "d4d:docExample": "https://ror.org/01yc7t268"
+      name:
+        slot_uri: schema:name
+        description: A human-readable name for the organization.
+        range: string
+        annotations:
+          "d4d:docExample": "University of Washington"
+      description:
+        slot_uri: schema:description
+        description: A human-readable description for the organization.
+        range: string
 
   # Base class for all dataset properties and components
   # Note: Does NOT inherit from NamedThing to avoid required id constraint

--- a/src/data_sheets_schema/schema/D4D_Collection.yaml
+++ b/src/data_sheets_schema/schema/D4D_Collection.yaml
@@ -68,7 +68,6 @@ classes:
           Free-text description of how data was acquired for each instance, including
           instruments, protocols, and any manual steps involved.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Retinal images captured with Heidelberg Spectralis OCT"
@@ -88,7 +87,6 @@ classes:
           the data (e.g., hardware model, software API, manual curation process),
           including how those mechanisms were validated.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "In-person clinical visit with standardized MOP"
@@ -112,7 +110,6 @@ classes:
           crowdworkers, contractors), their training or qualifications, and how they
           were compensated.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Certified study coordinators at 3 collection sites"
@@ -144,7 +141,6 @@ classes:
           matches the creation timeframe of the underlying data (e.g., historical records,
           prospective collection).
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Enrollment ongoing; data released annually"
@@ -165,7 +161,6 @@ classes:
           Free-text description of whether data was collected directly from individuals
           or obtained via third parties or other indirect sources, and what those sources are.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Collected directly from consented participants at clinical sites"
@@ -185,7 +180,6 @@ classes:
           missing at random, missing not at random).
         slot_uri: d4d:missingDataPatterns
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "CGM data missing for 15% of participants (device errors)"
       missing_data_causes:
@@ -194,7 +188,6 @@ classes:
           participant dropout, privacy constraints).
         slot_uri: d4d:missingDataCauses
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "Device malfunction, participant non-compliance, technical failures"
       handling_strategy:
@@ -229,7 +222,6 @@ classes:
           One or more types of raw source (e.g., sensor, database, user input, web scraping).
         slot_uri: d4d:sourceType
         range: string
-        multivalued: true
         broad_mappings:
           - dcterms:type
         annotations:
@@ -246,7 +238,6 @@ classes:
           One or more formats of the raw data before any preprocessing (e.g., CSV, DICOM, JSON).
         slot_uri: d4d:rawDataFormat
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "HL7 FHIR R4"
 

--- a/src/data_sheets_schema/schema/D4D_Composition.yaml
+++ b/src/data_sheets_schema/schema/D4D_Composition.yaml
@@ -129,7 +129,6 @@ classes:
           One or more descriptions of the larger sets from which the sample was drawn, if applicable.
         slot_uri: d4d:sourceData
         range: string
-        multivalued: true
       is_representative:
         description: >
           Indicates whether the sample is representative of the larger set.
@@ -150,7 +149,6 @@ classes:
           One or more explanations of why the sample is not representative of the larger set, if applicable.
         slot_uri: d4d:whyNotRepresentative
         range: string
-        multivalued: true
       strategies:
         description: >
           One or more sampling strategies used (e.g., deterministic, simple random,
@@ -202,7 +200,6 @@ classes:
           (e.g., graph edges, ratings matrices, foreign keys), including relationship types
           and any associated metadata.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Participants linked to multiple visits via participant_id foreign key"
@@ -219,7 +216,6 @@ classes:
           Free-text description of the recommended data splits (e.g., 80/10/10 train/
           validation/test), how they are defined, and the rationale for the split strategy.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "70/15/15 train/validation/test split stratified by site and T2DM severity"
@@ -235,7 +231,6 @@ classes:
           Free-text description of errors, noise sources, or redundancies in the dataset,
           including their known causes and estimated prevalence.
         range: string
-        multivalued: true
         slot_uri: d4d:anomalyDetails
         broad_mappings:
           - dcterms:description
@@ -339,7 +334,6 @@ classes:
           Explanation of any commitments that external resources will remain
           available and stable over time.
         range: string
-        multivalued: true
         slot_uri: d4d:availabilityGuarantee
         broad_mappings:
           - dcterms:description
@@ -376,7 +370,6 @@ classes:
           confidentiality (e.g., legal privilege, patient data), and how they are handled
           or restricted.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "ZIP codes suppressed; race/ethnicity available only in aggregate"
@@ -419,7 +412,6 @@ classes:
           How subpopulations are identified and defined (e.g., by age groups, gender,
           geographic region, disease status, or other demographic/clinical characteristics).
         range: string
-        multivalued: true
         slot_uri: d4d:subpopulationIdentification
         broad_mappings:
           - dcterms:description
@@ -428,7 +420,6 @@ classes:
           The distribution of instances across identified subpopulations, including counts,
           percentages, or proportions for each subgroup.
         range: string
-        multivalued: true
         slot_uri: d4d:subpopulationDistribution
         broad_mappings:
           - dcterms:description
@@ -460,7 +451,6 @@ classes:
         description: >
           Details on de-identification procedures and residual risks.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "HIPAA Safe Harbor method applied; expert re-identification risk assessment confirms low risk"
@@ -482,7 +472,6 @@ classes:
         description: >
           Details on sensitive data elements present and handling procedures.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Genetic sequencing data requires additional DUA"

--- a/src/data_sheets_schema/schema/D4D_Data_Governance.yaml
+++ b/src/data_sheets_schema/schema/D4D_Data_Governance.yaml
@@ -52,7 +52,6 @@ classes:
           or usage constraints (e.g., 'CC BY 4.0', 'Apache 2.0', 'MIT', 'CC BY-NC-SA 4.0',
           'proprietary - contact data@example.org for access').
         range: string
-        multivalued: true
         slot_uri: d4d:licenseDescription
         broad_mappings:
           - dcterms:license
@@ -138,7 +137,6 @@ classes:
           (e.g., CCPA, PIPEDA, industry-specific regulations).
         slot_uri: d4d:otherCompliance
         range: string
-        multivalued: true
       confidentiality_level:
         description: >-
           Confidentiality classification of the dataset indicating level of

--- a/src/data_sheets_schema/schema/D4D_Ethics.yaml
+++ b/src/data_sheets_schema/schema/D4D_Ethics.yaml
@@ -55,10 +55,13 @@ classes:
           - schema:contactPoint
       reviewing_organization:
         description: >-
-          Organization that conducted the ethical review (e.g., Institutional Review Board,
-          Ethics Committee, Research Ethics Board). Provides information about the body
-          responsible for ethical oversight.
-        range: Organization
+          Name or identifier of the organization that conducted the ethical
+          review (e.g., Institutional Review Board, Ethics Committee,
+          Research Ethics Board). A plain string: every one of the 245
+          corpus values here was a name, ROR or curie, and Organization no
+          longer carries the identifier that made string references
+          expressible (#360).
+        range: string
         slot_uri: schema:provider
         exact_mappings:
           - schema:provider
@@ -67,7 +70,6 @@ classes:
           Free-text description of the ethical review process, board decisions, outcomes,
           and any supporting documentation (e.g., IRB approval number, ethics committee name).
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "IRB approval: UAB IRB-300010084, UCSD IRB-811480, UW IRB-STUDY00017428"
@@ -85,7 +87,6 @@ classes:
           Free-text description of the data protection impact analysis, including methodology,
           privacy risks identified, mitigation measures taken, and any regulatory findings.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "DPIA conducted; minimal residual re-identification risk after de-identification"
@@ -107,7 +108,6 @@ classes:
           including the notification method (e.g., email, poster, in-person), timing,
           and the language or text of the notification itself if available.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Participants notified in-person at clinic visit; written information sheet provided in English and Spanish"
@@ -125,7 +125,6 @@ classes:
           Free-text description of how consent was requested (e.g., opt-in form, verbal
           agreement), provided, and documented, including the language individuals consented to.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Written informed consent obtained before any study procedures; available in English and Spanish"
@@ -143,7 +142,6 @@ classes:
           consent (e.g., opt-out portal, written request), the scope of revocation
           (full withdrawal or specific uses), and what happens to their data after revocation.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Participants may withdraw via written request; data retained but excluded from future analyses"

--- a/src/data_sheets_schema/schema/D4D_Human.yaml
+++ b/src/data_sheets_schema/schema/D4D_Human.yaml
@@ -62,7 +62,6 @@ classes:
           Include institution names and approval details.
         slot_uri: d4d:ethicsReviewBoard
         range: string
-        multivalued: true
       special_populations:
         description: >
           Does the research involve any special populations that require
@@ -96,7 +95,6 @@ classes:
           implied through participation)?
         slot_uri: d4d:consentType
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "Written informed consent with optional consent for future use of biospecimens"
       consent_documentation:
@@ -105,7 +103,6 @@ classes:
           or procedures used.
         slot_uri: d4d:consentDocumentation
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "Separate consent forms for main study, biorepository, and genetic analysis"
       withdrawal_mechanism:
@@ -114,14 +111,12 @@ classes:
           are in place for data deletion upon withdrawal?
         slot_uri: d4d:withdrawalMechanism
         range: string
-        multivalued: true
       consent_scope:
         description: >
           What specific uses did participants consent to? Are there
           limitations on data use based on consent?
         slot_uri: d4d:consentScope
         range: string
-        multivalued: true
 
 
   ParticipantPrivacy:
@@ -136,7 +131,6 @@ classes:
           Include technical details of privacy-preserving techniques.
         slot_uri: d4d:anonymizationMethod
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "De-identified per HIPAA Safe Harbor; 5-digit ZIP replaced with region codes"
       reidentification_risk:
@@ -145,7 +139,6 @@ classes:
           were taken to minimize this risk?
         slot_uri: d4d:reidentificationRisk
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "Low risk; expert determination per 45 CFR 164.514(b)(1)"
       privacy_techniques:
@@ -161,7 +154,6 @@ classes:
           compromise participant privacy?
         slot_uri: d4d:dataLinkage
         range: string
-        multivalued: true
 
 
   HumanSubjectCompensation:
@@ -179,7 +171,6 @@ classes:
           gift cards, course credit, other incentives)?
         slot_uri: d4d:compensationType
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "Monetary payment via gift card"
       compensation_amount:
@@ -188,7 +179,6 @@ classes:
           Include currency or equivalent value.
         slot_uri: d4d:compensationAmount
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "$75 for initial visit; $25 for annual follow-up"
       compensation_rationale:
@@ -197,7 +187,6 @@ classes:
           How was the amount determined to be appropriate?
         slot_uri: d4d:compensationRationale
         range: string
-        multivalued: true
 
 
   AtRiskPopulations:

--- a/src/data_sheets_schema/schema/D4D_Maintenance.yaml
+++ b/src/data_sheets_schema/schema/D4D_Maintenance.yaml
@@ -53,7 +53,6 @@ classes:
           Free-text description of the organization, team, or individual responsible for
           maintaining the dataset, including contact information and hosting arrangements.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "AI-READI Data Coordinating Center, University of Washington"
@@ -101,7 +100,6 @@ classes:
           Free-text description of planned update types (e.g., corrections, additions,
           deletions), responsible parties, and how updates will be communicated to users.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Quarterly releases with approximately 500 new participants per release"
@@ -127,7 +125,6 @@ classes:
           for those limits, and how they will be enforced (e.g., automated deletion,
           anonymization after the retention period).
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Data retained for minimum 10 years per NIH data sharing policy"
@@ -155,7 +152,6 @@ classes:
           Free-text description of version support policies, how long older versions will
           be hosted, and how dataset consumers will be notified when versions become obsolete.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "All versions available at fairhub.io; older versions archived on Zenodo"
@@ -180,7 +176,6 @@ classes:
           how contributions are validated (e.g., peer review, automated tests),
           and how accepted contributions will be communicated to the community.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "New modalities added via versioned data releases; schema extensions via GitHub PRs"

--- a/src/data_sheets_schema/schema/D4D_Motivation.yaml
+++ b/src/data_sheets_schema/schema/D4D_Motivation.yaml
@@ -90,7 +90,11 @@ classes:
     is_a: DatasetProperty
     attributes:
       principal_investigator:
-        description: "A key individual (Principal Investigator) responsible for or overseeing dataset creation."
+        description: >-
+          The name of the key individual (Principal Investigator)
+          responsible for or overseeing dataset creation — a person's name
+          such as 'Aaron Lee', never a yes/no flag. The slot name reads like
+          a boolean; the value is not one (#360).
         range: Person
         slot_uri: d4d:principalInvestigator
         broad_mappings:
@@ -123,8 +127,13 @@ classes:
     is_a: DatasetProperty
     attributes:
       grantor:
+        # range string, not Grantor: the description always said
+        # "name/identifier", all 328 corpus values were strings, and with
+        # Organization no longer identifiable a class range would force an
+        # inline object here (#360). The Grantor class remains defined for
+        # mappings and compatibility.
         description: "Name/identifier of the organization providing monetary or resource support."
-        range: Grantor
+        range: string
         slot_uri: d4d:grantor
         broad_mappings:
           - schema:funder
@@ -145,12 +154,30 @@ classes:
     # Additional attributes or specialized properties can be placed here if needed.
 
 
+  # Not a NamedThing, for the same reason as Organization (#360): the bundle
+  # names a grant and gives its grant_number far more often than it supplies
+  # a resolvable identifier, and the inherited required id produced 10
+  # validation failures across the corpus.
   Grant:
     description: >
       The name and/or identifier of the specific mechanism providing monetary support
       or other resources supporting creation of the dataset.
-    is_a: NamedThing
     attributes:
+      id:
+        slot_uri: schema:identifier
+        range: uriorcurie
+        recommended: true
+        description: >-
+          An identifier for the grant, when the source material supplies
+          one. The grant_number alone is a valid grant reference.
+      name:
+        slot_uri: schema:name
+        description: A human-readable name for the grant or funding mechanism.
+        range: string
+      description:
+        slot_uri: schema:description
+        description: A human-readable description of the grant.
+        range: string
       grant_number:
         description: "The alphanumeric identifier for the grant."
         range: string

--- a/src/data_sheets_schema/schema/D4D_Preprocessing.yaml
+++ b/src/data_sheets_schema/schema/D4D_Preprocessing.yaml
@@ -55,7 +55,6 @@ classes:
           including tools used, parameters, order of operations, and rationale
           for each step.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "DICOM to NIfTI conversion using dcm2niix v1.0.20211006"
@@ -75,7 +74,6 @@ classes:
           criteria for removing or correcting instances, tools used, and how
           removed instances are accounted for.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Outlier removal using 3-sigma rule; manual review of flagged records"
@@ -92,7 +90,6 @@ classes:
           One or more platforms or tools used for annotation (e.g., Label Studio, Prodigy,
           Amazon Mechanical Turk, custom annotation tool).
         range: string
-        multivalued: true
         slot_uri: rai:dataAnnotationPlatform
         annotations:
           "d4d:docExample": "Label Studio 1.7.3"
@@ -102,7 +99,6 @@ classes:
           Includes annotation guidelines, quality control procedures, and task definitions.
         slot_uri: d4d:dataAnnotationProtocol
         range: string
-        multivalued: true
         exact_mappings:
           - rai:dataAnnotationProtocol
       annotations_per_item:
@@ -137,7 +133,6 @@ classes:
           Free-text description of the labeling or annotation procedures, including
           annotation guidelines, task definitions, and quality control metrics.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Board-certified ophthalmologists graded retinal images using ETDRS scale"
@@ -160,7 +155,6 @@ classes:
           Free-text description of raw data availability, access procedures,
           and any conditions or restrictions on accessing the raw data.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
 
 

--- a/src/data_sheets_schema/schema/D4D_Uses.yaml
+++ b/src/data_sheets_schema/schema/D4D_Uses.yaml
@@ -81,7 +81,6 @@ classes:
           Free-text description of other potential tasks the dataset could support,
           including any prerequisites or limitations for those uses.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Longitudinal disease trajectory modeling"
@@ -103,7 +102,6 @@ classes:
           dataset's composition or collection (e.g., unfair treatment, privacy violations,
           legal or financial risks), and any recommended mitigation strategies.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Models trained on this data may reinforce existing health disparities if deployed without fairness audits"
@@ -120,7 +118,6 @@ classes:
           not recommended, with explanation of why (e.g., out-of-scope, risk of harm,
           poor coverage).
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "Not recommended for clinical diagnosis without additional validation"
@@ -154,7 +151,6 @@ classes:
           commercial, policy).
         slot_uri: d4d:useCategory
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "academic research"
 
@@ -173,6 +169,5 @@ classes:
           ethical concern, privacy risk, legal constraint).
         slot_uri: d4d:prohibitionReason
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "Re-identification of participants is strictly prohibited"

--- a/src/data_sheets_schema/schema/D4D_Variables.yaml
+++ b/src/data_sheets_schema/schema/D4D_Variables.yaml
@@ -162,7 +162,6 @@ classes:
           to this variable.
         slot_uri: d4d:qualityNotes
         range: string
-        multivalued: true
         broad_mappings:
           - dcterms:description
 

--- a/src/data_sheets_schema/schema/data_sheets_schema.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema.yaml
@@ -6,7 +6,7 @@ title: data-sheets-schema
 # version in pyproject.toml. Provenance records read this so a generated D4D
 # record states which schema version produced it, rather than pinning identity
 # by content hash alone. Bump on any change to classes, slots or enums.
-version: 1.0.0
+version: 2.0.0
 description: |-
   A LinkML schema for Datasheets for Datasets.
 license: MIT

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -1,10 +1,11 @@
+---
 name: data-sheets-schema
 description: A LinkML schema for Datasheets for Datasets.
 title: data-sheets-schema
 see_also:
 - https://bridge2ai.github.io/data-sheets-schema
 id: https://w3id.org/bridge2ai/data-sheets-schema
-version: 1.0.0
+version: 2.0.0
 license: MIT
 prefixes:
   AIO:
@@ -2467,11 +2468,12 @@ classes:
         owner: DatasetCollection
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -2481,7 +2483,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2556,11 +2557,12 @@ classes:
         owner: DatasetCollection
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -2570,7 +2572,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2645,12 +2646,13 @@ classes:
         owner: DatasetCollection
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -2660,7 +2662,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4201,11 +4202,12 @@ classes:
         owner: Dataset
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -4215,7 +4217,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4291,11 +4292,12 @@ classes:
         owner: Dataset
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -4305,7 +4307,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4380,12 +4381,13 @@ classes:
         owner: Dataset
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -4395,7 +4397,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5874,11 +5875,12 @@ classes:
         owner: DataSubset
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -5888,7 +5890,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5964,11 +5965,12 @@ classes:
         owner: DataSubset
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -5978,7 +5980,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6053,12 +6054,13 @@ classes:
         owner: DataSubset
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -6068,7 +6070,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6148,11 +6149,12 @@ classes:
         owner: NamedThing
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -6162,7 +6164,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6238,11 +6239,12 @@ classes:
         owner: NamedThing
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -6252,7 +6254,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6327,12 +6328,13 @@ classes:
         owner: NamedThing
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -6342,7 +6344,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6408,27 +6409,27 @@ classes:
     name: Organization
     description: Represents a group or organization.
     from_schema: https://w3id.org/bridge2ai/data-sheets-schema
-    is_a: NamedThing
     attributes:
       id:
         name: id
         annotations:
           d4d:docExample:
             tag: d4d:docExample
-            value: https://example.org/dataset/my-dataset-001
-        description: A unique identifier for a thing.
+            value: https://ror.org/01yc7t268
+        description: An identifier for the organization (for example a ROR), when
+          the source material supplies one. A name alone is a valid organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:identifier
-        identifier: true
         alias: id
         owner: Organization
         domain_of:
-        - NamedThing
-        - DatasetProperty
         - DatasetCollection
         - Dataset
         - DataSubset
+        - NamedThing
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -6437,88 +6438,27 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
         range: uriorcurie
-        required: true
+        recommended: true
       name:
         name: name
         annotations:
           d4d:docExample:
             tag: d4d:docExample
-            value: AI-READI Dataset
-        description: A human-readable name for a thing.
+            value: University of Washington
+        description: A human-readable name for the organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:name
         alias: name
         owner: Organization
         domain_of:
-        - NamedThing
-        - DatasetProperty
         - DatasetCollection
         - Dataset
         - DataSubset
+        - NamedThing
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -6527,88 +6467,23 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
         range: string
       description:
         name: description
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: A multimodal dataset of 4,000 participants with Type 2 Diabetes.
-        description: A human-readable description for a thing.
+        description: A human-readable description for the organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:description
         alias: description
         owner: Organization
         domain_of:
-        - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
+        - NamedThing
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -6617,67 +6492,6 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
         range: string
     class_uri: schema:Organization
   DatasetProperty:
@@ -6703,6 +6517,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -6712,7 +6527,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6786,6 +6600,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -6795,7 +6610,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6869,6 +6683,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -6879,7 +6694,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7088,11 +6902,12 @@ classes:
         owner: Software
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -7102,7 +6917,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7178,11 +6992,12 @@ classes:
         owner: Software
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -7192,7 +7007,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7267,12 +7081,13 @@ classes:
         owner: Software
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -7282,7 +7097,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7416,11 +7230,12 @@ classes:
         owner: Person
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -7430,7 +7245,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7506,11 +7320,12 @@ classes:
         owner: Person
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -7520,7 +7335,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7595,12 +7409,13 @@ classes:
         owner: Person
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -7610,7 +7425,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8106,11 +7920,12 @@ classes:
         owner: Information
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -8120,7 +7935,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8196,11 +8010,12 @@ classes:
         owner: Information
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -8210,7 +8025,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8285,12 +8099,13 @@ classes:
         owner: Information
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -8300,7 +8115,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8460,6 +8274,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8469,7 +8284,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8543,6 +8357,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8552,7 +8367,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8626,6 +8440,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -8636,7 +8451,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8813,6 +8627,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8822,7 +8637,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8896,6 +8710,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8905,7 +8720,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8979,6 +8793,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -8989,7 +8804,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9169,6 +8983,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9178,7 +8993,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9252,6 +9066,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9261,7 +9076,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9335,6 +9149,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -9345,7 +9160,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9492,8 +9306,10 @@ classes:
     attributes:
       principal_investigator:
         name: principal_investigator
-        description: A key individual (Principal Investigator) responsible for or
-          overseeing dataset creation.
+        description: The name of the key individual (Principal Investigator) responsible
+          for or overseeing dataset creation — a person's name such as 'Aaron Lee',
+          never a yes/no flag. The slot name reads like a boolean; the value is not
+          one (#360).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
         broad_mappings:
         - dcterms:creator
@@ -9549,6 +9365,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9558,7 +9375,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9632,6 +9448,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9641,7 +9458,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9715,6 +9531,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -9725,7 +9542,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9881,7 +9697,7 @@ classes:
         owner: FundingMechanism
         domain_of:
         - FundingMechanism
-        range: Grantor
+        range: string
       grants:
         name: grants
         description: Grant mechanisms supporting dataset creation. Multiple grants
@@ -9913,6 +9729,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9922,7 +9739,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9996,6 +9812,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10005,7 +9822,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10079,6 +9895,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -10089,7 +9906,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10238,20 +10054,21 @@ classes:
         annotations:
           d4d:docExample:
             tag: d4d:docExample
-            value: https://example.org/dataset/my-dataset-001
-        description: A unique identifier for a thing.
+            value: https://ror.org/01yc7t268
+        description: An identifier for the organization (for example a ROR), when
+          the source material supplies one. A name alone is a valid organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:identifier
-        identifier: true
         alias: id
         owner: Grantor
         domain_of:
-        - NamedThing
-        - DatasetProperty
         - DatasetCollection
         - Dataset
         - DataSubset
+        - NamedThing
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10260,88 +10077,27 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
         range: uriorcurie
-        required: true
+        recommended: true
       name:
         name: name
         annotations:
           d4d:docExample:
             tag: d4d:docExample
-            value: AI-READI Dataset
-        description: A human-readable name for a thing.
+            value: University of Washington
+        description: A human-readable name for the organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:name
         alias: name
         owner: Grantor
         domain_of:
-        - NamedThing
-        - DatasetProperty
         - DatasetCollection
         - Dataset
         - DataSubset
+        - NamedThing
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10350,88 +10106,23 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
         range: string
       description:
         name: description
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: A multimodal dataset of 4,000 participants with Type 2 Diabetes.
-        description: A human-readable description for a thing.
+        description: A human-readable description for the organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:description
         alias: description
         owner: Grantor
         domain_of:
-        - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
+        - NamedThing
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -10440,67 +10131,6 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
         range: string
   Grant:
     name: Grant
@@ -10509,8 +10139,85 @@ classes:
 
       '
     from_schema: https://w3id.org/bridge2ai/data-sheets-schema
-    is_a: NamedThing
     attributes:
+      id:
+        name: id
+        description: An identifier for the grant, when the source material supplies
+          one. The grant_number alone is a valid grant reference.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
+        slot_uri: schema:identifier
+        alias: id
+        owner: Grant
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Grant
+        range: uriorcurie
+        recommended: true
+      name:
+        name: name
+        description: A human-readable name for the grant or funding mechanism.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
+        slot_uri: schema:name
+        alias: name
+        owner: Grant
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Grant
+        range: string
+      description:
+        name: description
+        description: A human-readable description of the grant.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
+        slot_uri: schema:description
+        alias: description
+        owner: Grant
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Grant
+        - DatasetRelationship
+        range: string
       grant_number:
         name: grant_number
         annotations:
@@ -10526,275 +10233,6 @@ classes:
         owner: Grant
         domain_of:
         - Grant
-        range: string
-      id:
-        name: id
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: https://example.org/dataset/my-dataset-001
-        description: A unique identifier for a thing.
-        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
-        slot_uri: schema:identifier
-        identifier: true
-        alias: id
-        owner: Grant
-        domain_of:
-        - NamedThing
-        - DatasetProperty
-        - DatasetCollection
-        - Dataset
-        - DataSubset
-        - Organization
-        - Software
-        - Person
-        - Information
-        - Purpose
-        - Task
-        - AddressingGap
-        - Creator
-        - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
-        range: uriorcurie
-        required: true
-      name:
-        name: name
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: AI-READI Dataset
-        description: A human-readable name for a thing.
-        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
-        slot_uri: schema:name
-        alias: name
-        owner: Grant
-        domain_of:
-        - NamedThing
-        - DatasetProperty
-        - DatasetCollection
-        - Dataset
-        - DataSubset
-        - Organization
-        - Software
-        - Person
-        - Information
-        - Purpose
-        - Task
-        - AddressingGap
-        - Creator
-        - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
-        range: string
-      description:
-        name: description
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: A multimodal dataset of 4,000 participants with Type 2 Diabetes.
-        description: A human-readable description for a thing.
-        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
-        slot_uri: schema:description
-        alias: description
-        owner: Grant
-        domain_of:
-        - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
-        - DatasetCollection
-        - Dataset
-        - DataSubset
-        - Organization
-        - Software
-        - Person
-        - Information
-        - Purpose
-        - Task
-        - AddressingGap
-        - Creator
-        - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - File
         range: string
   Instance:
     name: Instance
@@ -10942,6 +10380,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10951,7 +10390,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11025,6 +10463,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11034,7 +10473,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11108,6 +10546,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -11118,7 +10557,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11304,7 +10742,6 @@ classes:
         domain_of:
         - SamplingStrategy
         range: string
-        multivalued: true
       is_representative:
         name: is_representative
         annotations:
@@ -11351,7 +10788,6 @@ classes:
         domain_of:
         - SamplingStrategy
         range: string
-        multivalued: true
       strategies:
         name: strategies
         annotations:
@@ -11388,6 +10824,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11397,7 +10834,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11471,6 +10907,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11480,7 +10917,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11554,6 +10990,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -11564,7 +11001,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11764,6 +11200,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11773,7 +11210,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11847,6 +11283,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11856,7 +11293,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11930,6 +11366,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -11940,7 +11377,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12103,7 +11539,6 @@ classes:
         domain_of:
         - Relationships
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -12122,6 +11557,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12131,7 +11567,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12205,6 +11640,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12214,7 +11650,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12288,6 +11723,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -12298,7 +11734,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12461,7 +11896,6 @@ classes:
         domain_of:
         - Splits
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -12480,6 +11914,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12489,7 +11924,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12563,6 +11997,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12572,7 +12007,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12646,6 +12080,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -12656,7 +12091,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12818,7 +12252,6 @@ classes:
         domain_of:
         - DataAnomaly
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -12837,6 +12270,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12846,7 +12280,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12920,6 +12353,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12929,7 +12363,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13003,6 +12436,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -13013,7 +12447,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13243,6 +12676,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -13252,7 +12686,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13326,6 +12759,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -13335,7 +12769,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13409,6 +12842,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -13419,7 +12853,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13645,6 +13078,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -13654,7 +13088,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13728,6 +13161,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -13737,7 +13171,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13811,6 +13244,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -13821,7 +13255,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13988,7 +13421,6 @@ classes:
         domain_of:
         - ExternalResource
         range: string
-        multivalued: true
       archival:
         name: archival
         description: 'Indicates whether official archival versions of external resources
@@ -14052,6 +13484,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14061,7 +13494,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14135,6 +13567,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14144,7 +13577,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14218,6 +13650,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -14228,7 +13661,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14400,7 +13832,6 @@ classes:
         domain_of:
         - Confidentiality
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -14419,6 +13850,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14428,7 +13860,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14502,6 +13933,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14511,7 +13943,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14585,6 +14016,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -14595,7 +14027,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14784,6 +14215,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14793,7 +14225,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14867,6 +14298,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14876,7 +14308,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14950,6 +14381,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -14960,7 +14392,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15128,7 +14559,6 @@ classes:
         domain_of:
         - Subpopulation
         range: string
-        multivalued: true
       distribution:
         name: distribution
         annotations:
@@ -15146,7 +14576,6 @@ classes:
         domain_of:
         - Subpopulation
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -15165,6 +14594,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15174,7 +14604,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15248,6 +14677,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15257,7 +14687,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15331,6 +14760,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -15341,7 +14771,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15533,7 +14962,6 @@ classes:
         domain_of:
         - Deidentification
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -15552,6 +14980,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15561,7 +14990,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15635,6 +15063,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15644,7 +15073,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15718,6 +15146,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -15728,7 +15157,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15900,7 +15328,6 @@ classes:
         domain_of:
         - SensitiveElement
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -15919,6 +15346,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15928,7 +15356,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16002,6 +15429,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16011,7 +15439,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16085,6 +15512,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -16095,7 +15523,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16332,6 +15759,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16341,7 +15769,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16415,6 +15842,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16424,7 +15852,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16630,7 +16057,6 @@ classes:
         domain_of:
         - InstanceAcquisition
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -16649,6 +16075,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16658,7 +16085,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16732,6 +16158,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16741,7 +16168,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16815,6 +16241,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -16825,7 +16252,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16990,7 +16416,6 @@ classes:
         domain_of:
         - CollectionMechanism
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -17009,6 +16434,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17018,7 +16444,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17092,6 +16517,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17101,7 +16527,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17175,6 +16600,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -17185,7 +16611,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17362,7 +16787,6 @@ classes:
         domain_of:
         - DataCollector
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -17381,6 +16805,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17390,7 +16815,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17464,6 +16888,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17473,7 +16898,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17547,6 +16971,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -17557,7 +16982,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17749,7 +17173,6 @@ classes:
         domain_of:
         - CollectionTimeframe
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -17768,6 +17191,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17777,7 +17201,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17851,6 +17274,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17860,7 +17284,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17934,6 +17357,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -17944,7 +17368,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18116,7 +17539,6 @@ classes:
         domain_of:
         - DirectCollection
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -18135,6 +17557,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18144,7 +17567,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18218,6 +17640,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18227,7 +17650,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18301,6 +17723,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -18311,7 +17734,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18474,7 +17896,6 @@ classes:
         domain_of:
         - MissingDataDocumentation
         range: string
-        multivalued: true
       missing_data_causes:
         name: missing_data_causes
         annotations:
@@ -18492,7 +17913,6 @@ classes:
         domain_of:
         - MissingDataDocumentation
         range: string
-        multivalued: true
       handling_strategy:
         name: handling_strategy
         annotations:
@@ -18528,6 +17948,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18537,7 +17958,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18611,6 +18031,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18620,7 +18041,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18694,6 +18114,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -18704,7 +18125,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18888,7 +18308,6 @@ classes:
         domain_of:
         - RawDataSource
         range: string
-        multivalued: true
       access_details:
         name: access_details
         annotations:
@@ -18922,7 +18341,6 @@ classes:
         domain_of:
         - RawDataSource
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -18941,6 +18359,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18950,7 +18369,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19024,6 +18442,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19033,7 +18452,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19107,6 +18525,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -19117,7 +18536,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19281,7 +18699,6 @@ classes:
         domain_of:
         - PreprocessingStrategy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -19300,6 +18717,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19309,7 +18727,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19383,6 +18800,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19392,7 +18810,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19466,6 +18883,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -19476,7 +18894,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19640,7 +19057,6 @@ classes:
         domain_of:
         - CleaningStrategy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -19659,6 +19075,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19668,7 +19085,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19742,6 +19158,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19751,7 +19168,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19825,6 +19241,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -19835,7 +19252,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19994,7 +19410,6 @@ classes:
         domain_of:
         - LabelingStrategy
         range: string
-        multivalued: true
       data_annotation_protocol:
         name: data_annotation_protocol
         description: Annotation methodology, tasks, and protocols followed during
@@ -20009,7 +19424,6 @@ classes:
         domain_of:
         - LabelingStrategy
         range: string
-        multivalued: true
       annotations_per_item:
         name: annotations_per_item
         annotations:
@@ -20076,7 +19490,6 @@ classes:
         domain_of:
         - LabelingStrategy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -20095,6 +19508,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20104,7 +19518,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20178,6 +19591,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20187,7 +19601,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20261,6 +19674,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -20271,7 +19685,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20442,7 +19855,6 @@ classes:
         domain_of:
         - RawData
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -20461,6 +19873,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20470,7 +19883,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20544,6 +19956,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20553,7 +19966,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20627,6 +20039,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -20637,7 +20050,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20866,6 +20278,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20875,7 +20288,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20949,6 +20361,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20958,7 +20371,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21032,6 +20444,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -21042,7 +20455,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21275,6 +20687,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21284,7 +20697,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21358,6 +20770,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21367,7 +20780,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21441,6 +20853,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -21451,7 +20864,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21672,6 +21084,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21681,7 +21094,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21755,6 +21167,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21764,7 +21177,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21838,6 +21250,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -21848,7 +21261,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22026,6 +21438,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22035,7 +21448,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22109,6 +21521,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22118,7 +21531,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22192,6 +21604,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -22202,7 +21615,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22390,6 +21802,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22399,7 +21812,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22473,6 +21885,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22482,7 +21895,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22556,6 +21968,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -22566,7 +21979,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22726,7 +22138,6 @@ classes:
         domain_of:
         - OtherTask
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -22745,6 +22156,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22754,7 +22166,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22828,6 +22239,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22837,7 +22249,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22911,6 +22322,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -22921,7 +22333,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23089,7 +22500,6 @@ classes:
         - FutureUseImpact
         - DataProtectionImpact
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -23108,6 +22518,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23117,7 +22528,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23191,6 +22601,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23200,7 +22611,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23274,6 +22684,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -23284,7 +22695,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23445,7 +22855,6 @@ classes:
         domain_of:
         - DiscouragedUse
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -23464,6 +22873,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23473,7 +22883,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23547,6 +22956,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23556,7 +22966,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23630,6 +23039,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -23640,7 +23050,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23832,7 +23241,6 @@ classes:
         domain_of:
         - IntendedUse
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -23851,6 +23259,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23860,7 +23269,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23934,6 +23342,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23943,7 +23352,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24017,6 +23425,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -24027,7 +23436,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24187,7 +23595,6 @@ classes:
         domain_of:
         - ProhibitedUse
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -24206,6 +23613,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24215,7 +23623,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24289,6 +23696,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24298,7 +23706,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24372,6 +23779,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -24382,7 +23790,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24558,6 +23965,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24567,7 +23975,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24641,6 +24048,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24650,7 +24058,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24724,6 +24131,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -24734,7 +24142,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24912,6 +24319,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24921,7 +24329,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24995,6 +24402,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25004,7 +24412,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25078,6 +24485,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -25088,7 +24496,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25268,6 +24675,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25277,7 +24685,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25351,6 +24758,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25360,7 +24768,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25434,6 +24841,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -25444,7 +24852,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25618,7 +25025,6 @@ classes:
         domain_of:
         - Maintainer
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -25637,6 +25043,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25646,7 +25053,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25720,6 +25126,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25729,7 +25136,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25803,6 +25209,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -25813,7 +25220,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26008,6 +25414,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26017,7 +25424,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26091,6 +25497,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26100,7 +25507,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26174,6 +25580,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -26184,7 +25591,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26364,7 +25770,6 @@ classes:
         domain_of:
         - UpdatePlan
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -26383,6 +25788,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26392,7 +25798,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26466,6 +25871,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26475,7 +25881,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26549,6 +25954,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -26559,7 +25965,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26737,7 +26142,6 @@ classes:
         domain_of:
         - RetentionLimits
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -26756,6 +26160,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26765,7 +26170,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26839,6 +26243,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26848,7 +26253,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26922,6 +26326,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -26932,7 +26337,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27122,7 +26526,6 @@ classes:
         domain_of:
         - VersionAccess
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -27141,6 +26544,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27150,7 +26554,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27224,6 +26627,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27233,7 +26637,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27307,6 +26710,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -27317,7 +26721,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27495,7 +26898,6 @@ classes:
         domain_of:
         - ExtensionMechanism
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -27514,6 +26916,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27523,7 +26926,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27597,6 +26999,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27606,7 +27009,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27680,6 +27082,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -27690,7 +27093,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27852,9 +27254,11 @@ classes:
         range: Person
       reviewing_organization:
         name: reviewing_organization
-        description: Organization that conducted the ethical review (e.g., Institutional
-          Review Board, Ethics Committee, Research Ethics Board). Provides information
-          about the body responsible for ethical oversight.
+        description: 'Name or identifier of the organization that conducted the ethical
+          review (e.g., Institutional Review Board, Ethics Committee, Research Ethics
+          Board). A plain string: every one of the 245 corpus values here was a name,
+          ROR or curie, and Organization no longer carries the identifier that made
+          string references expressible (#360).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/ethics
         exact_mappings:
         - schema:provider
@@ -27863,7 +27267,7 @@ classes:
         owner: EthicalReview
         domain_of:
         - EthicalReview
-        range: Organization
+        range: string
       review_details:
         name: review_details
         annotations:
@@ -27882,7 +27286,6 @@ classes:
         domain_of:
         - EthicalReview
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -27901,6 +27304,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27910,7 +27314,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27984,6 +27387,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27993,7 +27397,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28067,6 +27470,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -28077,7 +27481,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28242,7 +27645,6 @@ classes:
         - FutureUseImpact
         - DataProtectionImpact
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -28261,6 +27663,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28270,7 +27673,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28344,6 +27746,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28353,7 +27756,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28427,6 +27829,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -28437,7 +27840,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28602,7 +28004,6 @@ classes:
         domain_of:
         - CollectionNotification
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -28621,6 +28022,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28630,7 +28032,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28704,6 +28105,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28713,7 +28115,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28787,6 +28188,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -28797,7 +28199,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28961,7 +28362,6 @@ classes:
         domain_of:
         - CollectionConsent
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -28980,6 +28380,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28989,7 +28390,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29063,6 +28463,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -29072,7 +28473,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29146,6 +28546,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -29156,7 +28557,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29321,7 +28721,6 @@ classes:
         domain_of:
         - ConsentRevocation
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -29340,6 +28739,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -29349,7 +28749,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29423,6 +28822,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -29432,7 +28832,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29506,6 +28905,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -29516,7 +28916,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29702,7 +29101,6 @@ classes:
         domain_of:
         - HumanSubjectResearch
         range: string
-        multivalued: true
       special_populations:
         name: special_populations
         description: 'Does the research involve any special populations that require
@@ -29753,6 +29151,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -29762,7 +29161,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29836,6 +29234,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -29845,7 +29244,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29919,6 +29317,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -29929,7 +29328,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30101,7 +29499,6 @@ classes:
         domain_of:
         - InformedConsent
         range: string
-        multivalued: true
       consent_documentation:
         name: consent_documentation
         annotations:
@@ -30120,7 +29517,6 @@ classes:
         domain_of:
         - InformedConsent
         range: string
-        multivalued: true
       withdrawal_mechanism:
         name: withdrawal_mechanism
         description: 'How can participants withdraw their consent? What procedures
@@ -30134,7 +29530,6 @@ classes:
         domain_of:
         - InformedConsent
         range: string
-        multivalued: true
       consent_scope:
         name: consent_scope
         description: 'What specific uses did participants consent to? Are there limitations
@@ -30148,7 +29543,6 @@ classes:
         domain_of:
         - InformedConsent
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -30167,6 +29561,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -30176,7 +29571,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30250,6 +29644,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -30259,7 +29654,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30333,6 +29727,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -30343,7 +29738,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30505,7 +29899,6 @@ classes:
         domain_of:
         - ParticipantPrivacy
         range: string
-        multivalued: true
       reidentification_risk:
         name: reidentification_risk
         annotations:
@@ -30523,7 +29916,6 @@ classes:
         domain_of:
         - ParticipantPrivacy
         range: string
-        multivalued: true
       privacy_techniques:
         name: privacy_techniques
         description: 'What privacy-preserving techniques were applied (e.g., differential
@@ -30551,7 +29943,6 @@ classes:
         domain_of:
         - ParticipantPrivacy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -30570,6 +29961,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -30579,7 +29971,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30653,6 +30044,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -30662,7 +30054,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30736,6 +30127,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -30746,7 +30138,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30917,7 +30308,6 @@ classes:
         domain_of:
         - HumanSubjectCompensation
         range: string
-        multivalued: true
       compensation_amount:
         name: compensation_amount
         annotations:
@@ -30935,7 +30325,6 @@ classes:
         domain_of:
         - HumanSubjectCompensation
         range: string
-        multivalued: true
       compensation_rationale:
         name: compensation_rationale
         description: 'What was the rationale for the compensation structure? How was
@@ -30949,7 +30338,6 @@ classes:
         domain_of:
         - HumanSubjectCompensation
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -30968,6 +30356,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -30977,7 +30366,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31051,6 +30439,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -31060,7 +30449,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31134,6 +30522,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -31144,7 +30533,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31365,6 +30753,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -31374,7 +30763,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31448,6 +30836,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -31457,7 +30846,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31531,6 +30919,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -31541,7 +30930,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31705,7 +31093,6 @@ classes:
         domain_of:
         - LicenseAndUseTerms
         range: string
-        multivalued: true
       data_use_permission:
         name: data_use_permission
         annotations:
@@ -31760,6 +31147,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -31769,7 +31157,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31843,6 +31230,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -31852,7 +31240,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31926,6 +31313,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -31936,7 +31324,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -32120,6 +31507,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -32129,7 +31517,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -32203,6 +31590,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -32212,7 +31600,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -32286,6 +31673,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -32296,7 +31684,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -32492,7 +31879,6 @@ classes:
         domain_of:
         - ExportControlRegulatoryRestrictions
         range: string
-        multivalued: true
       confidentiality_level:
         name: confidentiality_level
         description: Confidentiality classification of the dataset indicating level
@@ -32536,6 +31922,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -32545,7 +31932,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -32619,6 +32005,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -32628,7 +32015,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -32702,6 +32088,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -32712,7 +32099,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -33062,7 +32448,6 @@ classes:
         domain_of:
         - VariableMetadata
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -33081,6 +32466,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -33090,7 +32476,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -33164,6 +32549,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -33173,7 +32559,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -33247,6 +32632,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -33257,7 +32643,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -33977,11 +33362,12 @@ classes:
         owner: File
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -33991,7 +33377,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -34067,11 +33452,12 @@ classes:
         owner: File
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -34081,7 +33467,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -34156,12 +33541,13 @@ classes:
         owner: File
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -34171,7 +33557,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -34778,11 +34163,12 @@ classes:
         owner: FileCollection
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -34792,7 +34178,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -34868,11 +34253,12 @@ classes:
         owner: FileCollection
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -34882,7 +34268,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -34957,12 +34342,13 @@ classes:
         owner: FileCollection
         domain_of:
         - NamedThing
+        - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - DatasetCollection
         - Dataset
         - DataSubset
-        - Organization
         - Software
         - Person
         - Information
@@ -34972,7 +34358,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -1867,8 +1867,9 @@ classes:
         owner: NamedThing
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -1878,7 +1879,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -1955,8 +1955,9 @@ classes:
         owner: NamedThing
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -1966,7 +1967,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2042,9 +2042,10 @@ classes:
         owner: NamedThing
         domain_of:
         - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -2054,7 +2055,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2121,24 +2121,24 @@ classes:
     name: Organization
     description: Represents a group or organization.
     from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
-    is_a: NamedThing
     attributes:
       id:
         name: id
         annotations:
           d4d:docExample:
             tag: d4d:docExample
-            value: https://example.org/dataset/my-dataset-001
-        description: A unique identifier for a thing.
+            value: https://ror.org/01yc7t268
+        description: An identifier for the organization (for example a ROR), when
+          the source material supplies one. A name alone is a valid organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:identifier
-        identifier: true
         alias: id
         owner: Organization
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -2147,86 +2147,24 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
         range: uriorcurie
-        required: true
+        recommended: true
       name:
         name: name
         annotations:
           d4d:docExample:
             tag: d4d:docExample
-            value: AI-READI Dataset
-        description: A human-readable name for a thing.
+            value: University of Washington
+        description: A human-readable name for the organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:name
         alias: name
         owner: Organization
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -2235,86 +2173,20 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
         range: string
       description:
         name: description
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: A multimodal dataset of 4,000 participants with Type 2 Diabetes.
-        description: A human-readable description for a thing.
+        description: A human-readable description for the organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:description
         alias: description
         owner: Organization
         domain_of:
         - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -2323,68 +2195,6 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
         range: string
     class_uri: schema:Organization
   DatasetProperty:
@@ -2407,6 +2217,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -2416,7 +2227,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2488,6 +2298,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -2497,7 +2308,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2569,6 +2379,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -2579,7 +2390,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2784,8 +2594,9 @@ classes:
         owner: Software
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -2795,7 +2606,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2858,7 +2668,6 @@ classes:
         - CoreDistribution
         - CoreDatasetCollection
         range: uriorcurie
-        required: true
       name:
         name: name
         annotations:
@@ -2872,8 +2681,9 @@ classes:
         owner: Software
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -2883,7 +2693,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -2959,9 +2768,10 @@ classes:
         owner: Software
         domain_of:
         - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -2971,7 +2781,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -3106,8 +2915,9 @@ classes:
         owner: Person
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -3117,7 +2927,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -3194,8 +3003,9 @@ classes:
         owner: Person
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -3205,7 +3015,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -3281,9 +3090,10 @@ classes:
         owner: Person
         domain_of:
         - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -3293,7 +3103,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -3730,8 +3539,9 @@ classes:
         owner: Information
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -3741,7 +3551,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -3818,8 +3627,9 @@ classes:
         owner: Information
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -3829,7 +3639,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -3905,9 +3714,10 @@ classes:
         owner: Information
         domain_of:
         - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -3917,7 +3727,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4075,6 +3884,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -4084,7 +3894,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4156,6 +3965,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -4165,7 +3975,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4237,6 +4046,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -4247,7 +4057,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4423,6 +4232,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -4432,7 +4242,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4504,6 +4313,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -4513,7 +4323,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4585,6 +4394,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -4595,7 +4405,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4774,6 +4583,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -4783,7 +4593,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4855,6 +4664,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -4864,7 +4674,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -4936,6 +4745,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -4946,7 +4756,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5095,8 +4904,10 @@ classes:
     attributes:
       principal_investigator:
         name: principal_investigator
-        description: A key individual (Principal Investigator) responsible for or
-          overseeing dataset creation.
+        description: The name of the key individual (Principal Investigator) responsible
+          for or overseeing dataset creation — a person's name such as 'Aaron Lee',
+          never a yes/no flag. The slot name reads like a boolean; the value is not
+          one (#360).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
         broad_mappings:
         - dcterms:creator
@@ -5149,6 +4960,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -5158,7 +4970,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5230,6 +5041,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -5239,7 +5051,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5311,6 +5122,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -5321,7 +5133,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5479,7 +5290,7 @@ classes:
         owner: FundingMechanism
         domain_of:
         - FundingMechanism
-        range: Grantor
+        range: string
       grants:
         name: grants
         description: Grant mechanisms supporting dataset creation. Multiple grants
@@ -5508,6 +5319,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -5517,7 +5329,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5589,6 +5400,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -5598,7 +5410,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5670,6 +5481,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -5680,7 +5492,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -5831,17 +5642,18 @@ classes:
         annotations:
           d4d:docExample:
             tag: d4d:docExample
-            value: https://example.org/dataset/my-dataset-001
-        description: A unique identifier for a thing.
+            value: https://ror.org/01yc7t268
+        description: An identifier for the organization (for example a ROR), when
+          the source material supplies one. A name alone is a valid organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:identifier
-        identifier: true
         alias: id
         owner: Grantor
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -5850,85 +5662,24 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
         range: uriorcurie
+        recommended: true
       name:
         name: name
         annotations:
           d4d:docExample:
             tag: d4d:docExample
-            value: AI-READI Dataset
-        description: A human-readable name for a thing.
+            value: University of Washington
+        description: A human-readable name for the organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:name
         alias: name
         owner: Grantor
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -5937,86 +5688,20 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
         range: string
       description:
         name: description
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: A multimodal dataset of 4,000 participants with Type 2 Diabetes.
-        description: A human-readable description for a thing.
+        description: A human-readable description for the organization.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:description
         alias: description
         owner: Grantor
         domain_of:
         - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -6025,68 +5710,6 @@ classes:
         - AddressingGap
         - Creator
         - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
         range: string
   Grant:
     name: Grant
@@ -6095,8 +5718,76 @@ classes:
 
       '
     from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
-    is_a: NamedThing
     attributes:
+      id:
+        name: id
+        description: An identifier for the grant, when the source material supplies
+          one. The grant_number alone is a valid grant reference.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
+        slot_uri: schema:identifier
+        alias: id
+        owner: Grant
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Grant
+        range: uriorcurie
+        recommended: true
+      name:
+        name: name
+        description: A human-readable name for the grant or funding mechanism.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
+        slot_uri: schema:name
+        alias: name
+        owner: Grant
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Grant
+        range: string
+      description:
+        name: description
+        description: A human-readable description of the grant.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
+        slot_uri: schema:description
+        alias: description
+        owner: Grant
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Grant
+        - DatasetRelationship
+        range: string
       grant_number:
         name: grant_number
         annotations:
@@ -6112,269 +5803,6 @@ classes:
         owner: Grant
         domain_of:
         - Grant
-        range: string
-      id:
-        name: id
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: https://example.org/dataset/my-dataset-001
-        description: A unique identifier for a thing.
-        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
-        slot_uri: schema:identifier
-        identifier: true
-        alias: id
-        owner: Grant
-        domain_of:
-        - NamedThing
-        - DatasetProperty
-        - Organization
-        - Software
-        - Person
-        - Information
-        - Purpose
-        - Task
-        - AddressingGap
-        - Creator
-        - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
-        range: uriorcurie
-        required: true
-      name:
-        name: name
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: AI-READI Dataset
-        description: A human-readable name for a thing.
-        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
-        slot_uri: schema:name
-        alias: name
-        owner: Grant
-        domain_of:
-        - NamedThing
-        - DatasetProperty
-        - Organization
-        - Software
-        - Person
-        - Information
-        - Purpose
-        - Task
-        - AddressingGap
-        - Creator
-        - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - DatasetRelationship
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
-        range: string
-      description:
-        name: description
-        annotations:
-          d4d:docExample:
-            tag: d4d:docExample
-            value: A multimodal dataset of 4,000 participants with Type 2 Diabetes.
-        description: A human-readable description for a thing.
-        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
-        slot_uri: schema:description
-        alias: description
-        owner: Grant
-        domain_of:
-        - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
-        - Organization
-        - Software
-        - Person
-        - Information
-        - Purpose
-        - Task
-        - AddressingGap
-        - Creator
-        - FundingMechanism
-        - Grantor
-        - Grant
-        - Instance
-        - SamplingStrategy
-        - MissingInfo
-        - Relationships
-        - Splits
-        - DataAnomaly
-        - DatasetBias
-        - DatasetLimitation
-        - ExternalResource
-        - Confidentiality
-        - ContentWarning
-        - Subpopulation
-        - Deidentification
-        - SensitiveElement
-        - InstanceAcquisition
-        - CollectionMechanism
-        - DataCollector
-        - CollectionTimeframe
-        - DirectCollection
-        - MissingDataDocumentation
-        - RawDataSource
-        - PreprocessingStrategy
-        - CleaningStrategy
-        - LabelingStrategy
-        - RawData
-        - ImputationProtocol
-        - AnnotationAnalysis
-        - MachineAnnotationTools
-        - ExistingUse
-        - UseRepository
-        - OtherTask
-        - FutureUseImpact
-        - DiscouragedUse
-        - IntendedUse
-        - ProhibitedUse
-        - ThirdPartySharing
-        - DistributionFormat
-        - DistributionDate
-        - Maintainer
-        - Erratum
-        - UpdatePlan
-        - RetentionLimits
-        - VersionAccess
-        - ExtensionMechanism
-        - EthicalReview
-        - DataProtectionImpact
-        - CollectionNotification
-        - CollectionConsent
-        - ConsentRevocation
-        - HumanSubjectResearch
-        - InformedConsent
-        - ParticipantPrivacy
-        - HumanSubjectCompensation
-        - AtRiskPopulations
-        - LicenseAndUseTerms
-        - IPRestrictions
-        - ExportControlRegulatoryRestrictions
-        - VariableMetadata
-        - CoreDistribution
-        - CoreDatasetCollection
         range: string
   Instance:
     name: Instance
@@ -6518,6 +5946,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -6527,7 +5956,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6599,6 +6027,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -6608,7 +6037,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6680,6 +6108,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -6690,7 +6119,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -6878,7 +6306,6 @@ classes:
         domain_of:
         - SamplingStrategy
         range: string
-        multivalued: true
       is_representative:
         name: is_representative
         annotations:
@@ -6925,7 +6352,6 @@ classes:
         domain_of:
         - SamplingStrategy
         range: string
-        multivalued: true
       strategies:
         name: strategies
         annotations:
@@ -6959,6 +6385,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -6968,7 +6395,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7040,6 +6466,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -7049,7 +6476,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7121,6 +6547,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -7131,7 +6558,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7330,6 +6756,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -7339,7 +6766,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7411,6 +6837,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -7420,7 +6847,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7492,6 +6918,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -7502,7 +6929,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7667,7 +7093,6 @@ classes:
         domain_of:
         - Relationships
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -7683,6 +7108,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -7692,7 +7118,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7764,6 +7189,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -7773,7 +7199,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -7845,6 +7270,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -7855,7 +7281,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8020,7 +7445,6 @@ classes:
         domain_of:
         - Splits
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -8036,6 +7460,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8045,7 +7470,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8117,6 +7541,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8126,7 +7551,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8198,6 +7622,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -8208,7 +7633,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8372,7 +7796,6 @@ classes:
         domain_of:
         - DataAnomaly
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -8388,6 +7811,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8397,7 +7821,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8469,6 +7892,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8478,7 +7902,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8550,6 +7973,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -8560,7 +7984,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8789,6 +8212,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8798,7 +8222,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8870,6 +8293,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -8879,7 +8303,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -8951,6 +8374,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -8961,7 +8385,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9186,6 +8609,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9195,7 +8619,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9267,6 +8690,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9276,7 +8700,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9348,6 +8771,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -9358,7 +8782,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9527,7 +8950,6 @@ classes:
         domain_of:
         - ExternalResource
         range: string
-        multivalued: true
       archival:
         name: archival
         description: 'Indicates whether official archival versions of external resources
@@ -9586,6 +9008,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9595,7 +9018,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9667,6 +9089,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9676,7 +9099,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9748,6 +9170,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -9758,7 +9181,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -9932,7 +9354,6 @@ classes:
         domain_of:
         - Confidentiality
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -9948,6 +9369,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -9957,7 +9379,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10029,6 +9450,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10038,7 +9460,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10110,6 +9531,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -10120,7 +9542,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10308,6 +9729,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10317,7 +9739,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10389,6 +9810,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10398,7 +9820,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10470,6 +9891,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -10480,7 +9902,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10650,7 +10071,6 @@ classes:
         domain_of:
         - Subpopulation
         range: string
-        multivalued: true
       distribution:
         name: distribution
         annotations:
@@ -10668,7 +10088,6 @@ classes:
         domain_of:
         - Subpopulation
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -10684,6 +10103,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10693,7 +10113,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10765,6 +10184,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -10774,7 +10194,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -10846,6 +10265,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -10856,7 +10276,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11050,7 +10469,6 @@ classes:
         domain_of:
         - Deidentification
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -11066,6 +10484,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11075,7 +10494,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11147,6 +10565,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11156,7 +10575,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11228,6 +10646,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -11238,7 +10657,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11412,7 +10830,6 @@ classes:
         domain_of:
         - SensitiveElement
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -11428,6 +10845,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11437,7 +10855,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11509,6 +10926,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11518,7 +10936,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11590,6 +11007,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -11600,7 +11018,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11749,8 +11166,18 @@ classes:
     attributes:
       target_dataset:
         name: target_dataset
-        description: The dataset that this relationship points to. Can be specified
-          by identifier, URL, or Dataset object.
+        description: The identifier or URL of the dataset this relationship points
+          to.
+        comments:
+        - 'A reference, not an inline dataset. The description used to promise "identifier,
+          URL, or Dataset object" while the range permitted only the first, and LinkML
+          cannot express the union: its JSON Schema generator always emits a top-level
+          type or $ref from the slot''s range, which ANDs with `any_of`, so whichever
+          branch the range names the other one fails. Verified both ways on VOICE
+          (#297).'
+        - 'A related dataset with its own DOI, protocol and approval is its own datasheet
+          and is referenced from here by identifier. That is the resolution of #292
+          for VOICE, whose pediatric companion has all three.'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/composition
         slot_uri: dcterms:relation
         alias: target_dataset
@@ -11823,6 +11250,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11832,7 +11260,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -11904,6 +11331,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -11913,7 +11341,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12121,7 +11548,6 @@ classes:
         domain_of:
         - InstanceAcquisition
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -12137,6 +11563,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12146,7 +11573,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12218,6 +11644,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12227,7 +11654,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12299,6 +11725,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -12309,7 +11736,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12476,7 +11902,6 @@ classes:
         domain_of:
         - CollectionMechanism
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -12492,6 +11917,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12501,7 +11927,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12573,6 +11998,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12582,7 +12008,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12654,6 +12079,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -12664,7 +12090,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12843,7 +12268,6 @@ classes:
         domain_of:
         - DataCollector
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -12859,6 +12283,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12868,7 +12293,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -12940,6 +12364,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -12949,7 +12374,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13021,6 +12445,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -13031,7 +12456,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13225,7 +12649,6 @@ classes:
         domain_of:
         - CollectionTimeframe
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -13241,6 +12664,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -13250,7 +12674,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13322,6 +12745,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -13331,7 +12755,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13403,6 +12826,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -13413,7 +12837,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13587,7 +13010,6 @@ classes:
         domain_of:
         - DirectCollection
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -13603,6 +13025,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -13612,7 +13035,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13684,6 +13106,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -13693,7 +13116,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13765,6 +13187,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -13775,7 +13198,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -13940,7 +13362,6 @@ classes:
         domain_of:
         - MissingDataDocumentation
         range: string
-        multivalued: true
       missing_data_causes:
         name: missing_data_causes
         annotations:
@@ -13958,7 +13379,6 @@ classes:
         domain_of:
         - MissingDataDocumentation
         range: string
-        multivalued: true
       handling_strategy:
         name: handling_strategy
         annotations:
@@ -13991,6 +13411,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14000,7 +13421,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14072,6 +13492,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14081,7 +13502,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14153,6 +13573,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -14163,7 +13584,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14349,7 +13769,6 @@ classes:
         domain_of:
         - RawDataSource
         range: string
-        multivalued: true
       access_details:
         name: access_details
         annotations:
@@ -14383,7 +13802,6 @@ classes:
         domain_of:
         - RawDataSource
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -14399,6 +13817,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14408,7 +13827,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14480,6 +13898,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14489,7 +13908,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14561,6 +13979,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -14571,7 +13990,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14737,7 +14155,6 @@ classes:
         domain_of:
         - PreprocessingStrategy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -14753,6 +14170,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14762,7 +14180,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14834,6 +14251,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -14843,7 +14261,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -14915,6 +14332,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -14925,7 +14343,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15091,7 +14508,6 @@ classes:
         domain_of:
         - CleaningStrategy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -15107,6 +14523,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15116,7 +14533,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15188,6 +14604,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15197,7 +14614,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15269,6 +14685,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -15279,7 +14696,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15440,7 +14856,6 @@ classes:
         domain_of:
         - LabelingStrategy
         range: string
-        multivalued: true
       data_annotation_protocol:
         name: data_annotation_protocol
         description: Annotation methodology, tasks, and protocols followed during
@@ -15455,7 +14870,6 @@ classes:
         domain_of:
         - LabelingStrategy
         range: string
-        multivalued: true
       annotations_per_item:
         name: annotations_per_item
         annotations:
@@ -15522,7 +14936,6 @@ classes:
         domain_of:
         - LabelingStrategy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -15538,6 +14951,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15547,7 +14961,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15619,6 +15032,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15628,7 +15042,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15700,6 +15113,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -15710,7 +15124,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15883,7 +15296,6 @@ classes:
         domain_of:
         - RawData
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -15899,6 +15311,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15908,7 +15321,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -15980,6 +15392,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -15989,7 +15402,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16061,6 +15473,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -16071,7 +15484,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16299,6 +15711,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16308,7 +15721,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16380,6 +15792,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16389,7 +15802,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16461,6 +15873,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -16471,7 +15884,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16703,6 +16115,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16712,7 +16125,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16784,6 +16196,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -16793,7 +16206,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -16865,6 +16277,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -16875,7 +16288,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17095,6 +16507,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17104,7 +16517,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17176,6 +16588,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17185,7 +16598,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17257,6 +16669,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -17267,7 +16680,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17444,6 +16856,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17453,7 +16866,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17525,6 +16937,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17534,7 +16947,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17606,6 +17018,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -17616,7 +17029,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17803,6 +17215,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17812,7 +17225,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17884,6 +17296,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -17893,7 +17306,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -17965,6 +17377,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -17975,7 +17388,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18137,7 +17549,6 @@ classes:
         domain_of:
         - OtherTask
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -18153,6 +17564,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18162,7 +17574,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18234,6 +17645,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18243,7 +17655,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18315,6 +17726,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -18325,7 +17737,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18495,7 +17906,6 @@ classes:
         - FutureUseImpact
         - DataProtectionImpact
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -18511,6 +17921,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18520,7 +17931,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18592,6 +18002,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18601,7 +18012,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18673,6 +18083,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -18683,7 +18094,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18846,7 +18256,6 @@ classes:
         domain_of:
         - DiscouragedUse
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -18862,6 +18271,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18871,7 +18281,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -18943,6 +18352,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -18952,7 +18362,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19024,6 +18433,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -19034,7 +18444,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19228,7 +18637,6 @@ classes:
         domain_of:
         - IntendedUse
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -19244,6 +18652,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19253,7 +18662,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19325,6 +18733,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19334,7 +18743,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19406,6 +18814,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -19416,7 +18825,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19578,7 +18986,6 @@ classes:
         domain_of:
         - ProhibitedUse
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -19594,6 +19001,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19603,7 +19011,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19675,6 +19082,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19684,7 +19092,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19756,6 +19163,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -19766,7 +19174,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -19941,6 +19348,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -19950,7 +19358,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20022,6 +19429,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20031,7 +19439,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20103,6 +19510,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -20113,7 +19521,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20290,6 +19697,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20299,7 +19707,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20371,6 +19778,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20380,7 +19788,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20452,6 +19859,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -20462,7 +19870,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20641,6 +20048,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20650,7 +20058,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20722,6 +20129,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -20731,7 +20139,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20803,6 +20210,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -20813,7 +20221,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -20989,7 +20396,6 @@ classes:
         domain_of:
         - Maintainer
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -21005,6 +20411,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21014,7 +20421,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21086,6 +20492,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21095,7 +20502,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21167,6 +20573,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -21177,7 +20584,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21371,6 +20777,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21380,7 +20787,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21452,6 +20858,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21461,7 +20868,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21533,6 +20939,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -21543,7 +20950,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21725,7 +21131,6 @@ classes:
         domain_of:
         - UpdatePlan
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -21741,6 +21146,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21750,7 +21156,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21822,6 +21227,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -21831,7 +21237,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -21903,6 +21308,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -21913,7 +21319,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22093,7 +21498,6 @@ classes:
         domain_of:
         - RetentionLimits
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -22109,6 +21513,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22118,7 +21523,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22190,6 +21594,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22199,7 +21604,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22271,6 +21675,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -22281,7 +21686,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22473,7 +21877,6 @@ classes:
         domain_of:
         - VersionAccess
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -22489,6 +21892,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22498,7 +21902,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22570,6 +21973,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22579,7 +21983,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22651,6 +22054,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -22661,7 +22065,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22841,7 +22244,6 @@ classes:
         domain_of:
         - ExtensionMechanism
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -22857,6 +22259,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22866,7 +22269,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -22938,6 +22340,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -22947,7 +22350,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23019,6 +22421,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -23029,7 +22432,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23193,9 +22595,11 @@ classes:
         range: Person
       reviewing_organization:
         name: reviewing_organization
-        description: Organization that conducted the ethical review (e.g., Institutional
-          Review Board, Ethics Committee, Research Ethics Board). Provides information
-          about the body responsible for ethical oversight.
+        description: 'Name or identifier of the organization that conducted the ethical
+          review (e.g., Institutional Review Board, Ethics Committee, Research Ethics
+          Board). A plain string: every one of the 245 corpus values here was a name,
+          ROR or curie, and Organization no longer carries the identifier that made
+          string references expressible (#360).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/ethics
         exact_mappings:
         - schema:provider
@@ -23204,7 +22608,7 @@ classes:
         owner: EthicalReview
         domain_of:
         - EthicalReview
-        range: Organization
+        range: string
       review_details:
         name: review_details
         annotations:
@@ -23223,7 +22627,6 @@ classes:
         domain_of:
         - EthicalReview
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -23239,6 +22642,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23248,7 +22652,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23320,6 +22723,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23329,7 +22733,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23401,6 +22804,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -23411,7 +22815,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23578,7 +22981,6 @@ classes:
         - FutureUseImpact
         - DataProtectionImpact
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -23594,6 +22996,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23603,7 +23006,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23675,6 +23077,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23684,7 +23087,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23756,6 +23158,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -23766,7 +23169,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -23933,7 +23335,6 @@ classes:
         domain_of:
         - CollectionNotification
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -23949,6 +23350,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -23958,7 +23360,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24030,6 +23431,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24039,7 +23441,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24111,6 +23512,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -24121,7 +23523,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24287,7 +23688,6 @@ classes:
         domain_of:
         - CollectionConsent
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -24303,6 +23703,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24312,7 +23713,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24384,6 +23784,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24393,7 +23794,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24465,6 +23865,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -24475,7 +23876,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24642,7 +24042,6 @@ classes:
         domain_of:
         - ConsentRevocation
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -24658,6 +24057,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24667,7 +24067,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24739,6 +24138,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -24748,7 +24148,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -24820,6 +24219,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -24830,7 +24230,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25018,7 +24417,6 @@ classes:
         domain_of:
         - HumanSubjectResearch
         range: string
-        multivalued: true
       special_populations:
         name: special_populations
         description: 'Does the research involve any special populations that require
@@ -25066,6 +24464,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25075,7 +24474,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25147,6 +24545,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25156,7 +24555,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25228,6 +24626,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -25238,7 +24637,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25412,7 +24810,6 @@ classes:
         domain_of:
         - InformedConsent
         range: string
-        multivalued: true
       consent_documentation:
         name: consent_documentation
         annotations:
@@ -25431,7 +24828,6 @@ classes:
         domain_of:
         - InformedConsent
         range: string
-        multivalued: true
       withdrawal_mechanism:
         name: withdrawal_mechanism
         description: 'How can participants withdraw their consent? What procedures
@@ -25445,7 +24841,6 @@ classes:
         domain_of:
         - InformedConsent
         range: string
-        multivalued: true
       consent_scope:
         name: consent_scope
         description: 'What specific uses did participants consent to? Are there limitations
@@ -25459,7 +24854,6 @@ classes:
         domain_of:
         - InformedConsent
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -25475,6 +24869,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25484,7 +24879,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25556,6 +24950,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25565,7 +24960,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25637,6 +25031,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -25647,7 +25042,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25811,7 +25205,6 @@ classes:
         domain_of:
         - ParticipantPrivacy
         range: string
-        multivalued: true
       reidentification_risk:
         name: reidentification_risk
         annotations:
@@ -25829,7 +25222,6 @@ classes:
         domain_of:
         - ParticipantPrivacy
         range: string
-        multivalued: true
       privacy_techniques:
         name: privacy_techniques
         description: 'What privacy-preserving techniques were applied (e.g., differential
@@ -25857,7 +25249,6 @@ classes:
         domain_of:
         - ParticipantPrivacy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -25873,6 +25264,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25882,7 +25274,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -25954,6 +25345,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -25963,7 +25355,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26035,6 +25426,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -26045,7 +25437,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26218,7 +25609,6 @@ classes:
         domain_of:
         - HumanSubjectCompensation
         range: string
-        multivalued: true
       compensation_amount:
         name: compensation_amount
         annotations:
@@ -26236,7 +25626,6 @@ classes:
         domain_of:
         - HumanSubjectCompensation
         range: string
-        multivalued: true
       compensation_rationale:
         name: compensation_rationale
         description: 'What was the rationale for the compensation structure? How was
@@ -26250,7 +25639,6 @@ classes:
         domain_of:
         - HumanSubjectCompensation
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -26266,6 +25654,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26275,7 +25664,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26347,6 +25735,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26356,7 +25745,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26428,6 +25816,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -26438,7 +25827,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26658,6 +26046,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26667,7 +26056,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26739,6 +26127,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -26748,7 +26137,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26820,6 +26208,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -26830,7 +26219,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -26996,7 +26384,6 @@ classes:
         domain_of:
         - LicenseAndUseTerms
         range: string
-        multivalued: true
       data_use_permission:
         name: data_use_permission
         annotations:
@@ -27048,6 +26435,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27057,7 +26445,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27129,6 +26516,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27138,7 +26526,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27210,6 +26597,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -27220,7 +26608,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27403,6 +26790,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27412,7 +26800,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27484,6 +26871,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27493,7 +26881,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27565,6 +26952,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -27575,7 +26963,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27772,7 +27159,6 @@ classes:
         domain_of:
         - ExportControlRegulatoryRestrictions
         range: string
-        multivalued: true
       confidentiality_level:
         name: confidentiality_level
         description: Confidentiality classification of the dataset indicating level
@@ -27813,6 +27199,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27822,7 +27209,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27894,6 +27280,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -27903,7 +27290,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -27975,6 +27361,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -27985,7 +27372,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28337,7 +27723,6 @@ classes:
         domain_of:
         - VariableMetadata
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -28353,6 +27738,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28362,7 +27748,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28434,6 +27819,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28443,7 +27829,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28515,6 +27900,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -28525,7 +27911,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28844,6 +28229,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28853,7 +28239,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -28925,6 +28310,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -28934,7 +28320,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29006,6 +28391,7 @@ classes:
         - NamedThing
         - Organization
         - DatasetProperty
+        - Grant
         - DatasetRelationship
         - Software
         - Person
@@ -29016,7 +28402,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29524,8 +28909,9 @@ classes:
         owner: CoreDatasetCollection
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -29535,7 +28921,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29612,8 +28997,9 @@ classes:
         owner: CoreDatasetCollection
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -29623,7 +29009,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -29699,9 +29084,10 @@ classes:
         owner: CoreDatasetCollection
         domain_of:
         - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -29711,7 +29097,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30907,8 +30292,9 @@ classes:
         owner: CoreDataset
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -30918,7 +30304,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -30995,8 +30380,9 @@ classes:
         owner: CoreDataset
         domain_of:
         - NamedThing
-        - DatasetProperty
         - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -31006,7 +30392,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo
@@ -31082,9 +30467,10 @@ classes:
         owner: CoreDataset
         domain_of:
         - NamedThing
-        - DatasetProperty
-        - DatasetRelationship
         - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
         - Software
         - Person
         - Information
@@ -31094,7 +30480,6 @@ classes:
         - Creator
         - FundingMechanism
         - Grantor
-        - Grant
         - Instance
         - SamplingStrategy
         - MissingInfo


### PR DESCRIPTION
Closes the fix half of #360. Every change is evidence-gated by the corpus inventory (#375: 583 findings over 299 records) and the array-usage census (99% of narrative-array uses were length-1).

## Changes

1. **55 narrative string slots scalarized** across 9 modules (the `*_details` family plus `use_category`, `source_type`, `raw_data_format`, `collection_type`, …). `restrictions`, `regulatory_restrictions`, `special_populations` keep arrays — genuine multi-item use observed.
2. **Organization and Grant stop inheriting NamedThing** (the in-repo `DatasetProperty` precedent): `id` optional + recommended, name-only organizations valid. This defuses 46 affiliation + 10 grant failures — including rep3's case where a *correct* `{name: …}` object failed only for lack of an id.
3. **String references where strings always lived**: LinkML can't express an optional identifier (`identifier: true` forces `required`, tested — the #297 wall), so de-identifying Organization flipped its reference slots to inline objects. `FundingMechanism.grantor` and `EthicalReview.reviewing_organization` become `range: string` — matching all 573 of their corpus values (RORs, names, curies) and their own "name/identifier" descriptions.
4. **`principal_investigator`**: description now names the boolean trap. No rename.
5. **Version 2.0.0** (breaking), full + core schemas regenerated.

## Verification

- **The decisive result:** the legacy v2 AI-READI record — "invalid" with dozens of findings under 1.0.0 — validates with **zero errors** under 2.0.0. The models' natural output was right all along; the schema was what was wrong. Symmetrically, our validator-driven "repairs" had been moving records *away* from the natural representation.
- Corpus re-scan under 2.0.0 (`trap_slot_inventory_v2_schema.yaml`, committed): the engineered regressions found mid-flight (grantor 328×, reviewing_organization 245× union mismatches from the identifier removal) are **0** after the string-reference fix. Remaining rows are legacy-content residuals plus the expected polarity flip: 213 array-compliant records now fail scalar slots — they validate under the 1.0.0 digest their provenance pins, and the sweep reruns under 2.0.0.
- Targeted check: `{name: University of Washington}` affiliation + `principal_investigator: Aaron Lee` → **No issues found**, both schemas.
- Full python suite: 1273 tests OK. `lint-modules` fails identically on main (86 pre-existing naming/prefix warnings).

## Expected effect on the rerun

The 55%+ repair-share tax and the two-invocation pattern should largely disappear; repair remains for the kept-array slots and genuine model errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)