### PR TITLE
Notes escape hatch and only-declared-keys instructions (#380)

### DIFF
--- a/project/jsonld/data_sheets_schema.jsonld
+++ b/project/jsonld/data_sheets_schema.jsonld
@@ -4068,6 +4068,22 @@
       "@type": "SlotDefinition"
     },
     {
+      "name": "namedThing__notes",
+      "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
+      "mappings": [
+        "http://schema.org/comment"
+      ],
+      "slot_uri": "http://schema.org/comment",
+      "alias": "notes",
+      "owner": "NamedThing",
+      "domain_of": [
+        "NamedThing"
+      ],
+      "range": "string",
+      "@type": "SlotDefinition"
+    },
+    {
       "name": "organization__id",
       "annotations": [
         {
@@ -4131,6 +4147,22 @@
       "@type": "SlotDefinition"
     },
     {
+      "name": "organization__notes",
+      "description": "Content about the organization that fits no dedicated slot; never invent keys (#380).",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
+      "mappings": [
+        "http://schema.org/comment"
+      ],
+      "slot_uri": "http://schema.org/comment",
+      "alias": "notes",
+      "owner": "Organization",
+      "domain_of": [
+        "Organization"
+      ],
+      "range": "string",
+      "@type": "SlotDefinition"
+    },
+    {
       "name": "datasetProperty__id",
       "annotations": [
         {
@@ -4178,6 +4210,22 @@
       ],
       "slot_uri": "http://schema.org/description",
       "alias": "description",
+      "owner": "DatasetProperty",
+      "domain_of": [
+        "DatasetProperty"
+      ],
+      "range": "string",
+      "@type": "SlotDefinition"
+    },
+    {
+      "name": "datasetProperty__notes",
+      "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
+      "mappings": [
+        "http://schema.org/comment"
+      ],
+      "slot_uri": "http://schema.org/comment",
+      "alias": "notes",
       "owner": "DatasetProperty",
       "domain_of": [
         "DatasetProperty"
@@ -4623,6 +4671,22 @@
       ],
       "slot_uri": "http://schema.org/description",
       "alias": "description",
+      "owner": "Grant",
+      "domain_of": [
+        "Grant"
+      ],
+      "range": "string",
+      "@type": "SlotDefinition"
+    },
+    {
+      "name": "grant__notes",
+      "description": "Content about the grant that fits no dedicated slot; never invent keys (#380).",
+      "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/motivation",
+      "mappings": [
+        "http://schema.org/comment"
+      ],
+      "slot_uri": "http://schema.org/comment",
+      "alias": "notes",
       "owner": "Grant",
       "domain_of": [
         "Grant"
@@ -8460,6 +8524,7 @@
         "namedThing__id",
         "namedThing__name",
         "namedThing__description",
+        "namedThing__notes",
         "compression",
         "conforms_to",
         "conforms_to_class",
@@ -8508,6 +8573,7 @@
         "namedThing__id",
         "namedThing__name",
         "namedThing__description",
+        "namedThing__notes",
         "compression",
         "conforms_to",
         "conforms_to_class",
@@ -9244,6 +9310,7 @@
         "namedThing__id",
         "namedThing__name",
         "namedThing__description",
+        "namedThing__notes",
         "compression",
         "conforms_to",
         "conforms_to_class",
@@ -9367,7 +9434,8 @@
       "slots": [
         "namedThing__id",
         "namedThing__name",
-        "namedThing__description"
+        "namedThing__description",
+        "namedThing__notes"
       ],
       "slot_usage": {},
       "attributes": [
@@ -9413,6 +9481,13 @@
           "slot_uri": "schema:description",
           "range": "string",
           "@type": "SlotDefinition"
+        },
+        {
+          "name": "notes",
+          "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+          "slot_uri": "schema:comment",
+          "range": "string",
+          "@type": "SlotDefinition"
         }
       ],
       "class_uri": "http://schema.org/Thing",
@@ -9429,7 +9504,8 @@
       "slots": [
         "organization__id",
         "organization__name",
-        "organization__description"
+        "organization__description",
+        "organization__notes"
       ],
       "slot_usage": {},
       "attributes": [
@@ -9468,6 +9544,13 @@
           "slot_uri": "schema:description",
           "range": "string",
           "@type": "SlotDefinition"
+        },
+        {
+          "name": "notes",
+          "description": "Content about the organization that fits no dedicated slot; never invent keys (#380).",
+          "slot_uri": "schema:comment",
+          "range": "string",
+          "@type": "SlotDefinition"
         }
       ],
       "class_uri": "http://schema.org/Organization",
@@ -9482,6 +9565,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software"
       ],
       "slot_usage": {},
@@ -9515,6 +9599,13 @@
           "@type": "SlotDefinition"
         },
         {
+          "name": "notes",
+          "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+          "slot_uri": "schema:comment",
+          "range": "string",
+          "@type": "SlotDefinition"
+        },
+        {
           "name": "used_software",
           "description": "What software was used as part of this dataset property?",
           "slot_uri": "d4d:usedSoftware",
@@ -9543,6 +9634,7 @@
         "namedThing__id",
         "namedThing__name",
         "namedThing__description",
+        "namedThing__notes",
         "software__version",
         "software__license",
         "software__url"
@@ -9608,6 +9700,7 @@
         "namedThing__id",
         "namedThing__name",
         "namedThing__description",
+        "namedThing__notes",
         "person__affiliation",
         "person__email",
         "person__orcid"
@@ -9671,6 +9764,7 @@
         "namedThing__id",
         "namedThing__name",
         "namedThing__description",
+        "namedThing__notes",
         "compression",
         "conforms_to",
         "conforms_to_class",
@@ -9749,6 +9843,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "purpose__response"
       ],
@@ -9785,6 +9880,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "task__response"
       ],
@@ -9821,6 +9917,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "addressingGap__response"
       ],
@@ -9857,6 +9954,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "creator__principal_investigator",
         "creator__affiliations",
@@ -9909,6 +10007,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "fundingMechanism__grantor",
         "fundingMechanism__grants"
@@ -9947,7 +10046,8 @@
       "slots": [
         "organization__id",
         "organization__name",
-        "organization__description"
+        "organization__description",
+        "organization__notes"
       ],
       "slot_usage": {},
       "class_uri": "https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grantor",
@@ -9962,6 +10062,7 @@
         "grant__id",
         "grant__name",
         "grant__description",
+        "grant__notes",
         "grant__grant_number"
       ],
       "slot_usage": {},
@@ -9985,6 +10086,13 @@
           "name": "description",
           "description": "A human-readable description of the grant.",
           "slot_uri": "schema:description",
+          "range": "string",
+          "@type": "SlotDefinition"
+        },
+        {
+          "name": "notes",
+          "description": "Content about the grant that fits no dedicated slot; never invent keys (#380).",
+          "slot_uri": "schema:comment",
           "range": "string",
           "@type": "SlotDefinition"
         },
@@ -10019,6 +10127,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "instance__data_topic",
         "instance__instance_type",
@@ -10129,6 +10238,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "samplingStrategy__is_sample",
         "samplingStrategy__is_random",
@@ -10236,6 +10346,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "missingInfo__missing",
         "missingInfo__why_missing"
@@ -10292,6 +10403,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "relationships__relationship_details"
       ],
@@ -10325,6 +10437,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "splits__split_details"
       ],
@@ -10358,6 +10471,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "dataAnomaly__anomaly_details"
       ],
@@ -10397,6 +10511,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "datasetBias__bias_type",
         "datasetBias__bias_description",
@@ -10472,6 +10587,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "datasetLimitation__limitation_type",
         "datasetLimitation__limitation_description",
@@ -10543,6 +10659,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "ExternalResource_external_resources",
         "externalResource__future_guarantees",
@@ -10593,6 +10710,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "confidentiality__confidential_elements_present",
         "confidentiality__confidentiality_details"
@@ -10634,6 +10752,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "contentWarning__content_warnings_present",
         "contentWarning__warnings"
