### PR TITLE
Build the render gate: check the instruction against the spec that produced it

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -219,6 +219,21 @@ class RunSpec:
     # Anthropic)" into a Claude Code header, a provider that run never touches.
     provider: str | None = None
 
+    def render_spec(self) -> dict[str, Any]:
+        """Everything `resolve_prompt` reads, for the record to keep.
+
+        A record that stores only the resolved hash can say the instruction
+        changed but not what it should have been. Storing the spec beside it
+        lets `verify_request()` re-render and compare, which is what turns
+        "do not intervene" from a rule into something detectable (#420).
+        """
+        return {"condition": self.condition, "arm": self.arm,
+                "manifest_line": self.manifest_line, "run_date": self.run_date,
+                "runtime": self.runtime,
+                "provider": self.provider or provider_identity()["provider"]
+                or PROVIDER,
+                "bundle": str(self.bundle)}
+
     @cached_property
     def instruction(self) -> str:
         """The resolved instruction, rendered once per spec.
@@ -1689,6 +1704,7 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         # record exactly what it sent rather than only what it was built from
         # (#419). `prompt_request_hash` was written for this and had no caller.
         prompt_request=spec.instruction,
+        prompt_request_spec=spec.render_spec(),
         schema_digest_md5=schema_digest.fingerprint(schema_digest.digest_text("Dataset")),
         extra_notes=[
             (f"Generated via {RUNTIME}; temperature {settings['temperature']} "

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -312,10 +312,12 @@ def check_cmd(method, label, project, strict):
     """
     from data_sheets_schema.runs import (check_provenance, discover,
                                          is_complete,
-                                         prompt_condition_mismatch)
+                                         prompt_condition_mismatch,
+                                         verify_request)
 
     rows = []
     mismatches = []
+    requests = []
     for run in discover():
         if run.is_core or run.deterministic:
             continue
@@ -333,6 +335,10 @@ def check_cmd(method, label, project, strict):
             if m:
                 mismatches.append({"project": proj, "label": run.label,
                                    "reason": m})
+            st, why = verify_request(run.method, run.label, proj)
+            if st in ("mismatch", "unverifiable"):
+                requests.append({"project": proj, "label": run.label,
+                                 "status": st, "reason": why})
 
     failed = [r for r in rows if not r["ok"]]
     required = [r for r in rows if r["required"]]
@@ -355,7 +361,21 @@ def check_cmd(method, label, project, strict):
         for m in mismatches:
             click.echo(f"   {m['project']:9} {m['label']:44} {m['reason']}")
 
-    if strict and failed:
+    # The render gate. A mismatch means the instruction sent was not the one
+    # the recorded spec produces — the intervention #419/#422 documented, now
+    # detectable rather than merely discouraged. Fatal under --strict, because
+    # unlike the label mismatch this is a claim about a run being made now:
+    # every record carrying a request hash was written after the field existed.
+    bad_requests = [r for r in requests if r["status"] == "mismatch"]
+    if requests:
+        click.echo(f"\n{len(requests)} run(s) whose recorded instruction could "
+                   "not be confirmed against its spec:")
+        for r in requests:
+            mark = "❌" if r["status"] == "mismatch" else "⚠️ "
+            click.echo(f"   {mark} {r['project']:9} {r['label']:44} "
+                       f"{r['status']}: {r['reason']}")
+
+    if strict and (failed or bad_requests):
         raise SystemExit(1)
 
 

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -141,7 +141,8 @@ def playbook_facts(paths: tuple[Path, ...] = AGENT_PLAYBOOKS) -> dict[str, Any]:
 
 
 def prompt_facts(prompt_paths: list[Path] | None,
-                 request_text: str | None = None) -> dict[str, Any]:
+                 request_text: str | None = None,
+                 request_spec: dict[str, Any] | None = None) -> dict[str, Any]:
     """Hash every prompt file a run consumed, and the instruction it was sent.
 
     The prompt is a generation input as much as the bundle is, and until now it
@@ -182,6 +183,13 @@ def prompt_facts(prompt_paths: list[Path] | None,
             "note": ("the instruction as sent, after substitution; the files "
                      "above are what it was built from"),
         }
+        if request_spec:
+            # Everything `resolve_prompt` reads, so the claim can be re-derived
+            # from the record alone rather than from scattered fields that were
+            # written for other purposes. `manifest_line` and `run_date` are
+            # here because nothing else records them, and both change the
+            # rendered bytes.
+            facts["request"]["spec"] = dict(request_spec)
     return facts
 
 
@@ -587,6 +595,7 @@ def build_record(project: str, method: str, label: str, *, mode: str,
                  concat_dir: Path = CONCAT_DIR,
                  prompt_paths: list[Path] | None = None,
                  prompt_request: str | None = None,
+                 prompt_request_spec: dict[str, Any] | None = None,
                  schema_digest_md5: str | None = None,
                  extra_notes: list[str] | None = None) -> ProvenanceRecord:
     """Assemble a provenance record for one project-run.
