### PR TITLE
Scalarize the straggler narrative slots the first schema-2 canary exposed

### DIFF
--- a/project/jsonld/data_sheets_schema.jsonld
+++ b/project/jsonld/data_sheets_schema.jsonld
@@ -5020,7 +5020,6 @@
         "SamplingStrategy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -5558,7 +5557,6 @@
         "Deidentification"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6496,7 +6494,6 @@
         "AnnotationAnalysis"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6540,7 +6537,6 @@
         "MachineAnnotationTools"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6625,7 +6621,6 @@
         "UseRepository"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -6931,7 +6926,6 @@
         "Erratum"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7539,7 +7533,6 @@
         "ParticipantPrivacy"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7690,7 +7683,6 @@
         "AtRiskPopulations"
       ],
       "range": "string",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -7761,7 +7753,6 @@
         "LicenseAndUseTerms"
       ],
       "range": "DataUsePermissionEnum",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -8249,7 +8240,6 @@
         "FileCollection"
       ],
       "range": "FileCollectionTypeEnum",
-      "multivalued": true,
       "@type": "SlotDefinition"
     },
     {
@@ -10329,7 +10319,6 @@
           "description": "One or more sampling strategies used (e.g., deterministic, simple random, stratified, cluster, systematic).\n",
           "slot_uri": "d4d:strategies",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -10878,7 +10867,6 @@
           "description": "List of identifier types removed during de-identification (e.g., 'name', 'date of birth', 'SSN', 'email address', 'geographic subdivision').",
           "slot_uri": "d4d:removedIdentifierTypes",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -11768,7 +11756,6 @@
           "description": "Additional details on annotation quality assessment and findings.\n",
           "slot_uri": "d4d:annotationQualityDetails",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -11819,7 +11806,6 @@
           "description": "Descriptions of what each tool does in the annotation process and what types of annotations it produces. Should correspond to the tools list.\n",
           "slot_uri": "d4d:toolDescriptions",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -11911,7 +11897,6 @@
           "description": "Free-text description of the repository of known dataset uses, including how it is maintained and how to contribute new use cases.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12305,7 +12290,6 @@
           "description": "Free-text description of the error, its scope, the affected data or records, and the correction applied.\n",
           "slot_uri": "dcterms:description",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         }
       ],
@@ -12913,7 +12897,6 @@
           "description": "What privacy-preserving techniques were applied (e.g., differential privacy, k-anonymity, data masking)?\n",
           "slot_uri": "d4d:privacyTechniques",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -13038,7 +13021,6 @@
           "description": "For research involving minors, what assent procedures were used? How was developmentally appropriate assent obtained?\n",
           "slot_uri": "d4d:assentProcedures",
           "range": "string",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -13104,7 +13086,6 @@
           ],
           "slot_uri": "DUO:0000001",
           "range": "DataUsePermissionEnum",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -13585,7 +13566,6 @@
           "description": "Type(s) of content in this file collection. A collection may have multiple types, for example a collection containing both raw_data and documentation files would have both types listed.",
           "slot_uri": "d4d:collectionType",
           "range": "FileCollectionTypeEnum",
-          "multivalued": true,
           "@type": "SlotDefinition"
         },
         {
@@ -13628,7 +13608,7 @@
   "source_file": "data_sheets_schema.yaml",
   "source_file_date": "2026-08-06T12:37:37",
   "source_file_size": 32488,
-  "generation_date": "2026-08-06T15:34:46",
+  "generation_date": "2026-08-06T20:21:35",
   "@type": "SchemaDefinition",
   "@context": [
     "project/jsonld/data_sheets_schema.context.jsonld",

--- a/project/jsonschema/data_sheets_schema.schema.json
+++ b/project/jsonschema/data_sheets_schema.schema.json
@@ -73,11 +73,8 @@
                 },
                 "annotation_quality_details": {
                     "description": "Additional details on annotation quality assessment and findings.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -146,11 +143,8 @@
             "properties": {
                 "assent_procedures": {
                     "description": "For research involving minors, what assent procedures were used? How was developmentally appropriate assent obtained?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3355,11 +3349,8 @@
                 },
                 "identifiers_removed": {
                     "description": "List of identifier types removed during de-identification (e.g., 'name', 'date of birth', 'SSN', 'email address', 'geographic subdivision').",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -3686,11 +3677,8 @@
                 },
                 "erratum_details": {
                     "description": "Free-text description of the error, its scope, the affected data or records, and the correction applied.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -4320,14 +4308,8 @@
             "description": "A collection of files with shared characteristics (format, purpose, structure). Represents a logical grouping of related files within a dataset, such as all training data files, all image files, or all raw data files. Maps to RO-Crate Dataset entities via schema:hasPart relationships.",
             "properties": {
                 "collection_type": {
-                    "description": "Type(s) of content in this file collection. A collection may have multiple types, for example a collection containing both raw_data and documentation files would have both types listed.",
-                    "items": {
-                        "$ref": "#/$defs/FileCollectionTypeEnum"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
+                    "$ref": "#/$defs/FileCollectionTypeEnum",
+                    "description": "Type(s) of content in this file collection. A collection may have multiple types, for example a collection containing both raw_data and documentation files would have both types listed."
                 },
                 "compression": {
                     "$ref": "#/$defs/CompressionEnum",
@@ -5768,14 +5750,8 @@
                     ]
                 },
                 "data_use_permission": {
-                    "description": "Structured data use permissions using the Data Use Ontology (DUO). Specifies permitted uses (e.g., general research, health/medical research, disease-specific research) and restrictions (e.g., non-commercial use, ethics approval required, collaboration required). See https://github.com/EBISPOT/DUO.",
-                    "items": {
-                        "$ref": "#/$defs/DataUsePermissionEnum"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
+                    "$ref": "#/$defs/DataUsePermissionEnum",
+                    "description": "Structured data use permissions using the Data Use Ontology (DUO). Specifies permitted uses (e.g., general research, health/medical research, disease-specific research) and restrictions (e.g., non-commercial use, ethics approval required, collaboration required). See https://github.com/EBISPOT/DUO."
                 },
                 "description": {
                     "description": "A human-readable description for this property.",
@@ -5884,11 +5860,8 @@
                 },
                 "tool_descriptions": {
                     "description": "Descriptions of what each tool does in the annotation process and what types of annotations it produces. Should correspond to the tools list.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6308,11 +6281,8 @@
                 },
                 "privacy_techniques": {
                     "description": "What privacy-preserving techniques were applied (e.g., differential privacy, k-anonymity, data masking)?\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -6876,11 +6846,8 @@
                 },
                 "strategies": {
                     "description": "One or more sampling strategies used (e.g., deterministic, simple random, stratified, cluster, systematic).\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },
@@ -7342,11 +7309,8 @@
                 },
                 "repository_details": {
                     "description": "Free-text description of the repository of known dataset uses, including how it is maintained and how to contribute new use cases.\n",
-                    "items": {
-                        "type": "string"
-                    },
                     "type": [
-                        "array",
+                        "string",
                         "null"
                     ]
                 },

--- a/project/owl/data_sheets_schema.owl.ttl
+++ b/project/owl/data_sheets_schema.owl.ttl
@@ -16,10 +16,10 @@ data_sheets_schema:DatasetCollection a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
             owl:onProperty data_sheets_schema:resources ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:resources ],
         data_sheets_schema:Information ;
     skos:altLabel "data resource collection",
@@ -34,50 +34,50 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FormatDialect" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:header ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:header ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:double_quote ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:quote_char ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:quote_char ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:double_quote ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:quote_char ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:quote_char ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:double_quote ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:header ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:delimiter ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:delimiter ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:header ],
+            owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:double_quote ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:delimiter ] ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:header ] ;
     skos:definition "Additional format information for a file." ;
     skos:inScheme data_sheets_schema:base .
 
@@ -109,22 +109,22 @@ data_sheets_schema:DataSubset a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataSubset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_data_split ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_subpopulation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty data_sheets_schema:is_subpopulation ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_subpopulation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_data_split ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_subpopulation ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:is_data_split ],
         data_sheets_schema:Dataset ;
     skos:definition "A subset of a dataset, likely containing multiple files of multiple potential purposes and properties." ;
@@ -134,92 +134,71 @@ data_sheets_schema:File a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "File" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:bytes ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FormatEnum ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:dialect ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:hash ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:media_type ],
+            owl:onProperty data_sheets_schema:md5 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:path ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:EncodingEnum ;
             owl:onProperty data_sheets_schema:encoding ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:FileTypeEnum ;
             owl:onProperty data_sheets_schema:file_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:hash ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:sha256 ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:file_type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:encoding ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty data_sheets_schema:bytes ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
+            owl:onProperty data_sheets_schema:bytes ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:hash ],
+            owl:onProperty data_sheets_schema:dialect ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:file_type ],
@@ -232,6 +211,27 @@ data_sheets_schema:File a owl:Class,
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FormatEnum ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:media_type ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "file",
@@ -245,59 +245,62 @@ data_sheets_schema:FileCollection a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FileCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:File ;
-            owl:onProperty data_sheets_schema:resources ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_bytes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_bytes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:file_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:file_count ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:path ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:file_count ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
             owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:total_bytes ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:file_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FileCollectionTypeEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:collection_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_bytes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:path ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:resources ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:collection_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FileCollectionTypeEnum ;
