### PR TITLE
Resolve organization identifiers from the vendored B2AI Standards registry (#378)

### DIFF
--- a/src/data_sheets_schema/cli/__init__.py
+++ b/src/data_sheets_schema/cli/__init__.py
@@ -18,7 +18,7 @@ def cli():
     pass
 
 # Import and register subcommands
-from . import download, evaluate, utils, rocrate, schema, render, healthsheet, runs, provenance, api
+from . import download, evaluate, utils, rocrate, schema, render, healthsheet, runs, provenance, api, enrich
 
 cli.add_command(download.download)
 cli.add_command(evaluate.evaluate)
@@ -26,6 +26,7 @@ cli.add_command(utils.utils)
 cli.add_command(rocrate.rocrate)
 cli.add_command(healthsheet.healthsheet)
 cli.add_command(runs.runs)
+cli.add_command(enrich.enrich)
 cli.add_command(provenance.provenance)
 cli.add_command(schema.schema)
 cli.add_command(render.render)

--- a/src/data_sheets_schema/cli/enrich.py
+++ b/src/data_sheets_schema/cli/enrich.py
@@ -1,0 +1,53 @@
+"""Enrichment commands — deterministic, provenance-marked additions (#378)."""
+
+from pathlib import Path
+
+import click
+
+
+@click.group()
+def enrich():
+    """Deterministic post-generation enrichment. Never runs inside generation."""
+
+
+@enrich.command("orgs")
+@click.argument("record", type=click.Path(exists=True))
+@click.option("-o", "--output", type=click.Path(), default=None,
+              help="write the enriched record here (default: dry run). A "
+                   "sidecar {output}.enrichment.yaml records what was added "
+                   "and from which registry snapshot. The original file is "
+                   "never touched — run provenance pins its bytes.")
+def orgs_cmd(record, output):
+    """Fill Organization ids with B2AI_ORG CURIEs from the vendored registry.
+
+    Strict lookup only (name, full name, or embedded ROR); organizations the
+    registry does not know keep their name and no id. Enrichment is not
+    extraction: the additions are recorded as such, never silently.
+    """
+    import yaml as _yaml
+
+    from data_sheets_schema.org_registry import (
+        OrgResolver, enrich_record, enrichment_block)
+
+    resolver = OrgResolver()
+    text = Path(record).read_text(encoding="utf-8")
+    data = _yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise click.ClickException(f"{record} is not a mapping")
+    _, log = enrich_record(data, resolver)
+    if not log:
+        click.echo("no organizations resolved; nothing to enrich")
+        return
+    for e in log:
+        click.echo(f"   {e['id']:<14} {e['name']}  ({e['path']})")
+    if not output:
+        click.echo(f"dry run: {len(log)} organization(s) would be enriched; "
+                   "pass -o to write")
+        return
+    out = Path(output)
+    out.write_text(_yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+                   encoding="utf-8")
+    side = out.with_suffix(out.suffix + ".enrichment.yaml")
+    side.write_text(_yaml.safe_dump(enrichment_block(log, resolver),
+                                    sort_keys=False), encoding="utf-8")
+    click.echo(f"✓ {len(log)} enriched -> {out} (+ {side.name})")

--- a/src/data_sheets_schema/org_registry.py
+++ b/src/data_sheets_schema/org_registry.py
@@ -1,0 +1,120 @@
+"""Resolve organization identifiers from the B2AI Standards registry (#378).
+
+The registry (https://github.com/bridge2ai/b2ai-standards-registry,
+``src/data/Organization.yaml``) assigns stable ``B2AI_ORG:N`` CURIEs to
+curated organizations, alongside ROR and Wikidata identifiers. A vendored
+snapshot lives beside this module so resolution is deterministic and
+offline; the snapshot's hash and fetch date are recorded in every
+enrichment, because "which registry" is part of the claim.
+
+Resolution is deliberately strict — exact match on normalized ``name``
+(acronym), ``description`` (full name) or ROR id. No fuzzy matching: a
+wrong identifier asserted confidently is worse than a name left alone,
+and this pass may never invent what the registry does not state.
+
+Enrichment is not extraction. Filling ``Organization.id`` from a lookup
+adds a fact no source document stated, so it happens only in this explicit
+post-generation pass, is recorded in provenance, and never runs inside the
+generation phases.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REGISTRY_PATH = Path(__file__).parent / "registry" / "b2ai_organizations.yaml"
+REGISTRY_SOURCE = ("https://github.com/bridge2ai/b2ai-standards-registry/"
+                   "blob/main/src/data/Organization.yaml")
+REGISTRY_FETCHED = "2026-08-06"
+
+_ROR_IN_TEXT = re.compile(r"ror\.org/([0-9a-z]+)")
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", str(s).lower()).strip()
+
+
+class OrgResolver:
+    """Name/ROR -> B2AI_ORG CURIE, from the vendored snapshot."""
+
+    def __init__(self, path: Path = REGISTRY_PATH):
+        raw = path.read_bytes()
+        self.snapshot_sha256 = hashlib.sha256(raw).hexdigest()
+        orgs = yaml.safe_load(raw)["organizations"]
+        self._by_name: dict[str, dict[str, Any]] = {}
+        self._by_ror: dict[str, dict[str, Any]] = {}
+        for o in orgs:
+            for key in ("name", "description"):
+                if o.get(key):
+                    # First writer wins: the registry occasionally reuses a
+                    # description; a collision must not silently re-point.
+                    self._by_name.setdefault(_norm(o[key]), o)
+            if o.get("ror_id"):
+                self._by_ror[str(o["ror_id"]).replace("ror:", "")] = o
+
+    def resolve(self, text: str) -> dict[str, Any] | None:
+        """The registry entry for a name, full name or embedded ROR, or None."""
+        if not text or not isinstance(text, str):
+            return None
+        ror = _ROR_IN_TEXT.search(text)
+        if ror and ror.group(1) in self._by_ror:
+            return self._by_ror[ror.group(1)]
+        return self._by_name.get(_norm(text))
+
+
+def enrich_record(record: dict[str, Any],
+                  resolver: OrgResolver | None = None,
+                  ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Fill Organization.id with B2AI_ORG CURIEs where the registry matches.
+
+    Touches only inline organization objects that have a ``name``, no ``id``,
+    and at most the Organization class's own keys — and only when the name
+    resolves. Returns (record, enrichments); each enrichment names the path,
+    the name matched, and the CURIE written, ready for provenance. The
+    record is modified in place and also returned.
+    """
+    resolver = resolver or OrgResolver()
+    log: list[dict[str, Any]] = []
+
+    def walk(v: Any, path: str) -> None:
+        if isinstance(v, dict):
+            keys = set(v)
+            if ("name" in keys and "id" not in keys
+                    and keys <= {"name", "description"}):
+                hit = resolver.resolve(v["name"])
+                if hit:
+                    v["id"] = hit["id"]
+                    log.append({"path": path, "name": v["name"],
+                                "id": hit["id"],
+                                "ror_id": hit.get("ror_id")})
+            for k, x in v.items():
+                walk(x, f"{path}/{k}")
+        elif isinstance(v, list):
+            for i, x in enumerate(v):
+                walk(x, f"{path}/{i}")
+
+    walk(record, "")
+    return record, log
+
+
+def enrichment_block(log: list[dict[str, Any]],
+                     resolver: OrgResolver) -> dict[str, Any]:
+    """The provenance block an enrichment pass writes beside its edits."""
+    return {
+        "kind": "organization_identifiers",
+        "source": REGISTRY_SOURCE,
+        "snapshot_sha256": resolver.snapshot_sha256,
+        "snapshot_fetched": REGISTRY_FETCHED,
+        "performed_at": datetime.now(timezone.utc).isoformat(
+            timespec="seconds"),
+        "note": ("Identifiers added by deterministic registry lookup — "
+                 "enrichment, not extraction; no source document stated "
+                 "them."),
+        "resolved": log,
+    }

--- a/src/data_sheets_schema/registry/b2ai_organizations.yaml
+++ b/src/data_sheets_schema/registry/b2ai_organizations.yaml
@@ -1,0 +1,1214 @@
+organizations:
+  - id: B2AI_ORG:1
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Seven Bridges Genomics
+    name: 7B
+    ror_id: ror:02r7ybh06
+    url: https://www.sevenbridges.com/
+    wikidata_id: wikidata:Q50039372
+  - id: B2AI_ORG:2
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: US Agency for Healthcare Research and Quality
+    name: AHRQ
+    ror_id: ror:03jmfdf59
+    subclass_of:
+      - B2AI_ORG:39
+    url: https://www.ahrq.gov/
+    wikidata_id: wikidata:Q4692008
+  - id: B2AI_ORG:3
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: American Medical Association
+    name: AMA
+    ror_id: ror:03p6gt485
+    url: https://www.ama-assn.org/
+    wikidata_id: wikidata:Q465697
+  - id: B2AI_ORG:4
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: American National Standards Institute
+    name: ANSI
+    ror_id: ror:02ttqft70
+    url: https://www.ansi.org/
+    wikidata_id: wikidata:Q180003
+  - id: B2AI_ORG:5
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Apache Software Foundation
+    name: Apache
+    url: https://www.apache.org/
+    wikidata_id: wikidata:Q489709
+  - id: B2AI_ORG:6
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Australian Research Data Commons
+    name: ARDC
+    ror_id: ror:038sjwq14
+    url: https://ardc.edu.au/
+    wikidata_id: wikidata:Q4824459
+  - id: B2AI_ORG:7
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Acoustical Society of America
+    name: ASA
+    ror_id: ror:049e4we54
+    url: https://acousticalsociety.org/
+    wikidata_id: wikidata:Q4064243
+  - id: B2AI_ORG:8
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: ASTM International
+    name: ASTM
+    ror_id: ror:01x994m09
+    url: https://www.astm.org/
+    wikidata_id: wikidata:Q621977
+  - id: B2AI_ORG:9
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Biological Magnetic Resonance Data Bank
+    name: BMRB
+    url: https://bmrb.io/
+    wikidata_id: wikidata:Q48814267
+  - id: B2AI_ORG:10
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: BPM+
+    name: BPM+
+    url: https://www.bpm-plus.org/
+  - id: B2AI_ORG:11
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Code Analysis Repository and Modelling for E-Neuroscience project
+    name: CARMEN
+    url: https://www.jstor.org/stable/25704705
+  - id: B2AI_ORG:12
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Centers for Disease Control and Prevention
+    name: CDC
+    ror_id: ror:042twtr12
+    url: https://www.cdc.gov/
+    wikidata_id: wikidata:Q583725
+  - id: B2AI_ORG:13
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: CDC Immunization Information Systems
+    name: CDC IIS
+    subclass_of:
+      - B2AI_ORG:12
+    url: https://www.cdc.gov/vaccines/programs/iis/index.html
+  - id: B2AI_ORG:14
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: CDC National Center for Health Statistics
+    name: CDC NCHS
+    ror_id: ror:03p15s250
+    subclass_of:
+      - B2AI_ORG:12
+    url: https://www.cdc.gov/nchs/index.htm
+    wikidata_id: wikidata:Q3336854
+  - id: B2AI_ORG:15
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Clinical Data Interchange Standards Consortium
+    name: CDISC
+    url: https://www.cdisc.org/
+    wikidata_id: wikidata:Q571067
+  - id: B2AI_ORG:16
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Clinical and Laboratory Standards Institute
+    name: CLSI
+    ror_id: ror:04j5ay321
+    url: https://clsi.org/
+    wikidata_id: wikidata:Q5133808
+  - id: B2AI_ORG:17
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: U.S. Centers for Medicare & Medicaid Services
+    name: CMS
+    ror_id: ror:02g02rq35
+    url: https://www.cms.gov/
+    wikidata_id: wikidata:Q5060058
+  - id: B2AI_ORG:18
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Department of Biomedical Informatics at Columbia University Medical Center
+    name: Columbia DBMI
+    url: https://www.dbmi.columbia.edu/
+  - id: B2AI_ORG:19
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: COmputational Modeling in BIology NEtwork
+    name: COMBINE
+    url: https://co.mbine.org/
+    wikidata_id: wikidata:Q16950320
+  - id: B2AI_ORG:20
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: COMPUTIS project
+    name: COMPUTIS
+    url: https://www.computis.org/
+  - id: B2AI_ORG:21
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: COordination Of Standards In MetabOlomicS Project
+    name: COSMOS
+    url: https://link.springer.com/article/10.1007/s11306-015-0810-y
+  - id: B2AI_ORG:22
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Data Management Association International
+    name: DAMA
+    url: https://www.dama.org/cpages/home
+    wikidata_id: wikidata:Q111966878
+  - id: B2AI_ORG:23
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Data Documentation Initiative Alliance
+    name: DDI
+    url: https://ddialliance.org/
+    wikidata_id: wikidata:Q1172209
+  - id: B2AI_ORG:24
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: DeepMind Technologies
+    name: DeepMind
+    ror_id: ror:00971b260
+    subclass_of:
+      - B2AI_ORG:37
+    url: https://www.deepmind.com/
+    wikidata_id: wikidata:Q15733006
+  - id: B2AI_ORG:25
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Digital Imaging and Communications in Medicine Standards Committee
+    name: DICOM
+    url: https://www.dicomstandard.org/
+  - id: B2AI_ORG:26
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: DirectTrust
+    name: DirectTrust
+    url: https://directtrust.org/
+  - id: B2AI_ORG:27
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Emergency Care Research Institute
+    name: ECRI
+    ror_id: ror:03f47x024
+    url: https://www.ecri.org/
+    wikidata_id: wikidata:Q5322742
+  - id: B2AI_ORG:28
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: European life-sciences Infrastructure for biological Information
+    name: ELIXIR
+    ror_id: ror:044rwnt51
+    url: https://elixir-europe.org/
+    wikidata_id: wikidata:Q12269561
+  - id: B2AI_ORG:29
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: European Molecular Biology Laboratory European Bioinformatics Institute
+    name: EMBL-EBI
+    ror_id: ror:03mstc592
+    url: https://www.ebi.ac.uk/
+    wikidata_id: wikidata:Q695267
+  - id: B2AI_ORG:30
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Functional Assessment of Chronic Illness Therapy
+    name: FACIT
+    url: https://www.facit.org/
+  - id: B2AI_ORG:31
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: United States Food and Drug Administration
+    name: FDA
+    ror_id: ror:034xvzb47
+    url: https://www.fda.gov/
+    wikidata_id: wikidata:Q204711
+  - id: B2AI_ORG:32
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Future of Scholarly Communication and e-Scholarship
+    name: FORCE11
+    url: https://force11.org/
+  - id: B2AI_ORG:33
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Fraunhofer Institute for Algorithms and Scientific Computing
+    name: FSCAI
+    url: https://www.scai.fraunhofer.de/en.html
+  - id: B2AI_ORG:34
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Global Alliance for Genomics and Health
+    name: GA4GH
+    url: https://www.ga4gh.org/
+    wikidata_id: wikidata:Q60750423
+  - id: B2AI_ORG:35
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: GMDN Agency Ltd.
+    name: GMDNA
+    url: https://www.gmdnagency.org/
+  - id: B2AI_ORG:36
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Gene Ontology Consortium
+    name: GO
+    url: http://geneontology.org/
+    wikidata_id: wikidata:Q23809253
+  - id: B2AI_ORG:37
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Google LLC
+    name: Google
+    ror_id: ror:00njsd438
+    url: https://www.google.com/
+    wikidata_id: wikidata:Q95
+  - id: B2AI_ORG:38
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Genomic Standards Consortium
+    name: GSC
+    url: https://www.gensc.org/
+    wikidata_id: wikidata:Q5533496
+  - id: B2AI_ORG:39
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: United States Department of Health and Human Services
+    name: HHS
+    ror_id: ror:033jnv181
+    url: https://www.hhs.gov/
+    wikidata_id: wikidata:Q942326
+  - id: B2AI_ORG:40
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Health Level Seven
+    name: HL7
+    ror_id: ror:029ga8k16
+    url: https://www.hl7.org/
+    wikidata_id: wikidata:Q17054989
+  - id: B2AI_ORG:41
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Human Proteome Organization Proteomics Standards Initiative
+    name: HUPO-PSI
+    url: https://www.psidev.info/
+  - id: B2AI_ORG:42
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Informatics for Integrating Biology & the Bedside
+    name: i2b2
+    url: https://www.i2b2.org/
+  - id: B2AI_ORG:43
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Internet Archive
+    name: IA
+    ror_id: ror:02z468g17
+    url: https://archive.org/
+    wikidata_id: wikidata:Q461
+  - id: B2AI_ORG:44
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Institute of Electrical and Electronics Engineers
+    name: IEEE
+    ror_id: ror:01n002310
+    url: https://www.ieee.org/
+    wikidata_id: wikidata:Q131566
+  - id: B2AI_ORG:45
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Internet Engineering Task Force
+    name: IETF
+    url: https://www.ietf.org/
+  - id: B2AI_ORG:46
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Integrating the Healthcare Enterprise
+    name: IHE
+    url: https://www.ihe.net/
+  - id: B2AI_ORG:47
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: ISA Commons
+    name: ISA Commons
+    url: https://www.isacommons.org/
+  - id: B2AI_ORG:48
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: International Society for Biological and Environmental Repositories
+    name: ISBER
+    url: https://www.isber.org/
+    wikidata_id: wikidata:Q17087916
+  - id: B2AI_ORG:49
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: International Organization for Standardization
+    name: ISO
+    url: https://www.iso.org/home.html
+    wikidata_id: wikidata:Q15028
+  - id: B2AI_ORG:50
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: International Telecommunication Union
+    name: ITU
+    ror_id: ror:005vs4q67
+    url: https://www.itu.int/
+    wikidata_id: wikidata:Q376150
+  - id: B2AI_ORG:51
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: International Union of Pure and Applied Chemistry
+    name: IUPAC
+    ror_id: ror:03ne2zw20
+    url: https://iupac.org/
+    wikidata_id: wikidata:Q33438
+  - id: B2AI_ORG:52
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Kyoto Encyclopedia of Genes and Genomes
+    name: KEGG
+    url: https://www.genome.jp/kegg/
+    wikidata_id: wikidata:Q909442
+  - id: B2AI_ORG:53
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Logical Observation Identifiers Names and Codes
+    name: LOINC
+    subclass_of:
+      - B2AI_ORG:84
+    url: https://loinc.org/
+    wikidata_id: wikidata:Q502480
+  - id: B2AI_ORG:54
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: The Medical Device Plug-and-Play Interoperability & Cybersecurity Program
+    name: MD PnP
+    url: https://mdpnp.org/
+  - id: B2AI_ORG:55
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Meta Platforms, Inc., doing business as Meta and formerly named Facebook, Inc.
+    name: Meta
+    ror_id: ror:01zbnvs85
+    url: https://www.meta.com/
+    wikidata_id: wikidata:Q380
+  - id: B2AI_ORG:56
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Microsoft Corporation
+    name: Microsoft
+    ror_id: ror:00d0nc645
+    url: https://www.microsoft.com/
+    wikidata_id: wikidata:Q2283
+  - id: B2AI_ORG:57
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Massachusetts Institute of Technology Laboratory for Computational Physiology
+    name: MIT-LCP
+    url: https://lcp.mit.edu/
+  - id: B2AI_ORG:58
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Monarch Initiative
+    name: Monarch
+    url: https://monarchinitiative.org/
+  - id: B2AI_ORG:59
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Mozilla Foundation
+    name: Mozilla
+    ror_id: ror:01y8r3379
+    url: https://foundation.mozilla.org/en/
+    wikidata_id: wikidata:Q55672
+  - id: B2AI_ORG:60
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Academies of Sciences, Engineering, and Medicine
+    name: NASEM
+    ror_id: ror:02eq2w707
+    url: https://www.nationalacademies.org/
+    wikidata_id: wikidata:Q3233780
+  - id: B2AI_ORG:61
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Nomenclature Committee of the International Union of Biochemistry and Molecular Biology
+    name: NC-IUBMB
+    url: https://iubmb.qmul.ac.uk/
+  - id: B2AI_ORG:62
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Center for Ecological Analysis and Synthesis
+    name: NCEAS
+    ror_id: ror:0146z4r19
+    url: https://www.nceas.ucsb.edu/
+    wikidata_id: wikidata:Q6971323
+  - id: B2AI_ORG:63
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Council for Prescription Drug Programs
+    name: NCPDP
+    url: https://www.ncpdp.org/
+  - id: B2AI_ORG:64
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Evaluation System for health Technology Coordinating Center
+    name: NESTcc
+    url: https://nestcc.org/
+  - id: B2AI_ORG:65
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Netflix, Inc.
+    name: Netflix
+    ror_id: ror:0197qw696
+    url: https://www.netflix.com/
+    wikidata_id: wikidata:Q907311
+  - id: B2AI_ORG:66
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Highway Traffic Safety Administration
+    name: NHTSA
+    ror_id: ror:04gcfqs37
+    url: https://www.nhtsa.gov/
+    wikidata_id: wikidata:Q1967350
+  - id: B2AI_ORG:67
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Institutes of Health
+    name: NIH
+    ror_id: ror:01cwqze88
+    subclass_of:
+      - B2AI_ORG:39
+    url: https://www.nih.gov/
+    wikidata_id: wikidata:Q390551
+  - id: B2AI_ORG:68
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: NIH Common Fund
+    name: NIH Common Fund
+    subclass_of:
+      - B2AI_ORG:67
+    url: https://commonfund.nih.gov/
+    wikidata_id: wikidata:Q16932298
+  - id: B2AI_ORG:69
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Center for Advancing Translational Sciences
+    name: NIH NCATS
+    ror_id: ror:04pw6fb54
+    subclass_of:
+      - B2AI_ORG:67
+    url: https://ncats.nih.gov/
+    wikidata_id: wikidata:Q16932123
+  - id: B2AI_ORG:70
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: NIH NCATS Biomedical Data Translator Consortium
+    name: NIH NCATS Translator
+    subclass_of:
+      - B2AI_ORG:69
+    url: https://ncats.nih.gov/translator
+  - id: B2AI_ORG:71
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: NIH National Cancer Institute
+    name: NIH NCI
+    ror_id: ror:040gcmg81
+    subclass_of:
+      - B2AI_ORG:67
+    url: https://www.cancer.gov/
+    wikidata_id: wikidata:Q664846
+  - id: B2AI_ORG:72
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Biorepositories and Biospecimen Research Branch of the Cancer Diagnosis Program, formerly Office of Biorepositories and Biospecimen Research
+    name: NIH NCI BBRB
+    subclass_of:
+      - B2AI_ORG:71
+    url: https://biospecimens.cancer.gov/
+  - id: B2AI_ORG:73
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: NIH National Human Genome Research Institute
+    name: NIH NHGRI
+    ror_id: ror:00baak391
+    subclass_of:
+      - B2AI_ORG:67
+    url: https://www.genome.gov/
+    wikidata_id: wikidata:Q1634459
+  - id: B2AI_ORG:74
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: NIH National Library of Medicine
+    name: NIH NLM
+    ror_id: ror:0060t0j89
+    subclass_of:
+      - B2AI_ORG:67
+    url: https://www.nlm.nih.gov/
+    wikidata_id: wikidata:Q611833
+  - id: B2AI_ORG:75
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Open Biological and Biomedical Ontology Foundry
+    name: OBO Foundry
+    url: https://obofoundry.org/
+    wikidata_id: wikidata:Q4117183
+  - id: B2AI_ORG:76
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Observational Health Data Sciences and Informatics
+    name: OHDSI
+    url: https://www.ohdsi.org/
+  - id: B2AI_ORG:77
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Open Microscopy Environment Consortium
+    name: OME
+    url: https://www.openmicroscopy.org/
+    wikidata_id: wikidata:Q115207411
+  - id: B2AI_ORG:78
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Observational Medical Outcomes Partnership
+    name: OMOP
+    url: https://ohdsi.org/omop/
+  - id: B2AI_ORG:79
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: openEHR Foundation
+    name: openEHR
+    url: https://www.openehr.org/
+  - id: B2AI_ORG:80
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Orphanet
+    name: Orphanet
+    ror_id: ror:03d3kf570
+    url: https://www.orpha.net/
+    wikidata_id: wikidata:Q1515833
+  - id: B2AI_ORG:81
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Patient-Centered Outcomes Research Institute
+    name: PCORI
+    ror_id: ror:014q65q44
+    url: http://www.pcori.org/
+    wikidata_id: wikidata:Q7144950
+  - id: B2AI_ORG:82
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Worldwide Protein Data Bank
+    name: PDB
+    url: http://www.wwpdb.org/
+    wikidata_id: wikidata:Q8036801
+  - id: B2AI_ORG:83
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Research Data Alliance
+    name: RDA
+    ror_id: ror:037x9qj67
+    url: https://www.rd-alliance.org/
+    wikidata_id: wikidata:Q106411999
+  - id: B2AI_ORG:84
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Regenstrief Institute
+    name: RI
+    ror_id: ror:05f2ywb48
+    url: https://www.regenstrief.org/
+    wikidata_id: wikidata:Q7308063
+  - id: B2AI_ORG:85
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Radiological Society of North America
+    name: RSNA
+    ror_id: ror:00rj4x019
+    url: https://www.rsna.org/
+    wikidata_id: wikidata:Q980502
+  - id: B2AI_ORG:86
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Sage Bionetworks
+    name: Sage
+    ror_id: ror:049ncjx51
+    url: https://sagebionetworks.org/
+    wikidata_id: wikidata:Q891621
+  - id: B2AI_ORG:87
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Samwald research group at Section for Artificial Intelligence and Decision Support, Medical University of Vienna
+    name: Samwald
+    url: https://samwald.info/
+  - id: B2AI_ORG:88
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: SDMX Initiative
+    name: SDMX
+    url: https://sdmx.org/
+    wikidata_id: wikidata:Q2713163
+  - id: B2AI_ORG:89
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Sentinel Initiative
+    name: Sentinel
+    url: https://www.sentinelinitiative.org/
+    wikidata_id: wikidata:Q65075162
+  - id: B2AI_ORG:90
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Seqera Labs
+    name: Seqera
+    url: https://seqera.io/
+  - id: B2AI_ORG:91
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: STROBE Initiative
+    name: STROBE
+    url: https://www.strobe-statement.org/
+  - id: B2AI_ORG:92
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Swedish National Veterinary Institute
+    name: SVA
+    ror_id: ror:00awbw743
+    url: https://www.sva.se/en/
+    wikidata_id: wikidata:Q10677733
+  - id: B2AI_ORG:93
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Biodiversity Information Standards
+    name: TDWG
+    ror_id: ror:03k171441
+    url: https://www.tdwg.org/
+  - id: B2AI_ORG:94
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: University of Alabama at Birmingham
+    name: UAB
+    ror_id: ror:008s83205
+    url: https://www.uab.edu/home/
+    wikidata_id: wikidata:Q1472663
+  - id: B2AI_ORG:95
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Christine Orengo research group at University College London
+    name: UCL Orengo
+    url: http://orengogroup.info/
+  - id: B2AI_ORG:96
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: University of Florida, Biomedical Informatics
+    name: UFBMI
+    url: https://www.ctsi.ufl.edu/about/ctsi-programs/biomedical-informatics/
+  - id: B2AI_ORG:97
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: UK Data Archive, University of Essex
+    name: UKDA
+    ror_id: ror:03fknw408
+    url: https://www.data-archive.ac.uk/
+    wikidata_id: wikidata:Q17039301
+  - id: B2AI_ORG:98
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: US Geological Survey
+    name: USGS
+    ror_id: ror:035a68863
+    url: https://www.usgs.gov/
+    wikidata_id: wikidata:Q193755
+  - id: B2AI_ORG:99
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: World Wide Web Consortium
+    name: W3C
+    ror_id: ror:0059y1582
+    url: https://www.w3.org/
+    wikidata_id: wikidata:37033
+  - id: B2AI_ORG:100
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: World Health Organisation
+    name: WHO
+    ror_id: ror:01f80g185
+    url: https://www.who.int/
+    wikidata_id: wikidata:Q7817
+  - id: B2AI_ORG:101
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Carl Zeiss AG
+    name: Zeiss
+    ror_id: ror:02mp31p96
+    url: https://www.zeiss.com/
+    wikidata_id: wikidata:Q282186
+  - id: B2AI_ORG:102
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Office of the National Coordinator for Health Information Technology
+    name: ONC
+    ror_id: ror:02fm3sv87
+    url: https://www.healthit.gov/
+    wikidata_id: wikidata:Q7079383
+  - id: B2AI_ORG:103
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Interoperability Standards Advisory
+    name: ISA
+    subclass_of:
+      - B2AI_ORG:102
+    url: https://www.healthit.gov/isa/
+  - id: B2AI_ORG:104
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: The International Business Machines Corporation
+    name: IBM
+    ror_id: ror:05hh8d621
+    url: https://www.ibm.com/
+    wikidata_id: wikidata:Q37156
+  - id: B2AI_ORG:105
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Epic Systems Corporation
+    name: Epic
+    ror_id: ror:029z3g861
+    url: https://www.epic.com/
+    wikidata_id: wikidata:Q5382468
+  - id: B2AI_ORG:106
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Bridge to Artificial Intelligence Consortium
+    name: Bridge2AI
+    url: https://bridge2ai.org/
+  - id: B2AI_ORG:107
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Bridge to Artificial Intelligence Consortium Bridge Center
+    name: Bridge2AI Bridge Center
+    subclass_of:
+      - B2AI_ORG:106
+    url: https://bridge2ai.org/bridge2ai-cores/
+  - id: B2AI_ORG:108
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Bridge to Artificial Intelligence Consortium Administrative Core
+    name: Bridge2AI Administrative Core
+    subclass_of:
+      - B2AI_ORG:107
+    url: https://bridge2ai.org/administrative-core/
+  - id: B2AI_ORG:109
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Bridge to Artificial Intelligence Consortium Ethics Core
+    name: Bridge2AI Ethics Core
+    subclass_of:
+      - B2AI_ORG:107
+    url: https://bridge2ai.org/ethics-core/
+  - id: B2AI_ORG:110
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Bridge to Artificial Intelligence Consortium Standards Core
+    name: Bridge2AI Standards Core
+    subclass_of:
+      - B2AI_ORG:107
+    url: https://bridge2ai.org/standards-core/
+  - id: B2AI_ORG:111
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Bridge to Artificial Intelligence Consortium Skills and Workforce Development Core
+    name: Bridge2AI SWD Core
+    subclass_of:
+      - B2AI_ORG:107
+    url: https://bridge2ai.org/skills-and-workforce-development-core/
+  - id: B2AI_ORG:112
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Bridge to Artificial Intelligence Consortium Teaming Core
+    name: Bridge2AI Teaming Core
+    subclass_of:
+      - B2AI_ORG:107
+    url: https://bridge2ai.org/teaming-core/
+  - id: B2AI_ORG:113
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Bridge to Artificial Intelligence Consortium Tools Optimization Core
+    name: Bridge2AI Tools Core
+    subclass_of:
+      - B2AI_ORG:107
+    url: https://bridge2ai.org/tools-optimization-core/
+  - id: B2AI_ORG:114
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: >-
+      The Bridge2AI Salutogenesis Grand Challenge, also known as the Artificial
+      Intelligence Ready and Equitable Atlas for Diabetes Insights project
+      (AI-READI).
+    name: Salutogenesis Grand Challenge
+    subclass_of:
+      - B2AI_ORG:106
+    url: https://aireadi.org/
+  - id: B2AI_ORG:115
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: >-
+      The Bridge2AI AI/ML for Clinical Care Grand Challenge (GC), also known as
+      the Patient-Focused Collaborative Hospital Repository Uniting Standards
+      project (CHoRUS)
+    name: AI/ML for Clinical Care Grand Challenge
+    subclass_of:
+      - B2AI_ORG:106
+    url: https://www.chorus4ai.org/
+  - id: B2AI_ORG:116
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: >-
+      The Bridge2AI Functional Genomics Grand Challenge (GC), also known
+      as the Cell Maps for AI project (CM4AI)
+    name: Functional Genomics Grand Challenge
+    subclass_of:
+      - B2AI_ORG:106
+    url: https://cm4ai.org/
+  - id: B2AI_ORG:117
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: >-
+      The Bridge2AI Precision Public Health Grand Challenge (GC), also
+      known as the Voice as a Biomarker of Health project (Voice)
+    name: Precision Public Health Grand Challenge
+    subclass_of:
+      - B2AI_ORG:106
+    url: https://b2ai-voice.org/
+  - id: B2AI_ORG:118
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Institute of Allergy and Infectious Diseases
+    name: NIAID
+    ror_id: ror:043z4tv69
+    subclass_of:
+      - B2AI_ORG:67
+    url: https://www.niaid.nih.gov/
+    wikidata_id: wikidata:Q3519875
+  - id: B2AI_ORG:119
+    category: B2AI_ORG:Organization
+    description: University of California, Santa Cruz
+    name: UCSC
+    ror_id: ror:03s65by71
+    url: https://www.ucsc.edu/
+    wikidata_id: wikidata:Q1047293
+  - id: B2AI_ORG:120
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Center for Biotechnology Information
+    name: NCBI
+    ror_id: ror:02meqm098
+    subclass_of:
+      - B2AI_ORG:74
+    url: https://www.ncbi.nlm.nih.gov/
+    wikidata_id: wikidata:Q82494
+  - id: B2AI_ORG:121
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: National Centre for the Replacement, Refinement and Reduction of Animals in Research
+    name: NC3Rs
+    ror_id: ror:02w0kg036
+    url: https://www.nc3rs.org.uk/
+    wikidata_id: wikidata:Q30296562
+  - id: B2AI_ORG:122
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Consumer Technology Association
+    name: CTA
+    url: https://www.cta.tech/
+    wikidata_id: wikidata:Q1128415
+  - id: B2AI_ORG:123
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Thermo Fisher Scientific Inc.
+    name: Thermo Fisher
+    ror_id: ror:03x1ewr52
+    url: https://www.thermofisher.com/us/en/home.html
+    wikidata_id: wikidata:Q643674
+  - id: B2AI_ORG:124
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Ensembl genome database project, a project of the European Bioinformatics Institute
+    name: Ensembl
+    url: https://www.ensembl.org/index.html
+    wikidata_id: wikidata:Q1344256
+    subclass_of:
+    - B2AI_ORG:29
+  - id: B2AI_ORG:125
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Generic Model Organism Database Project
+    name: GMOD
+    url: https://gmod.org/
+  - id: B2AI_ORG:126
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Social Interventions Research and Evaluation Network
+    name: SIREN
+    url: https://sirenetwork.ucsf.edu/
+  - id: B2AI_ORG:127
+    category: B2AI_ORG:Organization
+    contributor_github_name: caufieldjh
+    contributor_name: Harry Caufield
+    contributor_orcid: "ORCID:0000-0001-5705-7831"
+    description: Open Health Natural Language Processing Consortium
+    name: OHNLP
+    url: https://ohnlp.org/

--- a/tests/test_org_registry.py
+++ b/tests/test_org_registry.py
@@ -1,0 +1,68 @@
+"""Tests for B2AI organization-registry resolution and enrichment (#378)."""
+
+import unittest
+
+from data_sheets_schema.org_registry import (
+    OrgResolver,
+    enrich_record,
+    enrichment_block,
+)
+
+
+class TestOrgResolver(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.r = OrgResolver()
+
+    def test_resolves_acronym_full_name_and_ror(self):
+        by_acronym = self.r.resolve("AHRQ")
+        self.assertEqual(by_acronym["id"], "B2AI_ORG:2")
+        by_full = self.r.resolve("US Agency for Healthcare Research and Quality")
+        self.assertEqual(by_full["id"], "B2AI_ORG:2")
+        by_ror = self.r.resolve("see https://ror.org/03jmfdf59 for details")
+        self.assertEqual(by_ror["id"], "B2AI_ORG:2")
+
+    def test_no_fuzzy_matching(self):
+        # A wrong identifier asserted confidently is worse than none.
+        self.assertIsNone(self.r.resolve("Agency for Healthcare Research"))
+        self.assertIsNone(self.r.resolve("University of Nowhere"))
+        self.assertIsNone(self.r.resolve(""))
+
+    def test_snapshot_is_pinned(self):
+        self.assertEqual(len(self.r.snapshot_sha256), 64)
+
+
+class TestEnrichRecord(unittest.TestCase):
+    def test_fills_only_nameonly_org_objects_and_logs_paths(self):
+        record = {
+            "creators": [{"name": "Team", "affiliations": [
+                {"name": "AHRQ"},
+                {"name": "University of Nowhere"},
+                {"id": "existing:1", "name": "AMA"},
+            ]}],
+            "name": "AHRQ",   # a plain string slot, must not become an object
+        }
+        _, log = enrich_record(record, OrgResolver())
+        affs = record["creators"][0]["affiliations"]
+        self.assertEqual(affs[0]["id"], "B2AI_ORG:2")
+        self.assertNotIn("id", affs[1], "unresolved names stay name-only")
+        self.assertEqual(affs[2]["id"], "existing:1",
+                         "existing ids are never overwritten")
+        self.assertEqual(record["name"], "AHRQ")
+        self.assertEqual([e["path"] for e in log],
+                         ["/creators/0/affiliations/0"])
+
+    def test_enrichment_block_carries_the_claim_context(self):
+        r = OrgResolver()
+        record = {"creators": [{"name": "T",
+                                "affiliations": [{"name": "AMA"}]}]}
+        _, log = enrich_record(record, r)
+        block = enrichment_block(log, r)
+        self.assertEqual(block["kind"], "organization_identifiers")
+        self.assertEqual(block["snapshot_sha256"], r.snapshot_sha256)
+        self.assertIn("enrichment, not extraction", block["note"])
+        self.assertEqual(block["resolved"], log)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First half of #378 (the upstream university contribution remains a human call).

## What

- **Vendored snapshot** of the registry's `Organization.yaml` (127 orgs, `B2AI_ORG:N` CURIEs + ROR/Wikidata), pinned by sha256 + fetch date.
- **`OrgResolver`**: strict resolution on normalized acronym (`name`), full name (`description`), or ROR id embedded in text. Deliberately no fuzzy matching — a wrong identifier asserted confidently is worse than a name left alone.
- **`d4d enrich orgs RECORD [-o OUT]`**: fills `Organization.id` only on name-only inline org objects that resolve; existing ids never overwritten; plain string slots untouched. Dry-run by default; `-o` writes an enriched **copy** plus a `.enrichment.yaml` sidecar (snapshot hash, timestamp, every addition, and the statement that this is enrichment, not extraction). The original is never modified — run provenance pins its bytes.

## Why this shape

Schema 2.0.0 made name-only organizations valid, ending the fabrication pressure; this pass adds *real* identifiers where a curated source states them, provenance-marked, deterministic, post-generation only. On current (repaired) records it resolves nothing — repair already forced pseudo-ids — so its value begins with the rerun's natural records. Coverage grows if the ~30 unmatched Bridge2AI-performing universities are contributed upstream (census in #378).

## Testing

5 tests: acronym/full-name/ROR resolution against the real snapshot, no-fuzzy guarantees, name-only-object targeting with path logging, id-preservation, provenance block contents. Live dry-run on a sweep record behaves correctly (nothing to enrich, loudly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)