### PR TITLE
Slot-filling order: structured slots, then description, notes last (#385)

### DIFF
--- a/project/jsonld/data_sheets_schema.jsonld
+++ b/project/jsonld/data_sheets_schema.jsonld
@@ -4069,7 +4069,7 @@
     },
     {
       "name": "namedThing__notes",
-      "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+      "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
       "mappings": [
         "http://schema.org/comment"
@@ -4148,7 +4148,7 @@
     },
     {
       "name": "organization__notes",
-      "description": "Content about the organization that fits no dedicated slot; never invent keys (#380).",
+      "description": "Residual content about the organization after name, id and description are used (#385); never invent keys (#380).",
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
       "mappings": [
         "http://schema.org/comment"
@@ -4219,7 +4219,7 @@
     },
     {
       "name": "datasetProperty__notes",
-      "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+      "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/base",
       "mappings": [
         "http://schema.org/comment"
@@ -4680,7 +4680,7 @@
     },
     {
       "name": "grant__notes",
-      "description": "Content about the grant that fits no dedicated slot; never invent keys (#380).",
+      "description": "Residual content about the grant after name, grant_number and description are used (#385); never invent keys (#380).",
       "from_schema": "https://w3id.org/bridge2ai/data-sheets-schema/motivation",
       "mappings": [
         "http://schema.org/comment"
@@ -9474,7 +9474,7 @@
         },
         {
           "name": "notes",
-          "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+          "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
           "slot_uri": "schema:comment",
           "range": "string",
           "@type": "SlotDefinition"
@@ -9537,7 +9537,7 @@
         },
         {
           "name": "notes",
-          "description": "Content about the organization that fits no dedicated slot; never invent keys (#380).",
+          "description": "Residual content about the organization after name, id and description are used (#385); never invent keys (#380).",
           "slot_uri": "schema:comment",
           "range": "string",
           "@type": "SlotDefinition"
@@ -9590,7 +9590,7 @@
         },
         {
           "name": "notes",
-          "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+          "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
           "slot_uri": "schema:comment",
           "range": "string",
           "@type": "SlotDefinition"
@@ -10081,7 +10081,7 @@
         },
         {
           "name": "notes",
-          "description": "Content about the grant that fits no dedicated slot; never invent keys (#380).",
+          "description": "Residual content about the grant after name, grant_number and description are used (#385); never invent keys (#380).",
           "slot_uri": "schema:comment",
           "range": "string",
           "@type": "SlotDefinition"
@@ -13608,7 +13608,7 @@
   "source_file": "data_sheets_schema.yaml",
   "source_file_date": "2026-08-06T12:37:37",
   "source_file_size": 32488,
-  "generation_date": "2026-08-06T20:21:35",
+  "generation_date": "2026-08-07T09:59:03",
   "@type": "SchemaDefinition",
   "@context": [
     "project/jsonld/data_sheets_schema.context.jsonld",

--- a/project/jsonschema/data_sheets_schema.schema.json
+++ b/project/jsonschema/data_sheets_schema.schema.json
@@ -26,7 +26,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -117,7 +117,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -187,7 +187,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -297,7 +297,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -350,7 +350,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -403,7 +403,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -449,7 +449,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -510,7 +510,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -611,7 +611,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -667,7 +667,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -727,7 +727,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -803,7 +803,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -881,7 +881,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -934,7 +934,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -994,7 +994,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -1593,7 +1593,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -2510,7 +2510,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -2887,7 +2887,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3032,7 +3032,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3134,7 +3134,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3194,7 +3194,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3240,7 +3240,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3369,7 +3369,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3429,7 +3429,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3482,7 +3482,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3528,7 +3528,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3594,7 +3594,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3704,7 +3704,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3757,7 +3757,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3827,7 +3827,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3888,7 +3888,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -3965,7 +3965,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4035,7 +4035,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4234,7 +4234,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4449,7 +4449,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4672,7 +4672,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4725,7 +4725,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4778,7 +4778,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content about the grant that fits no dedicated slot; never invent keys (#380).",
+                    "description": "Residual content about the grant after name, grant_number and description are used (#385); never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4814,7 +4814,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content about the organization that fits no dedicated slot; never invent keys (#380).",
+                    "description": "Residual content about the organization after name, id and description are used (#385); never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4878,7 +4878,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -4948,7 +4948,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5014,7 +5014,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5107,7 +5107,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5252,7 +5252,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5361,7 +5361,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5466,7 +5466,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5529,7 +5529,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5613,7 +5613,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5718,7 +5718,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5782,7 +5782,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5842,7 +5842,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -5922,7 +5922,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6019,7 +6019,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6075,7 +6075,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6131,7 +6131,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6170,7 +6170,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content about the organization that fits no dedicated slot; never invent keys (#380).",
+                    "description": "Residual content about the organization after name, id and description are used (#385); never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6206,7 +6206,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6273,7 +6273,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6347,7 +6347,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6394,7 +6394,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6447,7 +6447,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6500,7 +6500,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6560,7 +6560,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6620,7 +6620,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6687,7 +6687,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6740,7 +6740,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6821,7 +6821,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6898,7 +6898,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -6962,7 +6962,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+                    "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7015,7 +7015,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7082,7 +7082,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7135,7 +7135,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7195,7 +7195,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7248,7 +7248,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7301,7 +7301,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7437,7 +7437,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7538,7 +7538,7 @@
                     ]
                 },
                 "notes": {
-                    "description": "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 \u2014 undeclared keys were the corpus's third-largest failure class).",
+                    "description": "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last \u2014 solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
                     "type": [
                         "string",
                         "null"
@@ -7713,7 +7713,7 @@
             ]
         },
         "notes": {
-            "description": "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
+            "description": "Residual content only, after every fitting slot is used \u2014 structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380).",
             "type": [
                 "string",
                 "null"

--- a/project/owl/data_sheets_schema.owl.ttl
+++ b/project/owl/data_sheets_schema.owl.ttl
@@ -16,10 +16,10 @@ data_sheets_schema:DatasetCollection a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:resources ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
             owl:onProperty data_sheets_schema:resources ],
         data_sheets_schema:Information ;
     skos:altLabel "data resource collection",
@@ -34,23 +34,29 @@ data_sheets_schema:FormatDialect a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FormatDialect" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:delimiter ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:header ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:double_quote ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:delimiter ],
+            owl:onProperty data_sheets_schema:header ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:quote_char ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:quote_char ],
+            owl:onProperty data_sheets_schema:double_quote ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:double_quote ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:double_quote ],
@@ -62,22 +68,16 @@ data_sheets_schema:FormatDialect a owl:Class,
             owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:comment_prefix ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:quote_char ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:delimiter ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:double_quote ],
+            owl:onProperty data_sheets_schema:comment_prefix ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:header ] ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:quote_char ] ;
     skos:definition "Additional format information for a file." ;
     skos:inScheme data_sheets_schema:base .
 
@@ -112,20 +112,20 @@ data_sheets_schema:DataSubset a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_data_split ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_subpopulation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_subpopulation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_data_split ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:is_subpopulation ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_subpopulation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty data_sheets_schema:is_data_split ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_data_split ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_subpopulation ],
         data_sheets_schema:Dataset ;
     skos:definition "A subset of a dataset, likely containing multiple files of multiple potential purposes and properties." ;
     skos:inScheme <https://w3id.org/bridge2ai/data-sheets-schema> .