@@ -10676,6 +10795,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "subpopulation__subpopulation_elements_present",
         "subpopulation__identification",
@@ -10731,6 +10851,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "deidentification__identifiable_elements_present",
         "deidentification__method",
@@ -10791,6 +10912,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "sensitiveElement__sensitive_elements_present",
         "sensitiveElement__sensitivity_details"
@@ -10831,6 +10953,7 @@
       "slots": [
         "datasetProperty__id",
         "datasetProperty__name",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "datasetRelationship__target_dataset",
         "datasetRelationship__relationship_type",
@@ -10878,6 +11001,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "instanceAcquisition__was_directly_observed",
         "instanceAcquisition__was_reported_by_subjects",
@@ -10946,6 +11070,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "collectionMechanism__mechanism_details"
       ],
@@ -10979,6 +11104,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "dataCollector__role",
         "dataCollector__collector_details"
@@ -11030,6 +11156,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "collectionTimeframe__start_date",
         "collectionTimeframe__end_date",
@@ -11093,6 +11220,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "directCollection__is_direct",
         "directCollection__collection_details"
@@ -11137,6 +11265,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "missingDataDocumentation__missing_data_patterns",
         "missingDataDocumentation__missing_data_causes",
@@ -11203,6 +11332,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "rawDataSource__source_description",
         "rawDataSource__source_type",
@@ -11288,6 +11418,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "preprocessingStrategy__preprocessing_details"
       ],
@@ -11324,6 +11455,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "cleaningStrategy__cleaning_details"
       ],
@@ -11357,6 +11489,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "labelingStrategy__data_annotation_platform",
         "labelingStrategy__data_annotation_protocol",
@@ -11461,6 +11594,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "rawData__access_url",
         "rawData__raw_data_details"
@@ -11505,6 +11639,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "imputationProtocol__imputation_method",
         "imputationProtocol__imputed_fields",
@@ -11582,6 +11717,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "annotationAnalysis__inter_annotator_agreement_score",
         "annotationAnalysis__agreement_metric",
@@ -11652,6 +11788,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "machineAnnotationTools__tools",
         "machineAnnotationTools__tool_descriptions",
@@ -11714,6 +11851,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "existingUse__examples"
       ],
@@ -11748,6 +11886,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "useRepository__repository_url",
         "useRepository__repository_details"
@@ -11789,6 +11928,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "otherTask__task_details"
       ],
@@ -11825,6 +11965,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "futureUseImpact__impact_details"
       ],
@@ -11858,6 +11999,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "discouragedUse__discouragement_details"
       ],
@@ -11894,6 +12036,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "intendedUse__examples",
         "intendedUse__usage_notes",
@@ -11956,6 +12099,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "prohibitedUse__prohibition_reason"
       ],
@@ -11989,6 +12133,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "thirdPartySharing__is_shared"
       ],
@@ -12015,6 +12160,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "distributionFormat__access_urls"
       ],
@@ -12049,6 +12195,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "distributionDate__release_dates"
       ],
@@ -12083,6 +12230,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "maintainer__role",
         "maintainer__maintainer_details"
@@ -12124,6 +12272,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "erratum__erratum_url",
         "erratum__erratum_details"
@@ -12176,6 +12325,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "updatePlan__frequency",
         "updatePlan__update_details"
@@ -12224,6 +12374,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "retentionLimits__retention_period",
         "retentionLimits__retention_details"
@@ -12272,6 +12423,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "versionAccess__latest_version_doi",
         "versionAccess__versions_available",
@@ -12329,6 +12481,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "extensionMechanism__contribution_url",
         "extensionMechanism__extension_details"
@@ -12377,6 +12530,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "ethicalReview__contact_person",
         "ethicalReview__reviewing_organization",
@@ -12432,6 +12586,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "dataProtectionImpact__impact_details"
       ],
@@ -12465,6 +12620,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "collectionNotification__notification_details"
       ],
@@ -12498,6 +12654,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "collectionConsent__consent_details"
       ],
@@ -12531,6 +12688,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "consentRevocation__revocation_details"
       ],
@@ -12564,6 +12722,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "humanSubjectResearch__involves_human_subjects",
         "humanSubjectResearch__irb_approval",
@@ -12639,6 +12798,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "informedConsent__consent_obtained",
         "informedConsent__consent_type",
@@ -12711,6 +12871,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "participantPrivacy__anonymization_method",
         "participantPrivacy__reidentification_risk",
@@ -12776,6 +12937,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "humanSubjectCompensation__compensation_provided",
         "humanSubjectCompensation__compensation_type",
@@ -12840,6 +13002,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "atRiskPopulations__at_risk_groups_included",
         "atRiskPopulations__special_protections",
@@ -12900,6 +13063,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "licenseAndUseTerms__license_terms",
         "licenseAndUseTerms__data_use_permission",
@@ -12967,6 +13131,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "iPRestrictions__restrictions"
       ],
@@ -13005,6 +13170,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "exportControlRegulatoryRestrictions__regulatory_restrictions",
         "exportControlRegulatoryRestrictions__hipaa_compliant",
@@ -13092,6 +13258,7 @@
         "datasetProperty__id",
         "datasetProperty__name",
         "datasetProperty__description",
+        "datasetProperty__notes",
         "datasetProperty__used_software",
         "variableMetadata__variable_name",
         "variableMetadata__data_type",
@@ -13314,6 +13481,7 @@
         "namedThing__id",
         "namedThing__name",
         "namedThing__description",
+        "namedThing__notes",
         "conforms_to",
         "conforms_to_class",
         "conforms_to_schema",
@@ -13382,6 +13550,7 @@
         "namedThing__id",
         "namedThing__name",
         "namedThing__description",
+        "namedThing__notes",
         "conforms_to",
         "conforms_to_class",
         "conforms_to_schema",
@@ -13457,9 +13626,9 @@
   ],
   "metamodel_version": "1.7.0",
   "source_file": "data_sheets_schema.yaml",
-  "source_file_date": "2026-08-06T11:46:39",
+  "source_file_date": "2026-08-06T12:37:37",
   "source_file_size": 32488,