+            owl:onProperty data_sheets_schema:collection_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_bytes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:File ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
         data_sheets_schema:Information ;
     skos:altLabel "data files",
         "file collection",
@@ -312,14 +315,8 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Software" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:version ],
@@ -327,16 +324,22 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:url ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:license ],
         data_sheets_schema:NamedThing ;
     skos:definition "A software program or library." ;
@@ -347,13 +350,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What mechanisms or procedures were used to collect the data (e.g., hardware, manual curation, software APIs)? Also covers how these mechanisms were validated.
@@ -366,31 +369,31 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "CollectionTimeframe" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:Date ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Date ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Date ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Over what timeframe was the data collected, and does this timeframe match the creation timeframe of the underlying data?
 """ ;
@@ -427,22 +430,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DirectCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Indicates whether the data was collected directly from the individuals in question or obtained via third parties/other sources.
@@ -453,50 +456,50 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "InstanceAcquisition" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Describes how data associated with each instance was acquired (e.g., directly observed, reported by subjects, inferred).
 """ ;
@@ -506,14 +509,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MissingDataDocumentation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
@@ -521,17 +530,11 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documentation of missing data in the dataset, including patterns, causes, and strategies for handling missing values.
 """ ;
@@ -542,21 +545,6 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "RawDataSource" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
         [ a owl:Restriction ;
@@ -564,19 +552,34 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Description of raw data sources before preprocessing, cleaning, or labeling. Documents where the original data comes from and how it can be accessed.
 """ ;
@@ -587,23 +590,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Confidentiality" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be confidential (e.g., protected by legal privilege, patient data, non-public communications)?
 """ ;
@@ -613,20 +616,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ContentWarning" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain any data that might be offensive, insulting, threatening, or otherwise anxiety-provoking if viewed directly?
 """ ;
@@ -636,13 +639,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataAnomaly" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are there any errors, sources of noise, or redundancies in the dataset?
@@ -653,29 +656,8 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetBias" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:BiasTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
@@ -683,8 +665,29 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documents known biases present in the dataset. Biases are systematic errors or prejudices that may affect the representativeness or fairness of the data. Distinct from anomalies (data quality issues) and limitations (scope constraints).
 """ ;
@@ -695,38 +698,38 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetLimitation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:LimitationTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
@@ -740,32 +743,32 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:DatasetRelationshipTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Typed relationship to another dataset, enabling precise specification of how datasets relate to each other (e.g., supplements, derives from, is version of). Supports RO-Crate-style dataset interlinking.
 """ ;
@@ -776,37 +779,40 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "Deidentification" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is it possible to identify individuals in the dataset, either directly or indirectly (in combination with other data)?
 """ ;
@@ -816,68 +822,68 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Instance" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
@@ -891,15 +897,15 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "MissingInfo" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is any information missing from individual instances? (e.g., unavailable data).
@@ -910,13 +916,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Relationships" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are relationships between individual instances made explicit (e.g., users' movie ratings, social network links)?
@@ -927,22 +933,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SensitiveElement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be considered sensitive (e.g., race, sexual orientation, religion, biometrics)?
@@ -954,13 +960,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Splits" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are there recommended data splits (e.g., training, validation, testing)? If so, how are they defined and why?
@@ -972,31 +978,31 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "Subpopulation" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset identify any subpopulations (e.g., by age, gender)? If so, how are they identified and what are their distributions?
 """ ;
@@ -1006,47 +1012,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExportControlRegulatoryRestrictions" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Do any export controls or other regulatory restrictions apply to the dataset or to individual instances? Includes compliance tracking for regulations like HIPAA and other US regulations. If so, please describe these restrictions and provide a link or copy of any supporting documentation. Maps to DUO terms related to ethics approval, geographic restrictions, and institutional requirements.
 """ ;
@@ -1073,25 +1079,28 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:DataUsePermissionEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed under a copyright or other IP license, and/or under applicable terms of use? Provide a link or copy of relevant licensing terms and any fees.
@@ -1116,10 +1125,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DistributionFormat" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#access_urls> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#access_urls> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """How will the dataset be distributed (e.g., tarball on a website, API, GitHub)?
@@ -1133,10 +1142,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed to third parties outside of the entity (e.g., company, institution, organization) on behalf of which the dataset was created?
@@ -1164,13 +1173,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionNotification" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#notification_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were the individuals in question notified about the data collection? If so, please describe (or show with screenshots, etc.) how notice was provided, and reproduce the language of the notification itself if possible.
@@ -1181,13 +1190,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ConsentRevocation" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If consent was obtained, were the consenting individuals provided with a mechanism to revoke their consent in the future or for certain uses? If so, please describe.
@@ -1201,10 +1210,10 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has an analysis of the potential impact of the dataset and its use on data subjects (e.g., a data protection impact analysis) been conducted? If so, please provide a description of this analysis, including the outcomes, and any supporting documentation.
@@ -1216,31 +1225,31 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "EthicalReview" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were any ethical or compliance review processes conducted (e.g., by an institutional review board)? If so, please provide a description of these review processes, including the frequency of review and documentation of outcomes, as well as a link or other access point to any supporting documentation.
 """ ;
@@ -1253,29 +1262,32 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about protections for at-risk populations in human subjects research.
 """ ;
@@ -1285,41 +1297,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "HumanSubjectCompensation" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about compensation or incentives provided to human research participants.
 """ ;
@@ -1329,40 +1341,40 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "HumanSubjectResearch" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about whether the dataset involves human subjects research and what regulatory or ethical review processes were followed.
@@ -1373,47 +1385,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "InformedConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
@@ -1426,38 +1438,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ParticipantPrivacy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about privacy protections and anonymization procedures for human research participants.
 """ ;
@@ -1467,20 +1482,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Erratum" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there an erratum? If so, please provide a link or other access point.
 """ ;
@@ -1490,23 +1508,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExtensionMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If others want to extend/augment/build on/contribute to the dataset, is there a mechanism for them to do so? If so, please describe how those contributions are validated and communicated.
 """ ;
@@ -1519,20 +1537,20 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who will be supporting/hosting/maintaining the dataset?
 """ ;
@@ -1543,12 +1561,6 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "RetentionLimits" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -1556,8 +1568,14 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If the dataset relates to people, are there applicable limits on the retention of their data (e.g., were individuals told their data would be deleted after a certain time)? If so, please describe these limits and how they will be enforced.
@@ -1568,23 +1586,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UpdatePlan" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be updated (e.g., to correct labeling errors, add new instances, delete instances)? If so, how often, by whom, and how will these updates be communicated?
 """ ;
@@ -1595,6 +1613,12 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VersionAccess" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
         [ a owl:Restriction ;
@@ -1602,22 +1626,16 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will older versions of the dataset continue to be supported/hosted/maintained? If so, how? If not, how will obsolescence be communicated to dataset consumers?
 """ ;
@@ -1627,13 +1645,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AddressingGap" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Was there a specific gap that needed to be filled by creation of the dataset?" ;
@@ -1643,11 +1661,14 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Creator" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
+            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CRediTRoleEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
@@ -1660,9 +1681,6 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliations> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who created the dataset (e.g., which team, research group) and on behalf of which entity (e.g., company, institution, organization)? This may also be considered a team.
 """ ;
@@ -1675,16 +1693,16 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who funded the creation of the dataset? If there is an associated grant, please provide the name of the grantor and the grant name and number.
@@ -1696,49 +1714,49 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "Grant" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ] ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ] ;
     skos:definition """The name and/or identifier of the specific mechanism providing monetary support or other resources supporting creation of the dataset.
 """ ;
     skos:inScheme data_sheets_schema:motivation .
@@ -1747,13 +1765,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Purpose" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "For what purpose was the dataset created?" ;
@@ -1766,10 +1784,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Was there a specific task in mind for the dataset's application?" ;
@@ -1779,44 +1797,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AnnotationAnalysis" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Float ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Analysis of annotation quality, inter-annotator agreement metrics, and systematic patterns in annotation disagreements.
 """ ;
@@ -1827,13 +1848,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CleaningStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any cleaning of the data done (e.g., removal of instances, processing of missing values)?
@@ -1846,31 +1867,31 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ImputationProtocol" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Description of data imputation methodology, including techniques used to handle missing values and rationale for chosen approaches.
 """ ;