@@ -134,14 +134,11 @@ data_sheets_schema:File a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "File" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:md5 ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:hash ],
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
+            owl:onProperty data_sheets_schema:encoding ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:md5 ],
@@ -149,8 +146,59 @@ data_sheets_schema:File a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:path ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:EncodingEnum ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:encoding ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:file_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:format ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:media_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:hash ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:file_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:sha256 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:dialect ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:bytes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:dialect ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:FileTypeEnum ;
             owl:onProperty data_sheets_schema:file_type ],
@@ -158,80 +206,32 @@ data_sheets_schema:File a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:hash ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:encoding ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_type ],
+            owl:onProperty data_sheets_schema:bytes ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:md5 ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:path ],
+            owl:allValuesFrom data_sheets_schema:FormatEnum ;
+            owl:onProperty data_sheets_schema:format ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:md5 ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:encoding ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:bytes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:file_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:sha256 ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:hash ],
+            owl:onProperty data_sheets_schema:media_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:MediaTypeEnum ;
             owl:onProperty data_sheets_schema:media_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:media_type ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:dialect ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CompressionEnum ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FormatEnum ;
-            owl:onProperty data_sheets_schema:format ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:media_type ],
+            owl:onProperty data_sheets_schema:sha256 ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "file",
@@ -245,62 +245,62 @@ data_sheets_schema:FileCollection a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FileCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:file_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:file_count ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_type ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:resources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:collection_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:path ],
-        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:FileCollectionTypeEnum ;
             owl:onProperty data_sheets_schema:collection_type ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:Integer ;
             owl:onProperty data_sheets_schema:total_bytes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:file_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:file_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CompressionEnum ;
             owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:File ;
-            owl:onProperty data_sheets_schema:resources ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:total_bytes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:file_count ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:path ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:collection_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_type ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:path ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:File ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_bytes ],
         data_sheets_schema:Information ;
     skos:altLabel "data files",
         "file collection",
@@ -315,31 +315,31 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Software" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:license ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:url ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:version ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:url ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:license ],
         data_sheets_schema:NamedThing ;
     skos:definition "A software program or library." ;
@@ -353,10 +353,10 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/mechanism_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What mechanisms or procedures were used to collect the data (e.g., hardware, manual curation, software APIs)? Also covers how these mechanisms were validated.
@@ -368,31 +368,31 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionTimeframe" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Date ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Date ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Date ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/start_date> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/timeframe_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/end_date> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Over what timeframe was the data collected, and does this timeframe match the creation timeframe of the underlying data?
@@ -404,23 +404,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataCollector" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collector_details> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/role> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who was involved in the data collection (e.g., students, crowdworkers, contractors), and how they were compensated.
 """ ;
@@ -430,19 +430,19 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DirectCollection" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/collection_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/is_direct> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -457,49 +457,49 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "InstanceAcquisition" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_validated_verified> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_directly_observed> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/acquisition_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_inferred_derived> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/was_reported_by_subjects> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Describes how data associated with each instance was acquired (e.g., directly observed, reported by subjects, inferred).
 """ ;
@@ -509,16 +509,7 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MissingDataDocumentation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -530,11 +521,20 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_causes> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/handling_strategy> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/missing_data_patterns> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documentation of missing data in the dataset, including patterns, causes, and strategies for handling missing values.
 """ ;
@@ -545,40 +545,40 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "RawDataSource" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/access_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/raw_data_format> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_type> ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/collection/source_description> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Description of raw data sources before preprocessing, cleaning, or labeling. Documents where the original data comes from and how it can be accessed.
@@ -590,22 +590,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Confidentiality" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidentiality_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#confidential_elements_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be confidential (e.g., protected by legal privilege, patient data, non-public communications)?
@@ -616,19 +616,19 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ContentWarning" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#warnings> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#content_warnings_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain any data that might be offensive, insulting, threatening, or otherwise anxiety-provoking if viewed directly?
@@ -639,13 +639,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataAnomaly" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#anomaly_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are there any errors, sources of noise, or redundancies in the dataset?
@@ -656,37 +656,37 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetBias" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:BiasTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#affected_subsets> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#bias_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#mitigation_strategy> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documents known biases present in the dataset. Biases are systematic errors or prejudices that may affect the representativeness or fairness of the data. Distinct from anomalies (data quality issues) and limitations (scope constraints).
@@ -698,41 +698,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetLimitation" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:LimitationTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#recommended_mitigation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#limitation_description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#scope_impact> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Documents known limitations of the dataset that may affect its use or interpretation. Distinct from biases (systematic errors) and anomalies (data quality issues).
 """ ;
@@ -744,31 +744,31 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "DatasetRelationship" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:DatasetRelationshipTypeEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#target_dataset> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#description> ],
+            owl:minCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_type> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Typed relationship to another dataset, enabling precise specification of how datasets relate to each other (e.g., supplements, derives from, is version of). Supports RO-Crate-style dataset interlinking.
 """ ;
@@ -778,41 +778,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Deidentification" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiable_elements_present> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identifiers_removed> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#deidentification_details> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#method> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is it possible to identify individuals in the dataset, either directly or indirectly (in combination with other data)?
 """ ;
@@ -822,26 +822,32 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Instance" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
@@ -849,44 +855,38 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_substrate> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sampling_strategies> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#instance_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label_description> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#counts> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#label> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#data_topic> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#MissingInfo> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing_information> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What do the instances that comprise the dataset represent (e.g., documents, photos, people, countries)?
 """ ;
@@ -896,17 +896,17 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MissingInfo" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#missing> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_missing> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is any information missing from individual instances? (e.g., unavailable data).
 """ ;
