### PR TITLE
Playbook parity: propagate the API pipeline's tuned guidance to the agentic paths

### DIFF
--- a/.claude/commands/d4d-agent.md
+++ b/.claude/commands/d4d-agent.md
@@ -130,6 +130,19 @@ For each project (AI_READI, CM4AI, VOICE, CHORUS):
    - Include every field required by the applicable class
    - Respect scalar versus multivalued and inlined-object constraints
    - Follow schema ranges for nested structures and enum values
+   - **Slot-filling order** (same contract as the API pipeline's phase
+     instructions): a class's structured slots first — `name`, `id`,
+     `affiliations`, `grants` and kin must not sit empty while their content
+     sits in prose — then `description` as the default home for narrative,
+     then `notes` only for content `description` cannot hold. Evidence
+     commentary (source conflicts, what a value was transcribed from,
+     questions the sources leave unanswered) goes in `source_caveats`,
+     never in `notes`. Never restate a sibling slot's value, and never
+     invent a key.
+   - **Shape check before writing**: a value must match its slot's range —
+     no prose where the schema requires a list, no enum values the schema
+     does not define, no commentary embedded inside a name, identifier or
+     affiliation value.
 
 9. **REQUIRED validation** (NON-SKIPPABLE):
    ```bash

--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -366,7 +366,15 @@ in either generated record.
    - identify unsupported, stale, omitted, or mis-scoped assertions;
    - verify repeated identifiers, versions, dates, counts, licenses, access
      rules, people, and organizations are internally consistent in each file;
-   - keep historical values only when their historical scope is explicit.
+   - keep historical values only when their historical scope is explicit;
+   - audit shape as well as evidence (same contract as the API pipeline's
+     audit phase): flag any value whose shape does not conform to the
+     schema — prose where the schema requires a list, enum values the
+     schema does not define, commentary embedded inside a name, identifier
+     or affiliation value — and any slot-filling violation: structured
+     slots left empty while their content sits in prose, narrative in
+     `notes` that belongs in `description`, sibling values restated in
+     `notes`, or evidence commentary outside `source_caveats`.
 4. Back-port every source-supported Phase 2 discovery into the full record in
    the correct full-schema slot. Correct the full record first whenever the
    source audit changes a fact.

--- a/.github/workflows/d4d_assistant_create.md
+++ b/.github/workflows/d4d_assistant_create.md
@@ -223,6 +223,23 @@ make full-schema
 - Identify field types (string, integer, enum, etc.)
 - Check for multivalued fields (lists)
 
+#### 1b-2. Slot-Filling Order (same contract as the API pipeline)
+
+Fill each class in this order, and never skip a tier:
+
+1. **Structured slots first** — `name`, `id`, `affiliations`, `grants` and
+   kin must not sit empty while their content sits in prose elsewhere.
+2. **`description`** is the default home for narrative.
+3. **`notes`** only for content `description` cannot hold. Never restate a
+   sibling slot's value in `notes`.
+4. **`source_caveats`** for evidence commentary only: source conflicts,
+   what a value was transcribed from, questions the sources leave
+   unanswered. Never mix it into `notes`.
+
+And match each value's shape to its slot's range: no prose where the schema
+requires a list, no enum values the schema does not define, no commentary
+embedded inside a name, identifier or affiliation value.
+
 #### 1c. Common Field Name Mistakes to AVOID
 
 **Problem**: Agents often invent semantic field names that "make sense" but aren't in the schema.

--- a/.github/workflows/d4d_assistant_edit.md
+++ b/.github/workflows/d4d_assistant_edit.md
@@ -196,6 +196,12 @@ purposes:
 - Maintain valid YAML syntax
 - Update only the requested fields, keeping others intact
 - Add comments if clarification is helpful (YAML supports `# comments`)
+- Follow the slot-filling order when placing new content (same contract as
+  the API pipeline and d4d_assistant_create.md §1b-2): structured slots
+  first, then `description`, then `notes` only for what `description`
+  cannot hold, with evidence commentary (source conflicts, transcription
+  provenance) in `source_caveats` — never restate a sibling value, never
+  invent a key, and match every value's shape to its slot's range
 
 **Examples:**
 


### PR DESCRIPTION
Closes the gap identified when assessing an agentic-path switch: everything tuned in `api_runner.PHASE_INSTRUCTIONS` this cycle (slot-filling order from the #385 notes audit, shape checking from #357/#360, never-invent-keys from #380, `source_caveats` routing from #388) now appears in the four agentic playbooks in their own idiom:

- **`d4d-agent.md`** — filling order + shape check added to the generate-YAML step.
- **`d4d-full-core.md`** — Phase 3 audit covers shape and slot-filling violations alongside evidence (mirrors the API audit instruction).
- **`d4d_assistant_create.md`** — new §1b-2 "Slot-Filling Order (same contract as the API pipeline)" beside the existing invented-field-names warnings.
- **`d4d_assistant_edit.md`** — the same order applied when placing edited content.

Doc-only; each playbook cross-references the shared contract so future instruction tuning has a checklist of the places to touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)