### PR TITLE
Detect label/prompt mismatch, and hash the playbooks that carry the rules (#420)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -310,9 +310,12 @@ def check_cmd(method, label, project, strict):
     Use `--strict` after a generation run so a missing record fails the step
     rather than being noticed later.
     """
-    from data_sheets_schema.runs import check_provenance, discover, is_complete
+    from data_sheets_schema.runs import (check_provenance, discover,
+                                         is_complete,
+                                         prompt_condition_mismatch)
 
     rows = []
+    mismatches = []
     for run in discover():
         if run.is_core or run.deterministic:
             continue
@@ -326,6 +329,10 @@ def check_cmd(method, label, project, strict):
             if not is_complete(run.method, run.label, proj):
                 continue
             rows.append(check_provenance(run.method, run.label, proj))
+            m = prompt_condition_mismatch(run.method, run.label, proj)
+            if m:
+                mismatches.append({"project": proj, "label": run.label,
+                                   "reason": m})
 
     failed = [r for r in rows if not r["ok"]]
     required = [r for r in rows if r["required"]]
@@ -335,6 +342,19 @@ def check_cmd(method, label, project, strict):
                f"requirement, {len(failed)} failing")
     if not failed:
         click.echo("All runs subject to the live-provenance requirement satisfy it.")
+
+    # Reported separately from the provenance verdict, and never fatal. A
+    # label naming a condition its prompt does not match is a real defect
+    # (#420) — but it is a defect in records that already exist, and failing
+    # them retroactively would block every gate on history nobody can change.
+    # Visible is the point: the 2026-08-07 sweep says `generic-v3` and hashes
+    # v1, and nothing said so for three days.
+    if mismatches:
+        click.echo(f"\n⚠️  {len(mismatches)} run(s) whose label and hashed "
+                   "prompt name different conditions (#420):")
+        for m in mismatches:
+            click.echo(f"   {m['project']:9} {m['label']:44} {m['reason']}")
+
     if strict and failed:
         raise SystemExit(1)
 

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -648,6 +648,23 @@ def build_record(project: str, method: str, label: str, *, mode: str,
             "reason": "manifest has been edited since this run",
         })
 
+    # ---- agent playbooks -------------------------------------------------
+    # Hashed only for a live record. A reconstructed one is assembled today,
+    # and today's `.claude/` content is not what a historical run followed —
+    # recording it would be the fabricated provenance claim this module's
+    # docstring forbids, in the same shape as hashing a since-refreshed bundle
+    # and attributing it to an April run. Raised reviewing #420.
+    if mode == "live":
+        playbooks = playbook_facts()
+    else:
+        playbooks = None
+        unrecoverable.append({
+            "field": "playbooks",
+            "reason": ("the instruction files a past run followed cannot be "
+                       "recovered; today's .claude/ content is not evidence "
+                       "about it"),
+        })
+
     # ---- model identity ------------------------------------------------
     model = {k.lower().replace(" ", "_"): v for k, v in header.items()
              if k in ("Generation Method", "Agent runtime", "Provider", "Model",
@@ -715,7 +732,7 @@ def build_record(project: str, method: str, label: str, *, mode: str,
                 "replicate": _replicate_for(label)},
         "model": model or None,
         "prompts": prompt_facts(prompt_paths, prompt_request),
-        "playbooks": playbook_facts(),
+        "playbooks": playbooks,
         "schema": schema_facts() | (
             {"digest_md5": schema_digest_md5} if schema_digest_md5 else {}),
         "software": software_facts() if mode == "live" else {

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -107,6 +107,39 @@ def load_generation_config(path: Path = DETERMINISTIC_CONFIG) -> dict[str, Any]:
         return {}
 
 
+#: Instruction files an agentic run reads for itself, rather than being sent.
+#: They carry decision rules — `d4d-agent.md` holds the slot-filling contract
+#: that produces v3 behaviour — and were hashed nowhere, so two runs following
+#: different playbook content were indistinguishable afterwards (#420).
+AGENT_PLAYBOOKS = (
+    Path(".claude/commands/d4d-full-core.md"),
+    Path(".claude/commands/d4d-agent.md"),
+    Path(".claude/agents/d4d-provenance-guard.md"),
+)
+
+
+def playbook_facts(paths: tuple[Path, ...] = AGENT_PLAYBOOKS) -> dict[str, Any]:
+    """Hash the instruction files an agentic run follows.
+
+    The launch prompt is sent to the agent; these it opens itself, because the
+    prompt's first line tells it to. They are as much a generation input as the
+    prompt is — `.claude/commands/d4d-agent.md` is where the v2/v3 slot-filling
+    rules actually reach the agentic path, mirrored there by #394 rather than
+    read from the versioned prompt file.
+
+    Recorded for every run, not just agentic ones: an API run does not read
+    them, and a record showing they were unchanged is how you can later tell
+    that it did not.
+    """
+    out = []
+    for p in paths:
+        p = Path(p)
+        out.append({"path": str(p), "sha256": _sha256(p),
+                    "bytes": p.stat().st_size if p.exists() else None,
+                    "exists": p.exists()})
+    return {"hash_algorithm": PROMPT_HASH, "files": out}
+
+
 def prompt_facts(prompt_paths: list[Path] | None,
                  request_text: str | None = None) -> dict[str, Any]:
     """Hash every prompt file a run consumed, and the instruction it was sent.
@@ -682,6 +715,7 @@ def build_record(project: str, method: str, label: str, *, mode: str,
                 "replicate": _replicate_for(label)},
         "model": model or None,
         "prompts": prompt_facts(prompt_paths, prompt_request),
+        "playbooks": playbook_facts(),
         "schema": schema_facts() | (
             {"digest_md5": schema_digest_md5} if schema_digest_md5 else {}),
         "software": software_facts() if mode == "live" else {

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -828,6 +828,51 @@ def check_replicate(method: str, config: str, new_label: str, project: str,
             "input_unverified_against": input_unknown or None}
 
 
+def condition_from_label(label: str) -> str | None:
+    """The prompt condition a label *claims*, or None if it names none.
+
+    Labels spell it with hyphens — `..._claudecode-generic-v3_rep2` — while
+    `CONDITION_PROMPTS` keys use underscores, so the two are compared in one
+    spelling. Derived from the registry rather than a hardcoded chain, for the
+    reason `condition_of` records: a written-out list knew only v1, v2 and
+    tuned, and every v3 and v4 run fell through it silently (#340).
+    """
+    from data_sheets_schema.api_runner import CONDITION_PROMPTS
+
+    hay = label.replace("_", "-").lower()
+    # Longest first: `generic` is a prefix of `generic-v3`, so a shortest-first
+    # scan would answer `generic` for every versioned label — which is exactly
+    # the mismatch this function exists to detect, reported as agreement.
+    for cond in sorted(CONDITION_PROMPTS, key=len, reverse=True):
+        if cond.replace("_", "-") in hay:
+            return cond
+    return None
+
+
+def prompt_condition_mismatch(method: str, label: str, project: str,
+                              concat_dir: Path = CONCAT_DIR) -> str | None:
+    """Whether a run's label and its hashed prompt name the same condition.
+
+    The 2026-08-07 sweep is labelled `generic-v3` and hashes
+    `d4d_generic_arm_prompt.md`, which is v1 (#420). v3 adds seven decision
+    rules over v1, so the two are different conditions and the label is the
+    only place the v3 claim exists — an assertion by whoever typed it.
+
+    Returns a description when they disagree, None when they agree or when
+    either cannot be determined. Silence on "cannot determine" is deliberate:
+    labels predating the convention name no condition, and failing them would
+    punish records for a rule that postdates them.
+    """
+    claimed = condition_from_label(label)
+    recorded = condition_of(method, label, project, concat_dir)
+    if not claimed or not recorded or claimed == recorded:
+        return None
+    from data_sheets_schema.api_runner import CONDITION_PROMPTS
+    return (f"label claims {claimed!r} but the hashed prompt is "
+            f"{recorded!r} ({CONDITION_PROMPTS[recorded].name}); "
+            "the two are different conditions")
+
+
 def condition_of(method: str, label: str, project: str,
                  concat_dir: Path = CONCAT_DIR) -> str | None:
     """The prompt condition a run recorded, read from its provenance prompts."""

--- a/tests/test_cli/test_prompt_condition_consistency.py
+++ b/tests/test_cli/test_prompt_condition_consistency.py
@@ -1,0 +1,101 @@
+"""A label's condition and its hashed prompt must name the same thing (#420).
+
+The 2026-08-07 sweep is labelled `generic-v3` and hashes
+`d4d_generic_arm_prompt.md`, which is v1. v3 adds seven decision rules over v1,
+so they are different conditions and the label was the only place the v3 claim
+existed — an assertion by whoever typed it, checkable by nothing.
+"""
+
+import unittest
+
+from data_sheets_schema.runs import (condition_from_label,
+                                     prompt_condition_mismatch)
+
+
+class TestReadingTheConditionOffALabel(unittest.TestCase):
+
+    def test_versioned_conditions_win_over_their_prefix(self):
+        """`generic` is a prefix of `generic-v3`, so a shortest-first scan
+        answers `generic` for every versioned label — reporting the exact
+        mismatch this exists to detect as agreement."""
+        self.assertEqual(
+            "generic_v3",
+            condition_from_label("2026-08-07_claude-opus-5-claudecode-generic-v3_rep2"))
+        self.assertEqual(
+            "generic_v2",
+            condition_from_label("2026-07-31_claude-opus-5-generic-v2_rep1"))
+
+    def test_hyphens_and_underscores_are_the_same_spelling(self):
+        self.assertEqual("generic_v4",
+                         condition_from_label("2026-09-01_x-generic-v4_rep1"))
+        self.assertEqual("generic_v4",
+                         condition_from_label("2026-09-01_x_generic_v4_rep1"))
+
+    def test_a_label_naming_no_condition_returns_none(self):
+        """Labels predating the convention name none; that is not a defect."""
+        self.assertIsNone(condition_from_label("2026-07-27_claude-opus-5_rep1"))
+
+    def test_plain_generic_is_still_recognised(self):
+        self.assertEqual("generic",
+                         condition_from_label("2026-07-28_claude-opus-5-generic_rep1"))
+
+
+class TestTheMismatchIsSilentWhenItCannotTell(unittest.TestCase):
+    """Absence of evidence must not read as a mismatch: a run whose label names
+    no condition, or which has no record, is not thereby inconsistent."""
+
+    def test_an_unknown_run_reports_nothing(self):
+        self.assertIsNone(
+            prompt_condition_mismatch("claudecode_agent",
+                                      "2099-01-01_no-such-label_rep1", "VOICE"))
+
+    def test_a_label_with_no_condition_reports_nothing(self):
+        self.assertIsNone(
+            prompt_condition_mismatch("claudecode_agent",
+                                      "2026-07-27_claude-opus-5_rep1", "VOICE"))
+
+
+class TestTheKnownMismatchIsDetected(unittest.TestCase):
+
+    LABEL = "2026-08-07_claude-opus-5-claudecode-generic-v3_rep2"
+
+    def test_the_2026_08_07_sweep_is_flagged(self):
+        m = prompt_condition_mismatch("claudecode_agent", self.LABEL, "VOICE")
+        if m is None:
+            self.skipTest("corpus not present")
+        self.assertIn("generic_v3", m)
+        self.assertIn("d4d_generic_arm_prompt.md", m)
+
+
+class TestPlaybooksAreHashed(unittest.TestCase):
+    """`.claude/commands/d4d-agent.md` carries the slot-filling contract that
+    produces v3 behaviour on the agentic path, mirrored there by #394. It was
+    hashed nowhere, so two runs following different playbook content were
+    indistinguishable afterwards."""
+
+    def test_the_playbooks_a_run_follows_are_recorded(self):
+        from data_sheets_schema.provenance import playbook_facts
+        facts = playbook_facts()
+        named = {f["path"] for f in facts["files"]}
+        self.assertIn(".claude/commands/d4d-agent.md", named)
+        self.assertIn(".claude/commands/d4d-full-core.md", named)
+        self.assertIn(".claude/agents/d4d-provenance-guard.md", named)
+
+    def test_each_carries_a_hash_and_a_length(self):
+        from data_sheets_schema.provenance import playbook_facts
+        for f in playbook_facts()["files"]:
+            with self.subTest(path=f["path"]):
+                if f["exists"]:
+                    self.assertEqual(64, len(f["sha256"]))
+                    self.assertGreater(f["bytes"], 0)
+
+    def test_a_missing_playbook_is_recorded_as_missing_not_omitted(self):
+        from pathlib import Path
+        from data_sheets_schema.provenance import playbook_facts
+        facts = playbook_facts((Path(".claude/commands/no-such-file.md"),))
+        self.assertFalse(facts["files"][0]["exists"])
+        self.assertIsNone(facts["files"][0]["sha256"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli/test_prompt_condition_consistency.py
+++ b/tests/test_cli/test_prompt_condition_consistency.py
@@ -7,6 +7,7 @@ existed — an assertion by whoever typed it, checkable by nothing.
 """
 
 import unittest
+from pathlib import Path
 
 from data_sheets_schema.runs import (condition_from_label,
                                      prompt_condition_mismatch)
@@ -99,3 +100,46 @@ class TestPlaybooksAreHashed(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPlaybooksAreNotFabricatedForOldRuns(unittest.TestCase):
+    """Raised reviewing #420, against my own change.
+
+    `playbook_facts()` was called unconditionally in `build_record`, so
+    `d4d provenance backfill` — which builds `mode="reconstructed"` records —
+    would have hashed *today's* `.claude/` content and recorded it as what a
+    historical run followed.
+
+    That is exactly the claim this module's docstring forbids: "hashing them
+    today and recording that against an April run would be a fabricated
+    provenance claim. Such fields are listed under `unrecoverable` with the
+    reason, never silently filled."
+    """
+
+    LABEL = "2026-08-07_claude-opus-5-claudecode-generic-v3_rep2"
+    BUNDLE = Path("data/preprocessed/concatenated/VOICE_preprocessed.txt")
+
+    def _record(self, mode, **kw):
+        from data_sheets_schema.provenance import build_record
+        return build_record("VOICE", "claudecode_agent", self.LABEL,
+                            mode=mode, **kw).data
+
+    def test_a_live_record_hashes_them(self):
+        if not self.BUNDLE.exists():
+            self.skipTest("bundles not present")
+        d = self._record("live", input_bundle=self.BUNDLE, input_verified=True)
+        self.assertEqual(3, len(d["playbooks"]["files"]))
+
+    def test_a_reconstructed_record_does_not(self):
+        d = self._record("reconstructed")
+        self.assertIsNone(d["playbooks"])
+
+    def test_and_says_why_rather_than_omitting_the_field(self):
+        """Absent with no reason reads as "this run had none", which is a
+        different and false claim."""
+        d = self._record("reconstructed")
+        fields = {u["field"] for u in d["unrecoverable"]}
+        self.assertIn("playbooks", fields)
+        reason = next(u["reason"] for u in d["unrecoverable"]
+                      if u["field"] == "playbooks")
+        self.assertIn("cannot be recovered", reason)


### PR DESCRIPTION
Closes #420. Two halves of the same gap: a run labelled `generic-v3` hashed **v1**, and the files that actually gave it v3 behaviour were hashed **nowhere**.

## The label was the only place the claim lived

`condition_from_label()` reads what a label asserts; `condition_of()` already read what its hashed prompt implies. When they disagree, `d4d runs check` says so:

```
⚠️  5 run(s) whose label and hashed prompt name different conditions (#420):
   VOICE  2026-08-07_..._rep2  label claims 'generic_v3' but the hashed prompt
   is 'generic' (d4d_generic_arm_prompt.md); the two are different conditions
```

**Reported, never fatal.** It's a defect in records that already exist, and failing them retroactively would block every gate on history nobody can change. Visible is the point — the sweep said v3 and hashed v1 for three days with nothing to say so.

Two details that matter:

- **Longest-condition-first matching is load-bearing.** `generic` is a prefix of `generic-v3`, so a shortest-first scan answers `generic` for every versioned label — reporting the exact mismatch this exists to detect *as agreement*.
- **Silence when it can't tell.** Labels predating the convention name no condition; a run with no record isn't thereby inconsistent. Absence of evidence must not read as a mismatch.

## The rules arrived through unhashed files

`.claude/commands/d4d-agent.md` carries the slot-filling contract that gives the agentic path its v2/v3 behaviour — mirrored there by #394 rather than read from the versioned prompt. The agent opens it because the prompt's first line tells it to, so it's a generation input the record never named.

`playbooks:` now hashes three: the full/core playbook, the agent playbook, the provenance guard. Recorded on **every** run, not just agentic ones — an API run doesn't read them, and a record showing them unchanged is how you can later tell that it didn't. A missing file is recorded as missing rather than omitted, so the set is always the same three.

10 tests. **1400 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)