@@ -916,10 +916,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Relationships" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#relationship_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
@@ -933,22 +933,22 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "SensitiveElement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitivity_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#sensitive_elements_present> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain data that might be considered sensitive (e.g., race, sexual orientation, religion, biometrics)?
@@ -960,13 +960,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Splits" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#split_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are there recommended data splits (e.g., training, validation, testing)? If so, how are they defined and why?
@@ -977,31 +977,31 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Subpopulation" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#subpopulation_elements_present> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#identification> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#distribution> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset identify any subpopulations (e.g., by age, gender)? If so, how are they identified and what are their distributions?
@@ -1012,47 +1012,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExportControlRegulatoryRestrictions" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:ComplianceStatusEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#regulatory_restrictions> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#hipaa_compliant> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:ConfidentialityLevelEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#confidentiality_level> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#other_compliance> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#governance_committee_contact> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Do any export controls or other regulatory restrictions apply to the dataset or to individual instances? Includes compliance tracking for regulations like HIPAA and other US regulations. If so, please describe these restrictions and provide a link or copy of any supporting documentation. Maps to DUO terms related to ethics approval, geographic restrictions, and institutional requirements.
 """ ;
@@ -1077,7 +1077,7 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "LicenseAndUseTerms" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
@@ -1085,22 +1085,22 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom data_sheets_schema:DataUsePermissionEnum ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#license_terms> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#data_use_permission> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#contact_person> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed under a copyright or other IP license, and/or under applicable terms of use? Provide a link or copy of relevant licensing terms and any fees.
@@ -1111,10 +1111,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DistributionDate" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#release_dates> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#release_dates> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """When will the dataset be distributed?
@@ -1125,10 +1125,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DistributionFormat" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#access_urls> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#access_urls> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """How will the dataset be distributed (e.g., tarball on a website, API, GitHub)?
@@ -1139,13 +1139,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ThirdPartySharing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/distribution#is_shared> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be distributed to third parties outside of the entity (e.g., company, institution, organization) on behalf of which the dataset was created?
@@ -1156,13 +1156,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CollectionConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#consent_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Did the individuals in question consent to the collection and use of their data? If so, how was consent requested and provided, and what language did individuals consent to?
@@ -1190,13 +1190,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ConsentRevocation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#revocation_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If consent was obtained, were the consenting individuals provided with a mechanism to revoke their consent in the future or for certain uses? If so, please describe.
@@ -1207,10 +1207,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DataProtectionImpact" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#impact_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -1225,18 +1225,24 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "EthicalReview" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#review_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -1244,12 +1250,6 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Person ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#contact_person> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/ethics#reviewing_organization> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Were any ethical or compliance review processes conducted (e.g., by an institutional review board)? If so, please provide a description of these review processes, including the frequency of review and documentation of outcomes, as well as a link or other access point to any supporting documentation.
 """ ;
@@ -1259,20 +1259,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AtRiskPopulations" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#guardian_consent> ],
@@ -1280,11 +1283,8 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_protections> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#at_risk_groups_included> ],
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#assent_procedures> ],
@@ -1297,41 +1297,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "HumanSubjectCompensation" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_amount> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_rationale> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#compensation_provided> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about compensation or incentives provided to human research participants.
 """ ;
@@ -1344,38 +1344,38 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#regulatory_compliance> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#involves_human_subjects> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#ethics_review_board> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#irb_approval> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#special_populations> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about whether the dataset involves human subjects research and what regulatory or ethical review processes were followed.
 """ ;
@@ -1386,48 +1386,48 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "InformedConsent" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_documentation> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_scope> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#consent_obtained> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#withdrawal_mechanism> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Details about informed consent procedures used in human subjects research.
@@ -1438,41 +1438,41 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ParticipantPrivacy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#anonymization_method> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#privacy_techniques> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#reidentification_risk> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/human#data_linkage> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Information about privacy protections and anonymization procedures for human research participants.
 """ ;
@@ -1482,23 +1482,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Erratum" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#erratum_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there an erratum? If so, please provide a link or other access point.
 """ ;
@@ -1508,10 +1508,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExtensionMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
@@ -1522,9 +1525,6 @@ data_sheets_schema:Software a owl:Class,
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#contribution_url> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#extension_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If others want to extend/augment/build on/contribute to the dataset, is there a mechanism for them to do so? If so, please describe how those contributions are validated and communicated.
 """ ;
@@ -1535,22 +1535,22 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "Maintainer" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#maintainer_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:CreatorOrMaintainerEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#role> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who will be supporting/hosting/maintaining the dataset?
 """ ;
@@ -1560,9 +1560,6 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "RetentionLimits" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
         [ a owl:Restriction ;
@@ -1573,10 +1570,13 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_period> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#retention_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """If the dataset relates to people, are there applicable limits on the retention of their data (e.g., were individuals told their data would be deleted after a certain time)? If so, please describe these limits and how they will be enforced.
 """ ;
@@ -1586,23 +1586,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UpdatePlan" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#update_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#frequency> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will the dataset be updated (e.g., to correct labeling errors, add new instances, delete instances)? If so, how often, by whom, and how will these updates be communicated?
 """ ;
@@ -1614,28 +1614,28 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "VersionAccess" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#version_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#versions_available> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#latest_version_doi> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Will older versions of the dataset continue to be supported/hosted/maintained? If so, how? If not, how will obsolescence be communicated to dataset consumers?
 """ ;
@@ -1645,13 +1645,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AddressingGap" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Was there a specific gap that needed to be filled by creation of the dataset?" ;
@@ -1661,26 +1661,26 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Creator" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Person ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:CRediTRoleEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Organization ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliations> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:CRediTRoleEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#credit_roles> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#affiliations> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Person ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who created the dataset (e.g., which team, research group) and on behalf of which entity (e.g., company, institution, organization)? This may also be considered a team.
 """ ;
@@ -1690,20 +1690,20 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "FundingMechanism" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Grant> ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grants> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grantor> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Who funded the creation of the dataset? If there is an associated grant, please provide the name of the grantor and the grant name and number.
 """ ;
@@ -1713,50 +1713,50 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Grant" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#name> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#id> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#grant_number> ] ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#description> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> ] ;
     skos:definition """The name and/or identifier of the specific mechanism providing monetary support or other resources supporting creation of the dataset.
 """ ;
     skos:inScheme data_sheets_schema:motivation .
@@ -1768,10 +1768,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "For what purpose was the dataset created?" ;
@@ -1781,10 +1781,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Task" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/motivation#response> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -1797,47 +1797,47 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "AnnotationAnalysis" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:Float ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#analysis_method> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotation_quality_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement_score> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#disagreement_patterns> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#agreement_metric> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Analysis of annotation quality, inter-annotator agreement metrics, and systematic patterns in annotation disagreements.
 """ ;