@@ -1882,55 +1903,55 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "LabelingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any labeling of the data done (e.g., part-of-speech tagging)? This class documents the annotation process and quality metrics.
 """ ;
@@ -1941,22 +1962,25 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "MachineAnnotationTools" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Automated or machine-learning-based annotation tools used in dataset creation, including NLP pipelines, computer vision models, or other automated labeling systems.
 """ ;
@@ -1967,13 +1991,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "PreprocessingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any preprocessing of the data done (e.g., discretization or bucketing, tokenization, SIFT feature extraction)?
@@ -1986,22 +2010,22 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "RawData" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was the "raw" data saved in addition to the preprocessed/cleaned/labeled data? If so, please provide a link or other access point to the "raw" data.
 """ ;
@@ -2011,10 +2035,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DiscouragedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -2028,10 +2052,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExistingUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has the dataset been used for any tasks already?
@@ -2042,13 +2066,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FutureUseImpact" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there anything about the dataset's composition or collection that might impact future uses or create risks/harm (e.g., unfair treatment, legal or financial risks)? If so, describe these impacts and any mitigation strategies.
@@ -2061,28 +2085,28 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "IntendedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of intended uses for this dataset. Complements FutureUseImpact by focusing on positive, recommended applications rather than risks. Aligns with RO-Crate "Intended Use" field.
 """ ;
@@ -2093,10 +2117,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "OtherTask" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -2113,10 +2137,10 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of prohibited or forbidden uses for this dataset. Stronger than DiscouragedUse - these are uses that are explicitly not permitted by license, ethics, or policy. Aligns with RO-Crate "Prohibited Uses" field.
@@ -2127,19 +2151,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UseRepository" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "A repository or registry of known uses of this dataset by third parties. Documents where the dataset has been applied, enabling discoverability of downstream use cases and impact tracking." ;
@@ -2149,62 +2176,56 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VariableMetadata" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
@@ -2213,46 +2234,22 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
@@ -2260,11 +2257,41 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Metadata describing an individual variable, field, or column in a dataset. Variables may represent measurements, observations, derived values, or categorical attributes." ;
     skos:exactMatch schema1:PropertyValue ;
@@ -3430,12 +3457,6 @@ data_sheets_schema:collection_timeframes a owl:ObjectProperty,
     skos:definition "Time periods during which data was collected. List of CollectionTimeframe objects from the Collection module describing collection start and end dates, and any gaps in the collection period." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
 
-data_sheets_schema:collection_type a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "collection_type" ;
-    skos:definition "Type(s) of content in this file collection. A collection may have multiple types, for example a collection containing both raw_data and documentation files would have both types listed." ;
-    skos:inScheme data_sheets_schema:file-collection .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExternalResource" ;
@@ -3443,32 +3464,32 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:external_resources ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is the dataset self-contained or does it rely on external resources (e.g., websites, other datasets)? If external, are there guarantees that those resources will remain available and unchanged?
 """ ;
@@ -3478,61 +3499,64 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
         linkml:ClassDefinition ;
     rdfs:label "SamplingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain all possible instances, or is it a sample (not necessarily random) of instances from a larger set? If so, how representative is it?
@@ -3546,12 +3570,6 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:composition ;
     data_sheets_schema:docExample "Training split underrepresents Asian participants" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "identifiers_removed" ;
-    skos:definition "List of identifier types removed during de-identification (e.g., 'name', 'date of birth', 'SSN', 'email address', 'geographic subdivision')." ;
-    skos:inScheme data_sheets_schema:composition .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -3592,14 +3610,6 @@ data_sheets_schema:collection_type a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:composition .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "strategies" ;
-    skos:definition """One or more sampling strategies used (e.g., deterministic, simple random, stratified, cluster, systematic).
-""" ;
-    skos:inScheme data_sheets_schema:composition ;
-    data_sheets_schema:docExample "Triple-balanced by race/ethnicity, sex, and T2DM severity" .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "warnings" ;
@@ -3639,14 +3649,6 @@ data_sheets_schema:creators a owl:ObjectProperty,
     rdfs:label "creators" ;
     skos:definition "Individuals or organizations who created the dataset. List of Creator objects describing authorship, roles, and affiliations of dataset creators." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "data_use_permission" ;
-    skos:definition "Structured data use permissions using the Data Use Ontology (DUO). Specifies permitted uses (e.g., general research, health/medical research, disease-specific research) and restrictions (e.g., non-commercial use, ethics approval required, collaboration required). See https://github.com/EBISPOT/DUO." ;
-    skos:exactMatch <http://purl.obolibrary.org/obo/DUO_0000001> ;
-    skos:inScheme data_sheets_schema:data-governance ;
-    data_sheets_schema:docExample "health_medical_biomedical_research" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -3755,13 +3757,6 @@ data_sheets_schema:future_use_impacts a owl:ObjectProperty,
     skos:definition "Anticipated impacts of future uses, including risks and benefits. List of FutureUseImpact objects from the Uses module describing foreseeable consequences of using this dataset in new applications." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "assent_procedures" ;
-    skos:definition """For research involving minors, what assent procedures were used? How was developmentally appropriate assent obtained?
-""" ;
-    skos:inScheme data_sheets_schema:human .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "guardian_consent" ;
@@ -3776,13 +3771,6 @@ data_sheets_schema:future_use_impacts a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:human ;
     data_sheets_schema:docExample "All participants provided written informed consent; study registered at ClinicalTrials.gov NCT05395169" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "privacy_techniques" ;
-    skos:definition """What privacy-preserving techniques were applied (e.g., differential privacy, k-anonymity, data masking)?
-""" ;
-    skos:inScheme data_sheets_schema:human .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -3868,14 +3856,6 @@ data_sheets_schema:maintainers a owl:ObjectProperty,
     skos:definition "Individuals or organizations responsible for maintaining the dataset. List of Maintainer objects from the Maintenance module describing maintenance contacts, roles, and support channels." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "erratum_details" ;
-    skos:definition """Free-text description of the error, its scope, the affected data or records, and the correction applied.
-""" ;
-    skos:inScheme data_sheets_schema:maintenance ;
-    data_sheets_schema:docExample "v1.0.1: Corrected mislabeled CGM device serial numbers for 12 participants" .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "versions_available" ;
@@ -3933,14 +3913,6 @@ data_sheets_schema:participant_privacy a owl:ObjectProperty,
     skos:definition "One or more records describing privacy protections and anonymization procedures for human research participants." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "annotation_quality_details" ;
-    skos:definition """Additional details on annotation quality assessment and findings.
-""" ;
-    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
-    data_sheets_schema:docExample "Inter-rater reliability: Cohen's κ = 0.82" .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "annotator_demographics" ;
@@ -3985,14 +3957,6 @@ data_sheets_schema:participant_privacy a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
     data_sheets_schema:docExample "DeepDR AUC: 0.94 on EYEPACS validation set" .
-
-<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "tool_descriptions" ;
-    skos:definition """Descriptions of what each tool does in the annotation process and what types of annotations it produces. Should correspond to the tools list.
-""" ;
-    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
-    data_sheets_schema:docExample "DeepDR automated grading system (AUC = 0.94)" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4098,13 +4062,6 @@ data_sheets_schema:used_software a owl:ObjectProperty,
     skos:definition "What software was used as part of this dataset property?" ;
     skos:inScheme data_sheets_schema:base .
 
-<https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> a owl:ObjectProperty,
-        linkml:SlotDefinition ;
-    rdfs:label "repository_details" ;
-    skos:definition """Free-text description of the repository of known dataset uses, including how it is maintained and how to contribute new use cases.
-""" ;
-    skos:inScheme data_sheets_schema:uses .
-
 <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "categories" ;
@@ -4159,41 +4116,41 @@ data_sheets_schema:NamedThing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "NamedThing" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:notes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:notes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ] ;
+            owl:onProperty data_sheets_schema:name ] ;
     skos:definition "A generic grouping for any identifiable entity." ;
     skos:exactMatch schema1:Thing ;
     skos:inScheme data_sheets_schema:base .
@@ -4202,17 +4159,26 @@ data_sheets_schema:Organization a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:notes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty data_sheets_schema:id ],
@@ -4221,22 +4187,13 @@ data_sheets_schema:Organization a owl:Class,
             owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:notes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:name ],
+            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:description ] ;
+            owl:onProperty data_sheets_schema:name ] ;
     skos:definition "Represents a group or organization." ;
     skos:exactMatch schema1:Organization ;
     skos:inScheme data_sheets_schema:base .
@@ -4410,6 +4367,12 @@ data_sheets_schema:citation a owl:ObjectProperty,
     skos:definition "True if the data underwent a validation or verification process (e.g., expert review, cross-checking with ground truth); false otherwise." ;
     skos:inScheme data_sheets_schema:collection .
 
+data_sheets_schema:collection_type a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "collection_type" ;
+    skos:definition "Type(s) of content in this file collection. A collection may have multiple types, for example a collection containing both raw_data and documentation files would have both types listed." ;
+    skos:inScheme data_sheets_schema:file-collection .
+
 data_sheets_schema:comment_prefix a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "comment_prefix" ;
@@ -4530,6 +4493,12 @@ data_sheets_schema:comment_prefix a owl:ObjectProperty,
     rdfs:label "identification" ;
     skos:broadMatch dcterms:description ;
     skos:definition "How subpopulations are identified and defined (e.g., by age groups, gender, geographic region, disease status, or other demographic/clinical characteristics)." ;
+    skos:inScheme data_sheets_schema:composition .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "identifiers_removed" ;
+    skos:definition "List of identifier types removed during de-identification (e.g., 'name', 'date of birth', 'SSN', 'email address', 'geographic subdivision')." ;
     skos:inScheme data_sheets_schema:composition .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> a owl:ObjectProperty,
@@ -4666,6 +4635,14 @@ data_sheets_schema:comment_prefix a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:composition ;
     data_sheets_schema:docExample "70/15/15 train/validation/test split stratified by site and T2DM severity" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "strategies" ;
+    skos:definition """One or more sampling strategies used (e.g., deterministic, simple random, stratified, cluster, systematic).
+""" ;
+    skos:inScheme data_sheets_schema:composition ;
+    data_sheets_schema:docExample "Triple-balanced by race/ethnicity, sex, and T2DM severity" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "subpopulation_elements_present" ;
@@ -4737,6 +4714,14 @@ data_sheets_schema:created_on a owl:ObjectProperty,
     skos:broadMatch schema1:contactPoint ;
     skos:definition "Contact person for licensing questions. Provides structured contact information including name, email, affiliation, and optional ORCID. This person can answer questions about licensing terms, usage restrictions, fees, and permissions." ;
     skos:inScheme data_sheets_schema:data-governance .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "data_use_permission" ;
+    skos:definition "Structured data use permissions using the Data Use Ontology (DUO). Specifies permitted uses (e.g., general research, health/medical research, disease-specific research) and restrictions (e.g., non-commercial use, ethics approval required, collaboration required). See https://github.com/EBISPOT/DUO." ;
+    skos:exactMatch <http://purl.obolibrary.org/obo/DUO_0000001> ;
+    skos:inScheme data_sheets_schema:data-governance ;
+    data_sheets_schema:docExample "health_medical_biomedical_research" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -4932,6 +4917,13 @@ data_sheets_schema:header a owl:ObjectProperty,
     skos:inScheme data_sheets_schema:human ;
     data_sheets_schema:docExample "De-identified per HIPAA Safe Harbor; 5-digit ZIP replaced with region codes" .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "assent_procedures" ;
+    skos:definition """For research involving minors, what assent procedures were used? How was developmentally appropriate assent obtained?
+""" ;
+    skos:inScheme data_sheets_schema:human .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "at_risk_groups_included" ;
@@ -5015,6 +5007,13 @@ data_sheets_schema:header a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "involves_human_subjects" ;
     skos:definition "Does this dataset involve human subjects research?" ;
+    skos:inScheme data_sheets_schema:human .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "privacy_techniques" ;
+    skos:definition """What privacy-preserving techniques were applied (e.g., differential privacy, k-anonymity, data masking)?
+""" ;
     skos:inScheme data_sheets_schema:human .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> a owl:ObjectProperty,
@@ -5104,6 +5103,14 @@ data_sheets_schema:license_and_use_terms a owl:ObjectProperty,
     skos:definition "URL for contribution guidelines or process." ;
     skos:inScheme data_sheets_schema:maintenance ;
     data_sheets_schema:docExample "https://example.org/dataset/contributing" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "erratum_details" ;
+    skos:definition """Free-text description of the error, its scope, the affected data or records, and the correction applied.
+""" ;
+    skos:inScheme data_sheets_schema:maintenance ;
+    data_sheets_schema:docExample "v1.0.1: Corrected mislabeled CGM device serial numbers for 12 participants" .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -5286,6 +5293,14 @@ data_sheets_schema:page a owl:ObjectProperty,
 """ ;
     skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling .
 