@@ -731,7 +740,8 @@ def build_record(project: str, method: str, label: str, *, mode: str,
                 "arm": _arm_for(base),
                 "replicate": _replicate_for(label)},
         "model": model or None,
-        "prompts": prompt_facts(prompt_paths, prompt_request),
+        "prompts": prompt_facts(prompt_paths, prompt_request,
+                                prompt_request_spec),
         "playbooks": playbooks,
         "schema": schema_facts() | (
             {"digest_md5": schema_digest_md5} if schema_digest_md5 else {}),

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -882,9 +882,53 @@ def verify_request(method: str, label: str, project: str,
 
     if got == req["sha256"]:
         return "match", None
+
+    # A differing hash has two causes and they are not the same finding: the
+    # instruction was edited, or the prompt file has moved since the run and
+    # re-rendering no longer reproduces what was sent. The second is ordinary
+    # evolution — v4 exists, v5 will — and reporting it as `mismatch` would make
+    # `--strict` fail every historical record the first time anyone edits a
+    # prompt. So establish which, from the file hashes the record already
+    # carries. Raised reviewing the gate.
+    drifted = _prompt_files_drifted(data)
+    if drifted is True:
+        return "unverifiable", ("the prompt file has changed since this run, so "
+                                "the instruction it produced cannot be "
+                                "re-rendered; the recorded hash still stands, "
+                                "it just cannot be re-derived here")
+    if drifted is None:
+        return "unverifiable", ("the recorded hash and a fresh render differ, "
+                                "but the record does not pin the prompt file, "
+                                "so an edited instruction cannot be told from a "
+                                "changed prompt")
     return "mismatch", (f"recorded {req['sha256'][:12]}… but the spec renders "
-                        f"{got[:12]}…; the instruction sent was not the one "
-                        "this spec produces")
+                        f"{got[:12]}… from an unchanged prompt file; the "
+                        "instruction sent was not the one this spec produces")
+
+
+def _prompt_files_drifted(record: dict) -> bool | None:
+    """Have the prompt files this record hashed changed on disk since?
+
+    True if any differs, False if all still match, None if it cannot be told —
+    no files recorded, none of them present, or an entry without a hash.
+    """
+    from data_sheets_schema.provenance import _sha256
+
+    files = (record.get("prompts") or {}).get("files") or []
+    seen = False
+    for entry in files:
+        if not isinstance(entry, dict):
+            continue
+        path, recorded = entry.get("path"), entry.get("sha256")
+        if not path or not recorded:
+            continue
+        current = _sha256(Path(path))
+        if current is None:
+            continue
+        seen = True
+        if current != recorded:
+            return True
+    return False if seen else None
 
 
 def condition_from_label(label: str) -> str | None:

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -828,6 +828,65 @@ def check_replicate(method: str, config: str, new_label: str, project: str,
             "input_unverified_against": input_unknown or None}
 
 
