### PR TITLE
Require new agentic runs to record their instruction (#419); pin the schema a verdict was reached against (#426)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1079,7 +1079,15 @@ def validation_block(spec: RunSpec, problems: list[dict[str, str]],
     for name, path in (("full", spec.full_path), ("core", spec.core_path)):
         artifacts[name] = {"path": str(path),
                            "md5": _md5(path) if path.exists() else None}
+    # The schema the verdict was reached against, not only the record it was
+    # reached on. "Validates" is a claim about a record *against a schema*, and
+    # pinning only the artifacts let a verdict survive a schema change that
+    # would have failed it — `validation_status` re-hashed the record, found it
+    # unchanged, and reported VALID for a check that no longer existed (#426).
+    from data_sheets_schema.provenance import CORE_SCHEMA, FULL_SCHEMA, _sha256
     block: dict[str, Any] = {"passed": not problems, "artifacts": artifacts,
+                             "schema": {"full_sha256": _sha256(FULL_SCHEMA),
+                                        "core_sha256": _sha256(CORE_SCHEMA)},
                              "recorded_by": recorded_by}
     if problems:
         block["problems"] = problems

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -313,6 +313,7 @@ def check_cmd(method, label, project, strict):
     from data_sheets_schema.runs import (check_provenance, discover,
                                          is_complete,
                                          prompt_condition_mismatch,
+                                         requires_request,
                                          verify_request)
 
     rows = []
@@ -336,7 +337,17 @@ def check_cmd(method, label, project, strict):
                 mismatches.append({"project": proj, "label": run.label,
                                    "reason": m})
             st, why = verify_request(run.method, run.label, proj)
-            if st in ("mismatch", "unverifiable"):
+            if st == "absent" and requires_request(run.label, run.method):
+                # Silent before the cutoff, required after it. The gate is
+                # otherwise opt-in by omission: an agentic launcher that simply
+                # does not pass --prompt-text records nothing, and nothing says
+                # so (#419).
+                requests.append({"project": proj, "label": run.label,
+                                 "status": "missing",
+                                 "reason": ("no instruction recorded; render it "
+                                            "with `d4d api render-prompt --out` "
+                                            "and pass `--prompt-text`")})
+            elif st in ("mismatch", "unverifiable"):
                 requests.append({"project": proj, "label": run.label,
                                  "status": st, "reason": why})
 
@@ -366,7 +377,8 @@ def check_cmd(method, label, project, strict):
     # detectable rather than merely discouraged. Fatal under --strict, because
     # unlike the label mismatch this is a claim about a run being made now:
     # every record carrying a request hash was written after the field existed.
-    bad_requests = [r for r in requests if r["status"] == "mismatch"]
+    bad_requests = [r for r in requests
+                    if r["status"] in ("mismatch", "missing")]
     if requests:
         click.echo(f"\n{len(requests)} run(s) whose recorded instruction could "
                    "not be confirmed against its spec:")

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -227,6 +227,21 @@ def validation_status(method: str, label: str, project: str,
             if ok is False:
                 return STALE
 
+    # And a verdict is about a schema. Pinning only the artifacts let one
+    # survive a schema change that would have failed it: the record was
+    # unchanged, so it reported VALID for a check that no longer existed
+    # (#426). Verdicts written before the pin carry no schema block and are
+    # left alone — absent is not stale, and failing them would discard every
+    # verdict in the corpus to enforce a rule that postdates them.
+    from data_sheets_schema.provenance import CORE_SCHEMA, FULL_SCHEMA, _sha256
+    pinned = v.get("schema")
+    if isinstance(pinned, dict):
+        for key, path in (("full_sha256", FULL_SCHEMA),
+                          ("core_sha256", CORE_SCHEMA)):
+            recorded = pinned.get(key)
+            if recorded and _sha256(path) != recorded:
+                return STALE
+
     return VALID if v["passed"] else INVALID
 
 
@@ -356,6 +371,40 @@ LIVE_REQUIRED_FROM = "2026-07-30"
 # from the requirement — an exemption anyone can take by writing one. The
 # unparseable case was already handled; this closes the parseable-nonsense case.
 EARLIEST_PLAUSIBLE_RUN = "2024-01-01"
+
+
+#: From this date an agentic run must record the instruction it was sent, not
+#: only the file it was built from. Dated rather than corpus-wide, for the same
+#: reason `LIVE_REQUIRED_FROM` is: 158 records predate the field, and failing
+#: them retroactively would discard placeable evidence to enforce a rule that
+#: postdates them (#419).
+REQUEST_REQUIRED_FROM = "2026-08-11"
+
+
+def requires_request(label: str, method: str) -> bool:
+    """Whether this run must record the instruction it was sent.
+
+    Agentic methods only. `d4d api run` builds its instruction with
+    `resolve_prompt` and records it in the same process, so it cannot omit one;
+    the agentic path can, because the launcher is a person or another agent and
+    `--prompt-text` is a flag they may simply not pass. That asymmetry is the
+    whole reason this requirement exists on one path and not the other.
+
+    Same date-prefix rule as `requires_live`, including that an unparseable
+    label counts as subject: a run that cannot say when it happened is a new
+    run for this purpose.
+    """
+    # Every agentic layout starts with this prefix — `_crate`, `_crate_only`,
+    # `_healthsheet` and the `_core` companions are all variants of it.
+    if not method.startswith("claudecode_agent"):
+        return False
+    m = re.match(r"(\d{4}-\d{2}-\d{2})", label or "")
+    if not m:
+        return True
+    dated = m.group(1)
+    if dated < EARLIEST_PLAUSIBLE_RUN:
+        return True
+    return dated >= REQUEST_REQUIRED_FROM
 
 
 def requires_live(label: str) -> bool:

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -378,7 +378,12 @@ EARLIEST_PLAUSIBLE_RUN = "2024-01-01"
 #: reason `LIVE_REQUIRED_FROM` is: 158 records predate the field, and failing
 #: them retroactively would discard placeable evidence to enforce a rule that
 #: postdates them (#419).
-REQUEST_REQUIRED_FROM = "2026-08-11"
+#:
+#: Today rather than tomorrow. A cutoff set a day ahead leaves a window in
+#: which a run escapes the rule for no reason, and there was nothing to
+#: protect: no run is labelled 2026-08-10 or later, and none is in flight, so
+#: taking effect immediately fails nothing that exists.
+REQUEST_REQUIRED_FROM = "2026-08-10"
 
 
 def requires_request(label: str, method: str) -> bool:

--- a/tests/test_cli/test_render_gate.py
+++ b/tests/test_cli/test_render_gate.py
@@ -180,3 +180,49 @@ class TestAChangedPromptFileIsNotATamperedInstruction(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestNewAgenticRunsMustRecordTheirInstruction(unittest.TestCase):
+    """#419's remaining piece. The gate was opt-in by omission: an agentic
+    launcher that simply did not pass `--prompt-text` recorded nothing, and
+    nothing said so.
+
+    Dated rather than corpus-wide, for the same reason `LIVE_REQUIRED_FROM` is:
+    158 records predate the field, and failing them retroactively would discard
+    placeable evidence to enforce a rule that postdates them.
+    """
+
+    def test_agentic_runs_after_the_cutoff_are_subject(self):
+        from data_sheets_schema.runs import requires_request
+        self.assertTrue(requires_request("2026-08-11_x_rep1", "claudecode_agent"))
+        self.assertTrue(requires_request("2026-09-01_x_rep1",
+                                         "claudecode_agent_crate"))
+
+    def test_agentic_runs_before_it_are_not(self):
+        from data_sheets_schema.runs import requires_request
+        self.assertFalse(requires_request(
+            "2026-08-07_claude-opus-5-claudecode-generic-v3_rep2",
+            "claudecode_agent"))
+
+    def test_the_api_path_is_exempt_because_it_cannot_omit_one(self):
+        """`d4d api run` builds its instruction with `resolve_prompt` and
+        records it in the same process. The asymmetry is the point."""
+        from data_sheets_schema.runs import requires_request
+        self.assertFalse(requires_request("2026-09-01_x_rep1", "rocrate_mapped"))
+        self.assertFalse(requires_request("2026-09-01_x_rep1",
+                                          "rocrate_static_map"))
+
+    def test_an_undated_label_is_subject(self):
+        """A run that cannot say when it happened is a new run for this
+        purpose; the alternative is an exemption anyone can take by accident."""
+        from data_sheets_schema.runs import requires_request
+        self.assertTrue(requires_request("no-date-here_rep1", "claudecode_agent"))
+
+    def test_the_existing_corpus_is_unaffected(self):
+        """Every record on disk predates the cutoff, so adding the rule must
+        not fail a single one."""
+        from data_sheets_schema.runs import discover, requires_request
+        subject = [r for r in discover()
+                   if not r.is_core and not r.deterministic
+                   and requires_request(r.label, r.method)]
+        self.assertEqual([], [r.label for r in subject])

--- a/tests/test_cli/test_verdict_pins_schema.py
+++ b/tests/test_cli/test_verdict_pins_schema.py
@@ -1,0 +1,100 @@
+"""A validation verdict is a claim about a record *against a schema* (#426).
+
+`validation.artifacts` pinned only the record. So `validation_status()`
+re-hashed the artifacts, found them unchanged, and reported VALID for a record
+that may never have been checked against the schema now in the tree — a schema
+change that tightened a constraint made every prior verdict a claim about a
+check that no longer existed, and nothing noticed.
+
+Raised reviewing #423, which mitigated half of it: a verdict *carried forward*
+across a re-record already compared the record's schema block. A verdict
+written once and never re-recorded had no binding at all.
+"""
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.provenance import CORE_SCHEMA, FULL_SCHEMA, _sha256
+from data_sheets_schema.runs import STALE, VALID, validation_status
+
+
+class TestTheVerdictCarriesItsSchema(unittest.TestCase):
+
+    def test_a_fresh_verdict_pins_both_schemas(self):
+        from data_sheets_schema.api_runner import RunSpec, validation_block
+        spec = RunSpec(project="VOICE", arm="x", method="claudecode_agent",
+                       bundle=Path("bundle.txt"), label="2026-08-11_x_rep1")
+        block = validation_block(spec, [], recorded_by="test")
+        self.assertEqual(_sha256(FULL_SCHEMA), block["schema"]["full_sha256"])
+        self.assertEqual(_sha256(CORE_SCHEMA), block["schema"]["core_sha256"])
+
+
+class TestStatusHonoursThePin(unittest.TestCase):
+    LABEL, METHOD, PROJECT = "2026-08-11_schema_rep1", "claudecode_agent", "VOICE"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.concat = Path(self.tmp.name) / "data/d4d_concatenated"
+        d = self.concat / f"{self.METHOD}_core" / self.LABEL
+        d.mkdir(parents=True)
+        self.artifact = d / f"{self.PROJECT}_d4d_core.yaml"
+        self.artifact.write_text("id: x\n")
+        self.record = d / f"{self.PROJECT}_provenance.yaml"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write(self, schema):
+        v = {"passed": True,
+             "artifacts": {"core": {
+                 "path": str(self.artifact),
+                 "md5": hashlib.md5(self.artifact.read_bytes()).hexdigest()}}}
+        if schema is not None:
+            v["schema"] = schema
+        self.record.write_text(yaml.safe_dump({"validation": v}, sort_keys=False))
+
+    def _status(self):
+        return validation_status(self.METHOD, self.LABEL, self.PROJECT, self.concat)
+
+    def test_an_unchanged_schema_stays_valid(self):
+        self._write({"full_sha256": _sha256(FULL_SCHEMA),
+                     "core_sha256": _sha256(CORE_SCHEMA)})
+        self.assertEqual(VALID, self._status())
+
+    def test_a_moved_full_schema_is_stale(self):
+        self._write({"full_sha256": "0" * 64,
+                     "core_sha256": _sha256(CORE_SCHEMA)})
+        self.assertEqual(STALE, self._status())
+
+    def test_a_moved_core_schema_is_stale(self):
+        self._write({"full_sha256": _sha256(FULL_SCHEMA),
+                     "core_sha256": "0" * 64})
+        self.assertEqual(STALE, self._status())
+
+    def test_a_verdict_without_a_pin_is_left_alone(self):
+        """Absent is not stale. Every verdict in the corpus predates the pin,
+        and failing them would discard the lot to enforce a rule that postdates
+        them — the same reasoning as the live-provenance cutoff."""
+        self._write(None)
+        self.assertEqual(VALID, self._status())
+
+    def test_a_partial_pin_checks_what_it_has(self):
+        """A block naming one schema and not the other is still evidence about
+        the one it names."""
+        self._write({"full_sha256": "0" * 64})
+        self.assertEqual(STALE, self._status())
+
+    def test_an_edited_artifact_is_still_stale(self):
+        """The pin must not displace the check it was added beside."""
+        self._write({"full_sha256": _sha256(FULL_SCHEMA),
+                     "core_sha256": _sha256(CORE_SCHEMA)})
+        self.artifact.write_text("id: x\n# edited after validating\n")
+        self.assertEqual(STALE, self._status())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #419. Closes #426. Two claims a record was making without evidence.

## #419 — the gate was opt-in by omission

#425 gave the agentic path a way to record the instruction it was sent; #430 checks it when present. Neither made it **required** — a launcher that simply didn't pass `--prompt-text` recorded nothing, and nothing said so. A control you can skip by not typing a flag is a convention with extra steps.

`requires_request()` makes it mandatory for agentic methods, using the same date-prefix rule as `requires_live` — including that an unparseable label counts as subject, because a run that cannot say when it happened is a new run for this purpose. `d4d runs check` reports a missing instruction and `--strict` fails on it.

**The API path is exempt, and the asymmetry is the point:** `d4d api run` builds its instruction with `resolve_prompt` and records it in the same process, so it cannot omit one. Only the agentic path has a launcher that might.

Dated rather than corpus-wide, for the reason the live-provenance cutoff is: 158 records predate the field. A test asserts **no existing run is subject**, so the rule fails nothing that already exists.

## #426 — a verdict did not name its schema

"Validates" is a claim about a record *against a schema*, and `validation.artifacts` pinned only the record. So `validation_status()` re-hashed the artifacts, found them unchanged, and reported VALID for a record that may never have been checked against the schema now in the tree.

`validation_block()` now records `schema.full_sha256` / `core_sha256`; `validation_status()` returns STALE when either moves — the same treatment an edited artifact already gets, and for the same reason: "validated, then the schema moved" and "never checked" are different problems that both mean *do not rely on it*.

#423 mitigated half of this by comparing the schema when *carrying* a verdict across a re-record. A verdict written once and never re-recorded had no binding at all; that's the half this closes.

Verdicts written before the pin are left alone — absent is not stale. A partial pin is still checked against what it names.

## Review found one thing, fixed here

The cutoff was set to **tomorrow**, leaving a one-day window in which a run escapes the rule for no reason. Nothing is labelled 2026-08-10 or later and nothing is in flight, so it now takes effect today and still fails nothing.

## Filed: #433

Every verdict currently in the corpus keeps **no** schema pin, because `d4d runs validate` skips already-VALID runs without `--recheck` — correct, but it means "VALID" now means two things depending on when it was written, and nothing reports how many are unpinned.

## Verification

- End to end on a real record: `d4d runs validate --recheck` writes the pin, status stays `valid`, `data/` restored clean.
- 13 tests, including that an edited artifact is **still** STALE — the pin must not displace the check it was added beside.
- `d4d runs check --strict`: 158 runs, 0 failing.
- **1427 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
