### PR TITLE
Triage the remaining ungrounded values: four matcher defects, both directions (#406)

### DIFF
--- a/src/data_sheets_schema/verifiable.py
+++ b/src/data_sheets_schema/verifiable.py
@@ -218,6 +218,13 @@ def _month_forms(m: int) -> list[str]:
     return list(dict.fromkeys(forms))
 
 
+def _ordinal(d: int) -> str:
+    """`17` -> `17th`. 11, 12 and 13 take `th` despite ending 1, 2, 3."""
+    if 11 <= d % 100 <= 13:
+        return f"{d}th"
+    return f"{d}{ {1: 'st', 2: 'nd', 3: 'rd'}.get(d % 10, 'th') }"
+
+
 def renderings(kind: str, value: str) -> list[str]:
     """Every spelling a source document might plausibly use for one token.
 
@@ -251,7 +258,11 @@ def renderings(kind: str, value: str) -> list[str]:
         out += [f"{month} {d}, {y}",
                 f"{month} {d:02d}, {y}",
                 f"{d} {month} {y}",
-                f"{d:02d} {month} {y}"]
+                f"{d:02d} {month} {y}",
+                # Ordinal day. The VOICE IRB protocol writes "January 17th,
+                # 2023", which no cardinal rendering matches (#406).
+                f"{month} {_ordinal(d)}, {y}",
+                f"{_ordinal(d)} {month} {y}"]
     out += [f"{m:02d}/{d:02d}/{y}",
             f"{m}/{d}/{y}",
             f"{y}/{m:02d}/{d:02d}"]
@@ -266,7 +277,13 @@ def normalise(kind: str, value: str) -> str:
     equating tokens that genuinely differ, which is the failure this is meant to
     detect.
     """
-    v = value.strip().rstrip(".,;)]").lower()
+    # `:` joined the strip set in #406. `rstrip` stops at the first character
+    # not in it, so `10.60775/fairhub.1):` halted on the colon and never
+    # reached the `)` — the DOI kept two characters of prose punctuation and
+    # could not match. Four values on the 2026-08-07 sweep. A DOI may contain a
+    # colon, but only a broken one *ends* with bare punctuation, which is the
+    # same trade already accepted for `.`, `;` and `)`.
+    v = value.strip().rstrip(".,;:)]").lower()
     # Applied to both kinds, and identically to the bundle. Stripping the
     # resolver from DOIs but not from DOI-shaped URLs made the two sides
     # asymmetric, so `https://doi.org/10.18130/V3/HIGT4C` could never match a
@@ -275,6 +292,35 @@ def normalise(kind: str, value: str) -> str:
     v = re.sub(r"^https?://", "", v)
     v = re.sub(r"^(?:dx\.)?doi\.org/|^doi:", "", v)
     return v.rstrip("/")
+
+
+def _is_whole_token(kind: str, text: str, start: int, end: int) -> bool:
+    """Is this match a token in its own right, or part of a longer one?
+
+    The same boundary rule `grounded_in` applies to the bundle, applied to the
+    record — because the question is the same question. `\\b\\d{4,}\\b` fires
+    inside a dotted identifier, so `2024.11.03.621734` yielded the claim
+    `621734`, a grant number `2021.0346` yielded `0346`, and `zenodo.17555036`
+    yielded `17555036`. None of those is a figure the record asserts; each was
+    counted in `stated` and then, correctly, never found (#406).
+
+    That inflated the denominator with tokens that were never claims, which
+    biases the reported rate *downward* — the opposite direction to the
+    false-negative bugs fixed alongside this, and the reason both had to be
+    settled before any rate from this check is quoted.
+
+    Applied to every kind, not just counts: the asymmetry between what is
+    extracted and what is looked for is the defect, and it is not specific to
+    one pattern.
+    """
+    before = text[start - 1] if start else ""
+    after = text[end] if end < len(text) else ""
+    if before and re.fullmatch(_PRECEDES.get(kind, r"\w"), before):
+        return False
+    # `_CONTINUES` entries may need two characters (`\.\d`), so test the tail.
+    if after and re.match(_CONTINUES.get(kind, r"\w"), text[end:]):
+        return False
+    return True
 
 
 def extract(record: dict[str, Any], *,
@@ -316,6 +362,8 @@ def extract(record: dict[str, Any], *,
                 for m in PATTERNS[kind].finditer(text):
                     if _overlaps(m.start(), m.end()):
                         continue
+                    if not _is_whole_token(kind, text, m.start(), m.end()):
+                        continue
                     taken.append((m.start(), m.end()))
                     yield Claim(kind=kind, value=m.group(),
                                 slot=slot or "(root)")
@@ -350,7 +398,16 @@ _CONTINUES = {
     "accession": r"[\w-]",
     # A dot continues a count only when a digit follows: `1234.5` is a different
     # quantity, while `1234.` ends a sentence. Same shape as the DOI rule.
-    "count": r"(?:[\d,]|\.\d)",
+    #
+    # A comma needs the identical treatment and did not get it (#406). It was
+    # `[\d,]`, so any comma continued the number — but a comma is a thousands
+    # separator only before a digit. After one it is a delimiter, and the
+    # commonest place a figure is followed by a delimiter is JSON:
+    # `"size": 3815969779678,`. That rejected every byte count in the FAIRhub
+    # API source, 10 values on the 2026-08-07 sweep, each of them plainly
+    # present. `1,234,567` must still not be matched by `1234`, which the
+    # `,\d` branch preserves.
+    "count": r"(?:\d|,\d|\.\d)",
     "iso_date": r"[\d-]",
 }
 # What may *precede* is narrower than what may follow. A slash is a path

--- a/tests/test_evaluation/test_verifiable.py
+++ b/tests/test_evaluation/test_verifiable.py
@@ -341,6 +341,99 @@ class TestTokenBoundaries(unittest.TestCase):
         self.assertTrue(self._grounded("accession", "GSE123", "see GSE123)"))
 
 
+class TestTheCommaIsBothSeparatorAndDelimiter(unittest.TestCase):
+    r"""#406. `_CONTINUES["count"]` was `[\d,]`, so *any* comma continued the
+    number. A comma is a thousands separator only before a digit; after one it
+    is a delimiter, and the commonest place a figure meets a delimiter is JSON.
+
+    That rejected every byte count in AI-READI's FAIRhub API source — ten
+    values on the 2026-08-07 sweep, `"size": 3815969779678,` and kin, each
+    plainly present in the bundle.
+    """
+
+    def _grounded(self, value, bundle):
+        return check_record({"counts": value}, bundle,
+                            skip_slots=set()).grounded == 1
+
+    def test_a_json_number_followed_by_a_comma_grounds(self):
+        self.assertTrue(self._grounded("3815969779678",
+                                       '"size": 3815969779678, "n": 2'))
+        self.assertTrue(self._grounded("1234", "the total was 1234, then more"))
+
+    def test_a_thousands_separator_still_blocks_a_partial_match(self):
+        """The reason the comma was a continuation in the first place."""
+        self.assertFalse(self._grounded("1234", "value 1,234,567 total"))
+        self.assertFalse(self._grounded("234", "value 1,234 total"))
+
+    def test_the_other_boundaries_are_unaffected(self):
+        self.assertFalse(self._grounded("1234", "value 12345"))
+        self.assertFalse(self._grounded("1234", "value 1234.5"))
+        self.assertTrue(self._grounded("1234", "value 1234. Next sentence"))
+
+
+class TestTrailingColonOnADoi(unittest.TestCase):
+    """#406. `rstrip` halts at the first character not in its set, so
+    `10.60775/fairhub.1):` stopped on the colon and never reached the `)`,
+    leaving two characters of prose punctuation on the DOI."""
+
+    def test_a_colon_is_stripped(self):
+        self.assertEqual("10.60775/fairhub.1",
+                         normalise("doi", "10.60775/fairhub.1):"))
+        self.assertEqual("10.18130/v3/b35xwx",
+                         normalise("doi", "10.18130/V3/B35XWX:"))
+
+    def test_the_previously_handled_punctuation_still_strips(self):
+        for suffix in (".", ",", ";", ")", "]"):
+            with self.subTest(suffix=suffix):
+                self.assertEqual("10.1234/x", normalise("doi", "10.1234/x" + suffix))
+
+
+class TestOrdinalDays(unittest.TestCase):
+    """#406. The VOICE IRB protocol writes "January 17th, 2023", which no
+    cardinal rendering matched."""
+
+    def test_an_ordinal_day_is_rendered(self):
+        r = renderings("iso_date", "2023-01-17")
+        self.assertIn("january 17th, 2023", r)
+        self.assertIn("17th january 2023", r)
+
+    def test_the_awkward_suffixes_are_right(self):
+        from data_sheets_schema.verifiable import _ordinal
+        self.assertEqual(
+            ["1st", "2nd", "3rd", "4th", "11th", "12th", "13th",
+             "21st", "22nd", "23rd", "31st"],
+            [_ordinal(d) for d in (1, 2, 3, 4, 11, 12, 13, 21, 22, 23, 31)],
+            "11-13 take 'th' despite ending in 1, 2, 3")
+
+
+class TestExtractionDoesNotInventClaims(unittest.TestCase):
+    r"""#406. `\b\d{4,}\b` fired inside dotted identifiers, so the record was
+    charged for figures it never asserted.
+
+    This is the denominator direction: a token that was never a claim inflates
+    `stated` and is then correctly never found, biasing the rate *downward* —
+    the opposite of the false negatives fixed alongside it. Both had to be
+    settled before any rate from this check could be quoted.
+    """
+
+    def _counts(self, text):
+        return [c.value for c in extract({"x": text}, skip_slots=set())
+                if c.kind == "count"]
+
+    def test_a_digit_run_inside_a_biorxiv_doi_is_not_a_claim(self):
+        self.assertNotIn("621734", self._counts("bioRxiv 2024.11.03.621734."))
+
+    def test_a_digit_run_inside_a_grant_number_is_not_a_claim(self):
+        self.assertEqual([], self._counts("Wallenberg Foundation (2021.0346)"))
+
+    def test_a_real_figure_beside_one_is_still_extracted(self):
+        self.assertEqual(["61937"], self._counts("61937 recordings"))
+        self.assertEqual(["3815969779678"], self._counts('"size": 3815969779678,'))
+
+    def test_a_standalone_year_is_still_extracted(self):
+        self.assertIn("2024", self._counts("published in 2024 by the team"))
+
+
 class TestThousandsSeparators(unittest.TestCase):
     """Sources group thousands; records do not.
 


### PR DESCRIPTION
Closes #406.

Classified all 74 values the check still reported after #404, fixed what was a defect, and explained what was not. **1970/2044 → 1991/2033** (96.4% → 97.9%).

The headline is not the rate. It is that after these fixes **the check reports no unsupported value anywhere in the sweep** — every one of the 42 remaining is a correct derivation.

## Three false negatives — present, reported invented

| defect | values | cause |
|---|---|---|
| delimiter comma read as a thousands separator | 10 | `_CONTINUES["count"]` was `[\d,]` |
| trailing colon left on a DOI | 4 | `rstrip` halts at the first char not in its set |
| no ordinal day forms | 2 | `renderings` emitted cardinals only |

The comma is the interesting one. A comma separates thousands only *before* a digit; after one it is a delimiter — and the commonest place a figure meets a delimiter is JSON. Every byte count in AI-READI's FAIRhub API source was rejected: `"size": 3815969779678,` and kin. The fix is `(?:\d|,\d|\.\d)`, **the exact shape the adjacent comment already described for the dot** — the rule had been reasoned out for `.` and never applied to `,`.

The colon: `10.60775/fairhub.1):` stopped `rstrip` on the colon and never reached the `)`, leaving two characters of prose punctuation on the DOI.

## One false positive — the denominator

`\b\d{4,}\b` fired *inside* dotted identifiers, so records were charged for figures they never asserted: `621734` from the bioRxiv DOI `2024.11.03.621734`, `0346` and `2021` from grant `2021.0346`, `1000` from `1000.1 KB`.

`extract` applied **no** boundary rule while `grounded_in` applied a careful one to the bundle. That asymmetry was the defect, so `_is_whole_token` now applies the same `_PRECEDES`/`_CONTINUES` rule to the record, for every kind rather than just counts.

Denominator 2044 → 2033. Eleven tokens that were never claims left, and **four had been counted as *grounded*** by coincidence — so this corrects the numerator too. It biases the rate the opposite way to the three above, which is why both directions had to be settled before any figure from this check is quoted.

## Adversarial review

**I enumerated every token the boundary rule removed** rather than trusting the aggregate — 5 distinct, 8 occurrences, each checked by hand. All correct removals; `1000` turned out to come from `1000.1 KB`, a truncated decimal rather than a stated figure. **Zero legitimate claims dropped.**

**I corrected an error in my own commit message.** The first draft called CHORUS's `counts: 1600000000` "the only remaining candidate for a genuinely unsupported figure". It is not — the bundle states "1.6 Billion" at line 1077 and the record expanded it to digits. I had read a `grep -c` result of `1` as a miss when it was a hit. The commit was amended; the corrected finding is stronger than the wrong one.

**Considered and dismissed:** applying the boundary rule to every kind means a hyphen-joined date range like `2025-01-17-2025-02-01` now yields no date claims, where it previously yielded two. The form occurs in **no record and no bundle**, and the conservative reading is defensible anyway since such a string is genuinely ambiguous. Noted rather than filed, because filing a zero-incidence hypothetical is noise.

Two cases that looked like drops in probing — `(10.1234/x)` and `https://ex.org/a,` — are pre-existing *pattern* behaviour (both charsets include that punctuation) and are cleaned up by `normalise`. Not caused by this change.

**Performance:** `_is_whole_token` adds two regex operations per match; a single-label sweep runs in 3.5s.

## Verification

- 11 new tests covering all four defects, including the cases that must **not** change: `1,234,567` still not matched by `1234`, `12345` still not matched by `1234`, a standalone year still extracted, a real figure beside an identifier still extracted.
- Full suite: **1362 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