@@ -1848,13 +1848,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "CleaningStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#cleaning_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any cleaning of the data done (e.g., removal of instances, processing of missing values)?
@@ -1867,31 +1867,31 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "ImputationProtocol" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_validation> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_method> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputed_fields> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#imputation_rationale> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Description of data imputation methodology, including techniques used to handle missing values and rationale for chosen approaches.
 """ ;
@@ -1902,56 +1902,56 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "LabelingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Integer ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_protocol> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotations_per_item> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#inter_annotator_agreement> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#annotator_demographics> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#data_annotation_platform> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#labeling_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any labeling of the data done (e.g., part-of-speech tagging)? This class documents the annotation process and quality metrics.
 """ ;
@@ -1961,26 +1961,26 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "MachineAnnotationTools" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_accuracy> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tool_descriptions> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#tools> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Automated or machine-learning-based annotation tools used in dataset creation, including NLP pipelines, computer vision models, or other automated labeling systems.
 """ ;
@@ -1991,13 +1991,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "PreprocessingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#preprocessing_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was any preprocessing of the data done (e.g., discretization or bucketing, tokenization, SIFT feature extraction)?
@@ -2010,10 +2010,10 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "RawData" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
@@ -2021,11 +2021,11 @@ data_sheets_schema:Software a owl:Class,
             owl:allValuesFrom linkml:Uri ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#raw_data_details> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#access_url> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Was the "raw" data saved in addition to the preprocessed/cleaned/labeled data? If so, please provide a link or other access point to the "raw" data.
 """ ;
@@ -2038,10 +2038,10 @@ data_sheets_schema:Software a owl:Class,
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#discouragement_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Are there tasks for which the dataset should not be used?
@@ -2052,10 +2052,10 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ExistingUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Has the dataset been used for any tasks already?
@@ -2069,10 +2069,10 @@ data_sheets_schema:Software a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#impact_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is there anything about the dataset's composition or collection that might impact future uses or create risks/harm (e.g., unfair treatment, legal or financial risks)? If so, describe these impacts and any mitigation strategies.
@@ -2085,12 +2085,15 @@ data_sheets_schema:Software a owl:Class,
     rdfs:label "IntendedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -2103,10 +2106,7 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#usage_notes> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#examples> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#use_category> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of intended uses for this dataset. Complements FutureUseImpact by focusing on positive, recommended applications rather than risks. Aligns with RO-Crate "Intended Use" field.
 """ ;
@@ -2117,13 +2117,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "OtherTask" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#task_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """What other tasks could the dataset be used for?
@@ -2134,13 +2134,13 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "ProhibitedUse" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#prohibition_reason> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Explicit statement of prohibited or forbidden uses for this dataset. Stronger than DiscouragedUse - these are uses that are explicitly not permitted by license, ethics, or policy. Aligns with RO-Crate "Prohibited Uses" field.
@@ -2151,23 +2151,23 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "UseRepository" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uri ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_url> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/uses#repository_details> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "A repository or registry of known uses of this dataset by third parties. Documents where the dataset has been applied, enabling discoverability of downstream use cases and impact tracking." ;
     skos:inScheme data_sheets_schema:uses .