+<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "annotation_quality_details" ;
+    skos:definition """Additional details on annotation quality assessment and findings.
+""" ;
+    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
+    data_sheets_schema:docExample "Inter-rater reliability: Cohen's κ = 0.82" .
+
 <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "annotations_per_item" ;
@@ -5360,6 +5375,14 @@ data_sheets_schema:page a owl:ObjectProperty,
     skos:definition """Free-text description of raw data availability, access procedures, and any conditions or restrictions on accessing the raw data.
 """ ;
     skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "tool_descriptions" ;
+    skos:definition """Descriptions of what each tool does in the annotation process and what types of annotations it produces. Should correspond to the tools list.
+""" ;
+    skos:inScheme data_sheets_schema:preprocessing-cleaning-labeling ;
+    data_sheets_schema:docExample "DeepDR automated grading system (AUC = 0.94)" .
 
 data_sheets_schema:publisher a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -5465,6 +5488,13 @@ data_sheets_schema:url a owl:ObjectProperty,
     skos:definition "One or more reasons why this use is prohibited (e.g., license restriction, ethical concern, privacy risk, legal constraint)." ;
     skos:inScheme data_sheets_schema:uses ;
     data_sheets_schema:docExample "Re-identification of participants is strictly prohibited" .
+
+<https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "repository_details" ;
+    skos:definition """Free-text description of the repository of known dataset uses, including how it is maintained and how to contribute new use cases.
+""" ;
+    skos:inScheme data_sheets_schema:uses .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> a owl:ObjectProperty,
         linkml:SlotDefinition ;
@@ -5616,101 +5646,119 @@ data_sheets_schema:Dataset a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
+            owl:onProperty data_sheets_schema:retention_limit ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#ConsentRevocation> ;
-            owl:onProperty data_sheets_schema:consent_revocations ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:imputation_protocols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:known_biases ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:resources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
-            owl:onProperty data_sheets_schema:content_warnings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
-            owl:onProperty data_sheets_schema:funders ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
             owl:onProperty data_sheets_schema:creators ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
+            owl:onProperty data_sheets_schema:confidential_elements ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
-            owl:onProperty data_sheets_schema:tasks ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetBias> ;
             owl:onProperty data_sheets_schema:known_biases ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:splits ],
+            owl:onProperty data_sheets_schema:ip_restrictions ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:citation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_notifications ],
+            owl:onProperty data_sheets_schema:raw_sources ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
-            owl:onProperty data_sheets_schema:existing_uses ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionConsent> ;
+            owl:onProperty data_sheets_schema:collection_consents ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/MissingDataDocumentation> ;
-            owl:onProperty data_sheets_schema:missing_data_documentation ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
+            owl:onProperty data_sheets_schema:distribution_dates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:DataSubset ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#MachineAnnotationTools> ;
+            owl:onProperty data_sheets_schema:machine_annotation_tools ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:content_warnings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/RawDataSource> ;
+            owl:onProperty data_sheets_schema:raw_data_sources ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
+            owl:onProperty data_sheets_schema:raw_sources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:at_risk_populations ],
@@ -5718,110 +5766,86 @@ data_sheets_schema:Dataset a owl:Class,
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
             owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version_access ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
+            owl:onProperty data_sheets_schema:anomalies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:future_use_impacts ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:related_datasets ],
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DataSubset ;
-            owl:onProperty data_sheets_schema:subsets ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
+            owl:onProperty data_sheets_schema:version_access ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
-            owl:onProperty data_sheets_schema:retention_limit ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
+            owl:onProperty data_sheets_schema:other_tasks ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:is_deidentified ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionConsent> ;
-            owl:onProperty data_sheets_schema:collection_consents ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:consent_revocations ],
+            owl:onProperty data_sheets_schema:file_collections ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DirectCollection> ;
+            owl:onProperty data_sheets_schema:direct_collection ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:existing_uses ],
+            owl:onProperty data_sheets_schema:total_size_bytes ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#MachineAnnotationTools> ;
-            owl:onProperty data_sheets_schema:machine_annotation_tools ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:imputation_protocols ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_notifications ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:cleaning_strategies ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
             owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
-            owl:onProperty data_sheets_schema:errata ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
             owl:onProperty data_sheets_schema:data_collectors ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