-  "generation_date": "2026-08-06T12:01:28",
+  "generation_date": "2026-08-06T15:34:46",
   "@type": "SchemaDefinition",
   "@context": [
     "project/jsonld/data_sheets_schema.context.jsonld",

--- a/project/jsonschema/data_sheets_schema.schema.json
+++ b/project/jsonschema/data_sheets_schema.schema.json
@@ -25,6 +25,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "response": {
                     "description": "Short explanation of the knowledge or resource gap that this dataset was intended to address.",
                     "type": [
@@ -112,6 +119,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -173,6 +187,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -281,6 +302,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -322,6 +350,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -373,6 +408,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -407,6 +449,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -461,6 +510,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -560,6 +616,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -604,6 +667,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -657,6 +727,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -726,6 +803,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -802,6 +886,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -843,6 +934,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -896,6 +994,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -1488,6 +1593,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for a thing.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -2403,6 +2515,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "other_tasks": {
                     "description": "Additional tasks the dataset may support beyond its original intent. List of OtherTask objects from the Uses module describing potential applications not originally planned by the dataset creators.",
                     "items": {
@@ -2773,6 +2892,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -2911,6 +3037,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "page": {
                     "description": "A landing page or web page providing access to or information about the resource.",
                     "type": [
@@ -3006,6 +3139,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "recommended_mitigation": {
                     "description": "Recommended approaches for users to address this limitation.\n",
                     "type": [
@@ -3059,6 +3199,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -3093,6 +3240,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -3223,6 +3377,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -3276,6 +3437,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -3322,6 +3490,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -3356,6 +3531,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -3415,6 +3597,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -3526,6 +3715,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -3567,6 +3763,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -3635,6 +3838,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -3684,6 +3894,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -3759,6 +3976,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -3817,6 +4041,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -4009,6 +4240,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for a thing.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4223,6 +4461,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for a thing.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4444,6 +4689,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -4485,6 +4737,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -4535,6 +4794,13 @@
                         "string",
                         "null"
                     ]
+                },
+                "notes": {
+                    "description": "Content about the grant that fits no dedicated slot; never invent keys (#380).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "title": "Grant",
@@ -4560,6 +4826,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for the organization.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content about the organization that fits no dedicated slot; never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4617,6 +4890,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -4685,6 +4965,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "regulatory_compliance": {
                     "description": "What regulatory frameworks govern this human subjects research (e.g., 45 CFR 46, HIPAA)?\n",
                     "items": {
@@ -4739,6 +5026,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -4825,6 +5119,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -4968,6 +5269,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "page": {
                     "description": "A landing page or web page providing access to or information about the resource.",
                     "type": [
@@ -5065,6 +5373,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -5168,6 +5483,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "sampling_strategies": {
                     "description": "References to one or more SamplingStrategy objects.\n",
                     "items": {
@@ -5219,6 +5541,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -5296,6 +5625,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -5399,6 +5735,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -5462,6 +5805,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -5510,6 +5860,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -5586,6 +5943,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -5681,6 +6045,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -5725,6 +6096,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -5778,6 +6156,13 @@
                         "string",
                         "null"
                     ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "required": [
@@ -5810,6 +6195,13 @@
                         "string",
                         "null"
                     ]
+                },
+                "notes": {
+                    "description": "Content about the organization that fits no dedicated slot; never invent keys (#380).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "title": "Organization",
@@ -5835,6 +6227,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -5895,6 +6294,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -5970,6 +6376,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "orcid": {
                     "description": "ORCID (Open Researcher and Contributor ID) - a persistent digital identifier for researchers. Format: 0000-0000-0000-0000 (16 digits in groups of 4). Use this for stable cross-dataset identification.",
                     "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$",
@@ -6005,6 +6418,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -6056,6 +6476,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "prohibition_reason": {
                     "description": "One or more reasons why this use is prohibited (e.g., license restriction, ethical concern, privacy risk, legal constraint).",
                     "type": [
@@ -6097,6 +6524,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -6155,6 +6589,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "raw_data_details": {
                     "description": "Free-text description of raw data availability, access procedures, and any conditions or restrictions on accessing the raw data.\n",
                     "type": [
@@ -6203,6 +6644,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -6268,6 +6716,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "relationship_details": {
                     "description": "Free-text description of how relationships between instances are represented (e.g., graph edges, ratings matrices, foreign keys), including relationship types and any associated metadata.\n",
                     "type": [
@@ -6309,6 +6764,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -6388,6 +6850,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "representative_verification": {
                     "description": "One or more explanations of how representativeness was validated or verified (e.g., statistical tests, domain expert review).\n",
                     "items": {
@@ -6461,6 +6930,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "sensitive_elements_present": {
                     "description": "Indicates whether sensitive data elements are present.",
                     "type": [
@@ -6518,6 +6994,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "url": {
                     "description": "URL where the software can be found (e.g., homepage, repository, or documentation).",
                     "type": [
@@ -6559,6 +7042,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -6624,6 +7114,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "subpopulation_elements_present": {
                     "description": "Indicates whether any subpopulations are explicitly identified.",
                     "type": [
@@ -6665,6 +7162,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -6723,6 +7227,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "used_software": {
                     "description": "What software was used as part of this dataset property?",
                     "items": {
@@ -6769,6 +7280,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "update_details": {
                     "description": "Free-text description of planned update types (e.g., corrections, additions, deletions), responsible parties, and how updates will be communicated to users.\n",
                     "type": [
@@ -6810,6 +7328,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -6947,6 +7472,13 @@
                         "null"
                     ]
                 },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "precision": {
                     "description": "The precision or number of decimal places for numeric variables.",
                     "type": [
@@ -7036,6 +7568,13 @@
                 },
                 "name": {
                     "description": "A human-readable name for this property.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "notes": {
+                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
                     "type": [
                         "string",
                         "null"
@@ -7204,6 +7743,13 @@
         },
         "name": {
             "description": "A human-readable name for a thing.",
+            "type": [
+                "string",
+                "null"
+            ]
+        },
+        "notes": {
+            "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
             "type": [
                 "string",
                 "null"

--- a/project/owl/data_sheets_schema.owl.ttl
+++ b/project/owl/data_sheets_schema.owl.ttl
@@ -34,50 +34,50 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FormatDialect" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:header ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:header ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:quote_char ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:header ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:header ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:double_quote ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:delimiter ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:delimiter ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:double_quote ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:delimiter ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:double_quote ],
+            owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:quote_char ] ;
+            owl:onProperty data_sheets_schema:delimiter ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:comment_prefix ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:header ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:double_quote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:delimiter ] ;
     skos:definition "Additional format information for a file." ;
     skos:inScheme data_sheets_schema:base .
 
@@ -109,10 +109,13 @@ data_sheets_schema:DataSubset a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataSubset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_subpopulation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
@@ -121,10 +124,7 @@ data_sheets_schema:DataSubset a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_subpopulation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_subpopulation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_data_split ],
         data_sheets_schema:Dataset ;
     skos:definition "A subset of a dataset, likely containing multiple files of multiple potential purposes and properties." ;
@@ -134,104 +134,104 @@ data_sheets_schema:File a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "File" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:md5 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:path ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:hash ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:hash ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:md5 ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:bytes ],
+            owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:media_type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:encoding ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:path ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:bytes ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:file_type ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:md5 ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:format ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sha256 ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:FormatEnum ;
             owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_type ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
+            owl:onProperty data_sheets_schema:bytes ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FileTypeEnum ;
-            owl:onProperty data_sheets_schema:file_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:hash ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:media_type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:dialect ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
+            owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FileTypeEnum ;
+            owl:onProperty data_sheets_schema:file_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:encoding ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:file_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
             owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:file_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:hash ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "file",
@@ -245,17 +245,38 @@ data_sheets_schema:FileCollection a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FileCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:File ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
             owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:file_count ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:path ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:resources ],
+            owl:onProperty data_sheets_schema:file_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:path ],
@@ -264,40 +285,19 @@ data_sheets_schema:FileCollection a owl:Class,
             owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:total_bytes ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:file_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:FileCollectionTypeEnum ;
             owl:onProperty data_sheets_schema:collection_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:File ;
             owl:onProperty data_sheets_schema:resources ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_bytes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:file_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
-            owl:onProperty data_sheets_schema:compression ],
         data_sheets_schema:Information ;
     skos:altLabel "data files",
         "file collection",
@@ -313,22 +313,13 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "Software" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:url ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:url ],
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:version ],
@@ -337,6 +328,15 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:url ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:url ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license ],
         data_sheets_schema:NamedThing ;
     skos:definition "A software program or library." ;
@@ -347,13 +347,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What mechanisms or procedures were used to collect the data (e.g., hardware, manual curation, software APIs)? Also covers how these mechanisms were validated.
@@ -366,19 +366,22 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "CollectionTimeframe" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:Date ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Date ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
@@ -386,11 +389,8 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Over what timeframe was the data collected, and does this timeframe match the creation timeframe of the underlying data?
 """ ;
@@ -401,23 +401,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataCollector" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who was involved in the data collection (e.g., students, crowdworkers, contractors), and how they were compensated.
 """ ;
@@ -427,22 +427,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DirectCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Indicates whether the data was collected directly from the individuals in question or obtained via third parties/other sources.
@@ -453,47 +453,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "InstanceAcquisition" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
@@ -506,31 +506,31 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MissingDataDocumentation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documentation of missing data in the dataset, including patterns, causes, and strategies for handling missing values.
@@ -542,40 +542,40 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "RawDataSource" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Description of raw data sources before preprocessing, cleaning, or labeling. Documents where the original data comes from and how it can be accessed.
@@ -590,8 +590,8 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
@@ -599,10 +599,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be confidential (e.g., protected by legal privilege, patient data, non-public communications)?
@@ -613,20 +613,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ContentWarning" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain any data that might be offensive, insulting, threatening, or otherwise anxiety-provoking if viewed directly?
 """ ;
@@ -636,13 +636,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataAnomaly" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are there any errors, sources of noise, or redundancies in the dataset?
@@ -653,38 +653,38 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetBias" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:BiasTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documents known biases present in the dataset. Biases are systematic errors or prejudices that may affect the representativeness or fairness of the data. Distinct from anomalies (data quality issues) and limitations (scope constraints).
 """ ;
@@ -695,41 +695,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetLimitation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:LimitationTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documents known limitations of the dataset that may affect its use or interpretation. Distinct from biases (systematic errors) and anomalies (data quality issues).
 """ ;
@@ -740,32 +740,32 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:DatasetRelationshipTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Typed relationship to another dataset, enabling precise specification of how datasets relate to each other (e.g., supplements, derives from, is version of). Supports RO-Crate-style dataset interlinking.
 """ ;
@@ -778,35 +778,35 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is it possible to identify individuals in the dataset, either directly or indirectly (in combination with other data)?
 """ ;
@@ -816,71 +816,71 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Instance" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What do the instances that comprise the dataset represent (e.g., documents, photos, people, countries)?
 """ ;
@@ -890,17 +890,17 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MissingInfo" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is any information missing from individual instances? (e.g., unavailable data).
 """ ;
@@ -910,13 +910,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Relationships" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are relationships between individual instances made explicit (e.g., users' movie ratings, social network links)?
@@ -927,23 +927,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SensitiveElement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be considered sensitive (e.g., race, sexual orientation, religion, biometrics)?
 """ ;
@@ -954,13 +954,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Splits" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are there recommended data splits (e.g., training, validation, testing)? If so, how are they defined and why?
@@ -971,31 +971,31 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Subpopulation" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset identify any subpopulations (e.g., by age, gender)? If so, how are they identified and what are their distributions?
@@ -1006,47 +1006,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExportControlRegulatoryRestrictions" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Do any export controls or other regulatory restrictions apply to the dataset or to individual instances? Includes compliance tracking for regulations like HIPAA and other US regulations. If so, please describe these restrictions and provide a link or copy of any supporting documentation. Maps to DUO terms related to ethics approval, geographic restrictions, and institutional requirements.
 """ ;
@@ -1073,26 +1073,26 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:DataUsePermissionEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed under a copyright or other IP license, and/or under applicable terms of use? Provide a link or copy of relevant licensing terms and any fees.
 """ ;
@@ -1116,10 +1116,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DistributionFormat" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#access_urls> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#access_urls> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """How will the dataset be distributed (e.g., tarball on a website, API, GitHub)?
@@ -1130,10 +1130,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ThirdPartySharing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
@@ -1147,13 +1147,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Did the individuals in question consent to the collection and use of their data? If so, how was consent requested and provided, and what language did individuals consent to?
@@ -1167,10 +1167,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were the individuals in question notified about the data collection? If so, please describe (or show with screenshots, etc.) how notice was provided, and reproduce the language of the notification itself if possible.
@@ -1184,10 +1184,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If consent was obtained, were the consenting individuals provided with a mechanism to revoke their consent in the future or for certain uses? If so, please describe.
@@ -1198,13 +1198,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataProtectionImpact" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has an analysis of the potential impact of the dataset and its use on data subjects (e.g., a data protection impact analysis) been conducted? If so, please provide a description of this analysis, including the outcomes, and any supporting documentation.
@@ -1218,29 +1218,29 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were any ethical or compliance review processes conducted (e.g., by an institutional review board)? If so, please provide a description of these review processes, including the frequency of review and documentation of outcomes, as well as a link or other access point to any supporting documentation.
 """ ;
@@ -1253,29 +1253,29 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about protections for at-risk populations in human subjects research.
 """ ;
@@ -1288,38 +1288,38 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about compensation or incentives provided to human research participants.
 """ ;
@@ -1330,7 +1330,19 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "HumanSubjectResearch" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
@@ -1338,31 +1350,19 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about whether the dataset involves human subjects research and what regulatory or ethical review processes were followed.
@@ -1374,49 +1374,49 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "InformedConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Details about informed consent procedures used in human subjects research.
 """ ;
@@ -1427,37 +1427,37 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ParticipantPrivacy" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about privacy protections and anonymization procedures for human research participants.
 """ ;
@@ -1467,19 +1467,19 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Erratum" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there an erratum? If so, please provide a link or other access point.
@@ -1490,22 +1490,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExtensionMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If others want to extend/augment/build on/contribute to the dataset, is there a mechanism for them to do so? If so, please describe how those contributions are validated and communicated.
@@ -1522,14 +1522,14 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
+            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
@@ -1546,19 +1546,19 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If the dataset relates to people, are there applicable limits on the retention of their data (e.g., were individuals told their data would be deleted after a certain time)? If so, please describe these limits and how they will be enforced.
 """ ;
@@ -1568,22 +1568,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UpdatePlan" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be updated (e.g., to correct labeling errors, add new instances, delete instances)? If so, how often, by whom, and how will these updates be communicated?
@@ -1595,11 +1595,14 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VersionAccess" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
@@ -1610,11 +1613,8 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
@@ -1627,13 +1627,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AddressingGap" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Was there a specific gap that needed to be filled by creation of the dataset?" ;
@@ -1643,25 +1643,25 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Creator" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CRediTRoleEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliations> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliations> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliations> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who created the dataset (e.g., which team, research group) and on behalf of which entity (e.g., company, institution, organization)? This may also be considered a team.
@@ -1672,20 +1672,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FundingMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who funded the creation of the dataset? If there is an associated grant, please provide the name of the grantor and the grant name and number.
 """ ;
@@ -1698,17 +1698,11 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
@@ -1716,20 +1710,35 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ] ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ] ;
     skos:definition """The name and/or identifier of the specific mechanism providing monetary support or other resources supporting creation of the dataset.
 """ ;
     skos:inScheme data_sheets_schema:motivation .
@@ -1738,13 +1747,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Purpose" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "For what purpose was the dataset created?" ;
@@ -1754,13 +1763,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Task" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Was there a specific task in mind for the dataset's application?" ;
@@ -1771,43 +1780,43 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "AnnotationAnalysis" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Float ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Analysis of annotation quality, inter-annotator agreement metrics, and systematic patterns in annotation disagreements.
 """ ;
@@ -1818,10 +1827,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CleaningStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -1837,16 +1846,7 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ImputationProtocol" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
@@ -1854,14 +1854,23 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Description of data imputation methodology, including techniques used to handle missing values and rationale for chosen approaches.
 """ ;
@@ -1873,52 +1882,52 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "LabelingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
@@ -1931,23 +1940,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MachineAnnotationTools" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Automated or machine-learning-based annotation tools used in dataset creation, including NLP pipelines, computer vision models, or other automated labeling systems.
 """ ;
@@ -1982,17 +1991,17 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was the "raw" data saved in addition to the preprocessed/cleaned/labeled data? If so, please provide a link or other access point to the "raw" data.
 """ ;
@@ -2002,10 +2011,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DiscouragedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -2019,10 +2028,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExistingUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has the dataset been used for any tasks already?
@@ -2033,13 +2042,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FutureUseImpact" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there anything about the dataset's composition or collection that might impact future uses or create risks/harm (e.g., unfair treatment, legal or financial risks)? If so, describe these impacts and any mitigation strategies.
@@ -2051,6 +2060,18 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "IntendedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
         [ a owl:Restriction ;
@@ -2058,22 +2079,10 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of intended uses for this dataset. Complements FutureUseImpact by focusing on positive, recommended applications rather than risks. Aligns with RO-Crate "Intended Use" field.
 """ ;
@@ -2087,10 +2096,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What other tasks could the dataset be used for?
@@ -2101,13 +2110,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ProhibitedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of prohibited or forbidden uses for this dataset. Stronger than DiscouragedUse - these are uses that are explicitly not permitted by license, ethics, or policy. Aligns with RO-Crate "Prohibited Uses" field.
@@ -2118,19 +2127,19 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UseRepository" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "A repository or registry of known uses of this dataset by third parties. Documents where the dataset has been applied, enabling discoverability of downstream use cases and impact tracking." ;
@@ -2141,121 +2150,121 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "VariableMetadata" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Float ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Metadata describing an individual variable, field, or column in a dataset. Variables may represent measurements, observations, derived values, or categorical attributes." ;
     skos:exactMatch schema1:PropertyValue ;
@@ -3432,27 +3441,15 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
     rdfs:label "ExternalResource" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
@@ -3460,6 +3457,18 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:external_resources ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is the dataset self-contained or does it rely on external resources (e.g., websites, other datasets)? If external, are there guarantees that those resources will remain available and unchanged?
 """ ;
@@ -3469,59 +3478,59 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
         linkml:ClassDefinition ;
     rdfs:label "SamplingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
@@ -4150,31 +4159,40 @@ data_sheets_schema:NamedThing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "NamedThing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:name ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:description ] ;
     skos:definition "A generic grouping for any identifiable entity." ;
     skos:exactMatch schema1:Thing ;
@@ -4184,32 +4202,41 @@ data_sheets_schema:Organization a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:id ] ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:description ] ;
     skos:definition "Represents a group or organization." ;
     skos:exactMatch schema1:Organization ;
     skos:inScheme data_sheets_schema:base .
@@ -5209,6 +5236,12 @@ data_sheets_schema:modified_by a owl:ObjectProperty,
     skos:definition "A human-readable name for the grant or funding mechanism." ;
     skos:inScheme data_sheets_schema:motivation .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "notes" ;
+    skos:definition "Content about the grant that fits no dedicated slot; never invent keys (#380)." ;
+    skos:inScheme data_sheets_schema:motivation .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "principal_investigator" ;
@@ -5583,473 +5616,473 @@ data_sheets_schema:Dataset a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:collection_mechanisms ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:purposes ],
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#ConsentRevocation> ;
+            owl:onProperty data_sheets_schema:consent_revocations ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:other_tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:imputation_protocols ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
+            owl:onProperty data_sheets_schema:other_tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:known_biases ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:resources ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
             owl:onProperty data_sheets_schema:content_warnings ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:content_warnings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:splits ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:raw_data_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:missing_data_documentation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:maintainers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:tasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#AtRiskPopulations> ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:machine_annotation_tools ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DataSubset ;
-            owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:known_limitations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FileCollection ;
-            owl:onProperty data_sheets_schema:file_collections ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
-            owl:onProperty data_sheets_schema:creators ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_file_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#ImputationProtocol> ;
-            owl:onProperty data_sheets_schema:imputation_protocols ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_consents ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
-            owl:onProperty data_sheets_schema:tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
-            owl:onProperty data_sheets_schema:anomalies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
-            owl:onProperty data_sheets_schema:maintainers ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/RawDataSource> ;
-            owl:onProperty data_sheets_schema:raw_data_sources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#MachineAnnotationTools> ;
-            owl:onProperty data_sheets_schema:machine_annotation_tools ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:resources ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetLimitation> ;
-            owl:onProperty data_sheets_schema:known_limitations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionNotification> ;
-            owl:onProperty data_sheets_schema:collection_notifications ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:annotation_analyses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:relationships ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:creators ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
-            owl:onProperty data_sheets_schema:errata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:errata ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:third_party_sharing ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Splits> ;
-            owl:onProperty data_sheets_schema:splits ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#ConsentRevocation> ;
-            owl:onProperty data_sheets_schema:consent_revocations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
-            owl:onProperty data_sheets_schema:purposes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
-            owl:onProperty data_sheets_schema:cleaning_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_notifications ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:imputation_protocols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetBias> ;
-            owl:onProperty data_sheets_schema:known_biases ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Relationships> ;
-            owl:onProperty data_sheets_schema:relationships ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:funders ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:direct_collection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:consent_revocations ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
             owl:onProperty data_sheets_schema:funders ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DirectCollection> ;
-            owl:onProperty data_sheets_schema:direct_collection ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#ThirdPartySharing> ;
-            owl:onProperty data_sheets_schema:third_party_sharing ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/MissingDataDocumentation> ;
-            owl:onProperty data_sheets_schema:missing_data_documentation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:updates ],
+            owl:onProperty data_sheets_schema:intended_uses ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
             owl:onProperty data_sheets_schema:participant_compensation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_tabular ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:creators ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
             owl:onProperty data_sheets_schema:distribution_formats ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subsets ],
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetBias> ;
+            owl:onProperty data_sheets_schema:known_biases ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:splits ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_notifications ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/MissingDataDocumentation> ;
+            owl:onProperty data_sheets_schema:missing_data_documentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
+            owl:onProperty data_sheets_schema:related_datasets ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:ip_restrictions ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:DataSubset ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionConsent> ;
+            owl:onProperty data_sheets_schema:collection_consents ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:consent_revocations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#MachineAnnotationTools> ;
+            owl:onProperty data_sheets_schema:machine_annotation_tools ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:content_warnings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
+            owl:onProperty data_sheets_schema:creators ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:anomalies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
+            owl:onProperty data_sheets_schema:annotation_analyses ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_file_count ],
+            owl:onProperty data_sheets_schema:is_tabular ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:raw_sources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:cleaning_strategies ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionConsent> ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:collection_consents ],
         [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
+            owl:onProperty data_sheets_schema:cleaning_strategies ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_file_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_collections ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
-            owl:onProperty data_sheets_schema:other_tasks ],
+            owl:onProperty data_sheets_schema:total_size_bytes ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#AnnotationAnalysis> ;
             owl:onProperty data_sheets_schema:annotation_analyses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:informed_consent ],
+            owl:onProperty data_sheets_schema:third_party_sharing ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#ThirdPartySharing> ;
+            owl:onProperty data_sheets_schema:third_party_sharing ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
+            owl:onProperty data_sheets_schema:version_access ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:known_biases ],
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:raw_data_sources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionNotification> ;
+            owl:onProperty data_sheets_schema:collection_notifications ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
+            owl:onProperty data_sheets_schema:raw_sources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Relationships> ;
+            owl:onProperty data_sheets_schema:relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetLimitation> ;
+            owl:onProperty data_sheets_schema:known_limitations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:distribution_dates ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:maintainers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/RawDataSource> ;
+            owl:onProperty data_sheets_schema:raw_data_sources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:machine_annotation_tools ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:file_collections ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#AtRiskPopulations> ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FileCollection ;
+            owl:onProperty data_sheets_schema:file_collections ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:known_limitations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
+            owl:onProperty data_sheets_schema:maintainers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:direct_collection ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:missing_data_documentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:distribution_formats ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#ImputationProtocol> ;
+            owl:onProperty data_sheets_schema:imputation_protocols ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
+            owl:onProperty data_sheets_schema:distribution_dates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DirectCollection> ;
+            owl:onProperty data_sheets_schema:direct_collection ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Splits> ;
+            owl:onProperty data_sheets_schema:splits ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
+            owl:onProperty data_sheets_schema:informed_consent ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "data package",
@@ -6063,116 +6096,29 @@ data_sheets_schema:Information a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Information" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:keywords ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:doi ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:publisher ],
+            owl:onProperty data_sheets_schema:language ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:publisher ],
+            owl:onProperty data_sheets_schema:doi ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:modified_by ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:page ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:conforms_to_class ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
             owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:keywords ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:page ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
@@ -6180,66 +6126,153 @@ data_sheets_schema:Information a owl:Class,
             owl:onProperty data_sheets_schema:doi ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:title ],
+            owl:onProperty data_sheets_schema:language ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:status ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
+            owl:onProperty data_sheets_schema:created_by ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:created_by ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:download_url ],
+            owl:onProperty data_sheets_schema:was_derived_from ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CompressionEnum ;
             owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uri ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:conforms_to ],
         data_sheets_schema:NamedThing ;
     skos:closeMatch schema1:CreativeWork ;
@@ -6250,10 +6283,13 @@ data_sheets_schema:Person a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:email ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:affiliation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:orcid ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty data_sheets_schema:affiliation ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
@@ -6262,19 +6298,16 @@ data_sheets_schema:Person a owl:Class,
                                 owl:withRestrictions ( [ xsd:pattern "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$" ] ) ] ) ] ;
             owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Organization ;
-            owl:onProperty data_sheets_schema:affiliation ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:orcid ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:orcid ],
         data_sheets_schema:NamedThing ;
     skos:definition "An individual human being. This class represents a person in the context of a specific dataset. Attributes like affiliation and email represent the person's current or most relevant contact information for this dataset. For stable cross-dataset identification, use the ORCID field. Note that contributor roles (CRediT) are specified in the usage context (e.g., Creator class) rather than on the Person directly, since roles vary by dataset." ;
@@ -6397,6 +6430,14 @@ data_sheets_schema:name a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:base ;
     data_sheets_schema:docExample "AI-READI Dataset",
         "University of Washington" .
+
+data_sheets_schema:notes a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "notes" ;
+    skos:definition "Content about the organization that fits no dedicated slot; never invent keys (#380).",
+        "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+        "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 — undeclared keys were the corpus's third-largest failure class)." ;
+    skos:inScheme data_sheets_schema:base .
 
 data_sheets_schema:ComplianceStatusEnum a owl:Class,
         linkml:EnumDefinition ;
@@ -6601,38 +6642,47 @@ data_sheets_schema:DatasetProperty a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetProperty" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Software ;
-            owl:onProperty data_sheets_schema:used_software ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:used_software ],
+            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Software ;
+            owl:onProperty data_sheets_schema:used_software ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:id ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:used_software ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
+            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:name ] ;
+            owl:onProperty data_sheets_schema:description ] ;
     skos:definition "Represents a single property of a dataset, or a set of related properties." ;
     skos:inScheme data_sheets_schema:base .
 

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -409,14 +409,17 @@ class PhaseRequest:
 
 PHASE_INSTRUCTIONS = {
     "full": (
-        "Phase 1. Produce the FULL D4D record for class `Dataset`. Output only "
-        "the YAML, beginning with the header comment block specified above. No "
-        "commentary before or after."),
+        "Phase 1. Produce the FULL D4D record for class `Dataset`. Use only "
+        "keys the schema digest declares; supported content that fits no "
+        "dedicated slot goes in the nearest class's `notes` slot, never in "
+        "an invented key. Output only the YAML, beginning with the header "
+        "comment block specified above. No commentary before or after."),
     "core": (
         "Phase 2. Produce the CORE D4D record for class `CoreDataset`, using "
         "the declared bundle and the completed full record supplied above. The "
         "core record must not assert anything the full record does not support. "
-        "Output only the YAML."),
+        "Use only keys the schema digest declares; unplaced content goes in "
+        "`notes`, never in an invented key. Output only the YAML."),
     "audit": (
         "Phase 3. Audit both records against the declared bundle and the "
         "evidence boundary. Report, as a JSON object with keys `findings` (a "

--- a/src/data_sheets_schema/datamodel/data_sheets_schema.py
+++ b/src/data_sheets_schema/datamodel/data_sheets_schema.py
@@ -1,5 +1,5 @@
 # Auto generated from data_sheets_schema.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-06T12:01:30
+# Generation date: 2026-08-06T15:34:49
 # Schema: data-sheets-schema
 #
 # id: https://w3id.org/bridge2ai/data-sheets-schema
@@ -149,6 +149,7 @@ class NamedThing(YAMLRoot):
     id: Union[str, NamedThingId] = None
     name: Optional[str] = None
     description: Optional[str] = None
+    notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -161,6 +162,9 @@ class NamedThing(YAMLRoot):
 
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
 
         super().__post_init__(**kwargs)
 
@@ -180,6 +184,7 @@ class Organization(YAMLRoot):
     id: Optional[Union[str, URIorCURIE]] = None
     name: Optional[str] = None
     description: Optional[str] = None
+    notes: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.id is not None and not isinstance(self.id, URIorCURIE):
@@ -190,6 +195,9 @@ class Organization(YAMLRoot):
 
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
 
         super().__post_init__(**kwargs)
 
@@ -209,6 +217,7 @@ class DatasetProperty(YAMLRoot):
     id: Optional[Union[str, URIorCURIE]] = None
     name: Optional[str] = None
     description: Optional[str] = None
+    notes: Optional[str] = None
     used_software: Optional[Union[dict[Union[str, SoftwareId], Union[dict, "Software"]], list[Union[dict, "Software"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -220,6 +229,9 @@ class DatasetProperty(YAMLRoot):
 
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
 
         self._normalize_inlined_as_list(slot_name="used_software", slot_type=Software, key_name="id", keyed=True)
 
@@ -1006,6 +1018,7 @@ class Grant(YAMLRoot):
     id: Optional[Union[str, URIorCURIE]] = None
     name: Optional[str] = None
     description: Optional[str] = None
+    notes: Optional[str] = None
     grant_number: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -1017,6 +1030,9 @@ class Grant(YAMLRoot):
 
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
 
         if self.grant_number is not None and not isinstance(self.grant_number, str):
             self.grant_number = str(self.grant_number)
@@ -4243,6 +4259,9 @@ slots.namedThing__name = Slot(uri=SCHEMA.name, name="namedThing__name", curie=SC
 slots.namedThing__description = Slot(uri=SCHEMA.description, name="namedThing__description", curie=SCHEMA.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.namedThing__description, domain=None, range=Optional[str])
 
+slots.namedThing__notes = Slot(uri=SCHEMA.comment, name="namedThing__notes", curie=SCHEMA.curie('comment'),
+                   model_uri=DATA_SHEETS_SCHEMA.namedThing__notes, domain=None, range=Optional[str])
+
 slots.organization__id = Slot(uri=SCHEMA.identifier, name="organization__id", curie=SCHEMA.curie('identifier'),
                    model_uri=DATA_SHEETS_SCHEMA.organization__id, domain=None, range=Optional[Union[str, URIorCURIE]])
 
@@ -4252,6 +4271,9 @@ slots.organization__name = Slot(uri=SCHEMA.name, name="organization__name", curi
 slots.organization__description = Slot(uri=SCHEMA.description, name="organization__description", curie=SCHEMA.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.organization__description, domain=None, range=Optional[str])
 
+slots.organization__notes = Slot(uri=SCHEMA.comment, name="organization__notes", curie=SCHEMA.curie('comment'),
+                   model_uri=DATA_SHEETS_SCHEMA.organization__notes, domain=None, range=Optional[str])
+
 slots.datasetProperty__id = Slot(uri=SCHEMA.identifier, name="datasetProperty__id", curie=SCHEMA.curie('identifier'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetProperty__id, domain=None, range=Optional[Union[str, URIorCURIE]])
 
@@ -4260,6 +4282,9 @@ slots.datasetProperty__name = Slot(uri=SCHEMA.name, name="datasetProperty__name"
 
 slots.datasetProperty__description = Slot(uri=SCHEMA.description, name="datasetProperty__description", curie=SCHEMA.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetProperty__description, domain=None, range=Optional[str])
+
+slots.datasetProperty__notes = Slot(uri=SCHEMA.comment, name="datasetProperty__notes", curie=SCHEMA.curie('comment'),
+                   model_uri=DATA_SHEETS_SCHEMA.datasetProperty__notes, domain=None, range=Optional[str])
 
 slots.datasetProperty__used_software = Slot(uri=D4D.usedSoftware, name="datasetProperty__used_software", curie=D4D.curie('usedSoftware'),
                    model_uri=DATA_SHEETS_SCHEMA.datasetProperty__used_software, domain=None, range=Optional[Union[dict[Union[str, SoftwareId], Union[dict, Software]], list[Union[dict, Software]]]])
@@ -4330,6 +4355,9 @@ slots.grant__name = Slot(uri=SCHEMA.name, name="grant__name", curie=SCHEMA.curie
 
 slots.grant__description = Slot(uri=SCHEMA.description, name="grant__description", curie=SCHEMA.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.grant__description, domain=None, range=Optional[str])
+
+slots.grant__notes = Slot(uri=SCHEMA.comment, name="grant__notes", curie=SCHEMA.curie('comment'),
+                   model_uri=DATA_SHEETS_SCHEMA.grant__notes, domain=None, range=Optional[str])
 
 slots.grant__grant_number = Slot(uri=D4D.grantIdentifier, name="grant__grant_number", curie=D4D.curie('grantIdentifier'),
                    model_uri=DATA_SHEETS_SCHEMA.grant__grant_number, domain=None, range=Optional[str])

--- a/src/data_sheets_schema/schema/D4D_Base_import.yaml
+++ b/src/data_sheets_schema/schema/D4D_Base_import.yaml
@@ -110,6 +110,13 @@ classes:
         range: string
         annotations:
           "d4d:docExample": "A multimodal dataset of 4,000 participants with Type 2 Diabetes."
+      notes:
+        slot_uri: schema:comment
+        range: string
+        description: >-
+          Content from the source material that belongs to this entity but
+          fits no dedicated slot. Use this rather than inventing keys the
+          schema does not declare (#380).
     class_uri: schema:Thing
 
   # Not a NamedThing, like DatasetProperty below and for the same reason:
@@ -144,6 +151,12 @@ classes:
         slot_uri: schema:description
         description: A human-readable description for the organization.
         range: string
+      notes:
+        slot_uri: schema:comment
+        range: string
+        description: >-
+          Content about the organization that fits no dedicated slot; never
+          invent keys (#380).
 
   # Base class for all dataset properties and components
   # Note: Does NOT inherit from NamedThing to avoid required id constraint
@@ -164,6 +177,15 @@ classes:
         slot_uri: schema:description
         description: A human-readable description for this property.
         range: string
+      notes:
+        slot_uri: schema:comment
+        range: string
+        description: >-
+          Content from the source material that belongs to this property but
+          fits no dedicated slot. The escape hatch that makes inventing keys
+          unnecessary: put the fact here with enough context to be findable,
+          rather than adding fields the schema does not declare (#380 —
+          undeclared keys were the corpus's third-largest failure class).
       used_software:
         description: "What software was used as part of this dataset property?"
         slot_uri: d4d:usedSoftware

--- a/src/data_sheets_schema/schema/D4D_Motivation.yaml
+++ b/src/data_sheets_schema/schema/D4D_Motivation.yaml
@@ -178,6 +178,12 @@ classes:
         slot_uri: schema:description
         description: A human-readable description of the grant.
         range: string
+      notes:
+        slot_uri: schema:comment
+        range: string
+        description: >-
+          Content about the grant that fits no dedicated slot; never invent
+          keys (#380).
       grant_number:
         description: "The alphanumeric identifier for the grant."
         range: string

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -2722,6 +2722,93 @@ classes:
         - VariableMetadata
         - File
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DatasetCollection
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
     tree_root: true
   Dataset:
     name: Dataset
@@ -4457,6 +4544,93 @@ classes:
         - VariableMetadata
         - File
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Dataset
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
     class_uri: dcat:Distribution
   DataSubset:
     name: DataSubset
@@ -6130,6 +6304,93 @@ classes:
         - VariableMetadata
         - File
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DataSubset
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
   NamedThing:
     name: NamedThing
     description: A generic grouping for any identifiable entity.
@@ -6404,6 +6665,93 @@ classes:
         - VariableMetadata
         - File
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: NamedThing
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
     class_uri: schema:Thing
   Organization:
     name: Organization
@@ -6484,6 +6832,31 @@ classes:
         - DatasetProperty
         - Grant
         - DatasetRelationship
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        range: string
+      notes:
+        name: notes
+        description: Content about the organization that fits no dedicated slot; never
+          invent keys (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Organization
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -6708,6 +7081,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DatasetProperty
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -7157,6 +7617,93 @@ classes:
         - VariableMetadata
         - File
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Software
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
     class_uri: schema:SoftwareApplication
   Person:
     name: Person
@@ -7439,6 +7986,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Person
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -8175,6 +8809,93 @@ classes:
         - VariableMetadata
         - File
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Information
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
   FormatDialect:
     name: FormatDialect
     description: Additional format information for a file.
@@ -8465,6 +9186,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Purpose
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -8862,6 +9670,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Task
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -9174,6 +10069,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: AddressingGap
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -9600,6 +10582,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Creator
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -9964,6 +11033,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: FundingMechanism
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -10132,6 +11288,31 @@ classes:
         - Creator
         - FundingMechanism
         range: string
+      notes:
+        name: notes
+        description: Content about the organization that fits no dedicated slot; never
+          invent keys (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Grantor
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        range: string
   Grant:
     name: Grant
     description: 'The name and/or identifier of the specific mechanism providing monetary
@@ -10217,6 +11398,32 @@ classes:
         - Grantor
         - Grant
         - DatasetRelationship
+        range: string
+      notes:
+        name: notes
+        description: Content about the grant that fits no dedicated slot; never invent
+          keys (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
+        slot_uri: schema:comment
+        alias: notes
+        owner: Grant
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Grant
         range: string
       grant_number:
         name: grant_number
@@ -10571,6 +11778,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Instance
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -11059,6 +12353,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: SamplingStrategy
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -11391,6 +12772,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: MissingInfo
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -11792,6 +13260,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Relationships
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -12149,6 +13704,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Splits
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -12461,6 +14103,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DataAnomaly
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -12911,6 +14640,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DatasetBias
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -13269,6 +15085,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DatasetLimitation
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -13719,6 +15622,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ExternalResource
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -14041,6 +16031,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Confidentiality
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -14450,6 +16527,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ContentWarning
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -14785,6 +16949,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Subpopulation
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -15215,6 +17466,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Deidentification
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -15581,6 +17919,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: SensitiveElement
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -15834,6 +18259,93 @@ classes:
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:name
         alias: name
+        owner: DatasetRelationship
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
         owner: DatasetRelationship
         domain_of:
         - DatasetCollection
@@ -16310,6 +18822,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: InstanceAcquisition
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -16625,6 +19224,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CollectionMechanism
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -16996,6 +19682,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DataCollector
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -17426,6 +20199,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CollectionTimeframe
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -17748,6 +20608,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DirectCollection
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -18139,6 +21086,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: MissingDataDocumentation
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -18594,6 +21628,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: RawDataSource
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -18952,6 +22073,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: PreprocessingStrategy
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -19266,6 +22474,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CleaningStrategy
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -19743,6 +23038,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: LabelingStrategy
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -20064,6 +23446,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: RawData
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -20469,6 +23938,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ImputationProtocol
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -20922,6 +24478,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: AnnotationAnalysis
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -21319,6 +24962,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: MachineAnnotationTools
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -21629,6 +25359,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ExistingUse
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -22037,6 +25854,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: UseRepository
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -22347,6 +26251,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: OtherTask
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -22753,6 +26744,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: FutureUseImpact
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -23064,6 +27142,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DiscouragedUse
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -23494,6 +27659,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: IntendedUse
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -23848,6 +28100,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ProhibitedUse
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -24156,6 +28495,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ThirdPartySharing
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -24554,6 +28980,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DistributionFormat
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -24866,6 +29379,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DistributionDate
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -25278,6 +29878,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Maintainer
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -25605,6 +30292,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Erratum
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -26023,6 +30797,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: UpdatePlan
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -26351,6 +31212,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: RetentionLimits
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -26779,6 +31727,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: VersionAccess
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -27107,6 +32142,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ExtensionMechanism
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -27539,6 +32661,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: EthicalReview
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -27854,6 +33063,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DataProtectionImpact
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -28257,6 +33553,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CollectionNotification
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -28571,6 +33954,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CollectionConsent
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -28930,6 +34400,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ConsentRevocation
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -29386,6 +34943,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: HumanSubjectResearch
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -29752,6 +35396,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: InformedConsent
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -30196,6 +35927,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ParticipantPrivacy
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -30547,6 +36365,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: HumanSubjectCompensation
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -30988,6 +36893,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: AtRiskPopulations
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -31382,6 +37374,93 @@ classes:
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: LicenseAndUseTerms
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -31698,6 +37777,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: IPRestrictions
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -32113,6 +38279,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ExportControlRegulatoryRestrictions
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -32657,6 +38910,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: VariableMetadata
+        domain_of:
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -33617,6 +39957,93 @@ classes:
         - VariableMetadata
         - File
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: File
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
     class_uri: schema:MediaObject
   FileCollection:
     name: FileCollection
@@ -34372,6 +40799,93 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - File
+        range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: FileCollection
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -2116,6 +2116,91 @@ classes:
         - CoreDistribution
         - CoreDatasetCollection
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: NamedThing
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: string
     class_uri: schema:Thing
   Organization:
     name: Organization
@@ -2187,6 +2272,28 @@ classes:
         - DatasetProperty
         - Grant
         - DatasetRelationship
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        range: string
+      notes:
+        name: notes
+        description: Content about the organization that fits no dedicated slot; never
+          invent keys (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Organization
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
         - Software
         - Person
         - Information
@@ -2404,6 +2511,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DatasetProperty
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -2842,6 +3034,91 @@ classes:
         - CoreDistribution
         - CoreDatasetCollection
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Software
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: string
     class_uri: schema:SoftwareApplication
   Person:
     name: Person
@@ -3117,6 +3394,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Person
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -3788,6 +4150,91 @@ classes:
         - CoreDistribution
         - CoreDatasetCollection
         range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Information
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: string
   FormatDialect:
     name: FormatDialect
     description: Additional format information for a file.
@@ -4071,6 +4518,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Purpose
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -4464,6 +4996,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Task
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -4770,6 +5387,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: AddressingGap
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -5192,6 +5894,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Creator
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -5551,6 +6338,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: FundingMechanism
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -5711,6 +6583,28 @@ classes:
         - Creator
         - FundingMechanism
         range: string
+      notes:
+        name: notes
+        description: Content about the organization that fits no dedicated slot; never
+          invent keys (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Grantor
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        range: string
   Grant:
     name: Grant
     description: 'The name and/or identifier of the specific mechanism providing monetary
@@ -5787,6 +6681,29 @@ classes:
         - Grantor
         - Grant
         - DatasetRelationship
+        range: string
+      notes:
+        name: notes
+        description: Content about the grant that fits no dedicated slot; never invent
+          keys (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
+        slot_uri: schema:comment
+        alias: notes
+        owner: Grant
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Grant
         range: string
       grant_number:
         name: grant_number
@@ -6133,6 +7050,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Instance
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -6617,6 +7619,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: SamplingStrategy
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -6943,6 +8030,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: MissingInfo
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -7340,6 +8512,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Relationships
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -7692,6 +8949,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Splits
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -7998,6 +9340,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DataAnomaly
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -8444,6 +9871,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DatasetBias
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -8796,6 +10308,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DatasetLimitation
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -9240,6 +10837,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ExternalResource
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -9556,6 +11238,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Confidentiality
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -9961,6 +11728,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ContentWarning
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -10290,6 +12142,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Subpopulation
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -10716,6 +12653,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Deidentification
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -11077,6 +13099,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: SensitiveElement
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -11326,6 +13433,91 @@ classes:
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:name
         alias: name
+        owner: DatasetRelationship
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
         owner: DatasetRelationship
         domain_of:
         - NamedThing
@@ -11795,6 +13987,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: InstanceAcquisition
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -12104,6 +14381,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CollectionMechanism
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -12470,6 +14832,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DataCollector
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -12896,6 +15343,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CollectionTimeframe
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -13212,6 +15744,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DirectCollection
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -13598,6 +16215,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: MissingDataDocumentation
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -14049,6 +16751,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: RawDataSource
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -14402,6 +17189,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: PreprocessingStrategy
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -14710,6 +17582,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CleaningStrategy
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -15183,6 +18140,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: LabelingStrategy
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -15498,6 +18540,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: RawData
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -15898,6 +19025,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ImputationProtocol
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -16347,6 +19559,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: AnnotationAnalysis
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -16739,6 +20036,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: MachineAnnotationTools
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -17043,6 +20425,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ExistingUse
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -17447,6 +20914,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: UseRepository
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -17751,6 +21303,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: OtherTask
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -18153,6 +21790,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: FutureUseImpact
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -18458,6 +22180,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DiscouragedUse
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -18884,6 +22691,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: IntendedUse
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -19233,6 +23125,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ProhibitedUse
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -19535,6 +23512,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ThirdPartySharing
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -19929,6 +23991,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DistributionFormat
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -20235,6 +24382,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DistributionDate
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -20643,6 +24875,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Maintainer
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -20964,6 +25281,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: Erratum
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -21378,6 +25780,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: UpdatePlan
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -21700,6 +26187,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: RetentionLimits
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -22124,6 +26696,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: VersionAccess
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -22446,6 +27103,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ExtensionMechanism
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -22874,6 +27616,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: EthicalReview
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -23183,6 +28010,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DataProtectionImpact
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -23582,6 +28494,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CollectionNotification
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -23890,6 +28887,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CollectionConsent
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -24244,6 +29326,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ConsentRevocation
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -24696,6 +29863,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: HumanSubjectResearch
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -25056,6 +30308,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: InformedConsent
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -25496,6 +30833,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ParticipantPrivacy
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -25841,6 +31263,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: HumanSubjectCompensation
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -26278,6 +31785,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: AtRiskPopulations
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -26667,6 +32259,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: LicenseAndUseTerms
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -26977,6 +32654,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: IPRestrictions
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -27386,6 +33148,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: ExportControlRegulatoryRestrictions
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -27970,6 +33817,91 @@ classes:
         - ExportControlRegulatoryRestrictions
         - VariableMetadata
         range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: VariableMetadata
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
       used_software:
         name: used_software
         description: What software was used as part of this dataset property?
@@ -28416,6 +34348,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Content from the source material that belongs to this property
+          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
+          put the fact here with enough context to be findable, rather than adding
+          fields the schema does not declare (#380 — undeclared keys were the corpus''s
+          third-largest failure class).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CoreDistribution
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -29111,6 +35128,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CoreDatasetCollection
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector
@@ -30494,6 +36596,91 @@ classes:
         - Subpopulation
         - Deidentification
         - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - VariableMetadata
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: string
+      notes:
+        name: notes
+        description: Content from the source material that belongs to this entity
+          but fits no dedicated slot. Use this rather than inventing keys the schema
+          does not declare (#380).
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: CoreDataset
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
         - InstanceAcquisition
         - CollectionMechanism
         - DataCollector


### PR DESCRIPTION
Addresses Harry's question about structure hallucination — analysis + the escape hatch, landed while the sweep is paused (this changes both schema and assembly).

- **Analysis** (on #380): 79 undeclared-key findings decompose into standard-vocabulary near-misses (majority — `affiliation` singular 47×, DCAT `download_url`/`checksum`, `grant` vs `grants`, `same_as`) and genuinely unplaced content (minority — Harry's hypothesis).
- **`notes` slot** (`schema:comment`, optional scalar string, consistent with the 2.0.0 scalarization evidence) on `DatasetProperty`, `NamedThing` (→ Dataset/Person/File/Software), `Organization`, `Grant`; schemas regenerated.
- **Instructions**: full/core phases now say only declared keys; unplaced content goes in `notes`, never an invented key. The `test_carry_instructions…`/assembly fingerprint machinery records the change.
- The one pre-notes phase-1 artifact under the fresh schema2 label is quarantined so the relaunched sweep is uniform from its first record.
- Slot-level aliases for the near-miss names (or adopting the DCAT-standard slots outright) stay open on #380 as a modeling decision.

Testing: 148 tests OK across the three touched suites; `notes` verified in regenerated full + core artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)