### PR TITLE
Render the agentic instruction instead of typing it (#419, #422)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -206,6 +206,18 @@ class RunSpec:
     # The GitHub assistant writes flat into data/sheets_d4dassistant. Rather than
     # two runners, the layout is a parameter — everything else is identical.
     out_dir: Path | None = None
+    # Which runtime the rendered instruction should declare. Defaults to this
+    # module's own, so the API path is unchanged. It is a parameter because the
+    # agentic path needs the same instruction rendered for `Claude Code`: the
+    # whole point of rendering is that nobody types the header by hand, and a
+    # hardcoded runtime would force exactly that (#419).
+    runtime: str = RUNTIME
+    # Likewise the provider. `provider_identity()` reports the endpoint *this
+    # process* is configured against, which is the right answer for a run this
+    # process is about to make and the wrong one for rendering an instruction
+    # another runtime will execute — it rendered "LBL CBORG (proxy to
+    # Anthropic)" into a Claude Code header, a provider that run never touches.
+    provider: str | None = None
 
     @property
     def full_path(self) -> Path:
@@ -325,8 +337,8 @@ def resolve_prompt(spec: RunSpec) -> str:
         # headed "Agent runtime: Claude Code" on "claude-opus-5[1m]" because
         # this prompt was written for the agent path and reused verbatim — the
         # artifact asserted a runtime and model it never touched.
-        "{RUNTIME}": RUNTIME,
-        "{PROVIDER}": ident["provider"] or PROVIDER,
+        "{RUNTIME}": spec.runtime,
+        "{PROVIDER}": spec.provider or ident["provider"] or PROVIDER,
         "{MODEL}": settings["name"],
         # v2 introduced `{DATE}` but nothing substituted it, so the literal
         # string reached the model. Its records carry the right date only
@@ -1654,6 +1666,10 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         spec.project, spec.method, spec.label, mode="live",
         input_bundle=spec.bundle, input_verified=True,
         prompt_paths=spec.prompt_files,
+        # The API path builds its instruction with `resolve_prompt`, so it can
+        # record exactly what it sent rather than only what it was built from
+        # (#419). `prompt_request_hash` was written for this and had no caller.
+        prompt_request=resolve_prompt(spec),
         schema_digest_md5=schema_digest.fingerprint(schema_digest.digest_text("Dataset")),
         extra_notes=[
             (f"Generated via {RUNTIME}; temperature {settings['temperature']} "

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -34,7 +34,7 @@ import re
 import subprocess
 import time
 from dataclasses import dataclass, field
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -219,6 +219,25 @@ class RunSpec:
     # Anthropic)" into a Claude Code header, a provider that run never touches.
     provider: str | None = None
 
+    @cached_property
+    def instruction(self) -> str:
+        """The resolved instruction, rendered once per spec.
+
+        `resolve_prompt` was called at send time and again when the provenance
+        record was built after the last phase. It reads `provider_identity()`
+        and `_model_settings()`, so anything that moved in between — an edited
+        deterministic config, a changed endpoint — would have the record attest
+        a prompt that was never sent.
+
+        That is the same failure `run_date` is frozen to avoid, and the comment
+        there says so: recomputing per call "made the provenance digest, which
+        is computed after the last phase, attest a prompt that was never sent".
+        A six-phase run takes tens of minutes, which is long enough for it to
+        happen. Resolving once closes it for the whole spec rather than for one
+        field of it.
+        """
+        return resolve_prompt(self)
+
     @property
     def full_path(self) -> Path:
         if self.out_dir:
@@ -312,7 +331,7 @@ def resolved_prompt_digest(spec: RunSpec) -> dict[str, Any]:
     their recorded prompt evidence. Substitution is exactly what makes the file
     and the request different objects, so the request needs its own hash.
     """
-    text = resolve_prompt(spec)
+    text = spec.instruction
     return {"sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
             "bytes": len(text.encode("utf-8"))}
 
@@ -523,7 +542,7 @@ def build_phase(spec: RunSpec, phase: str, *, carry: dict[str, str]) -> PhaseReq
     # that document instead of answering: ten consecutive core-phase attempts
     # produced a mid-record fragment growing an `extension_mechanism` slot.
     parts: list[dict[str, Any]] = list(cached)
-    parts.append({"type": "text", "text": resolve_prompt(spec)})
+    parts.append({"type": "text", "text": spec.instruction})
     for name, text in carry.items():
         parts.append({"type": "text",
                       "text": f"# {name}\n\n{text}"})
@@ -1669,7 +1688,7 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         # The API path builds its instruction with `resolve_prompt`, so it can
         # record exactly what it sent rather than only what it was built from
         # (#419). `prompt_request_hash` was written for this and had no caller.
-        prompt_request=resolve_prompt(spec),
+        prompt_request=spec.instruction,
         schema_digest_md5=schema_digest.fingerprint(schema_digest.digest_text("Dataset")),
         extra_notes=[
             (f"Generated via {RUNTIME}; temperature {settings['temperature']} "

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -33,7 +33,8 @@ ARMS = {
 _CONDITIONS = sorted(CONDITION_PROMPTS)
 
 
-def _spec(project, arm, label, condition, bundle=None, out_dir=None):
+def _spec(project, arm, label, condition, bundle=None, out_dir=None,
+          runtime=None, provider=None):
     """Resolve a run spec.
 
     `project` is a free string rather than a click.Choice because the GitHub
@@ -45,10 +46,15 @@ def _spec(project, arm, label, condition, bundle=None, out_dir=None):
     display, method, pattern, manifest = ARMS[arm]
     resolved = (Path(bundle) if bundle else
                 Path("data/preprocessed/concatenated") / pattern.format(p=project))
+    kw = {}
+    if runtime:
+        kw["runtime"] = runtime
+    if provider:
+        kw["provider"] = provider
     return RunSpec(project=project, arm=display, method=method,
                    bundle=resolved, label=label, condition=condition,
                    manifest_line=manifest,
-                   out_dir=Path(out_dir) if out_dir else None)
+                   out_dir=Path(out_dir) if out_dir else None, **kw)
 
 
 def _require_bundle(spec, project, bundle):
@@ -63,6 +69,61 @@ def _require_bundle(spec, project, bundle):
 @click.group()
 def api():
     """Generate D4D records via the Anthropic API (six-phase)."""
+
+
+@api.command("render-prompt")
+@click.option("--project", required=True,
+              help="AI_READI|CHORUS|CM4AI|VOICE, or any dataset name with --bundle")
+@click.option("--arm", type=click.Choice(sorted(ARMS)), default="baseline",
+              show_default=True)
+@click.option("--label", required=True, help="run label")
+@click.option("--condition", type=click.Choice(_CONDITIONS), default="generic",
+              show_default=True)
+@click.option("--bundle", type=click.Path(), default=None,
+              help="explicit input bundle; required for datasets outside PROJECTS")
+@click.option("--runtime", default="Claude Code", show_default=True,
+              help="runtime the instruction should declare")
+@click.option("--provider", default="Anthropic", show_default=True)
+@click.option("--out", type=click.Path(), default=None,
+              help="write the instruction here as well as printing its digest")
+def render_prompt_cmd(project, arm, label, condition, bundle, runtime,
+                      provider, out):
+    """Render the exact instruction a run should receive, for any runtime.
+
+    The API path never types an instruction: `resolve_prompt()` builds it from
+    the spec, so the condition, the substitutions and the per-project content
+    are all functions of declared inputs. The agentic path had no way to obtain
+    that text, so its launch prompts were hand-composed — and the VOICE run of
+    2026-08-07 was sent a project-specific scope paragraph that appears in no
+    prompt file, while its provenance recorded the base file and the header
+    said "identical for all projects" (#419, #422).
+
+    Rendering closes that by construction rather than by discipline. Per-project
+    content can then only enter through `--condition tuned`, which is a declared
+    door that the record names.
+
+    The digest is of the resolved text, not the file. Substitution is what makes
+    the two different objects, which is why `prompt_request_hash` exists.
+    """
+    import hashlib
+    from data_sheets_schema.api_runner import resolve_prompt
+
+    spec = _spec(project, arm, label, condition, bundle,
+                 runtime=runtime, provider=provider)
+    _require_bundle(spec, project, bundle)
+    text = resolve_prompt(spec)
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+    if out:
+        Path(out).write_text(text, encoding="utf-8")
+        click.echo(f"✓ {out}", err=True)
+    click.echo(f"# rendered {condition} for {project} / {arm} / runtime={runtime}",
+               err=True)
+    click.echo(f"# sha256 {digest}  ({len(text.encode('utf-8'))} bytes)", err=True)
+    click.echo(f"# record it with: d4d provenance record ... --prompt-text <file>",
+               err=True)
+    if not out:
+        click.echo(text)
 
 
 @api.command("plan")

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -19,7 +19,13 @@ def provenance():
               type=click.Path(exists=True, dir_okay=False),
               help='Prompt file this run was launched with; may repeat. '
                    'Hashed into the record.')
-def record(project, method, label, input_bundle, prompts):
+@click.option('--prompt-text', 'prompt_text',
+              type=click.Path(exists=True, dir_okay=False),
+              help='The instruction as actually sent, e.g. from '
+                   '`d4d api render-prompt --out`. Hashed as prompts.request. '
+                   'The file is what an instruction was built from; this is '
+                   'what it became.')
+def record(project, method, label, input_bundle, prompts, prompt_text):
     """Write a LIVE provenance record for a run just produced.
 
     Every field is observed at run time — hardware, software versions, input
@@ -38,7 +44,9 @@ def record(project, method, label, input_bundle, prompts):
     rec = build_record(project, method, label, mode="live",
                        input_bundle=Path(input_bundle) if input_bundle else None,
                        input_verified=True,
-                       prompt_paths=[Path(p) for p in prompts] or None)
+                       prompt_paths=[Path(p) for p in prompts] or None,
+                       prompt_request=(Path(prompt_text).read_text(encoding="utf-8")
+                                       if prompt_text else None))
     out = rec.write(record_path_for(project, method, label))
     click.echo(f"✓ {out}")
     # Say what happened to any prior verdict. Re-recording used to delete it

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -107,25 +107,49 @@ def load_generation_config(path: Path = DETERMINISTIC_CONFIG) -> dict[str, Any]:
         return {}
 
 
-def prompt_facts(prompt_paths: list[Path] | None) -> dict[str, Any]:
-    """Hash every prompt file a run consumed.
+def prompt_facts(prompt_paths: list[Path] | None,
+                 request_text: str | None = None) -> dict[str, Any]:
+    """Hash every prompt file a run consumed, and the instruction it was sent.
 
     The prompt is a generation input as much as the bundle is, and until now it
     was the one input this record did not name. A condition whose prompt cannot
     be identified cannot be replicated — which is exactly why the 2026-07-27
     tuned prompts, written inline and never saved, are unreproducible.
+
+    **The file is not the instruction.** Substitution turns one into the other,
+    and on the agentic path a human turned it into something else again: the
+    VOICE run of 2026-08-07 was sent a project-specific scope paragraph that
+    appears in no prompt file, while this block recorded the file and the
+    record header said "identical for all projects" (#419).
+
+    So `request` records the resolved text as sent. Both are kept — knowing
+    what an instruction was built from and what it became is the useful pair,
+    and a mismatch between them is the thing worth being able to detect. The
+    text itself is not stored, only its hash and length; the point is to be
+    able to prove sameness, and a record is not an archive.
     """
     if not prompt_paths:
-        return {"paths": None,
-                "note": ("no prompt files declared; the prompt was supplied "
-                         "inline and is not recoverable from this record")}
-    out = []
-    for p in prompt_paths:
-        p = Path(p)
-        out.append({"path": str(p), "sha256": _sha256(p),
-                    "bytes": p.stat().st_size if p.exists() else None,
-                    "exists": p.exists()})
-    return {"hash_algorithm": PROMPT_HASH, "files": out}
+        facts: dict[str, Any] = {
+            "paths": None,
+            "note": ("no prompt files declared; the prompt was supplied "
+                     "inline and is not recoverable from this record")}
+    else:
+        out = []
+        for p in prompt_paths:
+            p = Path(p)
+            out.append({"path": str(p), "sha256": _sha256(p),
+                        "bytes": p.stat().st_size if p.exists() else None,
+                        "exists": p.exists()})
+        facts = {"hash_algorithm": PROMPT_HASH, "files": out}
+
+    if request_text is not None:
+        facts["request"] = {
+            "sha256": hashlib.sha256(request_text.encode("utf-8")).hexdigest(),
+            "bytes": len(request_text.encode("utf-8")),
+            "note": ("the instruction as sent, after substitution; the files "
+                     "above are what it was built from"),
+        }
+    return facts
 
 
 def _run(cmd: list[str]) -> str | None:
@@ -529,6 +553,7 @@ def build_record(project: str, method: str, label: str, *, mode: str,
                  input_verified: bool = False,
                  concat_dir: Path = CONCAT_DIR,
                  prompt_paths: list[Path] | None = None,
+                 prompt_request: str | None = None,
                  schema_digest_md5: str | None = None,
                  extra_notes: list[str] | None = None) -> ProvenanceRecord:
     """Assemble a provenance record for one project-run.
@@ -656,7 +681,7 @@ def build_record(project: str, method: str, label: str, *, mode: str,
                 "arm": _arm_for(base),
                 "replicate": _replicate_for(label)},
         "model": model or None,
-        "prompts": prompt_facts(prompt_paths),
+        "prompts": prompt_facts(prompt_paths, prompt_request),
         "schema": schema_facts() | (
             {"digest_md5": schema_digest_md5} if schema_digest_md5 else {}),
         "software": software_facts() if mode == "live" else {

--- a/tests/test_cli/test_provenance_prompt.py
+++ b/tests/test_cli/test_provenance_prompt.py
@@ -134,3 +134,85 @@ class TestProvenancePromptFlag(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheRequestIsRecordedNotJustTheFile(unittest.TestCase):
+    """#419. The file is not the instruction — substitution turns one into the
+    other, and on the agentic path a human turned it into something else again.
+
+    The VOICE run of 2026-08-07 was sent a project-specific scope paragraph
+    that appears in no prompt file, while the record hashed the file and its
+    header said "identical for all projects". Recording the resolved text is
+    what makes that difference detectable instead of merely discouraged.
+    """
+
+    def setUp(self):
+        from data_sheets_schema.cli import provenance as prov_cli
+        self.cli = prov_cli.provenance
+        self.runner = CliRunner()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.label, self.method = "2026-08-10_test_rep1", "claudecode_agent"
+        concat = self.root / "data" / "d4d_concatenated"
+        (concat / self.method / self.label).mkdir(parents=True)
+        (concat / f"{self.method}_core" / self.label).mkdir(parents=True)
+        body = yaml.safe_dump({"id": "https://example.org/x", "name": "x"})
+        (concat / self.method / self.label / "P_d4d.yaml").write_text(body)
+        (concat / f"{self.method}_core" / self.label / "P_d4d_core.yaml").write_text(body)
+        (concat / f"{self.method}_core" / self.label
+         / "P_reconciliation.md").write_text("# r\n")
+        self.bundle = self.root / "b.txt"; self.bundle.write_text("docs\n")
+        self.base = self.root / "base.md"; self.base.write_text("# base\n")
+        self.sent = self.root / "sent.txt"
+        self.sent.write_text("Generate paired records for the P project.\n")
+        self.concat = concat
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _record(self, *extra):
+        args = ["record", "--project", "P", "--method", self.method,
+                "--label", self.label, "--input-bundle", str(self.bundle), *extra]
+        cwd = os.getcwd(); os.chdir(self.root)
+        try:
+            return self.runner.invoke(self.cli, args)
+        finally:
+            os.chdir(cwd)
+
+    def _prompts(self):
+        p = (self.concat / f"{self.method}_core" / self.label
+             / "P_provenance.yaml")
+        return yaml.safe_load(p.read_text())["prompts"]
+
+    def test_the_sent_instruction_is_hashed_alongside_the_file(self):
+        import hashlib
+        r = self._record("--prompt", str(self.base),
+                         "--prompt-text", str(self.sent))
+        self.assertEqual(r.exit_code, 0, r.output)
+        pr = self._prompts()
+        self.assertEqual(1, len(pr["files"]), "the base file is still recorded")
+        self.assertEqual(
+            hashlib.sha256(self.sent.read_bytes()).hexdigest(),
+            pr["request"]["sha256"])
+        self.assertEqual(self.sent.stat().st_size, pr["request"]["bytes"])
+
+    def test_the_two_hashes_differ_which_is_the_whole_point(self):
+        r = self._record("--prompt", str(self.base),
+                         "--prompt-text", str(self.sent))
+        self.assertEqual(r.exit_code, 0, r.output)
+        pr = self._prompts()
+        self.assertNotEqual(pr["files"][0]["sha256"], pr["request"]["sha256"])
+
+    def test_without_the_flag_no_request_is_claimed(self):
+        """Absent is honest; an absent block must not be filled with the file's
+        hash, which would assert the two were the same."""
+        self._record("--prompt", str(self.base))
+        self.assertNotIn("request", self._prompts())
+
+    def test_the_request_can_be_recorded_without_a_base_file(self):
+        """An agentic run may know what it was sent and not which file it came
+        from — that is still strictly more than recording nothing."""
+        self._record("--prompt-text", str(self.sent))
+        pr = self._prompts()
+        self.assertIsNone(pr["paths"])
+        self.assertIn("request", pr)

--- a/tests/test_cli/test_render_prompt.py
+++ b/tests/test_cli/test_render_prompt.py
@@ -1,0 +1,116 @@
+"""Render the agentic instruction instead of typing it (#419, #422).
+
+The API path never types an instruction: `resolve_prompt()` builds it from a
+`RunSpec`, so the condition, the substitutions and any per-project content are
+functions of declared inputs. The agentic path had no way to obtain that text,
+so its launch prompts were hand-composed — and the VOICE run of 2026-08-07 was
+sent a project-specific scope paragraph that appears in no prompt file, while
+its provenance recorded the base file and the record header said "identical for
+all projects".
+
+Rendering closes that by construction rather than by discipline: per-project
+content can only enter through `--condition tuned`, which is a declared door
+the record names.
+"""
+
+import hashlib
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from data_sheets_schema.api_runner import RunSpec, resolve_prompt
+from data_sheets_schema.cli.api import api
+
+BUNDLE = Path("data/preprocessed/concatenated/VOICE_preprocessed.txt")
+
+
+def _spec(**kw):
+    base = dict(project="VOICE", arm="BASELINE (input documents only)",
+                method="claudecode_agent", bundle=BUNDLE,
+                label="2026-08-10_test_rep1", condition="generic_v3")
+    base.update(kw)
+    return RunSpec(**base)
+
+
+class TestTheRuntimeIsAParameter(unittest.TestCase):
+    """It was a module constant, so the rendered header always said
+    "Claude API (direct)" — useless for rendering an instruction another
+    runtime will execute."""
+
+    def test_the_runtime_appears_in_the_rendered_header(self):
+        text = resolve_prompt(_spec(runtime="Claude Code"))
+        self.assertIn("# Agent runtime: Claude Code", text)
+
+    def test_the_default_is_unchanged_for_the_api_path(self):
+        from data_sheets_schema.api_runner import RUNTIME
+        self.assertEqual(RUNTIME, _spec().runtime)
+
+    def test_the_provider_is_a_parameter_too(self):
+        """`provider_identity()` reports the endpoint *this process* is
+        configured against, which rendered "LBL CBORG (proxy to Anthropic)"
+        into a Claude Code header — a provider that run never touches."""
+        text = resolve_prompt(_spec(runtime="Claude Code", provider="Anthropic"))
+        self.assertIn("# Provider: Anthropic", text)
+        self.assertNotIn("CBORG", text)
+
+
+@unittest.skipUnless(BUNDLE.exists(), "bundles not present")
+class TestRenderedInstructionsAreComplete(unittest.TestCase):
+
+    def test_nothing_is_left_unsubstituted(self):
+        """v2 introduced `{DATE}` and nothing substituted it, so the literal
+        string reached the model."""
+        import re
+        for condition in ("generic", "generic_v2", "generic_v3", "generic_v4"):
+            with self.subTest(condition=condition):
+                text = resolve_prompt(_spec(condition=condition,
+                                            runtime="Claude Code"))
+                self.assertEqual([], re.findall(r"\{[A-Z_]+\}", text))
+
+    def test_the_generic_conditions_name_no_project_they_were_not_given(self):
+        """The project appears only where it was substituted in. Any other GC
+        name would mean per-project content in a generic condition."""
+        text = resolve_prompt(_spec(condition="generic_v3", runtime="Claude Code"))
+        for other in ("AI_READI", "CHORUS", "CM4AI"):
+            with self.subTest(other=other):
+                self.assertNotIn(other, text)
+
+
+@unittest.skipUnless(BUNDLE.exists(), "bundles not present")
+class TestTheCommand(unittest.TestCase):
+
+    def _run(self, *args):
+        return CliRunner(mix_stderr=False).invoke(
+            api, ["render-prompt", "--project", "VOICE",
+                  "--label", "2026-08-10_test_rep1", *args])
+
+    def test_it_prints_the_instruction_on_stdout(self):
+        r = self._run("--condition", "generic_v3")
+        self.assertEqual(r.exit_code, 0, r.stderr)
+        self.assertIn("Generate paired full and core D4D records", r.stdout)
+
+    def test_stdout_is_the_instruction_alone_so_it_can_be_piped(self):
+        """Commentary goes to stderr; a caller redirecting stdout to a file
+        must get the instruction and nothing else."""
+        r = self._run("--condition", "generic_v3")
+        self.assertNotIn("sha256", r.stdout)
+        self.assertIn("sha256", r.stderr)
+
+    def test_the_digest_is_of_the_resolved_text_not_the_file(self):
+        """Substitution is what makes the file and the request different
+        objects, which is why the request needs its own hash."""
+        r = self._run("--condition", "generic_v3", "--runtime", "Claude Code")
+        expected = hashlib.sha256(
+            resolve_prompt(_spec(condition="generic_v3",
+                                 runtime="Claude Code",
+                                 provider="Anthropic")).encode()).hexdigest()
+        self.assertIn(expected, r.stderr)
+
+    def test_an_unknown_condition_is_refused(self):
+        r = self._run("--condition", "no-such-condition")
+        self.assertNotEqual(r.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli/test_render_prompt.py
+++ b/tests/test_cli/test_render_prompt.py
@@ -114,3 +114,39 @@ class TestTheCommand(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheInstructionIsResolvedOnce(unittest.TestCase):
+    """Raised reviewing #425.
+
+    `resolve_prompt` was called at send time and again when the provenance
+    record was built after the last phase. It reads `provider_identity()` and
+    `_model_settings()`, so anything moving in between would have the record
+    attest a prompt that was never sent — the same failure `run_date` is frozen
+    to avoid, on a six-phase run that takes tens of minutes.
+    """
+
+    def test_the_same_spec_returns_the_same_object(self):
+        s = _spec(runtime="Claude Code")
+        self.assertIs(s.instruction, s.instruction)
+
+    def test_it_does_not_re_read_the_environment(self):
+        """The record is built after the phases; if settings moved in between,
+        re-rendering would attest something else."""
+        import data_sheets_schema.api_runner as ar
+        s = _spec(runtime="Claude Code")
+        first = s.instruction
+        original = ar._model_settings
+        ar._model_settings = lambda: {"name": "SOME-OTHER-MODEL",
+                                      "temperature": 0.0}
+        try:
+            self.assertEqual(first, s.instruction)
+            self.assertNotIn("SOME-OTHER-MODEL", s.instruction)
+        finally:
+            ar._model_settings = original
+
+    def test_a_different_spec_resolves_separately(self):
+        a = _spec(runtime="Claude Code")
+        b = _spec(runtime="Codex CLI")
+        self.assertNotEqual(a.instruction, b.instruction)
+        self.assertIn("Codex CLI", b.instruction)


### PR DESCRIPTION
Addresses #419 and #422. Makes the agentic path standardized the way the API path already is.

## Why the API path is more standardized — the specific reason

It never types an instruction. `resolve_prompt()` builds the text from a `RunSpec`, so the condition, every substitution and any per-project content are **functions of declared inputs**. Per-GC content can enter through exactly one door — `--condition tuned` → `components/{PROJECT}.md` — and the record names it.

The agentic path had no way to obtain that text, so launch prompts were hand-composed. The VOICE run of 2026-08-07 was sent a project-specific scope paragraph naming the pediatric dataset and #292 — in no prompt file — while its provenance hashed the base file and the header said *"identical for all projects"*.

## The fix is mostly connecting parts that already existed

**`d4d api render-prompt`** emits exactly what a run should receive, for any runtime:

```
$ d4d api render-prompt --project VOICE --label 2026-08-10_x_rep1 \
    --condition generic_v3 --out /tmp/sent.txt
✓ /tmp/sent.txt
# rendered generic_v3 for VOICE / baseline / runtime=Claude Code
# sha256 32619074e100ea1c…  (5244 bytes)
```

The launcher now renders rather than writes, so "generic" versus "generic with a paragraph added" stops depending on who composed the prompt. Commentary goes to stderr so stdout pipes cleanly.

Two things had to become parameters. `RUNTIME` was a module constant, so every rendered header said "Claude API (direct)". And the provider came from `provider_identity()` — the endpoint *this process* is configured against, which is right for a run this process makes and wrong for rendering one another runtime executes: it put `LBL CBORG (proxy to Anthropic)` into a Claude Code header. Both default to the previous values, so **the API path is unchanged**.

## The record now carries what was sent

`prompt_facts` gains a `request` block (sha256 + length of the resolved text), `build_record` takes `prompt_request`, and both paths pass it — the API path from `resolve_prompt(spec)`, the agentic path from `d4d provenance record --prompt-text`. Only the hash is stored; the point is to prove sameness, and a record is not an archive.

**This was a shared defect, not an API-versus-agentic one.** Neither path recorded the resolved request. `prompt_request_hash()` was written for exactly this, with a docstring arguing for itself — *"substitution is exactly what makes the file and the request different objects, so the request needs its own hash"* — and had **no caller**. It does now.

## What this does not do

Nothing yet *checks* that an agentic record's request hash matches what its spec would render. That gate is the point of the exercise, and it needs this field to exist first — it's the natural next PR, and it's what turns "don't intervene" from a rule into something detectable.

## Verification

- 13 tests, including: the runtime and provider appear in the rendered header; no `{PLACEHOLDER}` survives in any of the four generic conditions; a generic render names no GC it wasn't given; stdout is the instruction alone; the digest is of the resolved text, not the file; the two hashes differ; absent stays absent when `--prompt-text` is omitted.
- Full suite: **1378 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)