+            owl:onProperty data_sheets_schema:variables ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:relationships ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
             owl:onProperty data_sheets_schema:extension_mechanism ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_file_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
             owl:onProperty data_sheets_schema:content_warnings ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
-            owl:onProperty data_sheets_schema:creators ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:anomalies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:annotation_analyses ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
+            owl:onProperty data_sheets_schema:citation ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
-            owl:onProperty data_sheets_schema:purposes ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/MissingDataDocumentation> ;
+            owl:onProperty data_sheets_schema:missing_data_documentation ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:cleaning_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
             owl:onProperty data_sheets_schema:ip_restrictions ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_consents ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
-            owl:onProperty data_sheets_schema:cleaning_strategies ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
+            owl:onProperty data_sheets_schema:distribution_formats ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#AnnotationAnalysis> ;
             owl:onProperty data_sheets_schema:annotation_analyses ],
@@ -5829,50 +5853,101 @@ data_sheets_schema:Dataset a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:third_party_sharing ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#ThirdPartySharing> ;
-            owl:onProperty data_sheets_schema:third_party_sharing ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:consent_revocations ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
-            owl:onProperty data_sheets_schema:version_access ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
+            owl:onProperty data_sheets_schema:direct_collection ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
-            owl:onProperty data_sheets_schema:instances ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
+            owl:onProperty data_sheets_schema:prohibited_uses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:citation ],
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:annotation_analyses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:raw_data_sources ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
+            owl:onProperty data_sheets_schema:informed_consent ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_file_count ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:use_repository ],
+            owl:onProperty data_sheets_schema:sampling_strategies ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:parent_datasets ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionNotification> ;
-            owl:onProperty data_sheets_schema:collection_notifications ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:missing_data_documentation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:errata ],
+            owl:onProperty data_sheets_schema:creators ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FileCollection ;
+            owl:onProperty data_sheets_schema:file_collections ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_consents ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#ConsentRevocation> ;
+            owl:onProperty data_sheets_schema:consent_revocations ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
             owl:onProperty data_sheets_schema:collection_timeframes ],
@@ -5880,209 +5955,164 @@ data_sheets_schema:Dataset a owl:Class,
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
             owl:onProperty data_sheets_schema:use_repository ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#ThirdPartySharing> ;
+            owl:onProperty data_sheets_schema:third_party_sharing ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:purposes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Relationships> ;
             owl:onProperty data_sheets_schema:relationships ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetLimitation> ;
-            owl:onProperty data_sheets_schema:known_limitations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:maintainers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/RawDataSource> ;
-            owl:onProperty data_sheets_schema:raw_data_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_file_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:machine_annotation_tools ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:funders ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_collections ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
-            owl:onProperty data_sheets_schema:anomalies ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#AtRiskPopulations> ;
             owl:onProperty data_sheets_schema:at_risk_populations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FileCollection ;
-            owl:onProperty data_sheets_schema:file_collections ],
+            owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:known_limitations ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:informed_consent ],
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:maintainers ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
             owl:onProperty data_sheets_schema:human_subject_research ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_file_count ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:known_biases ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:other_tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version_access ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:splits ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionNotification> ;
+            owl:onProperty data_sheets_schema:collection_notifications ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
             owl:onProperty data_sheets_schema:maintainers ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:direct_collection ],
+            owl:onProperty data_sheets_schema:human_subject_research ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetLimitation> ;
+            owl:onProperty data_sheets_schema:known_limitations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:missing_data_documentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#ImputationProtocol> ;
-            owl:onProperty data_sheets_schema:imputation_protocols ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
             owl:onProperty data_sheets_schema:distribution_dates ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DirectCollection> ;
-            owl:onProperty data_sheets_schema:direct_collection ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Splits> ;
             owl:onProperty data_sheets_schema:splits ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
-            owl:onProperty data_sheets_schema:informed_consent ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:errata ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#ImputationProtocol> ;
+            owl:onProperty data_sheets_schema:imputation_protocols ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Relationships> ;
+            owl:onProperty data_sheets_schema:relationships ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
+            owl:onProperty data_sheets_schema:distribution_formats ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
+            owl:onProperty data_sheets_schema:existing_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
+            owl:onProperty data_sheets_schema:cleaning_strategies ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "data package",
@@ -6096,157 +6126,31 @@ data_sheets_schema:Information a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Information" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:keywords ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:issued ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:onDatatype xsd:string ;
                     owl:withRestrictions ( [ xsd:pattern "10\\.\\d{4,}\\/.+" ] ) ] ;
             owl:onProperty data_sheets_schema:doi ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:language ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_on ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CompressionEnum ;
             owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
             owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:keywords ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Datetime ;
             owl:onProperty data_sheets_schema:created_on ],
@@ -6254,26 +6158,152 @@ data_sheets_schema:Information a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:publisher ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty data_sheets_schema:publisher ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_on ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:keywords ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_on ],
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uri ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:download_url ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:created_by ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:modified_by ],
         data_sheets_schema:NamedThing ;
     skos:closeMatch schema1:CreativeWork ;
     skos:definition "Grouping for datasets and data files." ;
@@ -6283,14 +6313,11 @@ data_sheets_schema:Person a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:affiliation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:orcid ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty data_sheets_schema:affiliation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( linkml:String [ a rdfs:Datatype ;
@@ -6299,7 +6326,10 @@ data_sheets_schema:Person a owl:Class,
             owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:email ],
+            owl:onProperty data_sheets_schema:orcid ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:email ],
@@ -6308,7 +6338,7 @@ data_sheets_schema:Person a owl:Class,
             owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:orcid ],
+            owl:onProperty data_sheets_schema:affiliation ],
         data_sheets_schema:NamedThing ;
     skos:definition "An individual human being. This class represents a person in the context of a specific dataset. Attributes like affiliation and email represent the person's current or most relevant contact information for this dataset. For stable cross-dataset identification, use the ORCID field. Note that contributor roles (CRediT) are specified in the usage context (e.g., Creator class) rather than on the Person directly, since roles vary by dataset." ;
     skos:exactMatch schema1:Person ;
@@ -6642,47 +6672,47 @@ data_sheets_schema:DatasetProperty a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetProperty" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:notes ],
+            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:notes ],
+            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:id ],
+            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:id ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Software ;
             owl:onProperty data_sheets_schema:used_software ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:name ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:used_software ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ] ;
+            owl:onProperty data_sheets_schema:name ] ;
     skos:definition "Represents a single property of a dataset, or a set of related properties." ;
     skos:inScheme data_sheets_schema:base .
 

--- a/src/data_sheets_schema/datamodel/data_sheets_schema.py
+++ b/src/data_sheets_schema/datamodel/data_sheets_schema.py
@@ -1,5 +1,5 @@
 # Auto generated from data_sheets_schema.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-06T15:34:49
+# Generation date: 2026-08-06T20:21:37
 # Schema: data-sheets-schema
 #
 # id: https://w3id.org/bridge2ai/data-sheets-schema
@@ -1110,7 +1110,7 @@ class SamplingStrategy(DatasetProperty):
     is_representative: Optional[Union[bool, Bool]] = None
     representative_verification: Optional[Union[str, list[str]]] = empty_list()
     why_not_representative: Optional[str] = None
-    strategies: Optional[Union[str, list[str]]] = empty_list()
+    strategies: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.is_sample is not None and not isinstance(self.is_sample, Bool):
@@ -1132,9 +1132,8 @@ class SamplingStrategy(DatasetProperty):
         if self.why_not_representative is not None and not isinstance(self.why_not_representative, str):
             self.why_not_representative = str(self.why_not_representative)
 
-        if not isinstance(self.strategies, list):
-            self.strategies = [self.strategies] if self.strategies is not None else []
-        self.strategies = [v if isinstance(v, str) else str(v) for v in self.strategies]
+        if self.strategies is not None and not isinstance(self.strategies, str):
+            self.strategies = str(self.strategies)
 
         super().__post_init__(**kwargs)
 
@@ -1433,7 +1432,7 @@ class Deidentification(DatasetProperty):
 
     identifiable_elements_present: Optional[Union[bool, Bool]] = None
     method: Optional[str] = None
-    identifiers_removed: Optional[Union[str, list[str]]] = empty_list()
+    identifiers_removed: Optional[str] = None
     deidentification_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -1443,9 +1442,8 @@ class Deidentification(DatasetProperty):
         if self.method is not None and not isinstance(self.method, str):
             self.method = str(self.method)
 
