### PR TITLE
Carry a still-true validation verdict across a re-record (#396)

### DIFF
--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -477,7 +477,17 @@ and it marks what it cannot recover rather than filling it in.
   closing rows were appended, and a whole series was hashed before its headers
   were edited. The API path cannot do this, because it writes provenance
   in-process after every phase; running the check gives this path the same
-  property. Re-run `d4d runs validate` and check again if anything changed.
+  property.
+
+  **Re-recording no longer discards the verdict** (#396). `provenance record`
+  used to rewrite the file from scratch and delete the `validation:` block that
+  `d4d runs validate` had written, so a re-record silently failed the gate while
+  printing a tick. It now carries the block forward when every artifact it names
+  still hashes to what it recorded, and drops it with a warning naming the
+  follow-up command when one does not. So the sequence is no longer
+  order-critical: record and validate in either order, and re-record freely.
+  Still run `d4d runs validate` once after the artifacts are final, because a
+  run that has never been validated has no verdict to carry.
 - Final summary to the user: per project, report full/core line counts as
   informational metadata, never as a quality gate, plus validation status.
 

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -41,6 +41,17 @@ def record(project, method, label, input_bundle, prompts):
                        prompt_paths=[Path(p) for p in prompts] or None)
     out = rec.write(record_path_for(project, method, label))
     click.echo(f"✓ {out}")
+    # Say what happened to any prior verdict. Re-recording used to delete it
+    # silently and the run then failed `--strict` with "nothing to verify",
+    # while this command printed a tick and exited 0 (#396).
+    if rec.validation_carried is True:
+        click.echo("  validation: carried forward — the artifacts it names "
+                   "still hash to what it recorded")
+    elif rec.validation_carried is False:
+        click.echo("  ⚠️  validation: dropped — the artifacts changed since it "
+                   "was recorded, so the verdict is about bytes that no longer "
+                   "exist.\n      Re-run `d4d runs validate --label "
+                   f"{label} --project {project}` before `d4d runs check`.")
 
 
 @provenance.command()

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -324,8 +324,17 @@ def preservable_validation(path: Path,
     is missing, the verdict is about a file that no longer exists in that form
     and is dropped — the same staleness rule `validation_status` applies.
 
+    **The schema must also be unchanged.** "Validates" is a claim about a
+    record *against a schema*, and `validation.artifacts` pins only the record.
+    `validation_status` has the same blind spot, but there it is bounded:
+    before this function existed, a re-record dropped the verdict and forced a
+    re-validation. Carrying it forward would let a verdict outlive the schema
+    it was reached against, so the record's own `schema` block is compared too
+    and any difference drops it. Raised in review of #396; the gap is #426.
+
     Returns None when there is nothing to carry, when the caller supplied its
-    own block, or when the prior one no longer describes the artifacts.
+    own block, when the prior one no longer describes the artifacts, or when
+    the schema has moved under it.
     """
     if "validation" in new_data:
         return None                      # caller's own verdict wins
@@ -347,6 +356,14 @@ def preservable_validation(path: Path,
     for entry in artifacts.values():
         if not isinstance(entry, dict) or verify_entry(entry) is not True:
             return None
+
+    # Same record, same bytes, different schema is a different question.
+    def _schema_id(d: dict[str, Any]) -> tuple[Any, Any]:
+        sch = d.get("schema") or {}
+        return (sch.get("full_sha256"), sch.get("core_sha256"))
+
+    if _schema_id(prior) != _schema_id(new_data):
+        return None
     return v
 
 

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -307,16 +307,80 @@ def verify_entry(entry: dict[str, Any]) -> bool | None:
     return hash_file(Path(path), algo) == value
 
 
+def preservable_validation(path: Path,
+                           new_data: dict[str, Any]) -> dict[str, Any] | None:
+    """A prior `validation:` block that a re-record may keep, or None.
+
+    `record` rewrites the file from scratch while `d4d runs validate` writes the
+    verdict separately, so re-recording used to delete it and the run failed
+    `--strict` immediately with "nothing to verify" — while `record` printed a
+    tick and exited 0 (#396). Re-recording is the *correct* response to several
+    situations (a header field was added, Phase 3 corrected an artifact), so
+    this was easy to hit and looked like success.
+
+    A verdict is a claim about specific bytes, and it is still true if those
+    bytes have not changed. So the block is carried forward only when every
+    artifact it names still hashes to what it recorded. If any differs, or any
+    is missing, the verdict is about a file that no longer exists in that form
+    and is dropped — the same staleness rule `validation_status` applies.
+
+    Returns None when there is nothing to carry, when the caller supplied its
+    own block, or when the prior one no longer describes the artifacts.
+    """
+    if "validation" in new_data:
+        return None                      # caller's own verdict wins
+    if not path.exists():
+        return None
+    try:
+        prior = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception:                                        # noqa: BLE001
+        return None
+    if not isinstance(prior, dict):
+        return None
+    v = prior.get("validation")
+    if not isinstance(v, dict) or "passed" not in v:
+        return None
+    artifacts = v.get("artifacts")
+    if not isinstance(artifacts, dict) or not artifacts:
+        # A verdict with nothing to re-hash cannot be shown still true.
+        return None
+    for entry in artifacts.values():
+        if not isinstance(entry, dict) or verify_entry(entry) is not True:
+            return None
+    return v
+
+
 @dataclass
 class ProvenanceRecord:
     data: dict[str, Any] = field(default_factory=dict)
 
+    #: Set by :meth:`write`. True if a prior verdict was carried forward, False
+    #: if one was found but dropped as stale, None if there was none. The CLI
+    #: reads it to say which happened, because a silently dropped verdict is
+    #: what made #396 hard to notice.
+    validation_carried: bool | None = None
+
     def write(self, path: Path) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)
+        data = dict(self.data)
+        had_prior = False
+        if "validation" not in data and path.exists():
+            try:
+                prior = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+                had_prior = isinstance(prior, dict) and isinstance(
+                    prior.get("validation"), dict)
+            except Exception:                                # noqa: BLE001
+                had_prior = False
+        carried = preservable_validation(path, data)
+        if carried is not None:
+            data["validation"] = carried
+            self.validation_carried = True
+        elif had_prior:
+            self.validation_carried = False
         path.write_text(
             "# D4D generation provenance record\n"
             f"# record_version {RECORD_VERSION} — see src/data_sheets_schema/provenance.py\n"
-            + yaml.safe_dump(self.data, sort_keys=False, allow_unicode=True),
+            + yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
             encoding="utf-8")
         return path
 

--- a/tests/test_cli/test_provenance_preserves_validation.py
+++ b/tests/test_cli/test_provenance_preserves_validation.py
@@ -153,3 +153,48 @@ class TestReRecordPreservesTheVerdict(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheVerdictDoesNotOutliveItsSchema(unittest.TestCase):
+    """Raised reviewing #396. "Validates" is a claim about a record *against a
+    schema*, and `validation.artifacts` pins only the record.
+
+    Before the carry-forward existed the gap was bounded: a re-record dropped
+    the verdict and forced re-validation. Carrying it would let a verdict
+    outlive the schema it was reached against, so the record's own `schema`
+    block is compared too. The underlying blind spot in `validation_status` is
+    #426.
+    """
+
+    def setUp(self):
+        from data_sheets_schema.provenance import preservable_validation
+        self.fn = preservable_validation
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "prov.yaml"
+        self.artifact = Path(self.tmp.name) / "rec.yaml"
+        self.artifact.write_text("id: x\n")
+        self.md5 = hashlib.md5(self.artifact.read_bytes()).hexdigest()
+        self.prior = {
+            "schema": {"full_sha256": "aaa", "core_sha256": "bbb"},
+            "validation": {
+                "passed": True,
+                "artifacts": {"full": {"path": str(self.artifact),
+                                       "md5": self.md5}},
+            },
+        }
+        self.path.write_text(yaml.safe_dump(self.prior, sort_keys=False))
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_same_schema_carries(self):
+        new = {"schema": {"full_sha256": "aaa", "core_sha256": "bbb"}}
+        self.assertIsNotNone(self.fn(self.path, new))
+
+    def test_a_changed_full_schema_drops_it(self):
+        new = {"schema": {"full_sha256": "CHANGED", "core_sha256": "bbb"}}
+        self.assertIsNone(self.fn(self.path, new))
+
+    def test_a_changed_core_schema_drops_it(self):
+        new = {"schema": {"full_sha256": "aaa", "core_sha256": "CHANGED"}}
+        self.assertIsNone(self.fn(self.path, new))

--- a/tests/test_cli/test_provenance_preserves_validation.py
+++ b/tests/test_cli/test_provenance_preserves_validation.py
@@ -1,0 +1,155 @@
+"""Re-recording provenance must not silently discard the validation verdict.
+
+`d4d provenance record` rewrites the record from scratch, while the
+`validation:` block is written separately by `d4d runs validate`. So any
+re-record deleted the verdict and the run failed `d4d runs check --strict`
+immediately with "nothing to verify" — while `record` printed a tick and exited
+0 (#396).
+
+That was easy to hit, because re-recording is the *correct* response to several
+situations: a header field was added, Phase 3 corrected an artifact, provenance
+was recorded before the last edit. The playbook worked around it with a
+five-step "the order is load-bearing" sequence that had to be executed by hand.
+
+A verdict is a claim about specific bytes, and it is still true if those bytes
+have not changed. So it is carried forward when every artifact it names still
+hashes to what it recorded, and dropped — loudly — when one does not.
+"""
+
+import hashlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+
+HEADER = """\
+# D4D Datasheet for TESTPROJ Dataset
+# Agent runtime: Claude Code
+# Provider: Anthropic
+# Model: claude-opus-5
+# Reasoning effort: high
+# Temperature: 0.0
+"""
+
+
+class TestReRecordPreservesTheVerdict(unittest.TestCase):
+    def setUp(self):
+        from data_sheets_schema.cli import provenance as prov_cli
+
+        self.cli = prov_cli.provenance
+        self.runner = CliRunner()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.label = "2026-08-07_test_rep1"
+        self.method = "claudecode_agent"
+
+        concat = self.root / "data" / "d4d_concatenated"
+        self.full_dir = concat / self.method / self.label
+        self.core_dir = concat / f"{self.method}_core" / self.label
+        self.full_dir.mkdir(parents=True)
+        self.core_dir.mkdir(parents=True)
+
+        body = yaml.safe_dump({"id": "https://example.org/x", "name": "x"})
+        self.full = self.full_dir / "TESTPROJ_d4d.yaml"
+        self.core = self.core_dir / "TESTPROJ_d4d_core.yaml"
+        self.full.write_text(HEADER + body)
+        self.core.write_text(HEADER + body)
+        (self.core_dir / "TESTPROJ_reconciliation.md").write_text("# report\n")
+
+        self.bundle = self.root / "bundle.txt"
+        self.bundle.write_text("source documents\n")
+        self.record_path = self.core_dir / "TESTPROJ_provenance.yaml"
+        self.concat = concat
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _record(self):
+        args = ["record", "--project", "TESTPROJ", "--method", self.method,
+                "--label", self.label, "--input-bundle", str(self.bundle)]
+        cwd = os.getcwd()
+        os.chdir(self.root)
+        try:
+            return self.runner.invoke(self.cli, args)
+        finally:
+            os.chdir(cwd)
+
+    def _md5(self, p: Path) -> str:
+        return hashlib.md5(p.read_bytes()).hexdigest()
+
+    def _add_verdict(self):
+        """What `d4d runs validate` writes, in the shape it writes it."""
+        data = yaml.safe_load(self.record_path.read_text())
+        data["validation"] = {
+            "passed": True,
+            "artifacts": {
+                "full": {"path": str(self.full), "md5": self._md5(self.full)},
+                "core": {"path": str(self.core), "md5": self._md5(self.core)},
+            },
+            "recorded_by": "d4d runs validate",
+        }
+        self.record_path.write_text(yaml.safe_dump(data, sort_keys=False))
+
+    def test_an_unchanged_verdict_survives_a_re_record(self):
+        self._record()
+        self._add_verdict()
+
+        result = self._record()
+        self.assertEqual(result.exit_code, 0, result.output)
+
+        v = yaml.safe_load(self.record_path.read_text()).get("validation")
+        self.assertIsInstance(v, dict, "the verdict was discarded (#396)")
+        self.assertTrue(v["passed"])
+        self.assertEqual({"full", "core"}, set(v["artifacts"]))
+        self.assertIn("carried forward", result.output)
+
+    def test_a_stale_verdict_is_dropped_and_the_drop_is_announced(self):
+        self._record()
+        self._add_verdict()
+        self.full.write_text(self.full.read_text() + "\n# edited after validating\n")
+
+        result = self._record()
+        self.assertEqual(result.exit_code, 0, result.output)
+
+        data = yaml.safe_load(self.record_path.read_text())
+        self.assertIsNone(data.get("validation"),
+                          "a verdict about bytes that changed must not survive")
+        self.assertIn("dropped", result.output)
+        self.assertIn("d4d runs validate", result.output,
+                      "the warning must name the command that fixes it")
+
+    def test_a_record_with_no_prior_verdict_says_nothing_about_one(self):
+        result = self._record()
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("carried forward", result.output)
+        self.assertNotIn("dropped", result.output)
+
+    def test_a_verdict_naming_a_deleted_artifact_is_dropped(self):
+        """`verify_entry` returns None, not False, when the file is gone — the
+        distinction that made an early version of this carry it forward."""
+        self._record()
+        self._add_verdict()
+        self.full.unlink()
+
+        self._record()
+        data = yaml.safe_load(self.record_path.read_text())
+        self.assertIsNone(data.get("validation"))
+
+    def test_a_verdict_with_no_artifacts_is_not_carried(self):
+        """Nothing to re-hash means nothing can be shown still true."""
+        self._record()
+        data = yaml.safe_load(self.record_path.read_text())
+        data["validation"] = {"passed": True, "recorded_by": "hand"}
+        self.record_path.write_text(yaml.safe_dump(data, sort_keys=False))
+
+        self._record()
+        self.assertIsNone(
+            yaml.safe_load(self.record_path.read_text()).get("validation"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #396.

`d4d provenance record` rewrote the record from scratch while `d4d runs validate` writes the `validation:` block separately, so **any re-record deleted the verdict** — the run then failed `d4d runs check --strict` with "nothing to verify", while `record` printed a tick and exited 0.

This was easy to hit, because re-recording is the *correct* response to several situations (a header field added, Phase 3 corrected an artifact, provenance recorded before the last edit). The playbook worked around it with an order-critical sequence executed **by hand on every run** — one of the six manual interventions the genericity audit (#418) catalogued.

## The fix

A verdict is a claim about specific bytes, and it is still true if those bytes have not changed. `preservable_validation()` carries the block forward when every artifact it names still hashes to what it recorded, and returns `None` otherwise — the same staleness rule `validation_status` already applies, so the two cannot disagree about what a verdict describes.

**Dropping is now loud**, which was the actual defect:

```
  validation: carried forward — the artifacts it names still hash to what it recorded

  ⚠️  validation: dropped — the artifacts changed since it was recorded, so the
      verdict is about bytes that no longer exist.
      Re-run `d4d runs validate --label <L> --project <P>` before `d4d runs check`.
```

Deleting the verdict is *correct* when the bytes changed. Doing it silently is what made a broken run look finished.

## Refused rather than carried

Four cases, each tested: a caller that supplied its own block; a verdict whose artifacts no longer match; one naming a **deleted** file (`verify_entry` returns `None` there, not `False` — the distinction an early version of this got wrong); and one with no artifacts at all, which cannot be shown still true.

## Verified end to end on a real record

- Re-recorded `2026-08-07_…_rep2` VOICE with artifacts unchanged → block preserved, `--strict` passed. **Before this change that sequence failed the gate.**
- Edited the full record, re-recorded → warning fired, block dropped.
- Restored the artifact byte-identically, re-validated → passing again, `data/` clean.

## Also

The playbook's completion criteria no longer prescribe the ordering, since it is no longer load-bearing — the manual step only really goes away if the instructions stop asking for it.

5 tests. **1370 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)