### PR TITLE
Move twelve stray D4D_*.yaml off the repository root into ATTIC (#409)

### DIFF
--- a/data/ATTIC/README.md
+++ b/data/ATTIC/README.md
@@ -6,6 +6,16 @@ historical reference.
 
 ## Directory Organization
 
+### root_schema_drafts_2026-08-08/ (from repository root)
+
+Twelve `D4D_*.yaml` schema modules that had accumulated in the repository root,
+moved on 2026-08-08 under #409. Stale copies from before classes were
+redistributed between modules — each shares its `id` with the live module of
+the same name in `src/data_sheets_schema/schema/`, which is why they could not
+be left in place. Never tracked in git before this move, so they had no
+recovery path until now. See the README in that directory for the per-file
+comparison and how they got there.
+
 ### root_downloads/ (from repository root)
 
 Legacy directories moved from repository root level on 2024-12-19:

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Collection.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Collection.yaml
@@ -1,0 +1,198 @@
+﻿id: https://w3id.org/bridge2ai/data-sheets-schema/collection
+name: d4d-collection
+title: "D4D Collection Subset"
+description: >
+  A LinkML schema subset for capturing how data was collected, including 
+  who collected it, over what timeframe, whether consent was gathered, 
+  notifications were provided, etc. Based on the “Collection” subset 
+  from the full Data Sheets for Datasets (D4D) schema.
+license: MIT
+
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  # You can add other prefixes as needed, e.g., schema, dcterms, etc.
+
+
+# If you have a "core" module or a "D4D-Metadata" module that defines NamedThing or DatasetProperty,
+# you can import it here instead of redefining them:
+# imports:
+#   - https://w3id.org/bridge2ai/data-sheets-schema/core
+
+
+subsets:
+  Collection:
+    description: >
+      The "Collection" subset focuses on who collected the data, how and when it was collected, 
+      whether participants were notified or gave consent, and related ethical considerations.
+
+
+#------------------------------------------------------------------------------
+# Minimal "foundation" classes (you can omit if imported from a core schema)
+#------------------------------------------------------------------------------
+
+
+classes:
+  NamedThing:
+    description: "A generic superclass for all identifiable entities."
+
+
+  DatasetProperty:
+    is_a: NamedThing
+    description: >
+      Represents a single property or aspect of a dataset.
+      Many specialized dataset elements will subclass DatasetProperty.
+
+
+#------------------------------------------------------------------------------
+# Collection-Related Classes
+#------------------------------------------------------------------------------
+
+
+  InstanceAcquisition:
+    is_a: DatasetProperty
+    description: >
+      Describes how data associated with each instance was acquired 
+      (e.g., directly observed, reported by subjects, inferred).
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Free-text description of the acquisition process
+        range: string
+        multivalued: true
+      was_directly_observed:
+        description: Whether the data was directly observed
+        range: boolean
+      was_reported_by_subjects:
+        description: Whether the data was reported directly by the subjects themselves
+        range: boolean
+      was_inferred_derived:
+        description: Whether the data was inferred or derived from other data
+        range: boolean
+      was_validated_verified:
+        description: Whether the data was validated or verified in any way
+        range: boolean
+
+
+  CollectionMechanism:
+    is_a: DatasetProperty
+    description: >
+      What mechanisms or procedures were used to collect the data (e.g., hardware, 
+      manual curation, software APIs)? Also covers how these mechanisms were validated.
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Free-text description of the collection mechanism(s)
+        range: string
+        multivalued: true
+
+
+  DataCollector:
+    is_a: DatasetProperty
+    description: >
+      Who was involved in the data collection (e.g., students, crowdworkers, contractors), 
+      and how they were compensated.
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Free-text details about the data collectors and compensation
+        range: string
+        multivalued: true
+
+
+  CollectionTimeframe:
+    is_a: DatasetProperty
+    description: >
+      Over what timeframe was the data collected, and does this timeframe match the 
+      creation timeframe of the underlying data?
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Free-text description of the data collection timeframe
+        range: string
+        multivalued: true
+
+
+  DirectCollection:
+    is_a: DatasetProperty
+    description: >
+      Indicates whether the data was collected directly from the individuals in question 
+      or obtained via third parties/other sources.
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Free-text description of data collection source(s)
+        range: string
+        multivalued: true
+
+
+  CollectionNotification:
+    is_a: DatasetProperty
+    description: >
+      Whether individuals were notified about data collection, and if so, how they were notified.
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Details of the notification method and language
+        range: string
+        multivalued: true
+
+
+  CollectionConsent:
+    is_a: DatasetProperty
+    description: >
+      Whether individuals consented to the collection and use of their data, and how consent 
+      was requested/provided.
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Details of the consent process and exact language
+        range: string
+        multivalued: true
+
+
+  ConsentRevocation:
+    is_a: DatasetProperty
+    description: >
+      If consent was obtained, was there a mechanism to revoke that consent in the future?
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Details or evidence of how consent can be revoked
+        range: string
+        multivalued: true
+
+
+  EthicalReview:
+    is_a: DatasetProperty
+    description: >
+      Whether any ethical review or IRB process was conducted, and what the outcomes were.
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Details or references for ethical review, outcomes, or documentation
+        range: string
+        multivalued: true
+
+
+  DataProtectionImpact:
+    is_a: DatasetProperty
+    description: >
+      Whether a data protection impact assessment (or similar) was conducted to evaluate risks 
+      to the data subjects, including outcomes or references to documentation.
+    in_subset:
+      - Collection
+    attributes:
+      description:
+        description: Free-text description of the impact assessment
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Composition.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Composition.yaml
@@ -1,0 +1,331 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/composition"
+name: "data-sheets-schema-composition"
+title: "Datasheets for Datasets – Composition Module"
+description: >
+  Subschema for Composition-related information in Datasheets for Datasets.
+  The questions in this section are intended to provide dataset consumers
+  with the information they need to make informed decisions about using the
+  dataset for their chosen tasks.
+
+
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  # Import the main data-sheets-schema so we can reference DatasetProperty, Dataset, etc.
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  Composition:
+    description: >
+      The questions in this section are intended to provide dataset consumers
+      with the information they need to make informed decisions about using
+      the dataset for their chosen tasks. Some of the questions are designed
+      to elicit information about compliance with the EU’s GDPR or comparable
+      regulations in other jurisdictions.
+
+
+prefixes:
+  linkml: "https://w3id.org/linkml/"
+  d4d-composition: "https://w3id.org/bridge2ai/data-sheets-schema/composition#"
+  # Additional prefixes if needed
+
+
+default_prefix: "d4d-composition"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  DataSubset:
+    description: >
+      A subset of a dataset, likely containing multiple files of multiple
+      potential purposes and properties.
+    is_a: Dataset
+    in_subset:
+      - Composition
+    attributes:
+      is_data_split:
+        description: >
+          Is this subset a split of the larger dataset, e.g., for model
+          training, testing, or validation?
+        range: boolean
+      is_subpopulation:
+        description: >
+          Is this subset a subpopulation of the larger dataset, e.g., a set
+          of data for a specific demographic?
+        range: boolean
+
+
+  Instance:
+    description: >
+      What do the instances that comprise the dataset represent (e.g.,
+      documents, photos, people, countries)?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      data_topic:
+        description: >
+          General topic of each instance (e.g., from Bridge2AI standards).
+        range: uriorcurie
+        values_from:
+          - B2AI_TOPIC
+      instance_type:
+        description: >
+          Multiple types of instances? (e.g., movies, users, and ratings).
+        range: string
+      data_substrate:
+        description: >
+          Type of data (e.g., raw text, images) from Bridge2AI standards.
+        range: uriorcurie
+        values_from:
+          - B2AI_SUBSTRATE
+      counts:
+        description: >
+          How many instances are there in total (of each type, if appropriate)?
+        range: integer
+      label:
+        description: >
+          Is there a label or target associated with each instance?
+        range: boolean
+      label_description:
+        description: >
+          If labeled, what pattern or format do labels follow?
+        range: string
+      sampling_strategies:
+        description: >
+          References to one or more SamplingStrategy objects.
+        range: SamplingStrategy
+        multivalued: true
+      missing_information:
+        description: >
+          References to one or more MissingInfo objects describing missing data.
+        range: MissingInfo
+        multivalued: true
+
+
+  SamplingStrategy:
+    description: >
+      Does the dataset contain all possible instances, or is it a sample
+      (not necessarily random) of instances from a larger set? If so, how
+      representative is it?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      is_sample:
+        description: "Indicates whether it is a sample of a larger set."
+        range: boolean
+        multivalued: true
+      is_random:
+        description: "Indicates whether the sample is random."
+        range: boolean
+        multivalued: true
+      source_data:
+        description: >
+          Description of the larger set from which the sample was drawn, if any.
+        range: string
+        multivalued: true
+      is_representative:
+        description: >
+          Indicates whether the sample is representative of the larger set.
+        range: boolean
+        multivalued: true
+      representative_verification:
+        description: >
+          Explanation of how representativeness was validated or verified.
+        range: string
+        multivalued: true
+      why_not_representative:
+        description: >
+          Explanation of why the sample is not representative, if applicable.
+        range: string
+        multivalued: true
+      strategies:
+        description: >
+          Description of the sampling strategy (deterministic, probabilistic, etc.).
+        range: string
+        multivalued: true
+
+
+  MissingInfo:
+    description: >
+      Is any information missing from individual instances? (e.g.,
+      unavailable data)
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      missing:
+        description: >
+          Description of the missing data fields or elements.
+        range: string
+        multivalued: true
+      why_missing:
+        description: >
+          Explanation of why each piece of data is missing.
+        range: string
+        multivalued: true
+
+
+  Relationships:
+    description: >
+      Are relationships between individual instances made explicit
+      (e.g., users’ movie ratings, social network links)?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      description:
+        description: "Explanation of how these relationships are represented."
+        range: string
+        multivalued: true
+
+
+  Splits:
+    description: >
+      Are there recommended data splits (e.g., training, validation, testing)?
+      If so, how are they defined and why?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  DataAnomaly:
+    description: >
+      Are there any errors, sources of noise, or redundancies in the dataset?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  ExternalResource:
+    description: >
+      Is the dataset self-contained or does it rely on external resources (e.g.,
+      websites, other datasets)? If external, are there guarantees that those
+      resources will remain available and unchanged?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      external_resources:
+        description: "List of links or identifiers for external resources."
+        range: string
+        multivalued: true
+      future_guarantees:
+        description: >
+          Explanation of any commitments that external resources will remain
+          available and stable over time.
+        range: string
+        multivalued: true
+      archival:
+        description: >
+          Indication whether official archival versions of external resources
+          are included.
+        range: boolean
+        multivalued: true
+      restrictions:
+        description: >
+          Description of any restrictions or fees associated with external resources.
+        range: string
+        multivalued: true
+
+
+  Confidentiality:
+    description: >
+      Does the dataset contain data that might be confidential (e.g., protected
+      by legal privilege, patient data, non-public communications)?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      confidential_elements_present:
+        range: boolean
+        description: "Indicates whether any confidential data elements are present."
+      description:
+        range: string
+        multivalued: true
+
+
+  ContentWarning:
+    description: >
+      Does the dataset contain any data that might be offensive, insulting,
+      threatening, or otherwise anxiety-provoking if viewed directly?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      content_warnings_present:
+        range: boolean
+        description: "Indicates whether any content warnings are needed."
+      warnings:
+        range: string
+        multivalued: true
+
+
+  Subpopulation:
+    description: >
+      Does the dataset identify any subpopulations (e.g., by age, gender)?
+      If so, how are they identified and what are their distributions?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      subpopulation_elements_present:
+        range: boolean
+        description: "Indicates whether any subpopulations are explicitly identified."
+      identification:
+        range: string
+        multivalued: true
+      distribution:
+        range: string
+        multivalued: true
+
+
+  Deidentification:
+    description: >
+      Is it possible to identify individuals in the dataset, either directly
+      or indirectly (in combination with other data)?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      identifiable_elements_present:
+        range: boolean
+        description: "Indicates whether data subjects can be identified."
+      description:
+        range: string
+        multivalued: true
+
+
+  SensitiveElement:
+    description: >
+      Does the dataset contain data that might be considered sensitive
+      (e.g., race, sexual orientation, religion, biometrics)?
+    is_a: DatasetProperty
+    in_subset:
+      - Composition
+    attributes:
+      sensitive_elements_present:
+        range: boolean
+        description: "Indicates whether sensitive data elements are present."
+      description:
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Data_Governance.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Data_Governance.yaml
@@ -1,0 +1,225 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/data-governance"
+name: "data-sheets-schema-data-governance"
+title: "Datasheets for Datasets – Data Governance Module"
+description: >
+  Subschema for data governance–related information in Datasheets for Datasets.
+  Encompasses dataset distribution, licensing, IP and regulatory restrictions,
+  as well as maintenance and versioning plans. 
+
+
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  DataGovernance:
+    description: >
+      The questions in this section relate to how the dataset is governed:
+      how it is distributed, licensed, and maintained over time, plus 
+      third-party restrictions and update policies.
+
+
+prefixes:
+  linkml: "https://w3id.org/linkml/"
+  d4d-data-governance: "https://w3id.org/bridge2ai/data-sheets-schema/data-governance#"
+
+
+default_prefix: "d4d-data-governance"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  ThirdPartySharing:
+    description: >
+      Will the dataset be distributed to third parties outside of the entity
+      (e.g., company, institution, organization) on behalf of which the dataset
+      was created?
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: >
+          Boolean or textual explanation regarding external distribution to 
+          third parties.
+        range: boolean
+
+
+  DistributionFormat:
+    description: >
+      How will the dataset be distributed (e.g., tarball on a website, API, GitHub)?
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: "Details of the distribution methods or format(s)."
+        range: string
+        multivalued: true
+
+
+  DistributionDate:
+    description: >
+      When will the dataset be distributed?
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: "Dates or schedules for dataset release or updates."
+        range: string
+        multivalued: true
+
+
+  LicenseAndUseTerms:
+    description: >
+      Will the dataset be distributed under a copyright or other IP license,
+      and/or under applicable terms of use? Provide a link or copy of relevant
+      licensing terms and any fees.
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: >
+          Description of the dataset’s license and terms of use (including 
+          links, costs, or usage constraints).
+        range: string
+        multivalued: true
+
+
+  IPRestrictions:
+    description: >
+      Have any third parties imposed IP-based or other restrictions on the data
+      associated with the instances? If so, describe them and note any relevant
+      fees or licensing terms.
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: "Explanation of third-party IP restrictions."
+        range: string
+        multivalued: true
+
+
+  ExportControlRegulatoryRestrictions:
+    description: >
+      Do any export controls or other regulatory restrictions apply to the dataset
+      or to individual instances? If so, please describe these restrictions and
+      provide a link or copy of any supporting documentation.
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: "Export or regulatory restrictions on the dataset."
+        range: string
+        multivalued: true
+
+
+  Maintainer:
+    description: >
+      Who will be supporting/hosting/maintaining the dataset?
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: >
+          Name or role of the maintainer, or references to an enumeration 
+          (e.g., CreatorOrMaintainerEnum).
+        range: CreatorOrMaintainerEnum
+        multivalued: true
+
+
+  Erratum:
+    description: >
+      Is there an erratum? If so, please provide a link or other access point.
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: >
+          Description or reference to the erratum, including location 
+          or summary of known issues.
+        range: string
+        multivalued: true
+
+
+  UpdatePlan:
+    description: >
+      Will the dataset be updated (e.g., to correct labeling errors, add new 
+      instances, or delete instances)? If so, describe how often, by whom, and 
+      how these updates will be communicated.
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: >
+          Details of the dataset’s update policy, frequency, responsible parties, 
+          and communication methods.
+        range: string
+        multivalued: true
+
+
+  RetentionLimits:
+    description: >
+      If the dataset relates to people, are there applicable limits on the retention
+      of the data (e.g., a fixed retention period)? If so, describe these limits and
+      how they will be enforced.
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: >
+          Policies or regulations about data retention and 
+          how they are implemented.
+        range: string
+        multivalued: true
+
+
+  VersionAccess:
+    description: >
+      Will older versions of the dataset continue to be supported/hosted/maintained?
+      If so, how? If not, how will obsolescence be communicated to consumers?
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: >
+          Explanation of version-management policy and plan.
+        range: string
+        multivalued: true
+
+
+  ExtensionMechanism:
+    description: >
+      If others want to extend/augment/build on/contribute to the dataset, is there
+      a mechanism for them to do so? If so, how will contributions be validated and
+      communicated to consumers?
+    is_a: DatasetProperty
+    in_subset:
+      - DataGovernance
+    attributes:
+      description:
+        description: >
+          Describes processes or tools for extending and validating 
+          new contributions to the dataset.
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Distribution.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Distribution.yaml
@@ -1,0 +1,138 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/distribution"
+name: "data-sheets-schema-distribution"
+title: "Datasheets for Datasets – Distribution Module"
+description: >
+  Subschema for distribution-related information in Datasheets for Datasets.
+  The questions in this section pertain to how the dataset is distributed,
+  including whether it will be shared with third parties, under what license,
+  and any regulatory restrictions.
+
+
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  # Import the main schema so that we can reference DatasetProperty, etc.
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  Distribution:
+    description: >
+      The questions in this section relate to how the dataset will be distributed,
+      whether it will be shared externally, any fees or licensing terms, and
+      export or regulatory restrictions that may apply.
+
+
+prefixes:
+  linkml: "https://w3id.org/linkml/"
+  d4d-distribution: "https://w3id.org/bridge2ai/data-sheets-schema/distribution#"
+
+
+default_prefix: "d4d-distribution"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  ThirdPartySharing:
+    description: >
+      Will the dataset be distributed to third parties outside of the entity
+      (e.g., company, institution, organization) on behalf of which the dataset
+      was created?
+    is_a: DatasetProperty
+    in_subset:
+      - Distribution
+    attributes:
+      description:
+        description: >
+          Boolean or textual explanation regarding distribution to 
+          parties external to the dataset-creating entity.
+        range: boolean
+
+
+  DistributionFormat:
+    description: >
+      How will the dataset be distributed (e.g., tarball on a website,
+      API, GitHub)?
+    is_a: DatasetProperty
+    in_subset:
+      - Distribution
+    attributes:
+      description:
+        description: "Details of the distribution channel(s) or format(s)."
+        range: string
+        multivalued: true
+
+
+  DistributionDate:
+    description: >
+      When will the dataset be distributed?
+    is_a: DatasetProperty
+    in_subset:
+      - Distribution
+    attributes:
+      description:
+        description: >
+          Dates or timeframe for dataset release. Could be a one-time release date
+          or multiple scheduled releases.
+        range: string
+        multivalued: true
+
+
+  LicenseAndUseTerms:
+    description: >
+      Will the dataset be distributed under a copyright or other intellectual
+      property license, and/or under applicable terms of use (ToU)? If so, describe
+      this license/ToU, include any fees, and provide a link or copy of relevant terms.
+    is_a: DatasetProperty
+    in_subset:
+      - Distribution
+    attributes:
+      description:
+        description: >
+          Information on licenses or terms of use, including references,
+          links, or summaries of the key terms, usage restrictions, or fees.
+        range: string
+        multivalued: true
+
+
+  IPRestrictions:
+    description: >
+      Have any third parties imposed IP-based or other restrictions on the data
+      associated with the instances? If so, describe these restrictions, referencing
+      any licenses or fees.
+    is_a: DatasetProperty
+    in_subset:
+      - Distribution
+    attributes:
+      description:
+        description: >
+          Explanation of third-party intellectual property restrictions that may
+          limit or constrain dataset distribution.
+        range: string
+        multivalued: true
+
+
+  ExportControlRegulatoryRestrictions:
+    description: >
+      Do any export controls or other regulatory restrictions apply to the dataset
+      or to individual instances? If so, describe them, referencing relevant legal
+      documentation or guidelines.
+    is_a: DatasetProperty
+    in_subset:
+      - Distribution
+    attributes:
+      description:
+        description: >
+          Details of export control or other regulatory constraints that apply
+          to distributing the dataset.
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Ethics.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Ethics.yaml
@@ -1,0 +1,129 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/ethics"
+name: "data-sheets-schema-ethics"
+title: "Datasheets for Datasets – Ethics Module"
+description: >
+  Subschema for ethics-related information in Datasheets for Datasets.
+  This includes any ethical review processes, consent procedures, and other
+  data-protection considerations.
+
+
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  Ethics:
+    description: >
+      The questions in this section address ethical and data-protection concerns,
+      including review by institutional bodies, consent and notification to data
+      subjects, and potential impacts on data-protection rights.
+
+
+prefixes:
+  linkml: "https://w3id.org/linkml/"
+  d4d-ethics: "https://w3id.org/bridge2ai/data-sheets-schema/ethics#"
+
+
+default_prefix: "d4d-ethics"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  EthicalReview:
+    description: >
+      Were any ethical or compliance review processes conducted (e.g., by an institutional
+      review board)? If so, please provide a description of these review processes,
+      including the frequency of review and documentation of outcomes, as well as a link or other access point to any
+      supporting documentation.
+    is_a: DatasetProperty
+    in_subset:
+      - Ethics
+    attributes:
+      description:
+        description: "Short summary or details about the ethical review process(es)."
+        range: string
+        multivalued: true
+
+
+  DataProtectionImpact:
+    description: >
+      Has an analysis of the potential impact of the dataset and its use on data subjects
+      (e.g., a data protection impact analysis) been conducted? If so, please provide a
+      description of this analysis, including the outcomes, and any supporting documentation.
+    is_a: DatasetProperty
+    in_subset:
+      - Ethics
+    attributes:
+      description:
+        description: "Details of the data protection impact analysis, if conducted."
+        range: string
+        multivalued: true
+
+
+  DirectCollection:
+    description: >
+      Did you collect the data from the individuals in question directly, or obtain it via
+      third parties or other sources (e.g., websites)?
+    is_a: DatasetProperty
+    in_subset:
+      - Ethics
+    attributes:
+      description:
+        description: "Explanation of how data were obtained, e.g., from the subjects or elsewhere."
+        range: string
+        multivalued: true
+
+
+  CollectionNotification:
+    description: >
+      Were the individuals in question notified about the data collection? If so, please
+      describe (or show with screenshots, etc.) how notice was provided, and reproduce the
+      language of the notification itself if possible.
+    is_a: DatasetProperty
+    in_subset:
+      - Ethics
+    attributes:
+      description:
+        description: "Details about any notification provided to individuals whose data was collected."
+        range: string
+        multivalued: true
+
+
+  CollectionConsent:
+    description: >
+      Did the individuals in question consent to the collection and use of their data?
+      If so, how was consent requested and provided, and what language did individuals
+      consent to?
+    is_a: DatasetProperty
+    in_subset:
+      - Ethics
+    attributes:
+      description:
+        description: "Details about how consent was sought, provided, and documented."
+        range: string
+        multivalued: true
+
+
+  ConsentRevocation:
+    description: >
+      If consent was obtained, were the consenting individuals provided with a mechanism
+      to revoke their consent in the future or for certain uses? If so, please describe.
+    is_a: DatasetProperty
+    in_subset:
+      - Ethics
+    attributes:
+      description:
+        description: "Information about any consent-revocation mechanism offered to data subjects."
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Human.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Human.yaml
@@ -1,0 +1,301 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/human"
+name: "data-sheets-schema-human"
+title: "Datasheets for Datasets – Human Module"
+description: >
+  Subschema for human-related information in Datasheets for Datasets.
+  This module covers classes, attributes, and properties connected to 
+  data about or from human subjects (e.g., privacy, consent, ethical reviews).
+
+
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  # Import the full data-sheets-schema so we can reference its definitions
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  Human:
+    description: >
+      Classes and properties relating to data about or collected from
+      human subjects, including consent, ethics, privacy, confidentiality,
+      subpopulations, and personal identifiers.
+
+
+prefixes:
+  linkml: "https://w3id.org/linkml/"
+  d4d-human: "https://w3id.org/bridge2ai/data-sheets-schema/human#"
+
+
+default_prefix: "d4d-human"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  Person:
+    description: >
+      An individual human being.
+    # This was already defined in the main schema as Person is_a NamedThing.
+    # Here, we mark it for the Human subset. 
+    is_a: NamedThing
+    in_subset:
+      - Human
+    attributes:
+      affiliation:
+        description: "The organization(s) to which the person belongs."
+        range: Organization
+        multivalued: true
+      email:
+        description: "The email address of the person."
+        range: string
+
+
+  Creator:
+    description: >
+      Who created the dataset (e.g., which team or research group) and on behalf
+      of which entity (e.g., company, institution, organization)? Potentially a team.
+    # Already exists as a DatasetProperty in the main schema. 
+    # For the 'Human' module, we highlight it if it includes human roles.
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      principal_investigator:
+        range: Person
+        description: "Individual primarily responsible for or overseeing creation."
+      affiliation:
+        range: Organization
+        description: "Organization(s) affiliated with the dataset creator(s)."
+
+
+  DataCollector:
+    description: >
+      Who was involved in the data collection process (e.g., students, crowdworkers, contractors)
+      and how they were compensated (e.g., wages)?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  Subpopulation:
+    description: >
+      Does the dataset identify any subpopulations (e.g., by age, gender)?
+      If so, how and what are their distributions?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      subpopulation_elements_present:
+        range: boolean
+        description: "Whether explicit subpopulations are identified."
+      identification:
+        range: string
+        multivalued: true
+      distribution:
+        range: string
+        multivalued: true
+
+
+  SensitiveElement:
+    description: >
+      Does the dataset contain data that might be considered sensitive
+      (race, ethnic origins, sexual orientations, religious beliefs, etc.)?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      sensitive_elements_present:
+        range: boolean
+        description: "Whether sensitive data elements are present."
+      description:
+        range: string
+        multivalued: true
+
+
+  Deidentification:
+    description: >
+      Is it possible to identify individuals, either directly or indirectly
+      from the dataset?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      identifiable_elements_present:
+        range: boolean
+        description: >
+          Whether one or more natural persons can be identified directly
+          or indirectly.
+      description:
+        range: string
+        multivalued: true
+
+
+  Confidentiality:
+    description: >
+      Does the dataset contain data that might be confidential, such as data
+      protected by legal privilege or by doctor-patient confidentiality?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      confidential_elements_present:
+        range: boolean
+        description: "Indicates the presence of confidential information."
+      description:
+        range: string
+        multivalued: true
+
+
+  ContentWarning:
+    description: >
+      Does the dataset contain data that might be offensive, insulting,
+      threatening, or otherwise cause anxiety if viewed directly?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      content_warnings_present:
+        range: boolean
+        description: "Indicates whether content warnings apply."
+      warnings:
+        range: string
+        multivalued: true
+
+
+  InstanceAcquisition:
+    description: >
+      How was the data associated with each instance acquired? For instance,
+      was it directly observed, reported by subjects, or inferred from other data?
+      If reported or inferred, was it validated?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+      was_directly_observed:
+        range: boolean
+      was_reported_by_subjects:
+        range: boolean
+      was_inferred_derived:
+        range: boolean
+      was_validated_verified:
+        range: boolean
+
+
+  CollectionMechanism:
+    description: >
+      What mechanisms or procedures were used to collect the data (e.g., hardware
+      sensors, manual human curation, software APIs)? How were these mechanisms validated?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  CollectionTimeframe:
+    description: >
+      Over what timeframe was the data collected, and does that timeframe match
+      the creation timeframe of the underlying data?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  DirectCollection:
+    description: >
+      Were data collected directly from individuals or acquired via third parties
+      or other sources (e.g., websites)?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  CollectionNotification:
+    description: >
+      Were individuals notified about the data collection? If so, how was notice
+      provided, and what was its exact wording?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  CollectionConsent:
+    description: >
+      Did individuals consent to the collection and use of their data? 
+      If so, how was consent requested, provided, and documented?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  ConsentRevocation:
+    description: >
+      If consent was obtained, were individuals given a mechanism to revoke
+      their consent in the future or for certain uses?
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  EthicalReview:
+    description: >
+      Were any ethical review processes (e.g., IRB) conducted for the dataset?
+      Provide a description of the process, outcomes, and supporting documentation.
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true
+
+
+  DataProtectionImpact:
+    description: >
+      Was a data protection impact analysis (DPIA) or similar performed?
+      If so, provide details and outcomes, plus any relevant documentation.
+    is_a: DatasetProperty
+    in_subset:
+      - Human
+    attributes:
+      description:
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Maintenance.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Maintenance.yaml
@@ -1,0 +1,139 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/maintenance"
+name: "data-sheets-schema-maintenance"
+title: "Datasheets for Datasets – Maintenance Module"
+description: >
+  Subschema for maintenance-related information in Datasheets for Datasets.
+  The questions in this section are intended to encourage dataset creators to
+  plan for dataset maintenance and communicate this plan to dataset consumers.
+
+
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  Maintenance:
+    description: >
+      The questions in this section are intended to encourage dataset creators
+      to plan for dataset maintenance (including updates, versioning, error
+      corrections, etc.) and communicate this plan to dataset consumers.
+
+
+prefixes:
+  linkml: "https://w3id.org/linkml/"
+  d4d-maintenance: "https://w3id.org/bridge2ai/data-sheets-schema/maintenance#"
+
+
+default_prefix: "d4d-maintenance"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  Maintainer:
+    description: >
+      Who will be supporting/hosting/maintaining the dataset?
+    is_a: DatasetProperty
+    in_subset:
+      - Maintenance
+    attributes:
+      description:
+        description: >
+          Name or role of the maintainer, possibly referencing 
+          CreatorOrMaintainerEnum or other details.
+        range: CreatorOrMaintainerEnum
+        multivalued: true
+
+
+  Erratum:
+    description: >
+      Is there an erratum? If so, please provide a link or other access point.
+    is_a: DatasetProperty
+    in_subset:
+      - Maintenance
+    attributes:
+      description:
+        description: >
+          Description or reference to the erratum, including details on known 
+          issues and how they may be corrected.
+        range: string
+        multivalued: true
+
+
+  UpdatePlan:
+    description: >
+      Will the dataset be updated (e.g., to correct labeling errors, add new 
+      instances, delete instances)? If so, how often, by whom, and how will 
+      these updates be communicated?
+    is_a: DatasetProperty
+    in_subset:
+      - Maintenance
+    attributes:
+      description:
+        description: >
+          Details on the dataset's update policy, schedule, responsible parties, 
+          and communication channels (e.g., mailing list, GitHub releases).
+        range: string
+        multivalued: true
+
+
+  RetentionLimits:
+    description: >
+      If the dataset relates to people, are there applicable limits on the
+      retention of their data (e.g., were individuals told their data would
+      be deleted after a certain time)? If so, please describe these limits
+      and how they will be enforced.
+    is_a: DatasetProperty
+    in_subset:
+      - Maintenance
+    attributes:
+      description:
+        description: >
+          Policies or regulations around data retention, including any 
+          enforcement mechanisms or responsibilities.
+        range: string
+        multivalued: true
+
+
+  VersionAccess:
+    description: >
+      Will older versions of the dataset continue to be supported/hosted/maintained?
+      If so, how? If not, how will obsolescence be communicated to dataset consumers?
+    is_a: DatasetProperty
+    in_subset:
+      - Maintenance
+    attributes:
+      description:
+        description: >
+          Explanation of whether and how previous dataset versions remain accessible,
+          including versioning policies and deprecation announcements.
+        range: string
+        multivalued: true
+
+
+  ExtensionMechanism:
+    description: >
+      If others want to extend/augment/build on/contribute to the dataset,
+      is there a mechanism for them to do so? If so, please describe how
+      those contributions are validated and communicated.
+    is_a: DatasetProperty
+    in_subset:
+      - Maintenance
+    attributes:
+      description:
+        description: >
+          Details on processes or tools that facilitate extensions, 
+          augmentations, or third-party contributions, including any 
+          review/approval workflows.
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Metadata.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Metadata.yaml
@@ -1,0 +1,363 @@
+﻿id: https://w3id.org/bridge2ai/data-sheets-schema/metadata
+name: d4d-metadata
+title: "D4D Metadata Module"
+description: >
+  A LinkML schema subset for high-level, generic dataset metadata from 
+  the Bridge2AI "Datasheets for Datasets" schema. Focuses on classes 
+  like Information, Dataset, and DatasetCollection, plus related slots.
+
+
+license: MIT
+
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  dcterms: http://purl.org/dc/terms/
+  dcat: http://www.w3.org/ns/dcat#
+  schema: http://schema.org/
+  pav: http://purl.org/pav/
+  oslc: http://open-services.net/ns/core#
+  bibo: http://purl.org/ontology/bibo/
+  prov: http://www.w3.org/ns/prov#
+  csvw: http://www.w3.org/ns/csvw#
+
+
+default_prefix: https://example.org/d4d/metadata#
+
+
+#########################
+#   ENUM DEFINITIONS    #
+#########################
+
+
+enums:
+  FormatEnum:
+    description: >
+      Common file/data formats (e.g., CSV, JSON) 
+      used for the "format" slot.
+    permissible_values:
+      CSV:
+      JSON:
+      TXT:
+      OTHER:
+
+
+  CompressionEnum:
+    description: >
+      Common compression formats (e.g., zip, gzip) 
+      used for the "compression" slot.
+    permissible_values:
+      ZIP:
+      GZIP:
+      NONE:
+      OTHER:
+
+
+  EncodingEnum:
+    description: >
+      Common encodings (e.g., UTF-8, ASCII) 
+      used for the "encoding" slot.
+    permissible_values:
+      UTF-8:
+      ASCII:
+      OTHER:
+
+
+  CreatorOrMaintainerEnum:
+    description: >
+      Indicates whether an agent is acting as a creator, maintainer, or both.
+    permissible_values:
+      CREATOR:
+      MAINTAINER:
+      BOTH:
+
+
+#########################
+#   CLASS DEFINITIONS   #
+#########################
+
+
+# A minimal superclass (optional if you import a "core" module).
+classes:
+  NamedThing:
+    description: "A generic superclass for all identifiable entities."
+    slots:
+      - id
+
+
+  Information:
+    description: "Grouping class for generic datasets, data files, or other top-level metadata."
+    is_a: NamedThing
+    slots:
+      - title
+      - description
+      - keywords
+      - language
+      - license
+      - version
+      - created_on
+      - created_by
+      - last_updated_on
+      - modified_by
+      - doi
+      - conforms_to
+      - issued
+      - publisher
+      - page
+      - status
+      - was_derived_from
+
+
+  DatasetCollection:
+    description: >
+      A collection of related datasets, likely containing multiple files/resources 
+      with distinct metadata or purposes.
+    is_a: Information
+    slots:
+      - resources
+
+
+  Dataset:
+    description: >
+      A single dataset (e.g., one file or data resource) with associated metadata.
+    is_a: Information
+    slots:
+      - download_url
+      - path
+      - format
+      - encoding
+      - compression
+      - media_type
+      - bytes
+      - hash
+      - md5
+      - sha256
+      - dialect
+      - conforms_to_class
+      - conforms_to_schema
+      - profile
+
+
+  FormatDialect:
+    description: "Additional format information for a file."
+    is_a: NamedThing
+    attributes:
+      comment_prefix:
+        range: string
+      delimiter:
+        range: string
+      double_quote:
+        range: boolean
+      header:
+        range: boolean
+      quote_char:
+        range: string
+
+
+#########################
+#    SLOT DEFINITIONS   #
+#########################
+
+
+slots:
+
+
+  ## From NamedThing
+  id:
+    description: "A unique identifier for the element (dataset, collection, etc.)."
+    slot_uri: schema:identifier
+    range: string
+    required: true
+
+
+  ## Core metadata slots
+  title:
+    description: "The official title or name of the data element."
+    slot_uri: dcterms:title
+    range: string
+
+
+  description:
+    description: "A free-text description or summary."
+    slot_uri: dcterms:description
+    range: string
+
+
+  keywords:
+    description: "Keywords or tags describing the data."
+    slot_uri: dcat:keyword
+    range: string
+    multivalued: true
+
+
+  language:
+    description: "The language(s) of the dataset."
+    slot_uri: dcterms:language
+    range: string
+    multivalued: true
+
+
+  license:
+    description: "The license or usage terms for the data."
+    slot_uri: dcterms:license
+    range: string
+
+
+  version:
+    description: "The version identifier of the dataset or metadata."
+    slot_uri: pav:version
+    range: string
+
+
+  created_on:
+    description: "Timestamp when the dataset was created or published."
+    slot_uri: pav:createdOn
+    range: datetime
+
+
+  created_by:
+    description: "Agent that created the dataset (person or organization)."
+    slot_uri: pav:createdBy
+    range: CreatorOrMaintainerEnum
+    multivalued: true
+
+
+  last_updated_on:
+    description: "Timestamp of the most recent update."
+    slot_uri: pav:lastUpdatedOn
+    range: datetime
+
+
+  modified_by:
+    description: "Agent that last modified the dataset or metadata."
+    slot_uri: oslc:modifiedBy
+    range: CreatorOrMaintainerEnum
+    multivalued: true
+
+
+  doi:
+    description: "Digital Object Identifier for the dataset, if applicable."
+    range: uriorcurie
+
+
+  conforms_to:
+    description: "A standard or specification to which this data conforms."
+    slot_uri: dcterms:conformsTo
+    range: uriorcurie
+
+
+  issued:
+    description: "Date when the dataset was officially issued or published."
+    slot_uri: dcterms:issued
+    range: datetime
+
+
+  publisher:
+    description: "Publisher or entity distributing the dataset."
+    slot_uri: dcterms:publisher
+    range: uriorcurie
+
+
+  status:
+    description: "Status of the dataset (e.g., draft, stable, deprecated)."
+    slot_uri: bibo:status
+    range: uriorcurie
+
+
+  page:
+    description: "A landing page or URL describing the dataset."
+    slot_uri: dcat:landingPage
+    range: string
+
+
+  was_derived_from:
+    description: "Indicates derivation from some other dataset or source."
+    slot_uri: prov:wasDerivedFrom
+    range: string
+
+
+  ## DatasetCollection-specific slot
+  resources:
+    description: "List of Datasets in this collection."
+    range: Dataset
+    multivalued: true
+
+
+  ## Dataset-specific slots
+  download_url:
+    description: >
+      URL from which the data can be downloaded. This is not the same 
+      as a landing page, but points directly to the data.
+    slot_uri: dcat:downloadURL
+    range: uri
+
+
+  path:
+    description: "Local or remote path to the data file."
+    range: string
+
+
+  format:
+    description: >
+      Format of the data (e.g., CSV, JSON). Not to be confused 
+      with `media_type` (e.g., text/csv).
+    slot_uri: dcterms:format
+    range: FormatEnum
+
+
+  encoding:
+    description: "The encoding of the data (e.g., UTF-8, ASCII)."
+    range: EncodingEnum
+
+
+  compression:
+    description: "The compression format used (e.g., zip, gzip)."
+    range: CompressionEnum
+
+
+  media_type:
+    description: "MIME type of the data (e.g., text/csv, application/json)."
+    slot_uri: dcat:mediaType
+    range: string
+
+
+  bytes:
+    description: "File size in bytes."
+    slot_uri: dcat:byteSize
+    range: integer
+
+
+  hash:
+    description: "A generic hash of the data."
+    range: string
+
+
+  md5:
+    description: "MD5 hash of the data."
+    is_a: hash
+
+
+  sha256:
+    description: "SHA-256 hash of the data."
+    is_a: hash
+
+
+  dialect:
+    description: "Reference to an object describing the file's format dialect (e.g., CSV dialect)."
+    slot_uri: csvw:dialect
+    range: FormatDialect
+
+
+  conforms_to_class:
+    description: "Class definition from the schema that this data instantiates."
+    is_a: conforms_to
+
+
+  conforms_to_schema:
+    description: "Schema reference that this data instantiates."
+    is_a: conforms_to
+
+
+  profile:
+    description: "A frictionless data profile to which this dataset conforms."
+    range: uriorcurie

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Minimal.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Minimal.yaml
@@ -1,0 +1,208 @@
+﻿id: https://w3id.org/bridge2ai/data-sheets-schema/minimal
+name: minimal-data-sheets-schema
+title: Minimal Data Sheets Schema
+description: >
+  A very minimal LinkML schema for generic dataset metadata. 
+  This version omits human-subject–specific elements and 
+  focuses on high-level metadata only.
+license: MIT
+see_also:
+  - https://bridge2ai.github.io/data-sheets-schema
+
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  dcterms: http://purl.org/dc/terms/
+  dcat: http://www.w3.org/ns/dcat#
+  schema: http://schema.org/
+
+
+default_prefix: http://example.org/minimal-schema#
+
+
+# Minimal set of classes
+classes:
+
+
+  Information:
+    description: A generic class for basic descriptive metadata.
+    slots:
+      - id
+      - title
+      - description
+      - keywords
+      - language
+      - license
+      - version
+      - created_on
+      - created_by
+      - last_updated_on
+      - modified_by
+      - doi
+      - conforms_to
+
+
+  DatasetCollection:
+    description: A top-level collection or package that contains one or more datasets.
+    is_a: Information
+    attributes:
+      resources:
+        description: The datasets in this collection.
+        range: Dataset
+        multivalued: true
+
+
+  Dataset:
+    description: A single dataset (e.g., one file or resource) with associated metadata.
+    is_a: Information
+    slots:
+      - download_url
+      - path
+      - format
+      - encoding
+      - compression
+      - media_type
+      - bytes
+      - hash
+      - md5
+      - sha256
+
+
+# Minimal set of slots
+slots:
+
+
+  id:
+    description: A unique identifier for the element (dataset or collection).
+    slot_uri: schema:identifier
+    range: string
+
+
+  title:
+    description: The official title or name of the dataset.
+    slot_uri: dcterms:title
+    range: string
+
+
+  description:
+    description: A short summary or free-text description of the dataset.
+    slot_uri: dcterms:description
+    range: string
+    multivalued: false
+
+
+  keywords:
+    description: Keywords or tags describing the dataset.
+    slot_uri: dcat:keyword
+    range: string
+    multivalued: true
+
+
+  language:
+    description: The language(s) of the dataset, if applicable.
+    slot_uri: dcterms:language
+    range: string
+    multivalued: true
+
+
+  license:
+    description: The license or usage terms for the dataset.
+    slot_uri: dcterms:license
+    range: string
+
+
+  version:
+    description: The current version identifier of the dataset or schema.
+    slot_uri: schema:version
+    range: string
+
+
+  created_on:
+    description: Timestamp when the dataset was first created or published.
+    slot_uri: schema:dateCreated
+    range: datetime
+
+
+  created_by:
+    description: Agent (person or organization) that created the dataset or schema.
+    slot_uri: schema:creator
+    range: string
+    multivalued: true
+
+
+  last_updated_on:
+    description: Timestamp of the most recent update to the dataset or schema.
+    slot_uri: schema:dateModified
+    range: datetime
+
+
+  modified_by:
+    description: Agent (person or organization) that modified the dataset or schema.
+    slot_uri: schema:editor
+    range: string
+    multivalued: true
+
+
+  doi:
+    description: Digital Object Identifier for the dataset, if applicable.
+    range: uriorcurie
+
+
+  conforms_to:
+    description: A standard or schema to which the dataset conforms.
+    slot_uri: dcterms:conformsTo
+    range: uriorcurie
+
+
+  download_url:
+    description: URL pointing directly to the raw data file.
+    slot_uri: dcat:downloadURL
+    range: uri
+
+
+  path:
+    description: Path or location of the data file within a local or remote system.
+    range: string
+
+
+  format:
+    description: The format of the data (e.g. “CSV,” “JSON,” “TXT”).
+    slot_uri: dcterms:format
+    range: string
+
+
+  encoding:
+    description: The encoding of the data (e.g. “UTF-8,” “ASCII”).
+    range: string
+
+
+  compression:
+    description: The compression method, if any (e.g. “zip,” “gzip”).
+    range: string
+
+
+  media_type:
+    description: The MIME type of the data (e.g. “text/csv,” “application/json”).
+    slot_uri: dcat:mediaType
+    range: string
+
+
+  bytes:
+    description: Size of the data in bytes.
+    slot_uri: dcat:byteSize
+    range: integer
+
+
+  hash:
+    description: A generic hash of the data.
+    range: string
+
+
+  md5:
+    description: An MD5 hash of the data.
+    is_a: hash
+
+
+  sha256:
+    description: A SHA-256 hash of the data.
+    is_a: hash

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Motivation.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Motivation.yaml
@@ -1,0 +1,129 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/motivation"
+name: "data-sheets-schema-motivation"
+title: "Datasheets for Datasets – Motivation Module"
+description: >
+  Subschema for Motivation-related information in Datasheets for Datasets.
+  The questions in this section are primarily intended to encourage dataset 
+  creators to articulate their reasons for creating the dataset and to 
+  promote transparency about funding interests.
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  # Import the main data-sheets-schema so we can reference DatasetProperty, Person, Organization, etc.
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  Motivation:
+    description: >
+      The questions in this section are primarily intended to encourage dataset
+      creators to clearly articulate their reasons for creating the dataset and
+      to promote transparency about funding interests. The latter may be particularly
+      relevant for datasets created for research purposes.
+
+
+prefixes:
+  # Common LinkML prefixes and any that your environment requires
+  linkml: "https://w3id.org/linkml/"
+  d4d-motivation: "https://w3id.org/bridge2ai/data-sheets-schema/motivation#"
+  # You can add or customize additional prefixes as needed:
+  # ex: "http://example.org/"
+
+
+default_prefix: "d4d-motivation"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  Purpose:
+    description: "For what purpose was the dataset created?"
+    is_a: DatasetProperty
+    in_subset:
+      - Motivation
+    attributes:
+      response:
+        description: "Short explanation describing the primary purpose of creating the dataset."
+        range: string
+
+
+  Task:
+    description: "Was there a specific task in mind for the dataset's application?"
+    is_a: DatasetProperty
+    in_subset:
+      - Motivation
+    attributes:
+      response:
+        description: "Short explanation describing the specific task or tasks for which this dataset was created."
+        range: string
+
+
+  AddressingGap:
+    description: "Was there a specific gap that needed to be filled by creation of the dataset?"
+    is_a: DatasetProperty
+    in_subset:
+      - Motivation
+    attributes:
+      response:
+        description: "Short explanation of the knowledge or resource gap that this dataset was intended to address."
+        range: string
+
+
+  Creator:
+    description: >
+      Who created the dataset (e.g., which team, research group) and on behalf of which 
+      entity (e.g., company, institution, organization)? This may also be considered a team.
+    is_a: DatasetProperty
+    in_subset:
+      - Motivation
+    attributes:
+      principal_investigator:
+        description: "A key individual (Principal Investigator) responsible for or overseeing dataset creation."
+        range: Person
+      affiliation:
+        description: "Organization(s) with which the creator or team is affiliated."
+        range: Organization
+
+
+  FundingMechanism:
+    description: >
+      Who funded the creation of the dataset? If there is an associated grant, please provide
+      the name of the grantor and the grant name and number.
+    is_a: DatasetProperty
+    in_subset:
+      - Motivation
+    attributes:
+      grantor:
+        description: "Name/identifier of the organization providing monetary or resource support."
+        range: Grantor
+      grant:
+        description: "Name/identifier of the specific grant mechanism supporting dataset creation."
+        range: Grant
+
+
+  Grantor:
+    description: >
+      The name and/or identifier of the organization providing monetary support 
+      or other resources supporting creation of the dataset.
+    is_a: Organization
+    # The Organization class is inherited from the main schema (import).
+    # Additional attributes or specialized properties can be placed here if needed.
+
+
+  Grant:
+    description: >
+      The name and/or identifier of the specific mechanism providing monetary support
+      or other resources supporting creation of the dataset.
+    is_a: NamedThing
+    attributes:
+      grant_number:
+        description: "The alphanumeric identifier for the grant."
+        range: string

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Preprocessing.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Preprocessing.yaml
@@ -1,0 +1,97 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling"
+name: "data-sheets-schema-preprocessing"
+title: "Datasheets for Datasets – Preprocessing-Cleaning-Labeling Module"
+description: >
+  Subschema for Preprocessing, Cleaning, and Labeling–related information in
+  Datasheets for Datasets. The questions in this section are intended to provide
+  dataset consumers with information needed to determine whether the “raw” data
+  has been processed in ways that are compatible with their chosen tasks.
+
+
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  # Import the main data-sheets-schema so we can reference DatasetProperty, etc.
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  Preprocessing-Cleaning-Labeling:
+    description: >
+      The questions in this section are intended to provide dataset consumers
+      with the information they need to determine whether the “raw” data has
+      been processed in ways that are compatible with their chosen tasks.
+
+
+prefixes:
+  linkml: "https://w3id.org/linkml/"
+  d4d-preprocessing: "https://w3id.org/bridge2ai/data-sheets-schema/preprocessing-cleaning-labeling#"
+
+
+default_prefix: "d4d-preprocessing"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  PreprocessingStrategy:
+    description: >
+      Was any preprocessing of the data done (e.g., discretization or bucketing,
+      tokenization, SIFT feature extraction)?
+    is_a: DatasetProperty
+    in_subset:
+      - Preprocessing-Cleaning-Labeling
+    attributes:
+      description:
+        description: "Explanation of any preprocessing steps performed on the data."
+        range: string
+        multivalued: true
+
+
+  CleaningStrategy:
+    description: >
+      Was any cleaning of the data done (e.g., removal of instances,
+      processing of missing values)?
+    is_a: DatasetProperty
+    in_subset:
+      - Preprocessing-Cleaning-Labeling
+    attributes:
+      description:
+        description: "Explanation of any data cleaning steps performed."
+        range: string
+        multivalued: true
+
+
+  LabelingStrategy:
+    description: >
+      Was any labeling of the data done (e.g., part-of-speech tagging)?
+    is_a: DatasetProperty
+    in_subset:
+      - Preprocessing-Cleaning-Labeling
+    attributes:
+      description:
+        description: "Explanation of any labeling steps performed."
+        range: string
+        multivalued: true
+
+
+  RawData:
+    description: >
+      Was the “raw” data saved in addition to the preprocessed/cleaned/labeled
+      data? If so, please provide a link or other access point to the “raw” data.
+    is_a: DatasetProperty
+    in_subset:
+      - Preprocessing-Cleaning-Labeling
+    attributes:
+      description:
+        description: "Details about the availability or location of raw data."
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Uses.yaml
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/D4D_Uses.yaml
@@ -1,0 +1,109 @@
+﻿id: "https://w3id.org/bridge2ai/data-sheets-schema/uses"
+name: "data-sheets-schema-uses"
+title: "Datasheets for Datasets – Uses Module"
+description: >
+  Subschema for data uses–related information in Datasheets for Datasets.
+  The questions in this section are intended to encourage dataset creators
+  to reflect on the tasks for which the dataset should (and should not) be used.
+
+
+license: MIT
+see_also:
+  - "https://bridge2ai.github.io/data-sheets-schema"
+
+
+imports:
+  - "https://w3id.org/bridge2ai/data-sheets-schema"
+
+
+subsets:
+  Uses:
+    description: >
+      The questions in this section are intended to encourage dataset creators
+      to reflect on the tasks for which the dataset should and should not be
+      used, as well as future or previously established uses.
+
+
+prefixes:
+  linkml: "https://w3id.org/linkml/"
+  d4d-uses: "https://w3id.org/bridge2ai/data-sheets-schema/uses#"
+
+
+default_prefix: "d4d-uses"
+
+
+# ------------------------------------------------------------------------------
+# Classes
+# ------------------------------------------------------------------------------
+
+
+classes:
+
+
+  ExistingUse:
+    description: >
+      Has the dataset been used for any tasks already?
+    is_a: DatasetProperty
+    in_subset:
+      - Uses
+    attributes:
+      description:
+        description: "List or summary of known/previous uses of the dataset."
+        range: string
+        multivalued: true
+
+
+  UseRepository:
+    description: >
+      Is there a repository that links to any or all papers or systems
+      that use the dataset? If so, provide a link or other access point.
+    is_a: DatasetProperty
+    in_subset:
+      - Uses
+    attributes:
+      description:
+        description: "Reference(s) to a repository of known dataset uses."
+        range: string
+        multivalued: true
+
+
+  OtherTask:
+    description: >
+      What other tasks could the dataset be used for?
+    is_a: DatasetProperty
+    in_subset:
+      - Uses
+    attributes:
+      description:
+        description: "Potential additional tasks or domains for dataset usage."
+        range: string
+        multivalued: true
+
+
+  FutureUseImpact:
+    description: >
+      Is there anything about the dataset's composition or collection
+      that might impact future uses or create risks/harm (e.g., unfair
+      treatment, legal or financial risks)? If so, describe these
+      impacts and any mitigation strategies.
+    is_a: DatasetProperty
+    in_subset:
+      - Uses
+    attributes:
+      description:
+        description: "Details regarding the possible future impacts or risks of use."
+        range: string
+        multivalued: true
+
+
+  DiscouragedUse:
+    description: >
+      Are there tasks for which the dataset should not be used?
+    is_a: DatasetProperty
+    in_subset:
+      - Uses
+    attributes:
+      description:
+        description: "Description of tasks or contexts in which dataset use is discouraged."
+        range: string
+        multivalued: true

--- a/data/ATTIC/root_schema_drafts_2026-08-08/README.md
+++ b/data/ATTIC/root_schema_drafts_2026-08-08/README.md
@@ -1,0 +1,43 @@
+# Root-level D4D schema drafts, moved 2026-08-08 (#409)
+
+Twelve `D4D_*.yaml` files that had accumulated in the **repository root**,
+where no schema module belongs. Moved here rather than deleted: they were never
+tracked in git, so until this commit they had no recovery path at all.
+
+Following the precedent of `data/ATTIC/root_downloads/`, which holds legacy
+directories moved off the repository root on 2024-12-19.
+
+## What they are
+
+Stale copies of the schema modules from **before classes were redistributed
+between modules** — not an alternative design, and not the current modules.
+Each shares its `id` and `name` with the live module of the same filename in
+`src/data_sheets_schema/schema/`, but carries an older class inventory:
+
+| file | this copy has | the live module has |
+|---|---|---|
+| `D4D_Minimal.yaml` | `Dataset`, `DatasetCollection`, `Information` | `MinimalDataset`, `MinimalDatasetCollection` — renamed to stop clashing with the main classes |
+| `D4D_Collection.yaml` | 12 classes, incl. `EthicalReview`, `CollectionConsent`, `DataProtectionImpact`, `DatasetProperty` | 7 classes; those moved to `D4D_Ethics` and `D4D_Base_import` |
+| `D4D_Ethics.yaml` | 6 classes, incl. `DirectCollection` | 5; `DirectCollection` moved into `D4D_Collection` |
+
+Sharing an `id` with a live module is why they could not simply be left in
+place: anything that imported one would collide with the real module.
+
+## How they got there
+
+Every file carries a UTF-8 BOM and CRLF line endings. Nothing in this
+repository writes either — `gen-project` and LinkML emit LF without a BOM — so
+they arrived from a Windows editor or a browser download rather than from any
+tool here. They were referenced by nothing: the only occurrences of these
+filenames in the tree are in `CLAUDE.md` and the agent definitions, and all of
+those mean the modules under `src/data_sheets_schema/schema/`.
+
+The bytes are unchanged by the move, BOM and CRLF included; md5s were compared
+before and after.
+
+## If you need one
+
+They are superseded. The current modules are in
+`src/data_sheets_schema/schema/`, and `make gen-project` regenerates everything
+derived from them. Nothing in the build, the tests, or the documentation reads
+this directory.


### PR DESCRIPTION
Closes #409.

Twelve `D4D_*.yaml` files had accumulated in the **repository root**, where no schema module belongs — `CLAUDE.md` says they live in `src/data_sheets_schema/schema/`. They were the last untracked noise in `git status`, which is how a real untracked file gets missed.

## What they turned out to be

Stale copies from **before classes were redistributed between modules** — not an alternative design:

| file | this copy has | the live module has |
|---|---|---|
| `D4D_Minimal.yaml` | `Dataset`, `DatasetCollection`, `Information` | `MinimalDataset`, `MinimalDatasetCollection` — renamed to stop clashing with the main classes |
| `D4D_Collection.yaml` | 12 classes, incl. `EthicalReview`, `CollectionConsent`, `DataProtectionImpact`, `DatasetProperty` | 7; those moved to `D4D_Ethics` and `D4D_Base_import` |
| `D4D_Ethics.yaml` | 6 classes, incl. `DirectCollection` | 5; `DirectCollection` moved the other way |

Each shares its `id` **and** `name` with the live module of the same filename, so anything importing one would collide with the real module. Leaving them in place was not neutral.

## Moved, not deleted

They had never been tracked in git — `git log --all --diff-filter=AD` is empty for them — so until this commit there was **no way to get them back**. Committing them to ATTIC gives them a recovery path for the first time, which is why I recommended this over deletion.

Follows the existing `data/ATTIC/root_downloads/` precedent for things moved off the repository root (2024-12-19).

## Provenance, recorded because none existed

Every file carries a UTF-8 BOM **and** CRLF line endings. Nothing in this repository writes either — `gen-project` and LinkML emit LF without a BOM — so they arrived from a Windows editor or a browser download. They were referenced by nothing: the only occurrences of these filenames in the tree are in `CLAUDE.md` and the agent definitions, and all of those mean the live modules.

## Verification

- **Bytes unchanged.** md5 compared before and after each move; BOM (`efbbbf`) and CRLF (`0d0a`) confirmed intact in the moved copies.
- Full schema still builds: 78 classes, 289 slots.
- Nothing reads the new directory.
- Full suite: **1365 passed, 4 skipped, 0 failed.**
- A README in the new directory records the per-file comparison and how they got there; `data/ATTIC/README.md` gains an entry beside the 2024-12-19 one.

After this, the only entry left in `git status` is the pre-existing `aurelian` submodule pointer, which is unrelated to this work and untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