-        if not isinstance(self.identifiers_removed, list):
-            self.identifiers_removed = [self.identifiers_removed] if self.identifiers_removed is not None else []
-        self.identifiers_removed = [v if isinstance(v, str) else str(v) for v in self.identifiers_removed]
+        if self.identifiers_removed is not None and not isinstance(self.identifiers_removed, str):
+            self.identifiers_removed = str(self.identifiers_removed)
 
         if self.deidentification_details is not None and not isinstance(self.deidentification_details, str):
             self.deidentification_details = str(self.deidentification_details)
@@ -1885,7 +1883,7 @@ class AnnotationAnalysis(DatasetProperty):
     agreement_metric: Optional[str] = None
     analysis_method: Optional[str] = None
     disagreement_patterns: Optional[Union[str, list[str]]] = empty_list()
-    annotation_quality_details: Optional[Union[str, list[str]]] = empty_list()
+    annotation_quality_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.inter_annotator_agreement_score is not None and not isinstance(self.inter_annotator_agreement_score, float):
@@ -1901,9 +1899,8 @@ class AnnotationAnalysis(DatasetProperty):
             self.disagreement_patterns = [self.disagreement_patterns] if self.disagreement_patterns is not None else []
         self.disagreement_patterns = [v if isinstance(v, str) else str(v) for v in self.disagreement_patterns]
 
-        if not isinstance(self.annotation_quality_details, list):
-            self.annotation_quality_details = [self.annotation_quality_details] if self.annotation_quality_details is not None else []
-        self.annotation_quality_details = [v if isinstance(v, str) else str(v) for v in self.annotation_quality_details]
+        if self.annotation_quality_details is not None and not isinstance(self.annotation_quality_details, str):
+            self.annotation_quality_details = str(self.annotation_quality_details)
 
         super().__post_init__(**kwargs)
 