+def verify_request(method: str, label: str, project: str,
+                   concat_dir: Path = CONCAT_DIR) -> tuple[str, str | None]:
+    """Does the instruction a run recorded match what its spec renders?
+
+    The gate the whole prompt-provenance thread is for. Rendering the
+    instruction (#425) made hand-editing avoidable; this makes it *detectable*,
+    which is the difference between a convention and a control.
+
+    Four outcomes, and the two negative ones are deliberately distinct:
+
+    - ``match``       — re-rendering the recorded spec reproduces the recorded
+      hash. The run received what its spec says it should have.
+    - ``mismatch``    — it does not. Something was edited between rendering and
+      sending, or the prompt file has changed since. Either way the record's
+      condition label no longer describes what was sent.
+    - ``unverifiable`` — the record has a request hash but no spec, or the spec
+      is incomplete. Common for records written before the spec was stored.
+    - ``absent``      — no request hash at all. Every record written before
+      #425, which is all of them.
+
+    `absent` is not `mismatch`. Failing history for a field that postdates it is
+    the same error the live-provenance cutoff exists to avoid.
+    """
+    import yaml as _yaml
+    from data_sheets_schema.provenance import record_path_for
+
+    p = record_path_for(project, method, label, concat_dir)
+    if not p.exists():
+        return "absent", "no provenance record"
+    data = _yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    req = ((data.get("prompts") or {}).get("request")) or {}
+    if not req.get("sha256"):
+        return "absent", None
+    spec_d = req.get("spec")
+    if not isinstance(spec_d, dict) or not spec_d.get("condition"):
+        return "unverifiable", "request hash recorded without the spec that produced it"
+
+    try:
+        import hashlib
+        from data_sheets_schema.api_runner import RunSpec, resolve_prompt
+        spec = RunSpec(
+            project=project, arm=spec_d.get("arm", ""), method=method,
+            bundle=Path(spec_d.get("bundle", "")), label=label,
+            condition=spec_d["condition"],
+            manifest_line=spec_d.get("manifest_line", ""),
+            run_date=spec_d.get("run_date", ""),
+            runtime=spec_d.get("runtime", ""),
+            provider=spec_d.get("provider"))
+        got = hashlib.sha256(resolve_prompt(spec).encode("utf-8")).hexdigest()
+    except Exception as exc:                                 # noqa: BLE001
+        return "unverifiable", f"could not re-render: {exc}"
+
+    if got == req["sha256"]:
+        return "match", None
+    return "mismatch", (f"recorded {req['sha256'][:12]}… but the spec renders "
+                        f"{got[:12]}…; the instruction sent was not the one "
+                        "this spec produces")
+
+
 def condition_from_label(label: str) -> str | None:
     """The prompt condition a label *claims*, or None if it names none.
 

--- a/tests/test_cli/test_render_gate.py
+++ b/tests/test_cli/test_render_gate.py
@@ -1,0 +1,107 @@
+"""The render gate: does a record's instruction match what its spec produces?
+
+Rendering the instruction (#425) made hand-editing avoidable. This makes it
+detectable, which is the difference between a convention and a control — and
+the intervention it catches is the real one: a `CRITICAL SCOPE BOUNDARY`
+paragraph appended to a VOICE launch prompt, naming the project, the pediatric
+dataset and issue #292, while the provenance recorded the base file and the
+header said "identical for all projects" (#419, #422).
+"""
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.api_runner import RunSpec
+from data_sheets_schema.runs import verify_request
+
+BUNDLE = Path("data/preprocessed/concatenated/VOICE_preprocessed.txt")
+
+
+@unittest.skipUnless(BUNDLE.exists(), "bundles not present")
+class TestTheGate(unittest.TestCase):
+    LABEL, METHOD, PROJECT = "2026-08-10_gate_rep1", "claudecode_agent", "VOICE"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.concat = Path(self.tmp.name) / "data/d4d_concatenated"
+        (self.concat / f"{self.METHOD}_core" / self.LABEL).mkdir(parents=True)
+        self.spec = RunSpec(
+            project=self.PROJECT, arm="BASELINE (input documents only)",
+            method=self.METHOD, bundle=BUNDLE, label=self.LABEL,
+            condition="generic_v3", runtime="Claude Code", provider="Anthropic")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write(self, prompts):
+        (self.concat / f"{self.METHOD}_core" / self.LABEL
+         / f"{self.PROJECT}_provenance.yaml").write_text(
+            yaml.safe_dump({"prompts": prompts}, sort_keys=False))
+
+    def _request(self, text, spec=True):
+        r = {"sha256": hashlib.sha256(text.encode()).hexdigest(),
+             "bytes": len(text.encode())}
+        if spec:
+            r["spec"] = self.spec.render_spec()
+        return {"files": [], "request": r}
+
+    def _verify(self):
+        return verify_request(self.METHOD, self.LABEL, self.PROJECT, self.concat)
+
+    def test_an_unedited_rendered_instruction_matches(self):
+        self._write(self._request(self.spec.instruction))
+        self.assertEqual("match", self._verify()[0])
+
+    def test_the_scope_paragraph_that_started_this_is_caught(self):
+        tampered = self.spec.instruction + (
+            "\n\nCRITICAL SCOPE BOUNDARY: this run covers the adult dataset "
+            "ONLY. VOICE_PEDIATRIC is a separate project (#292).\n")
+        self._write(self._request(tampered))
+        status, why = self._verify()
+        self.assertEqual("mismatch", status)
+        self.assertIn("not the one this spec produces", why)
+
+    def test_even_one_character_is_caught(self):
+        self._write(self._request(self.spec.instruction + " "))
+        self.assertEqual("mismatch", self._verify()[0])
+
+    def test_a_hash_without_a_spec_is_unverifiable_not_a_mismatch(self):
+        """The two say different things. "Cannot check" must not be reported as
+        "checked and wrong"."""
+        self._write(self._request(self.spec.instruction, spec=False))
+        status, why = self._verify()
+        self.assertEqual("unverifiable", status)
+        self.assertIn("without the spec", why)
+
+    def test_no_request_hash_is_absent_not_a_mismatch(self):
+        """Every record written before #425. Failing history for a field that
+        postdates it is the error the live-provenance cutoff exists to avoid."""
+        self._write({"files": []})
+        self.assertEqual("absent", self._verify()[0])
+
+    def test_a_missing_record_is_absent(self):
+        self.assertEqual("absent", verify_request(
+            self.METHOD, "2099-01-01_nope_rep1", self.PROJECT, self.concat)[0])
+
+    def test_an_unrenderable_spec_is_unverifiable_not_a_crash(self):
+        p = self._request(self.spec.instruction)
+        p["request"]["spec"] = dict(p["request"]["spec"], condition="no-such")
+        self._write(p)
+        self.assertEqual("unverifiable", self._verify()[0])
+
+    def test_a_changed_condition_in_the_spec_changes_the_verdict(self):
+        """The spec is what the claim is checked against, so editing it is the
+        one way to make a tampered instruction pass — and it changes the
+        condition the record asserts, which the label check then catches."""
+        p = self._request(self.spec.instruction)
+        p["request"]["spec"] = dict(p["request"]["spec"], condition="generic")
+        self._write(p)
+        self.assertEqual("mismatch", self._verify()[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli/test_render_gate.py
+++ b/tests/test_cli/test_render_gate.py
@@ -42,12 +42,17 @@ class TestTheGate(unittest.TestCase):
          / f"{self.PROJECT}_provenance.yaml").write_text(
             yaml.safe_dump({"prompts": prompts}, sort_keys=False))
 
-    def _request(self, text, spec=True):
+    PROMPT = Path("src/download/prompts/d4d_generic_arm_prompt_v3.md")
+
+    def _request(self, text, spec=True, pin=True):
+        from data_sheets_schema.provenance import _sha256
         r = {"sha256": hashlib.sha256(text.encode()).hexdigest(),
              "bytes": len(text.encode())}
         if spec:
             r["spec"] = self.spec.render_spec()
-        return {"files": [], "request": r}
+        files = ([{"path": str(self.PROMPT), "sha256": _sha256(self.PROMPT)}]
+                 if pin else [])
+        return {"files": files, "request": r}
 
     def _verify(self):
         return verify_request(self.METHOD, self.LABEL, self.PROJECT, self.concat)
@@ -101,6 +106,76 @@ class TestTheGate(unittest.TestCase):
         p["request"]["spec"] = dict(p["request"]["spec"], condition="generic")
         self._write(p)
         self.assertEqual("mismatch", self._verify()[0])
+
+
+class TestAChangedPromptFileIsNotATamperedInstruction(unittest.TestCase):
+    """Raised reviewing the gate. A differing hash has two causes and they are
+    not the same finding.
+
+    The instruction may have been edited, or the prompt file may have moved
+    since the run so that re-rendering no longer reproduces what was sent. The
+    second is ordinary evolution — v4 exists, v5 will — and reporting it as
+    `mismatch` would make `--strict` fail every historical record the first time
+    anyone edited a prompt.
+    """
+
+    LABEL, METHOD, PROJECT = "2026-08-10_drift_rep1", "claudecode_agent", "VOICE"
+    PROMPT = Path("src/download/prompts/d4d_generic_arm_prompt_v3.md")
+
+    def setUp(self):
+        if not (BUNDLE.exists() and self.PROMPT.exists()):
+            self.skipTest("corpus not present")
+        self.tmp = tempfile.TemporaryDirectory()
+        self.concat = Path(self.tmp.name) / "data/d4d_concatenated"
+        (self.concat / f"{self.METHOD}_core" / self.LABEL).mkdir(parents=True)
+        self.spec = RunSpec(
+            project=self.PROJECT, arm="BASELINE (input documents only)",
+            method=self.METHOD, bundle=BUNDLE, label=self.LABEL,
+            condition="generic_v3", runtime="Claude Code", provider="Anthropic")
+        self.backup = self.PROMPT.read_bytes()
+
+    def tearDown(self):
+        self.PROMPT.write_bytes(self.backup)
+        self.tmp.cleanup()
+
+    def _write(self, text, pin=True):
+        from data_sheets_schema.provenance import _sha256
+        files = ([{"path": str(self.PROMPT), "sha256": _sha256(self.PROMPT)}]
+                 if pin else [])
+        (self.concat / f"{self.METHOD}_core" / self.LABEL
+         / f"{self.PROJECT}_provenance.yaml").write_text(yaml.safe_dump(
+            {"prompts": {"files": files, "request": {
+                "sha256": hashlib.sha256(text.encode()).hexdigest(),
+                "bytes": len(text.encode()),
+                "spec": self.spec.render_spec()}}}, sort_keys=False))
+
+    def _verify(self):
+        return verify_request(self.METHOD, self.LABEL, self.PROJECT, self.concat)
+
+    def test_an_edited_instruction_is_still_a_mismatch(self):
+        """The discrimination must not be bought by weakening the real case."""
+        self._write(self.spec.instruction + "\nEDITED\n")
+        self.assertEqual("mismatch", self._verify()[0])
+
+    def test_a_changed_prompt_file_is_unverifiable_not_a_mismatch(self):
+        self._write(self.spec.instruction)
+        self.PROMPT.write_bytes(self.backup + b"\n- a rule added later\n")
+        status, why = self._verify()
+        self.assertEqual("unverifiable", status)
+        self.assertIn("prompt file has changed", why)
+
+    def test_without_a_pinned_file_it_will_not_guess(self):
+        """If the record does not pin the prompt, an edited instruction cannot
+        be told from a changed one — say so rather than pick."""
+        self._write(self.spec.instruction + "\nEDITED\n", pin=False)
+        status, why = self._verify()
+        self.assertEqual("unverifiable", status)
+        self.assertIn("does not pin the prompt file", why)
+
+    def test_the_mismatch_message_says_the_file_was_unchanged(self):
+        """So a reader knows the verdict rests on having ruled drift out."""
+        self._write(self.spec.instruction + "\nEDITED\n")
+        self.assertIn("unchanged prompt file", self._verify()[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #429 (#420). Merge that first.

Rendering the instruction (#425) made hand-editing **avoidable**. This makes it **detectable** — the difference between a convention and a control.

## It catches the real thing

Demonstrated against the actual intervention that started this thread, a `CRITICAL SCOPE BOUNDARY` paragraph appended to a VOICE launch prompt naming the project, the pediatric dataset and #292:

```
rendered, unedited      -> match
a scope paragraph added -> mismatch
    recorded ac65085a5807… but the spec renders f959a43f5aea…
```

One added space is caught too.

## The record now carries what it was rendered from

`prompts.request.spec` holds everything `resolve_prompt` reads. Two of those fields — `manifest_line` and `run_date` — were recorded **nowhere**, and both change the rendered bytes, so reconstructing a spec from the record's other blocks would have been guesswork that failed intermittently. Storing it makes the record able to re-derive its own claim.

## Four outcomes, and the negative ones are distinct

| status | meaning | under `--strict` |
|---|---|---|
| `match` | the run received what its spec says it should have | pass |
| `mismatch` | it did not | **fatal** |
| `unverifiable` | a hash with no spec, or a spec that will not render | reported |
| `absent` | no request hash — every record before #425 | silent |

`mismatch` is fatal because every record carrying a request hash was written *after* the field existed, so it is a claim about a run made now. `absent` is silent because failing history for a field that postdates it is the error the live-provenance cutoff exists to avoid. And `unverifiable` is not `mismatch`: "cannot check" and "checked and wrong" say different things.

## The remaining hole, stated

The one way to make a tampered instruction pass is to **edit the recorded spec to match it**. That changes the condition the record asserts, and the label check in #429 catches it. Tested — but it is a two-step consistency argument, not a single lock, and worth knowing.

8 tests. **1408 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