@@ -2176,60 +2176,6 @@ data_sheets_schema:Software a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "VariableMetadata" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Float ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         [ a owl:Restriction ;
@@ -2237,22 +2183,19 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
@@ -2261,37 +2204,94 @@ data_sheets_schema:Software a owl:Class,
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#missing_value_code> ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#examples> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#precision> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#measurement_technique> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#derivation> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_sensitive> ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#categories> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#unit> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Float ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#minimum_value> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#quality_notes> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#maximum_value> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#is_identifier> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:VariableTypeEnum ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#data_type> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/variables#variable_name> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition "Metadata describing an individual variable, field, or column in a dataset. Variables may represent measurements, observations, derived values, or categorical attributes." ;
     skos:exactMatch schema1:PropertyValue ;
@@ -3461,35 +3461,35 @@ data_sheets_schema:collection_timeframes a owl:ObjectProperty,
         linkml:ClassDefinition ;
     rdfs:label "ExternalResource" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
         [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:external_resources ],
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Boolean ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#restrictions> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#future_guarantees> ],
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#archival> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Is the dataset self-contained or does it rely on external resources (e.g., websites, other datasets)? If external, are there guarantees that those resources will remain available and unchanged?
 """ ;
@@ -3499,65 +3499,65 @@ data_sheets_schema:collection_timeframes a owl:ObjectProperty,
         linkml:ClassDefinition ;
     rdfs:label "SamplingStrategy" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#representative_verification> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#why_not_representative> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#source_data> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_random> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_sample> ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#is_representative> ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty <https://w3id.org/bridge2ai/data-sheets-schema/composition#strategies> ],
         data_sheets_schema:DatasetProperty ;
     skos:definition """Does the dataset contain all possible instances, or is it a sample (not necessarily random) of instances from a larger set? If so, how representative is it?
 """ ;
@@ -4116,6 +4116,21 @@ data_sheets_schema:NamedThing a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "NamedThing" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
@@ -4123,22 +4138,7 @@ data_sheets_schema:NamedThing a owl:Class,
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:notes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty data_sheets_schema:id ],
@@ -4147,9 +4147,9 @@ data_sheets_schema:NamedThing a owl:Class,
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:notes ],
+            owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:name ] ;
     skos:definition "A generic grouping for any identifiable entity." ;
     skos:exactMatch schema1:Thing ;
@@ -4160,37 +4160,37 @@ data_sheets_schema:Organization a owl:Class,
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:notes ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:notes ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:Uriorcurie ;
             owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:description ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:name ] ;
@@ -5246,7 +5246,7 @@ data_sheets_schema:modified_by a owl:ObjectProperty,
 <https://w3id.org/bridge2ai/data-sheets-schema/motivation#notes> a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "notes" ;
-    skos:definition "Content about the grant that fits no dedicated slot; never invent keys (#380)." ;
+    skos:definition "Residual content about the grant after name, grant_number and description are used (#385); never invent keys (#380)." ;
     skos:inScheme data_sheets_schema:motivation .
 
 <https://w3id.org/bridge2ai/data-sheets-schema/motivation#principal_investigator> a owl:ObjectProperty,
@@ -5647,211 +5647,142 @@ data_sheets_schema:Dataset a owl:Class,
     rdfs:label "Dataset" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
+            owl:onProperty data_sheets_schema:direct_collection ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
-            owl:onProperty data_sheets_schema:creators ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:related_datasets ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
+            owl:onProperty data_sheets_schema:labeling_strategies ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
             owl:onProperty data_sheets_schema:confidential_elements ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:data_protection_impacts ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetBias> ;
-            owl:onProperty data_sheets_schema:known_biases ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
+            owl:onProperty data_sheets_schema:raw_sources ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
+            owl:onProperty data_sheets_schema:distribution_dates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:use_repository ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:regulatory_restrictions ],
         [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_notifications ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#ConsentRevocation> ;
+            owl:onProperty data_sheets_schema:consent_revocations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:acquisition_methods ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#MachineAnnotationTools> ;
+            owl:onProperty data_sheets_schema:machine_annotation_tools ],
+        [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#UpdatePlan> ;
             owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:missing_data_documentation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_consents ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:file_collections ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#ThirdPartySharing> ;
+            owl:onProperty data_sheets_schema:third_party_sharing ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#RetentionLimits> ;
             owl:onProperty data_sheets_schema:retention_limit ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:citation ],
+            owl:onProperty data_sheets_schema:existing_uses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:raw_sources ],
+            owl:onProperty data_sheets_schema:distribution_formats ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionConsent> ;
-            owl:onProperty data_sheets_schema:collection_consents ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/InstanceAcquisition> ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionDate> ;
-            owl:onProperty data_sheets_schema:distribution_dates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Creator> ;
+            owl:onProperty data_sheets_schema:creators ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#EthicalReview> ;
             owl:onProperty data_sheets_schema:ethical_reviews ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:DataSubset ;
-            owl:onProperty data_sheets_schema:subsets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
-            owl:onProperty data_sheets_schema:purposes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Confidentiality> ;
-            owl:onProperty data_sheets_schema:confidential_elements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#MachineAnnotationTools> ;
-            owl:onProperty data_sheets_schema:machine_annotation_tools ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:funders ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:discouraged_uses ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_file_count ],
+            owl:onProperty data_sheets_schema:subpopulations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:content_warnings ],
+            owl:onProperty data_sheets_schema:errata ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/RawDataSource> ;
-            owl:onProperty data_sheets_schema:raw_data_sources ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version_access ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:acquisition_methods ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#RawData> ;
-            owl:onProperty data_sheets_schema:raw_sources ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#LicenseAndUseTerms> ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
-            owl:onProperty data_sheets_schema:anomalies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:future_use_impacts ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
-            owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:regulatory_restrictions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:file_collections ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DirectCollection> ;
-            owl:onProperty data_sheets_schema:direct_collection ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:imputation_protocols ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_notifications ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:cleaning_strategies ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:retention_limit ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_tabular ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ExternalResource> ;
             owl:onProperty data_sheets_schema:external_resources ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:intended_uses ],
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
-            owl:onProperty data_sheets_schema:variables ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
+            owl:onProperty data_sheets_schema:data_protection_impacts ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
             owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
-            owl:onProperty data_sheets_schema:content_warnings ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:citation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
-            owl:onProperty data_sheets_schema:discouraged_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/MissingDataDocumentation> ;
-            owl:onProperty data_sheets_schema:missing_data_documentation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#IPRestrictions> ;
-            owl:onProperty data_sheets_schema:ip_restrictions ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#AnnotationAnalysis> ;
-            owl:onProperty data_sheets_schema:annotation_analyses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:third_party_sharing ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:consent_revocations ],
@@ -5859,182 +5790,32 @@ data_sheets_schema:Dataset a owl:Class,
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Erratum> ;
             owl:onProperty data_sheets_schema:errata ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#ParticipantPrivacy> ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:direct_collection ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#LabelingStrategy> ;
-            owl:onProperty data_sheets_schema:labeling_strategies ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license_and_use_terms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:prohibited_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:data_collectors ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:anomalies ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:annotation_analyses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:raw_data_sources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectCompensation> ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
-            owl:onProperty data_sheets_schema:addressing_gaps ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Integer ;
-            owl:onProperty data_sheets_schema:total_file_count ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sampling_strategies ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_size_bytes ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:total_file_count ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:is_deidentified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:parent_datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:missing_data_documentation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:creators ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Boolean ;
-            owl:onProperty data_sheets_schema:is_tabular ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:FileCollection ;
-            owl:onProperty data_sheets_schema:file_collections ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_consents ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#ConsentRevocation> ;
-            owl:onProperty data_sheets_schema:consent_revocations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
-            owl:onProperty data_sheets_schema:collection_timeframes ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
-            owl:onProperty data_sheets_schema:tasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#ThirdPartySharing> ;
-            owl:onProperty data_sheets_schema:third_party_sharing ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:relationships ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:machine_annotation_tools ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#AtRiskPopulations> ;
-            owl:onProperty data_sheets_schema:at_risk_populations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:external_resources ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:known_limitations ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#ExtensionMechanism> ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:extension_mechanism ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:maintainers ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
-            owl:onProperty data_sheets_schema:subpopulations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:ethical_reviews ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:informed_consent ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_compensation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:known_biases ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:other_tasks ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#VersionAccess> ;
             owl:onProperty data_sheets_schema:version_access ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
-            owl:onProperty data_sheets_schema:intended_uses ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Instance> ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:splits ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
-            owl:onProperty data_sheets_schema:related_datasets ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:resources ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionNotification> ;
             owl:onProperty data_sheets_schema:collection_notifications ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
-            owl:onProperty data_sheets_schema:maintainers ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ip_restrictions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Splits> ;
+            owl:onProperty data_sheets_schema:splits ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:human_subject_research ],
+            owl:onProperty data_sheets_schema:machine_annotation_tools ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:third_party_sharing ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#AddressingGap> ;
+            owl:onProperty data_sheets_schema:addressing_gaps ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetLimitation> ;
             owl:onProperty data_sheets_schema:known_limitations ],
@@ -6042,77 +5823,296 @@ data_sheets_schema:Dataset a owl:Class,
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:distribution_dates ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#AtRiskPopulations> ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:updates ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:tasks ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#FundingMechanism> ;
-            owl:onProperty data_sheets_schema:funders ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:instances ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:sensitive_elements ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Splits> ;
-            owl:onProperty data_sheets_schema:splits ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#DataProtectionImpact> ;
-            owl:onProperty data_sheets_schema:data_protection_impacts ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
             owl:onProperty data_sheets_schema:existing_uses ],
         [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:parent_datasets ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:participant_privacy ],
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:raw_sources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:Dataset ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DataCollector> ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SamplingStrategy> ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:addressing_gaps ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:purposes ],
+            owl:onProperty data_sheets_schema:labeling_strategies ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:errata ],
+            owl:onProperty data_sheets_schema:funders ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:DataSubset ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:annotation_analyses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/data-governance#ExportControlRegulatoryRestrictions> ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:external_resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:creators ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#DiscouragedUse> ;
+            owl:onProperty data_sheets_schema:discouraged_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Relationships> ;
+            owl:onProperty data_sheets_schema:relationships ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:content_warnings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DataAnomaly> ;
+            owl:onProperty data_sheets_schema:anomalies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:cleaning_strategies ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Deidentification> ;
             owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:maintainers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:at_risk_populations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#PreprocessingStrategy> ;
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:instances ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:updates ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:total_file_count ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Subpopulation> ;
+            owl:onProperty data_sheets_schema:subpopulations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license_and_use_terms ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:retention_limit ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/variables#VariableMetadata> ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:extension_mechanism ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/RawDataSource> ;
+            owl:onProperty data_sheets_schema:raw_data_sources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:imputation_protocols ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom data_sheets_schema:FileCollection ;
+            owl:onProperty data_sheets_schema:file_collections ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#ContentWarning> ;
+            owl:onProperty data_sheets_schema:content_warnings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetBias> ;
+            owl:onProperty data_sheets_schema:known_biases ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#InformedConsent> ;
+            owl:onProperty data_sheets_schema:informed_consent ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:splits ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:known_biases ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ProhibitedUse> ;
+            owl:onProperty data_sheets_schema:prohibited_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/DirectCollection> ;
+            owl:onProperty data_sheets_schema:direct_collection ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_privacy ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/ethics#CollectionConsent> ;
+            owl:onProperty data_sheets_schema:collection_consents ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:subsets ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:is_deidentified ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sampling_strategies ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#AnnotationAnalysis> ;
+            owl:onProperty data_sheets_schema:annotation_analyses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:citation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:confidential_elements ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:participant_compensation ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
+            owl:onProperty data_sheets_schema:distribution_formats ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#OtherTask> ;
+            owl:onProperty data_sheets_schema:other_tasks ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/MissingDataDocumentation> ;
+            owl:onProperty data_sheets_schema:missing_data_documentation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:ethical_reviews ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:data_collectors ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Task> ;
+            owl:onProperty data_sheets_schema:tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:variables ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#UseRepository> ;
+            owl:onProperty data_sheets_schema:use_repository ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:other_tasks ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:raw_data_sources ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#ImputationProtocol> ;
             owl:onProperty data_sheets_schema:imputation_protocols ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:collection_mechanisms ],
+            owl:onProperty data_sheets_schema:preprocessing_strategies ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#Relationships> ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:relationships ],
         [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/distribution#DistributionFormat> ;
-            owl:onProperty data_sheets_schema:distribution_formats ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:use_repository ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:variables ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Dataset ;
-            owl:onProperty data_sheets_schema:resources ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#ExistingUse> ;
-            owl:onProperty data_sheets_schema:existing_uses ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:subsets ],
+            owl:onProperty data_sheets_schema:version_access ],
         [ a owl:Restriction ;
             owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#CleaningStrategy> ;
             owl:onProperty data_sheets_schema:cleaning_strategies ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Boolean ;
+            owl:onProperty data_sheets_schema:is_tabular ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/motivation#Purpose> ;
+            owl:onProperty data_sheets_schema:purposes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#SensitiveElement> ;
+            owl:onProperty data_sheets_schema:sensitive_elements ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/composition#DatasetRelationship> ;
+            owl:onProperty data_sheets_schema:related_datasets ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionTimeframe> ;
+            owl:onProperty data_sheets_schema:collection_timeframes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/human#HumanSubjectResearch> ;
+            owl:onProperty data_sheets_schema:human_subject_research ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Integer ;
+            owl:onProperty data_sheets_schema:total_size_bytes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#IntendedUse> ;
+            owl:onProperty data_sheets_schema:intended_uses ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/uses#FutureUseImpact> ;
+            owl:onProperty data_sheets_schema:future_use_impacts ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/collection/CollectionMechanism> ;
+            owl:onProperty data_sheets_schema:collection_mechanisms ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom <https://w3id.org/bridge2ai/data-sheets-schema/maintenance#Maintainer> ;
+            owl:onProperty data_sheets_schema:maintainers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:resources ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:regulatory_restrictions ],
         data_sheets_schema:Information ;
     skos:altLabel "data file",
         "data package",
@@ -6126,8 +6126,149 @@ data_sheets_schema:Information a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Information" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:language ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:page ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uri ;
+            owl:onProperty data_sheets_schema:download_url ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:modified_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:keywords ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:compression ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_on ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:created_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:was_derived_from ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:doi ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:status ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:conforms_to_class ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:issued ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
+            owl:onProperty data_sheets_schema:last_updated_on ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:license ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:page ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:language ],
@@ -6137,173 +6278,32 @@ data_sheets_schema:Information a owl:Class,
                     owl:withRestrictions ( [ xsd:pattern "10\\.\\d{4,}\\/.+" ] ) ] ;
             owl:onProperty data_sheets_schema:doi ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:version ],
+        [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:conforms_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Datetime ;
             owl:onProperty data_sheets_schema:created_on ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_on ],
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:created_by ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:status ],
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:publisher ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:title ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:conforms_to_schema ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:CompressionEnum ;
             owl:onProperty data_sheets_schema:compression ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:created_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:keywords ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:publisher ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:modified_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:last_updated_on ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:keywords ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uri ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:license ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:status ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:page ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:created_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:version ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Datetime ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_class ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:doi ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:issued ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:title ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:conforms_to_schema ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:compression ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:download_url ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:was_derived_from ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:language ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:modified_by ],
         data_sheets_schema:NamedThing ;
     skos:closeMatch schema1:CreativeWork ;
     skos:definition "Grouping for datasets and data files." ;
@@ -6313,11 +6313,8 @@ data_sheets_schema:Person a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom data_sheets_schema:Organization ;
-            owl:onProperty data_sheets_schema:affiliation ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:email ],
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( linkml:String [ a rdfs:Datatype ;
@@ -6326,19 +6323,22 @@ data_sheets_schema:Person a owl:Class,
             owl:onProperty data_sheets_schema:orcid ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:orcid ],
+            owl:onProperty data_sheets_schema:affiliation ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:orcid ],
+            owl:allValuesFrom data_sheets_schema:Organization ;
+            owl:onProperty data_sheets_schema:affiliation ],
         [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:email ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:affiliation ],
+            owl:onProperty data_sheets_schema:orcid ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:email ],
         data_sheets_schema:NamedThing ;
     skos:definition "An individual human being. This class represents a person in the context of a specific dataset. Attributes like affiliation and email represent the person's current or most relevant contact information for this dataset. For stable cross-dataset identification, use the ORCID field. Note that contributor roles (CRediT) are specified in the usage context (e.g., Creator class) rather than on the Person directly, since roles vary by dataset." ;
     skos:exactMatch schema1:Person ;
@@ -6464,9 +6464,9 @@ data_sheets_schema:name a owl:ObjectProperty,
 data_sheets_schema:notes a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "notes" ;
-    skos:definition "Content about the organization that fits no dedicated slot; never invent keys (#380).",
-        "Content from the source material that belongs to this entity but fits no dedicated slot. Use this rather than inventing keys the schema does not declare (#380).",
-        "Content from the source material that belongs to this property but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary: put the fact here with enough context to be findable, rather than adding fields the schema does not declare (#380 — undeclared keys were the corpus's third-largest failure class)." ;
+    skos:definition "Residual content about the organization after name, id and description are used (#385); never invent keys (#380).",
+        "Residual content only, after every fitting slot is used (#385): structured slots first, description as the default home for narrative, notes last — solely for content description cannot hold. Never a restatement of a sibling slot's value, and never a substitute for inventing keys the schema does not declare (#380).",
+        "Residual content only, after every fitting slot is used — structured slots first, then description; notes solely for what description cannot hold (#385). Never invent keys (#380)." ;
     skos:inScheme data_sheets_schema:base .
 
 data_sheets_schema:ComplianceStatusEnum a owl:Class,
@@ -6672,47 +6672,47 @@ data_sheets_schema:DatasetProperty a owl:Class,
         linkml:ClassDefinition ;
     rdfs:label "DatasetProperty" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom linkml:Uriorcurie ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:notes ],
-        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:id ],
+            owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:Uriorcurie ;
+            owl:onProperty data_sheets_schema:id ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty data_sheets_schema:notes ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:used_software ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom linkml:String ;
+            owl:onProperty data_sheets_schema:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom data_sheets_schema:Software ;
             owl:onProperty data_sheets_schema:used_software ],
         [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty data_sheets_schema:id ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty data_sheets_schema:name ],
+        [ a owl:Restriction ;
             owl:allValuesFrom linkml:String ;
             owl:onProperty data_sheets_schema:notes ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty data_sheets_schema:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom linkml:String ;
-            owl:onProperty data_sheets_schema:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:used_software ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty data_sheets_schema:name ] ;
+            owl:onProperty data_sheets_schema:description ] ;
     skos:definition "Represents a single property of a dataset, or a set of related properties." ;
     skos:inScheme data_sheets_schema:base .
 

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -410,16 +410,22 @@ class PhaseRequest:
 PHASE_INSTRUCTIONS = {
     "full": (
         "Phase 1. Produce the FULL D4D record for class `Dataset`. Use only "
-        "keys the schema digest declares; supported content that fits no "
-        "dedicated slot goes in the nearest class's `notes` slot, never in "
-        "an invented key. Output only the YAML, beginning with the header "
-        "comment block specified above. No commentary before or after."),
+        "keys the schema digest declares, and fill them in this order: a "
+        "class's structured slots first (name, id, affiliations, grants and "
+        "kin must not sit empty while their content sits in prose), then "
+        "`description` as the default home for narrative, and `notes` last — "
+        "only for content `description` cannot hold. Never restate a sibling "
+        "slot's value in `notes`, and never invent a key. Output only the "
+        "YAML, beginning with the header comment block specified above. No "
+        "commentary before or after."),
     "core": (
         "Phase 2. Produce the CORE D4D record for class `CoreDataset`, using "
         "the declared bundle and the completed full record supplied above. The "
         "core record must not assert anything the full record does not support. "
-        "Use only keys the schema digest declares; unplaced content goes in "
-        "`notes`, never in an invented key. Output only the YAML."),
+        "Use only keys the schema digest declares; structured slots first, "
+        "then `description`, with `notes` last and only for content "
+        "`description` cannot hold — never an invented key. Output only the "
+        "YAML."),
     "audit": (
         "Phase 3. Audit both records against the declared bundle and the "
         "evidence boundary. Report, as a JSON object with keys `findings` (a "

--- a/src/data_sheets_schema/datamodel/data_sheets_schema.py
+++ b/src/data_sheets_schema/datamodel/data_sheets_schema.py
@@ -1,5 +1,5 @@
 # Auto generated from data_sheets_schema.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-06T20:21:37
+# Generation date: 2026-08-07T09:59:04
 # Schema: data-sheets-schema
 #
 # id: https://w3id.org/bridge2ai/data-sheets-schema

--- a/src/data_sheets_schema/schema/D4D_Base_import.yaml
+++ b/src/data_sheets_schema/schema/D4D_Base_import.yaml
@@ -114,9 +114,9 @@ classes:
         slot_uri: schema:comment
         range: string
         description: >-
-          Content from the source material that belongs to this entity but
-          fits no dedicated slot. Use this rather than inventing keys the
-          schema does not declare (#380).
+          Residual content only, after every fitting slot is used —
+          structured slots first, then description; notes solely for what
+          description cannot hold (#385). Never invent keys (#380).
     class_uri: schema:Thing
 
   # Not a NamedThing, like DatasetProperty below and for the same reason:
@@ -155,8 +155,8 @@ classes:
         slot_uri: schema:comment
         range: string
         description: >-
-          Content about the organization that fits no dedicated slot; never
-          invent keys (#380).
+          Residual content about the organization after name, id and
+          description are used (#385); never invent keys (#380).
 
   # Base class for all dataset properties and components
   # Note: Does NOT inherit from NamedThing to avoid required id constraint
@@ -181,11 +181,11 @@ classes:
         slot_uri: schema:comment
         range: string
         description: >-
-          Content from the source material that belongs to this property but
-          fits no dedicated slot. The escape hatch that makes inventing keys
-          unnecessary: put the fact here with enough context to be findable,
-          rather than adding fields the schema does not declare (#380 —
-          undeclared keys were the corpus's third-largest failure class).
+          Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for
+          narrative, notes last — solely for content description cannot
+          hold. Never a restatement of a sibling slot's value, and never a
+          substitute for inventing keys the schema does not declare (#380).
       used_software:
         description: "What software was used as part of this dataset property?"
         slot_uri: d4d:usedSoftware

--- a/src/data_sheets_schema/schema/D4D_Motivation.yaml
+++ b/src/data_sheets_schema/schema/D4D_Motivation.yaml
@@ -182,8 +182,8 @@ classes:
         slot_uri: schema:comment
         range: string
         description: >-
-          Content about the grant that fits no dedicated slot; never invent
-          keys (#380).
+          Residual content about the grant after name, grant_number and
+          description are used (#385); never invent keys (#380).
       grant_number:
         description: "The alphanumeric identifier for the grant."
         range: string

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -2724,9 +2724,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -4546,9 +4546,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -6306,9 +6306,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -6667,9 +6667,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -6843,8 +6843,8 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content about the organization that fits no dedicated slot; never
-          invent keys (#380).
+        description: Residual content about the organization after name, id and description
+          are used (#385); never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -7127,11 +7127,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -7619,9 +7619,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -8034,9 +8034,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -8811,9 +8811,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -9232,11 +9232,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -9672,11 +9672,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -10115,11 +10115,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -10584,11 +10584,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -11035,11 +11035,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -11290,8 +11290,8 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content about the organization that fits no dedicated slot; never
-          invent keys (#380).
+        description: Residual content about the organization after name, id and description
+          are used (#385); never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -11401,8 +11401,8 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content about the grant that fits no dedicated slot; never invent
-          keys (#380).
+        description: Residual content about the grant after name, grant_number and
+          description are used (#385); never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
         slot_uri: schema:comment
         alias: notes
@@ -11824,11 +11824,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -12354,11 +12354,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -12817,11 +12817,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -13261,11 +13261,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -13705,11 +13705,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -14148,11 +14148,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -14641,11 +14641,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -15130,11 +15130,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -15623,11 +15623,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -16076,11 +16076,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -16528,11 +16528,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -16994,11 +16994,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -17466,11 +17466,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -17919,11 +17919,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -18336,11 +18336,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -18822,11 +18822,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -19268,11 +19268,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -19726,11 +19726,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -20199,11 +20199,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -20652,11 +20652,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -21130,11 +21130,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -21628,11 +21628,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -22073,11 +22073,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -22518,11 +22518,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -23038,11 +23038,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -23490,11 +23490,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -23982,11 +23982,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -24477,11 +24477,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -24960,11 +24960,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -25401,11 +25401,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -25851,11 +25851,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -26292,11 +26292,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -26741,11 +26741,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -27183,11 +27183,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -27656,11 +27656,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -28097,11 +28097,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -28536,11 +28536,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -28977,11 +28977,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -29420,11 +29420,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -29875,11 +29875,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -30332,11 +30332,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -30793,11 +30793,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -31252,11 +31252,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -31723,11 +31723,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -32182,11 +32182,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -32657,11 +32657,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -33103,11 +33103,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -33549,11 +33549,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -33994,11 +33994,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -34440,11 +34440,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -34939,11 +34939,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -35436,11 +35436,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -35922,11 +35922,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -36404,11 +36404,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -36887,11 +36887,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -37367,11 +37367,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -37814,11 +37814,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -38316,11 +38316,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -38947,11 +38947,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -39950,9 +39950,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -40837,9 +40837,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -2118,9 +2118,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -2283,8 +2283,8 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content about the organization that fits no dedicated slot; never
-          invent keys (#380).
+        description: Residual content about the organization after name, id and description
+          are used (#385); never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -2558,11 +2558,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -3036,9 +3036,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -3443,9 +3443,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -4152,9 +4152,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -4565,11 +4565,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -4998,11 +4998,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -5434,11 +5434,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -5896,11 +5896,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -6340,11 +6340,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -6585,8 +6585,8 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content about the organization that fits no dedicated slot; never
-          invent keys (#380).
+        description: Residual content about the organization after name, id and description
+          are used (#385); never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -6684,8 +6684,8 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content about the grant that fits no dedicated slot; never invent
-          keys (#380).
+        description: Residual content about the grant after name, grant_number and
+          description are used (#385); never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/motivation
         slot_uri: schema:comment
         alias: notes
@@ -7097,11 +7097,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -7620,11 +7620,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -8076,11 +8076,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -8513,11 +8513,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -8950,11 +8950,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -9386,11 +9386,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -9872,11 +9872,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -10354,11 +10354,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -10838,11 +10838,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -11284,11 +11284,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -11729,11 +11729,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -12188,11 +12188,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -12653,11 +12653,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -13099,11 +13099,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -13508,11 +13508,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -13987,11 +13987,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -14426,11 +14426,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -14877,11 +14877,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -15343,11 +15343,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -15789,11 +15789,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -16260,11 +16260,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -16751,11 +16751,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -17189,11 +17189,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -17627,11 +17627,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -18140,11 +18140,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -18585,11 +18585,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -19070,11 +19070,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -19558,11 +19558,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -20034,11 +20034,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -20468,11 +20468,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -20911,11 +20911,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -21345,11 +21345,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -21787,11 +21787,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -22222,11 +22222,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -22688,11 +22688,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -23122,11 +23122,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -23554,11 +23554,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -23988,11 +23988,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -24424,11 +24424,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -24872,11 +24872,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -25322,11 +25322,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -25776,11 +25776,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -26228,11 +26228,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -26692,11 +26692,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -27144,11 +27144,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -27612,11 +27612,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -28051,11 +28051,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -28490,11 +28490,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -28928,11 +28928,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -29367,11 +29367,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -29859,11 +29859,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -30349,11 +30349,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -30828,11 +30828,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -31303,11 +31303,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -31779,11 +31779,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -32252,11 +32252,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -32692,11 +32692,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -33186,11 +33186,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -33810,11 +33810,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -34386,11 +34386,11 @@ classes:
         range: string
       notes:
         name: notes
-        description: 'Content from the source material that belongs to this property
-          but fits no dedicated slot. The escape hatch that makes inventing keys unnecessary:
-          put the fact here with enough context to be findable, rather than adding
-          fields the schema does not declare (#380 — undeclared keys were the corpus''s
-          third-largest failure class).'
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -35168,9 +35168,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes
@@ -36636,9 +36636,9 @@ classes:
         range: string
       notes:
         name: notes
-        description: Content from the source material that belongs to this entity
-          but fits no dedicated slot. Use this rather than inventing keys the schema
-          does not declare (#380).
+        description: Residual content only, after every fitting slot is used — structured
+          slots first, then description; notes solely for what description cannot
+          hold (#385). Never invent keys (#380).
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
         slot_uri: schema:comment
         alias: notes


### PR DESCRIPTION
The instruction half of #385's fix menu, landed between sweeps:

- Full/core phase instructions now state the filling order — structured slots first (name, id, affiliations, grants "must not sit empty while their content sits in prose"), `description` as the default narrative home, `notes` last and only for what description cannot hold; sibling restatement forbidden.
- The four `notes` slot descriptions carry the same rule in-schema.

Not included (still open on #385): a dedicated evidence-commentary slot (the 12% of notes usage that is genuinely homeless and arguably a feature), and mechanical lifting of affiliation/grant prose by repair/enrichment.

131 tests OK; schemas regenerated. Next: CHORUS + AI-READI rerun under a fresh label to measure the effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)