@@ -1922,7 +1919,7 @@ class MachineAnnotationTools(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.MachineAnnotationTools
 
     tools: Optional[Union[str, list[str]]] = empty_list()
-    tool_descriptions: Optional[Union[str, list[str]]] = empty_list()
+    tool_descriptions: Optional[str] = None
     tool_accuracy: Optional[Union[str, list[str]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -1930,9 +1927,8 @@ class MachineAnnotationTools(DatasetProperty):
             self.tools = [self.tools] if self.tools is not None else []
         self.tools = [v if isinstance(v, str) else str(v) for v in self.tools]
 
-        if not isinstance(self.tool_descriptions, list):
-            self.tool_descriptions = [self.tool_descriptions] if self.tool_descriptions is not None else []
-        self.tool_descriptions = [v if isinstance(v, str) else str(v) for v in self.tool_descriptions]
+        if self.tool_descriptions is not None and not isinstance(self.tool_descriptions, str):
+            self.tool_descriptions = str(self.tool_descriptions)
 
         if not isinstance(self.tool_accuracy, list):
             self.tool_accuracy = [self.tool_accuracy] if self.tool_accuracy is not None else []
@@ -1977,15 +1973,14 @@ class UseRepository(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.UseRepository
 
     repository_url: Optional[Union[str, URI]] = None
-    repository_details: Optional[Union[str, list[str]]] = empty_list()
+    repository_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.repository_url is not None and not isinstance(self.repository_url, URI):
             self.repository_url = URI(self.repository_url)
 
-        if not isinstance(self.repository_details, list):
-            self.repository_details = [self.repository_details] if self.repository_details is not None else []
-        self.repository_details = [v if isinstance(v, str) else str(v) for v in self.repository_details]
+        if self.repository_details is not None and not isinstance(self.repository_details, str):
+            self.repository_details = str(self.repository_details)
 
         super().__post_init__(**kwargs)
 
@@ -2211,15 +2206,14 @@ class Erratum(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.Erratum
 
     erratum_url: Optional[Union[str, URI]] = None
-    erratum_details: Optional[Union[str, list[str]]] = empty_list()
+    erratum_details: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.erratum_url is not None and not isinstance(self.erratum_url, URI):
             self.erratum_url = URI(self.erratum_url)
 
-        if not isinstance(self.erratum_details, list):
-            self.erratum_details = [self.erratum_details] if self.erratum_details is not None else []
-        self.erratum_details = [v if isinstance(v, str) else str(v) for v in self.erratum_details]
+        if self.erratum_details is not None and not isinstance(self.erratum_details, str):
+            self.erratum_details = str(self.erratum_details)
 
         super().__post_init__(**kwargs)
 
@@ -2546,7 +2540,7 @@ class ParticipantPrivacy(DatasetProperty):
 
     anonymization_method: Optional[str] = None
     reidentification_risk: Optional[str] = None
-    privacy_techniques: Optional[Union[str, list[str]]] = empty_list()
+    privacy_techniques: Optional[str] = None
     data_linkage: Optional[str] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -2556,9 +2550,8 @@ class ParticipantPrivacy(DatasetProperty):
         if self.reidentification_risk is not None and not isinstance(self.reidentification_risk, str):
             self.reidentification_risk = str(self.reidentification_risk)
 
-        if not isinstance(self.privacy_techniques, list):
-            self.privacy_techniques = [self.privacy_techniques] if self.privacy_techniques is not None else []
-        self.privacy_techniques = [v if isinstance(v, str) else str(v) for v in self.privacy_techniques]
+        if self.privacy_techniques is not None and not isinstance(self.privacy_techniques, str):
+            self.privacy_techniques = str(self.privacy_techniques)
 
         if self.data_linkage is not None and not isinstance(self.data_linkage, str):
             self.data_linkage = str(self.data_linkage)
@@ -2613,7 +2606,7 @@ class AtRiskPopulations(DatasetProperty):
 
     at_risk_groups_included: Optional[Union[bool, Bool]] = None
     special_protections: Optional[Union[str, list[str]]] = empty_list()
-    assent_procedures: Optional[Union[str, list[str]]] = empty_list()
+    assent_procedures: Optional[str] = None
     guardian_consent: Optional[Union[str, list[str]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -2624,9 +2617,8 @@ class AtRiskPopulations(DatasetProperty):
             self.special_protections = [self.special_protections] if self.special_protections is not None else []
         self.special_protections = [v if isinstance(v, str) else str(v) for v in self.special_protections]
 
-        if not isinstance(self.assent_procedures, list):
-            self.assent_procedures = [self.assent_procedures] if self.assent_procedures is not None else []
-        self.assent_procedures = [v if isinstance(v, str) else str(v) for v in self.assent_procedures]
+        if self.assent_procedures is not None and not isinstance(self.assent_procedures, str):
+            self.assent_procedures = str(self.assent_procedures)
 
         if not isinstance(self.guardian_consent, list):
             self.guardian_consent = [self.guardian_consent] if self.guardian_consent is not None else []
@@ -2649,16 +2641,15 @@ class LicenseAndUseTerms(DatasetProperty):
     class_model_uri: ClassVar[URIRef] = DATA_SHEETS_SCHEMA.LicenseAndUseTerms
 
     license_terms: Optional[str] = None
-    data_use_permission: Optional[Union[Union[str, "DataUsePermissionEnum"], list[Union[str, "DataUsePermissionEnum"]]]] = empty_list()
+    data_use_permission: Optional[Union[str, "DataUsePermissionEnum"]] = None
     contact_person: Optional[Union[str, PersonId]] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.license_terms is not None and not isinstance(self.license_terms, str):
             self.license_terms = str(self.license_terms)
 
-        if not isinstance(self.data_use_permission, list):
-            self.data_use_permission = [self.data_use_permission] if self.data_use_permission is not None else []
-        self.data_use_permission = [v if isinstance(v, DataUsePermissionEnum) else DataUsePermissionEnum(v) for v in self.data_use_permission]
+        if self.data_use_permission is not None and not isinstance(self.data_use_permission, DataUsePermissionEnum):
+            self.data_use_permission = DataUsePermissionEnum(self.data_use_permission)
 
         if self.contact_person is not None and not isinstance(self.contact_person, PersonId):
             self.contact_person = PersonId(self.contact_person)
@@ -2897,7 +2888,7 @@ class FileCollection(Information):
     compression: Optional[Union[str, "CompressionEnum"]] = None
     external_resources: Optional[Union[Union[dict, ExternalResource], list[Union[dict, ExternalResource]]]] = empty_list()
     resources: Optional[Union[dict[Union[str, FileId], Union[dict, File]], list[Union[dict, File]]]] = empty_dict()
-    collection_type: Optional[Union[Union[str, "FileCollectionTypeEnum"], list[Union[str, "FileCollectionTypeEnum"]]]] = empty_list()
+    collection_type: Optional[Union[str, "FileCollectionTypeEnum"]] = None
     file_count: Optional[int] = None
     total_bytes: Optional[int] = None
 
@@ -2919,9 +2910,8 @@ class FileCollection(Information):
 
         self._normalize_inlined_as_list(slot_name="resources", slot_type=File, key_name="id", keyed=True)
 
-        if not isinstance(self.collection_type, list):
-            self.collection_type = [self.collection_type] if self.collection_type is not None else []
-        self.collection_type = [v if isinstance(v, FileCollectionTypeEnum) else FileCollectionTypeEnum(v) for v in self.collection_type]
+        if self.collection_type is not None and not isinstance(self.collection_type, FileCollectionTypeEnum):
+            self.collection_type = FileCollectionTypeEnum(self.collection_type)
 
         if self.file_count is not None and not isinstance(self.file_count, int):
             self.file_count = int(self.file_count)
@@ -4405,7 +4395,7 @@ slots.samplingStrategy__why_not_representative = Slot(uri=D4D.whyNotRepresentati
                    model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__why_not_representative, domain=None, range=Optional[str])
 
 slots.samplingStrategy__strategies = Slot(uri=D4D.strategies, name="samplingStrategy__strategies", curie=D4D.curie('strategies'),
-                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__strategies, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.samplingStrategy__strategies, domain=None, range=Optional[str])
 
 slots.missingInfo__missing = Slot(uri=D4D.missingDataDescription, name="missingInfo__missing", curie=D4D.curie('missingDataDescription'),
                    model_uri=DATA_SHEETS_SCHEMA.missingInfo__missing, domain=None, range=Optional[Union[str, list[str]]])
@@ -4483,7 +4473,7 @@ slots.deidentification__method = Slot(uri=D4DCOMPOSITION.method, name="deidentif
                    model_uri=DATA_SHEETS_SCHEMA.deidentification__method, domain=None, range=Optional[str])
 
 slots.deidentification__identifiers_removed = Slot(uri=D4D.removedIdentifierTypes, name="deidentification__identifiers_removed", curie=D4D.curie('removedIdentifierTypes'),
-                   model_uri=DATA_SHEETS_SCHEMA.deidentification__identifiers_removed, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.deidentification__identifiers_removed, domain=None, range=Optional[str])
 
 slots.deidentification__deidentification_details = Slot(uri=DCTERMS.description, name="deidentification__deidentification_details", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.deidentification__deidentification_details, domain=None, range=Optional[str])
@@ -4618,13 +4608,13 @@ slots.annotationAnalysis__disagreement_patterns = Slot(uri=D4D.disagreementPatte
                    model_uri=DATA_SHEETS_SCHEMA.annotationAnalysis__disagreement_patterns, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.annotationAnalysis__annotation_quality_details = Slot(uri=D4D.annotationQualityDetails, name="annotationAnalysis__annotation_quality_details", curie=D4D.curie('annotationQualityDetails'),
-                   model_uri=DATA_SHEETS_SCHEMA.annotationAnalysis__annotation_quality_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.annotationAnalysis__annotation_quality_details, domain=None, range=Optional[str])
 
 slots.machineAnnotationTools__tools = Slot(uri=D4D.toolNames, name="machineAnnotationTools__tools", curie=D4D.curie('toolNames'),
                    model_uri=DATA_SHEETS_SCHEMA.machineAnnotationTools__tools, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.machineAnnotationTools__tool_descriptions = Slot(uri=D4D.toolDescriptions, name="machineAnnotationTools__tool_descriptions", curie=D4D.curie('toolDescriptions'),
-                   model_uri=DATA_SHEETS_SCHEMA.machineAnnotationTools__tool_descriptions, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.machineAnnotationTools__tool_descriptions, domain=None, range=Optional[str])
 
 slots.machineAnnotationTools__tool_accuracy = Slot(uri=D4D.toolAccuracy, name="machineAnnotationTools__tool_accuracy", curie=D4D.curie('toolAccuracy'),
                    model_uri=DATA_SHEETS_SCHEMA.machineAnnotationTools__tool_accuracy, domain=None, range=Optional[Union[str, list[str]]])
@@ -4636,7 +4626,7 @@ slots.useRepository__repository_url = Slot(uri=D4DUSES.repository_url, name="use
                    model_uri=DATA_SHEETS_SCHEMA.useRepository__repository_url, domain=None, range=Optional[Union[str, URI]])
 
 slots.useRepository__repository_details = Slot(uri=DCTERMS.description, name="useRepository__repository_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.useRepository__repository_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.useRepository__repository_details, domain=None, range=Optional[str])
 
 slots.otherTask__task_details = Slot(uri=DCTERMS.description, name="otherTask__task_details", curie=DCTERMS.curie('description'),
                    model_uri=DATA_SHEETS_SCHEMA.otherTask__task_details, domain=None, range=Optional[str])
@@ -4678,7 +4668,7 @@ slots.erratum__erratum_url = Slot(uri=D4D.erratumURL, name="erratum__erratum_url
                    model_uri=DATA_SHEETS_SCHEMA.erratum__erratum_url, domain=None, range=Optional[Union[str, URI]])
 
 slots.erratum__erratum_details = Slot(uri=DCTERMS.description, name="erratum__erratum_details", curie=DCTERMS.curie('description'),
-                   model_uri=DATA_SHEETS_SCHEMA.erratum__erratum_details, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.erratum__erratum_details, domain=None, range=Optional[str])
 
 slots.updatePlan__frequency = Slot(uri=D4D.frequency, name="updatePlan__frequency", curie=D4D.curie('frequency'),
                    model_uri=DATA_SHEETS_SCHEMA.updatePlan__frequency, domain=None, range=Optional[str])
@@ -4765,7 +4755,7 @@ slots.participantPrivacy__reidentification_risk = Slot(uri=D4D.reidentificationR
                    model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__reidentification_risk, domain=None, range=Optional[str])
 
 slots.participantPrivacy__privacy_techniques = Slot(uri=D4D.privacyTechniques, name="participantPrivacy__privacy_techniques", curie=D4D.curie('privacyTechniques'),
-                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__privacy_techniques, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__privacy_techniques, domain=None, range=Optional[str])
 
 slots.participantPrivacy__data_linkage = Slot(uri=D4D.dataLinkage, name="participantPrivacy__data_linkage", curie=D4D.curie('dataLinkage'),
                    model_uri=DATA_SHEETS_SCHEMA.participantPrivacy__data_linkage, domain=None, range=Optional[str])
@@ -4789,7 +4779,7 @@ slots.atRiskPopulations__special_protections = Slot(uri=D4D.specialProtections, 
                    model_uri=DATA_SHEETS_SCHEMA.atRiskPopulations__special_protections, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.atRiskPopulations__assent_procedures = Slot(uri=D4D.assentProcedures, name="atRiskPopulations__assent_procedures", curie=D4D.curie('assentProcedures'),
-                   model_uri=DATA_SHEETS_SCHEMA.atRiskPopulations__assent_procedures, domain=None, range=Optional[Union[str, list[str]]])
+                   model_uri=DATA_SHEETS_SCHEMA.atRiskPopulations__assent_procedures, domain=None, range=Optional[str])
 
 slots.atRiskPopulations__guardian_consent = Slot(uri=D4D.guardianConsent, name="atRiskPopulations__guardian_consent", curie=D4D.curie('guardianConsent'),
                    model_uri=DATA_SHEETS_SCHEMA.atRiskPopulations__guardian_consent, domain=None, range=Optional[Union[str, list[str]]])
@@ -4798,7 +4788,7 @@ slots.licenseAndUseTerms__license_terms = Slot(uri=D4D.licenseDescription, name=
                    model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__license_terms, domain=None, range=Optional[str])
 
 slots.licenseAndUseTerms__data_use_permission = Slot(uri=DUO['0000001'], name="licenseAndUseTerms__data_use_permission", curie=DUO.curie('0000001'),
-                   model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__data_use_permission, domain=None, range=Optional[Union[Union[str, "DataUsePermissionEnum"], list[Union[str, "DataUsePermissionEnum"]]]])
+                   model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__data_use_permission, domain=None, range=Optional[Union[str, "DataUsePermissionEnum"]])
 
 slots.licenseAndUseTerms__contact_person = Slot(uri=D4D.licenseContactPoint, name="licenseAndUseTerms__contact_person", curie=D4D.curie('licenseContactPoint'),
                    model_uri=DATA_SHEETS_SCHEMA.licenseAndUseTerms__contact_person, domain=None, range=Optional[Union[str, PersonId]])
@@ -4867,7 +4857,7 @@ slots.file__file_type = Slot(uri=D4D.fileType, name="file__file_type", curie=D4D
                    model_uri=DATA_SHEETS_SCHEMA.file__file_type, domain=None, range=Optional[Union[str, "FileTypeEnum"]])
 
 slots.fileCollection__collection_type = Slot(uri=D4D.collectionType, name="fileCollection__collection_type", curie=D4D.curie('collectionType'),
-                   model_uri=DATA_SHEETS_SCHEMA.fileCollection__collection_type, domain=None, range=Optional[Union[Union[str, "FileCollectionTypeEnum"], list[Union[str, "FileCollectionTypeEnum"]]]])
+                   model_uri=DATA_SHEETS_SCHEMA.fileCollection__collection_type, domain=None, range=Optional[Union[str, "FileCollectionTypeEnum"]])
 
 slots.fileCollection__file_count = Slot(uri=D4D.fileCount, name="fileCollection__file_count", curie=D4D.curie('fileCount'),
                    model_uri=DATA_SHEETS_SCHEMA.fileCollection__file_count, domain=None, range=Optional[int])

--- a/src/data_sheets_schema/schema/D4D_Composition.yaml
+++ b/src/data_sheets_schema/schema/D4D_Composition.yaml
@@ -155,7 +155,6 @@ classes:
           stratified, cluster, systematic).
         slot_uri: d4d:strategies
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "Triple-balanced by race/ethnicity, sex, and T2DM severity"
 
@@ -442,7 +441,6 @@ classes:
         description: "Method used for de-identification (e.g., HIPAA Safe Harbor)."
       identifiers_removed:
         range: string
-        multivalued: true
         description: >-
           List of identifier types removed during de-identification
           (e.g., 'name', 'date of birth', 'SSN', 'email address', 'geographic subdivision').

--- a/src/data_sheets_schema/schema/D4D_Data_Governance.yaml
+++ b/src/data_sheets_schema/schema/D4D_Data_Governance.yaml
@@ -65,7 +65,6 @@ classes:
           disease-specific research) and restrictions (e.g., non-commercial use,
           ethics approval required, collaboration required). See https://github.com/EBISPOT/DUO.
         range: DataUsePermissionEnum
-        multivalued: true
         slot_uri: DUO:0000001
         exact_mappings:
           - DUO:0000001

--- a/src/data_sheets_schema/schema/D4D_FileCollection.yaml
+++ b/src/data_sheets_schema/schema/D4D_FileCollection.yaml
@@ -138,7 +138,6 @@ classes:
           and documentation files would have both types listed.
         range: FileCollectionTypeEnum
         slot_uri: d4d:collectionType
-        multivalued: true
       file_count:
         description: Number of files in this collection.
         range: integer

--- a/src/data_sheets_schema/schema/D4D_Human.yaml
+++ b/src/data_sheets_schema/schema/D4D_Human.yaml
@@ -147,7 +147,6 @@ classes:
           privacy, k-anonymity, data masking)?
         slot_uri: d4d:privacyTechniques
         range: string
-        multivalued: true
       data_linkage:
         description: >
           Can this dataset be linked to other datasets in ways that might
@@ -215,7 +214,6 @@ classes:
           How was developmentally appropriate assent obtained?
         slot_uri: d4d:assentProcedures
         range: string
-        multivalued: true
       guardian_consent:
         description: >
           For participants unable to provide their own consent, how was

--- a/src/data_sheets_schema/schema/D4D_Maintenance.yaml
+++ b/src/data_sheets_schema/schema/D4D_Maintenance.yaml
@@ -74,7 +74,6 @@ classes:
           Free-text description of the error, its scope, the affected data or records,
           and the correction applied.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
         annotations:
           "d4d:docExample": "v1.0.1: Corrected mislabeled CGM device serial numbers for 12 participants"

--- a/src/data_sheets_schema/schema/D4D_Preprocessing.yaml
+++ b/src/data_sheets_schema/schema/D4D_Preprocessing.yaml
@@ -236,7 +236,6 @@ classes:
           Additional details on annotation quality assessment and findings.
         slot_uri: d4d:annotationQualityDetails
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "Inter-rater reliability: Cohen's κ = 0.82"
 
@@ -265,7 +264,6 @@ classes:
           what types of annotations it produces. Should correspond to the tools list.
         slot_uri: d4d:toolDescriptions
         range: string
-        multivalued: true
         annotations:
           "d4d:docExample": "DeepDR automated grading system (AUC = 0.94)"
       tool_accuracy:

--- a/src/data_sheets_schema/schema/D4D_Uses.yaml
+++ b/src/data_sheets_schema/schema/D4D_Uses.yaml
@@ -67,7 +67,6 @@ classes:
           Free-text description of the repository of known dataset uses, including
           how it is maintained and how to contribute new use cases.
         range: string
-        multivalued: true
         slot_uri: dcterms:description
 
 

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -12099,7 +12099,6 @@ classes:
         domain_of:
         - SamplingStrategy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -17195,7 +17194,6 @@ classes:
         domain_of:
         - Deidentification
         range: string
-        multivalued: true
       deidentification_details:
         name: deidentification_details
         annotations:
@@ -24224,7 +24222,6 @@ classes:
         domain_of:
         - AnnotationAnalysis
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -24689,7 +24686,6 @@ classes:
         domain_of:
         - MachineAnnotationTools
         range: string
-        multivalued: true
       tool_accuracy:
         name: tool_accuracy
         annotations:
@@ -25600,7 +25596,6 @@ classes:
         domain_of:
         - UseRepository
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -30082,7 +30077,6 @@ classes:
         domain_of:
         - Erratum
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -35660,7 +35654,6 @@ classes:
         domain_of:
         - ParticipantPrivacy
         range: string
-        multivalued: true
       data_linkage:
         name: data_linkage
         description: 'Can this dataset be linked to other datasets in ways that might
@@ -36625,7 +36618,6 @@ classes:
         domain_of:
         - AtRiskPopulations
         range: string
-        multivalued: true
       guardian_consent:
         name: guardian_consent
         description: 'For participants unable to provide their own consent, how was
@@ -37104,7 +37096,6 @@ classes:
         domain_of:
         - LicenseAndUseTerms
         range: DataUsePermissionEnum
-        multivalued: true
       contact_person:
         name: contact_person
         description: Contact person for licensing questions. Provides structured contact
@@ -40103,7 +40094,6 @@ classes:
         domain_of:
         - FileCollection
         range: FileCollectionTypeEnum
-        multivalued: true
       file_count:
         name: file_count
         annotations:

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -7371,7 +7371,6 @@ classes:
         domain_of:
         - SamplingStrategy
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -12388,7 +12387,6 @@ classes:
         domain_of:
         - Deidentification
         range: string
-        multivalued: true
       deidentification_details:
         name: deidentification_details
         annotations:
@@ -19311,7 +19309,6 @@ classes:
         domain_of:
         - AnnotationAnalysis
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -19769,7 +19766,6 @@ classes:
         domain_of:
         - MachineAnnotationTools
         range: string
-        multivalued: true
       tool_accuracy:
         name: tool_accuracy
         annotations:
@@ -20666,7 +20662,6 @@ classes:
         domain_of:
         - UseRepository
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -25078,7 +25073,6 @@ classes:
         domain_of:
         - Erratum
         range: string
-        multivalued: true
       id:
         name: id
         annotations:
@@ -30572,7 +30566,6 @@ classes:
         domain_of:
         - ParticipantPrivacy
         range: string
-        multivalued: true
       data_linkage:
         name: data_linkage
         description: 'Can this dataset be linked to other datasets in ways that might
@@ -31523,7 +31516,6 @@ classes:
         domain_of:
         - AtRiskPopulations
         range: string
-        multivalued: true
       guardian_consent:
         name: guardian_consent
         description: 'For participants unable to provide their own consent, how was
@@ -31995,7 +31987,6 @@ classes:
         domain_of:
         - LicenseAndUseTerms
         range: DataUsePermissionEnum
-        multivalued: true
       contact_person:
         name: contact_person
         description: Contact person for licensing questions. Provides structured contact


### PR DESCRIPTION
The schema-2 CHORUS canary ran **valid on its first invocation** (a first) but repair still processed 24 findings. The intermediate snapshots (#370) made the diagnosis mechanical:

- 9× `collection_type` — enum-ranged multivalued, skipped by #376's `range: string` guard; always used single-valued. Scalarized, guard extended to `*Enum` ranges.
- 5 static-list stragglers (`tool_descriptions`, `privacy_techniques`, `strategies`, `identifiers_removed`, +) previously left for lack of observed evidence — the canary supplied it. Scalarized (10 declarations total).
- The remaining 11 findings are the string-vs-object affiliation class — inexpressible union (#297), now repair's cheap and *honest* job (`{name: …}`, no fabricated ids) — plus the three deliberately-kept arrays receiving occasional prose.

Also learned and worth recording: the schema digest lists nested slots by name only, so the model never sees that `affiliations` items are objects — why that class persists at generation time.

Verified: the canary's pre-repair snapshot re-validates at 24 → 11 findings under the updated schema. 148 tests OK; examples pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)