### PR TITLE
Pin each condition's prompt text, so an edit made before rendering is a finding (#432)

### DIFF
--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -442,7 +442,9 @@ After Phase 4 validates, emit a machine-readable provenance record:
 ```bash
 poetry run d4d provenance record \
   --project {PROJECT} --method {METHOD} --label {VERSION} \
-  --input-bundle {EXACT INPUT BUNDLE PATH}
+  --input-bundle {EXACT INPUT BUNDLE PATH} \
+  --prompt {EACH PROMPT FILE THE RUN CONSUMED} \
+  --prompt-text {THE INSTRUCTION AS SENT}
 ```
 
 Writes `{METHOD}_core/{VERSION}/{PROJECT}_provenance.yaml` capturing schema
@@ -454,6 +456,24 @@ if the input bundle is unreadable, because a run that cannot identify its own
 input has not produced reproducible output. Do not substitute a reconstructed
 record — `d4d provenance backfill` exists only for runs that predate this step,
 and it marks what it cannot recover rather than filling it in.
+
+**The prompt is an input like the bundle.** `--prompt` may repeat; pass every
+file the condition is built from. `--prompt-text` takes the instruction as
+actually sent — render it with `d4d api render-prompt --condition {CONDITION}
+--out <file>` rather than retyping it, so the text and its hash come from the
+same place. From 2026-08-10 a run without a recorded instruction fails
+`d4d runs check --strict` (#419): the gate was otherwise opt-in by omission,
+since a launcher that simply passes neither flag records nothing and nothing
+says so.
+
+Recording the file is not the same as vouching for it. A paragraph edited into
+a prompt file *before* rendering re-renders to itself, so the render gate
+reports `match` about an instruction nobody published (#432). What catches that
+is the canonical pin: `d4d api prompts check` compares each condition's prompt
+against the hash this repo declared for it, and `d4d runs check` compares the
+hash in the record. If either reports `uncanonical`, the run was made under
+text that is not a published version of its condition — say so in the
+reconciliation report rather than pinning the edit to make the check pass.
 
 ## Completion criteria (per project)
 
@@ -469,7 +489,8 @@ and it marks what it cannot recover rather than filling it in.
 - The provenance audit confirms that no older full/core YAML was used.
 - The core header contains `Phase 4 reconciliation: completed`.
 - The Phase 3/4 reconciliation report is present.
-- The live provenance record is present and its `record_mode` is `live`.
+- The live provenance record is present and its `record_mode` is `live`, and it
+  names both the prompt files and the instruction as sent.
 - `d4d runs check --strict` passes for the run. **Recording provenance is not the
   same as recording it correctly.** This path writes provenance as a step
   separate from writing the artifacts, so a record can pin a state the files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,31 @@ make gen-d4d-html
 make d4d-pipeline-{individual|concatenated|full}-gpt5
 ```
 
+## Canonical Prompt Registry
+
+Each condition's prompt files are pinned by hash in
+`src/download/prompts/canonical_hashes.yaml`.
+
+```bash
+d4d api prompts check --strict          # working tree vs the pins (CI gate)
+d4d api prompts pin --file <path> --reason '<why this is the text>'
+```
+
+**Editing a prompt file without rotating its pin fails
+`tests/test_prompt_registry.py` and blocks `d4d api run`.** That is deliberate:
+the edit and the declaration that it is now the condition's canonical text are
+two acts, and the second is small enough for a reviewer to read.
+
+Why it exists (#432): the render gate re-renders a record's spec and compares it
+to the recorded instruction, which catches text edited *after* rendering. Text
+edited into the prompt file *before* rendering re-renders to itself and reports
+`match`. The pin is the only value the file can be checked against. `d4d runs
+check` reports `uncanonical` — fatal under `--strict` — when a record hashes a
+prompt that was never pinned; `superseded` (pinned once, since rotated) and
+`unpinned` are reported and not failed.
+
+This is not tamper-proofing. Whoever can edit a prompt can rotate its pin.
+
 ## Model Reasoning Capture
 
 Each API generation phase and each evidence-scoring judgement writes a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,14 +349,19 @@ d4d api prompts pin --file <path> --reason '<why this is the text>'
 **Editing a prompt file without rotating its pin fails
 `tests/test_prompt_registry.py` and blocks `d4d api run`.** That is deliberate:
 the edit and the declaration that it is now the condition's canonical text are
-two acts, and the second is small enough for a reviewer to read.
+two acts, and the second is small enough for a reviewer to read. Commit the
+prompt edit before pinning it — a pin records the commit it was taken at and
+offers `git show <commit>:<path>` as the audit route, so pinning uncommitted
+bytes is refused.
 
 Why it exists (#432): the render gate re-renders a record's spec and compares it
 to the recorded instruction, which catches text edited *after* rendering. Text
 edited into the prompt file *before* rendering re-renders to itself and reports
 `match`. The pin is the only value the file can be checked against. `d4d runs
-check` reports `uncanonical` — fatal under `--strict` — when a record hashes a
-prompt that was never pinned; `superseded` (pinned once, since rotated) and
+check` is fatal under `--strict` on `uncanonical` (a prompt that was never
+pinned, or a labelled condition whose record hashes no condition prompt at all —
+the `cp`-to-another-path bypass, #436) and on `missing` (a pinned path the
+record hashed nothing for). `superseded` (pinned once, since rotated) and
 `unpinned` are reported and not failed.
 
 This is not tamper-proofing. Whoever can edit a prompt can rotate its pin.

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -474,7 +474,8 @@ Acted on the same day:
 | the launch prompt was typed, not rendered | #419, #422 | **addressed** (#425) |
 | label says `generic-v3`, provenance hashes v1 | #420 | open |
 | `verification_url` still injected; 0 values depend on it | #427 | open, cosmetic |
-| a verdict does not pin the schema it was reached against | #426 | open |
+| a verdict does not pin the schema it was reached against | #426 | **fixed** |
+| the render gate cannot see an edit made *before* rendering | #432 | **closed** |
 
 **What #424 caught.** 4 values in the canonical sweep were grounded only by a
 curation note, all the same DOI — `10.60775/fairhub.4`, cited by AI_READI
@@ -483,12 +484,18 @@ document**; the manifest mentions it only to say it was *not* captured. All five
 bundle hashes changed; `source_manifest.yaml: bundle_hash_history` maps
 before/after, because 55 provenance records reference the old ones.
 
-**What is left, and it is the load-bearing one.** Rendering makes intervention
-*avoidable*, not *impossible* — nothing yet checks that an agentic record's
-`prompts.request` hash matches what its spec would render. That gate is what
-turns "do not intervene" from a rule into something detectable, and it is cheap
-now the field exists. `.claude/` playbooks still carry decision rules and are
-still hashed nowhere (#420).
+**What was left, and is now built.** Rendering made intervention *avoidable*;
+the render gate (#429) made an instruction edited after rendering *detectable*;
+the canonical prompt registry (#432) closes the remaining direction — an edit
+made to the prompt file *before* rendering, which re-renders to itself and
+reports `match`. Three comparisons now: the recorded instruction, a fresh
+render, and the hash this repo declared for that condition
+(`src/download/prompts/canonical_hashes.yaml`).
+
+The registry is not tamper-proofing and does not claim to be — anyone who can
+edit a prompt can rotate its pin. What it buys is that the two are separate,
+deliberate acts, and a rotation leaves a dated line with a stated reason in a
+small file, rather than a paragraph inside a 200-line prompt.
 
 ---
 

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -369,7 +369,8 @@ def prompts_check_cmd(strict):
     bad = [r for r in rows if r["status"] != pr.CANONICAL]
     for r in rows:
         mark = {"canonical": "✓", "superseded": "⚠️ ",
-                "uncanonical": "❌", "unpinned": "❌"}[r["status"]]
+                "uncanonical": "❌", "unpinned": "❌",
+                "missing": "❌"}[r["status"]]
         click.echo(f" {mark} {r['status']:12} {r['path']}")
         if r["reason"]:
             click.echo(f"       {r['reason']}")

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -57,6 +57,30 @@ def _spec(project, arm, label, condition, bundle=None, out_dir=None,
                    out_dir=Path(out_dir) if out_dir else None, **kw)
 
 
+def _require_canonical_prompts(spec):
+    """Refuse to spend money under a prompt file nobody declared (#432).
+
+    Checked before the cost confirmation, because the cheapest place to catch
+    an undeclared prompt is before it has produced a record that then has to be
+    argued about. There is no override flag: declaring the text is one command
+    and leaves the dated line that makes the condition auditable, which is the
+    entire mechanism. A new prompt version is *meant* to stop here once.
+    """
+    from data_sheets_schema import prompt_registry as pr
+
+    bad = [(p, pr.disk_status(p)) for p in spec.prompt_files]
+    bad = [(p, why) for p, (st, why) in bad if st != pr.CANONICAL]
+    if not bad:
+        return
+    lines = "\n".join(f"   {pr.normalise(p)}: {why}" for p, why in bad)
+    raise click.ClickException(
+        f"prompt file(s) not at their canonical hash for condition "
+        f"{spec.condition!r}:\n{lines}\n"
+        "Declare the text with `d4d api prompts pin --file <path> --reason "
+        "'<why>'`, then re-run. A run under an undeclared prompt cannot be "
+        "placed in the study.")
+
+
 def _require_bundle(spec, project, bundle):
     if bundle is None and project not in PROJECTS:
         raise click.ClickException(
@@ -106,11 +130,24 @@ def render_prompt_cmd(project, arm, label, condition, bundle, runtime,
     the two different objects, which is why `prompt_request_hash` exists.
     """
     import hashlib
+    from data_sheets_schema import prompt_registry as pr
     from data_sheets_schema.api_runner import resolve_prompt
 
     spec = _spec(project, arm, label, condition, bundle,
                  runtime=runtime, provider=provider)
     _require_bundle(spec, project, bundle)
+
+    # Warned, not refused. Rendering is free and reading the text of a draft
+    # condition is a legitimate reason to be here; `d4d api run` refuses and
+    # `d4d runs check` fails, so the fatal gates sit where a claim is made
+    # rather than where text is inspected. But this is the agentic path's
+    # launch point, and an edit made before rendering is invisible downstream
+    # by construction (#432) — so it has to be said here.
+    for f in spec.prompt_files:
+        st, why = pr.disk_status(f)
+        if st != pr.CANONICAL:
+            click.echo(f"# ⚠️  {st}: {why}", err=True)
+
     text = resolve_prompt(spec)
     digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
 
@@ -182,6 +219,7 @@ def run_cmd(project, arm, label, condition, bundle, out_dir, yes):
     from data_sheets_schema.api_runner import execute, plan
     spec = _spec(project, arm, label, condition, bundle, out_dir)
     _require_bundle(spec, project, bundle)
+    _require_canonical_prompts(spec)
     if spec.full_path.exists():
         raise click.ClickException(
             f"{spec.full_path} already exists; a run label is never reused")
@@ -247,6 +285,7 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
             if not s.bundle.exists():
                 raise click.ClickException(
                     f"bundle not found for {p}: {s.bundle}")
+            _require_canonical_prompts(s)
             specs.append(s)
 
     plans = [plan(s) for s in specs]
@@ -302,3 +341,66 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
         click.echo(f"   {p} {lbl}: {err[:90]}")
     if failed:
         sys.exit(1)
+
+
+@api.group("prompts")
+def prompts_group():
+    """The canonical prompt registry — what each condition's text is (#432)."""
+
+
+@prompts_group.command("check")
+@click.option("--strict", is_flag=True,
+              help="Exit non-zero if any prompt file differs from its pin.")
+def prompts_check_cmd(strict):
+    """Check the prompt files on disk against their canonical hashes.
+
+    The repo-state half of #432. `d4d runs check` asks the same question of
+    records; this asks it of the working tree, so an undeclared edit is caught
+    before it produces a run rather than after.
+    """
+    from data_sheets_schema import prompt_registry as pr
+
+    rows = pr.check_disk()
+    # Every state other than `canonical` fails here, `unpinned` included. The
+    # record gate treats an unpinned path as absence of evidence, because a
+    # record may legitimately name a prompt the registry does not cover; the
+    # working tree has no such excuse. A condition prompt nobody pinned is
+    # text that was never declared, which is the hole (#432), not a gap in it.
+    bad = [r for r in rows if r["status"] != pr.CANONICAL]
+    for r in rows:
+        mark = {"canonical": "✓", "superseded": "⚠️ ",
+                "uncanonical": "❌", "unpinned": "❌"}[r["status"]]
+        click.echo(f" {mark} {r['status']:12} {r['path']}")
+        if r["reason"]:
+            click.echo(f"       {r['reason']}")
+    click.echo(f"\n{len(rows)} prompt file(s), {len(bad)} not at their pin")
+    if bad:
+        click.echo("Declare them with `d4d api prompts pin --file <path> "
+                   "--reason '<why this is the condition's text>'`. Editing a "
+                   "prompt without rotating its pin, or adding one without a "
+                   "pin at all, is what this command is for.")
+    if strict and bad:
+        sys.exit(1)
+
+
+@prompts_group.command("pin")
+@click.option("--file", "path", required=True,
+              type=click.Path(exists=True, dir_okay=False))
+@click.option("--reason", required=True,
+              help="Why this text is now canonical for its condition.")
+def prompts_pin_cmd(path, reason):
+    """Declare a prompt file's current bytes canonical, retiring the old pin.
+
+    The previous hash is kept, not dropped: records written under it stay
+    `superseded` rather than turning `uncanonical` the moment a prompt moves.
+    """
+    from data_sheets_schema import prompt_registry as pr
+
+    res = pr.pin(path, reason)
+    if res["status"] == "unchanged":
+        click.echo(f"already pinned at {res['sha256'][:12]}… — nothing to do")
+        return
+    click.echo(f"✓ {res['path']} pinned at {res['sha256'][:12]}…")
+    if res.get("previous"):
+        click.echo(f"  previous {res['previous'][:12]}… kept as superseded, so "
+                   "runs made under it still verify")

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -49,6 +49,19 @@ def record(project, method, label, input_bundle, prompts, prompt_text):
                                        if prompt_text else None))
     out = rec.write(record_path_for(project, method, label))
     click.echo(f"✓ {out}")
+
+    # Say it here, but do not refuse. Recording an uncanonical prompt is the
+    # honest act — it is what puts the evidence in the record for `d4d runs
+    # check` to fail on (#432). Refusing would reward not recording at all,
+    # which is the state this whole thread has been climbing out of.
+    from data_sheets_schema import prompt_registry as _pr
+    for p in prompts:
+        st, why = _pr.disk_status(p)
+        if st != _pr.CANONICAL:
+            click.echo(f"  ⚠️  prompt {st}: {why}")
+            click.echo("      This is recorded, and `d4d runs check` reports "
+                       "it. If the text is intentional, declare it with "
+                       "`d4d api prompts pin`.")
     # Say what happened to any prior verdict. Re-recording used to delete it
     # silently and the run then failed `--strict` with "nothing to verify",
     # while this command printed a tick and exited 0 (#396).

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -310,7 +310,8 @@ def check_cmd(method, label, project, strict):
     Use `--strict` after a generation run so a missing record fails the step
     rather than being noticed later.
     """
-    from data_sheets_schema.runs import (check_provenance, discover,
+    from data_sheets_schema.runs import (canonical_prompt_status,
+                                         check_provenance, discover,
                                          is_complete,
                                          prompt_condition_mismatch,
                                          requires_request,
@@ -319,6 +320,7 @@ def check_cmd(method, label, project, strict):
     rows = []
     mismatches = []
     requests = []
+    uncanonical = []
     for run in discover():
         if run.is_core or run.deterministic:
             continue
@@ -350,6 +352,15 @@ def check_cmd(method, label, project, strict):
             elif st in ("mismatch", "unverifiable"):
                 requests.append({"project": proj, "label": run.label,
                                  "status": st, "reason": why})
+
+            # The third comparison (#432). A prompt file edited before the
+            # instruction was rendered re-renders to itself, so `verify_request`
+            # says `match` and means it. Only the pin can tell that the file was
+            # not a published version of its condition.
+            cst, cwhy = canonical_prompt_status(run.method, run.label, proj)
+            if cst in ("uncanonical", "unpinned", "superseded"):
+                uncanonical.append({"project": proj, "label": run.label,
+                                    "status": cst, "reason": cwhy})
 
     failed = [r for r in rows if not r["ok"]]
     required = [r for r in rows if r["required"]]
@@ -387,7 +398,20 @@ def check_cmd(method, label, project, strict):
             click.echo(f"   {mark} {r['project']:9} {r['label']:44} "
                        f"{r['status']}: {r['reason']}")
 
-    if strict and (failed or bad_requests):
+    # Fatal only for `uncanonical`: a run whose prompt file was never a
+    # published version of its condition. `superseded` is a condition that has
+    # moved on since, `unpinned` is a file the registry does not cover — both
+    # are worth seeing and neither is a defect in the run.
+    never_pinned = [r for r in uncanonical if r["status"] == "uncanonical"]
+    if uncanonical:
+        click.echo(f"\n{len(uncanonical)} run(s) whose prompt files are not the "
+                   "current canonical text of their condition (#432):")
+        for r in uncanonical:
+            mark = "❌" if r["status"] == "uncanonical" else "⚠️ "
+            click.echo(f"   {mark} {r['project']:9} {r['label']:44} "
+                       f"{r['status']}: {r['reason']}")
+
+    if strict and (failed or bad_requests or never_pinned):
         raise SystemExit(1)
 
 

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -358,7 +358,8 @@ def check_cmd(method, label, project, strict):
             # says `match` and means it. Only the pin can tell that the file was
             # not a published version of its condition.
             cst, cwhy = canonical_prompt_status(run.method, run.label, proj)
-            if cst in ("uncanonical", "unpinned", "superseded"):
+            if cst in ("uncanonical", "missing", "unpinned",
+                       "superseded"):
                 uncanonical.append({"project": proj, "label": run.label,
                                     "status": cst, "reason": cwhy})
 
@@ -398,16 +399,19 @@ def check_cmd(method, label, project, strict):
             click.echo(f"   {mark} {r['project']:9} {r['label']:44} "
                        f"{r['status']}: {r['reason']}")
 
-    # Fatal only for `uncanonical`: a run whose prompt file was never a
-    # published version of its condition. `superseded` is a condition that has
-    # moved on since, `unpinned` is a file the registry does not cover — both
-    # are worth seeing and neither is a defect in the run.
-    never_pinned = [r for r in uncanonical if r["status"] == "uncanonical"]
+    # Fatal for `uncanonical` — a run whose prompt was never a published
+    # version of its condition — and for `missing`, a run that named a pinned
+    # prompt file and hashed nothing for it. `superseded` is a condition that
+    # has moved on since, `unpinned` is a file the registry does not cover;
+    # both are worth seeing and neither is a defect in the run.
+    never_pinned = [r for r in uncanonical
+                    if r["status"] in ("uncanonical", "missing")]
     if uncanonical:
         click.echo(f"\n{len(uncanonical)} run(s) whose prompt files are not the "
                    "current canonical text of their condition (#432):")
         for r in uncanonical:
-            mark = "❌" if r["status"] == "uncanonical" else "⚠️ "
+            mark = ("❌" if r["status"] in ("uncanonical", "missing")
+                    else "⚠️ ")
             click.echo(f"   {mark} {r['project']:9} {r['label']:44} "
                        f"{r['status']}: {r['reason']}")
 

--- a/src/data_sheets_schema/prompt_registry.py
+++ b/src/data_sheets_schema/prompt_registry.py
@@ -17,9 +17,13 @@ the vocabulary to say which of four things a hash is.
   study's whole point is that they do so visibly and in order.
 - ``uncanonical`` — a hash that was never pinned. The finding: whatever
   produced it was not a published version of its condition.
-- ``unpinned``    — no pin exists for that path. Reported, never failed; the
-  registry is not required to be exhaustive and a missing pin is an absence of
-  evidence.
+- ``missing``     — pinned, but there are no bytes to check: the file has been
+  deleted, or a record named it and hashed nothing. Evidence of an absence, as
+  against the next one (#437).
+- ``unpinned``    — no pin exists for that path. Reported, never failed on the
+  record side; the registry is not required to be exhaustive and a missing pin
+  is an absence of evidence. On the working-tree side it *is* failed, because a
+  condition prompt nobody pinned is text that was never declared.
 
 **What this does not do.** The pin lives in the repo, so anyone who can edit a
 prompt file can also rotate its pin. This is not tamper-proofing and nothing
@@ -47,6 +51,10 @@ CANONICAL = "canonical"
 SUPERSEDED = "superseded"
 UNCANONICAL = "uncanonical"
 UNPINNED = "unpinned"
+# Pinned, but there are no bytes to check: the file has been deleted, or the
+# record named it and hashed nothing. Distinct from `unpinned`, which is an
+# absence of evidence — this is evidence of an absence (#437).
+MISSING = "missing"
 
 
 def sha256_of(path: Path) -> str | None:
@@ -102,7 +110,9 @@ def status_of_hash(path: str | Path, sha: str | None,
     if entry is None:
         return UNPINNED, f"no canonical hash pinned for {normalise(path)}"
     if not sha:
-        return UNPINNED, "no hash recorded to compare"
+        return MISSING, (f"{normalise(path)} is pinned, but no hash was "
+                         "recorded for it — the run named a prompt file it did "
+                         "not read")
     if sha == entry.get("sha256"):
         return CANONICAL, None
     for old in entry.get("superseded") or []:
@@ -128,7 +138,13 @@ def disk_status(path: str | Path,
     """
     sha = sha256_of(Path(path))
     if sha is None:
-        return UNPINNED, f"{normalise(path)} is not on disk"
+        # A pinned file that has been deleted is not an absence of evidence:
+        # the condition's declared text is gone, which is a stronger finding
+        # than never having pinned it (#437).
+        if entry_for(path, registry) is not None:
+            return MISSING, (f"{normalise(path)} is pinned but not on disk; "
+                             "the declared text of its condition is gone")
+        return UNPINNED, f"{normalise(path)} is neither pinned nor on disk"
     return status_of_hash(path, sha, registry)
 
 
@@ -165,13 +181,31 @@ def check_disk(paths: list[Path] | None = None,
     return rows
 
 
-def _head_commit() -> str | None:
+def _git(*args: str) -> str | None:
+    """Run a git command, or None if git cannot answer (not a repo, no git)."""
     try:
-        out = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True,
-                             text=True, timeout=10)
+        out = subprocess.run(["git", *args], capture_output=True, text=True,
+                             timeout=10)
     except (OSError, subprocess.SubprocessError):
         return None
-    return out.stdout.strip() or None if out.returncode == 0 else None
+    return out.stdout if out.returncode == 0 else None
+
+
+def _head_commit() -> str | None:
+    out = _git("rev-parse", "HEAD")
+    return (out or "").strip() or None
+
+
+def _is_dirty(path: Path) -> bool:
+    """Does the working tree differ from HEAD for this file?
+
+    `pinned_at_commit` is offered as the audit route — `git show <commit>:<path>`
+    should reproduce the pinned bytes. Pinning an uncommitted edit would name a
+    commit that hashes to something else, and produce the wrong answer for
+    exactly the case the registry exists to catch (#438).
+    """
+    out = _git("status", "--porcelain", "--", str(path))
+    return bool((out or "").strip())
 
 
 def pin(path: str | Path, reason: str, registry: Path = REGISTRY,
@@ -193,6 +227,13 @@ def pin(path: str | Path, reason: str, registry: Path = REGISTRY,
     sha = sha256_of(p)
     if sha is None:
         raise FileNotFoundError(f"{p} is not on disk; nothing to pin")
+    if _is_dirty(p):
+        raise ValueError(
+            f"{p} has uncommitted changes. Commit the prompt first, then pin "
+            "it: the pin records the commit it was taken at and offers "
+            "`git show <commit>:<path>` as the way to audit it, which is false "
+            "for bytes that are not in history (#438). A canonical text that "
+            "cannot be found in the repository's history is not canonical.")
     today = today or _dt.date.today().isoformat()
 
     data = load(registry)

--- a/src/data_sheets_schema/prompt_registry.py
+++ b/src/data_sheets_schema/prompt_registry.py
@@ -1,0 +1,238 @@
+"""Canonical hashes for the prompt files each condition is defined by (#432).
+
+The render gate (#425, #430) proves a run's recorded instruction is what its
+spec renders *from the files as they stand now*. That catches an instruction
+edited after rendering. It cannot catch one edited **before**: add a paragraph
+to `d4d_generic_arm_prompt_v3.md`, render, run, record — and re-rendering reads
+the same edited file and reports `match`. The record is self-consistent and the
+condition label is a lie.
+
+What is missing is a value the prompt file can be checked *against*, rather than
+only against itself. That is all this module is: a versioned pin per file, and
+the vocabulary to say which of four things a hash is.
+
+- ``canonical``   — the pinned hash for that file.
+- ``superseded``  — a hash this file used to be pinned at. A run made under the
+  prompt of the day is not a defect; conditions are allowed to evolve, and the
+  study's whole point is that they do so visibly and in order.
+- ``uncanonical`` — a hash that was never pinned. The finding: whatever
+  produced it was not a published version of its condition.
+- ``unpinned``    — no pin exists for that path. Reported, never failed; the
+  registry is not required to be exhaustive and a missing pin is an absence of
+  evidence.
+
+**What this does not do.** The pin lives in the repo, so anyone who can edit a
+prompt file can also rotate its pin. This is not tamper-proofing and nothing
+here should be read as claiming it is. What it buys is that the two are now
+*separate, deliberate acts*, and rotating a pin leaves a dated line in a small
+file that a reviewer reads, rather than a paragraph inside a 200-line prompt
+that they do not. `pinned_at_commit` makes each pin re-derivable with
+`git show <commit>:<path>`, so the registry can be audited against history
+instead of trusted.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REGISTRY = Path("src/download/prompts/canonical_hashes.yaml")
+
+CANONICAL = "canonical"
+SUPERSEDED = "superseded"
+UNCANONICAL = "uncanonical"
+UNPINNED = "unpinned"
+
+
+def sha256_of(path: Path) -> str | None:
+    if not path or not Path(path).exists():
+        return None
+    h = hashlib.sha256()
+    with Path(path).open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def normalise(path: str | Path) -> str:
+    """Registry key for a path: repo-relative, posix.
+
+    Records store the path the launcher passed, which is repo-relative in every
+    real run and absolute in tests. Keying on the basename instead would be
+    simpler and wrong — two files can share a name, and the pin would then
+    vouch for the wrong one.
+    """
+    p = Path(path)
+    if p.is_absolute():
+        try:
+            p = p.relative_to(Path.cwd())
+        except ValueError:
+            return p.as_posix()
+    return p.as_posix()
+
+
+def load(registry: Path = REGISTRY) -> dict[str, Any]:
+    if not Path(registry).exists():
+        return {"hash_algorithm": "sha256", "files": {}}
+    return yaml.safe_load(Path(registry).read_text(encoding="utf-8")) or {
+        "hash_algorithm": "sha256", "files": {}}
+
+
+def pins(registry: Path = REGISTRY) -> dict[str, dict]:
+    return (load(registry).get("files") or {})
+
+
+def entry_for(path: str | Path, registry: Path = REGISTRY) -> dict | None:
+    return pins(registry).get(normalise(path))
+
+
+def status_of_hash(path: str | Path, sha: str | None,
+                   registry: Path = REGISTRY) -> tuple[str, str | None]:
+    """What a *recorded* hash is, relative to the pin for its file.
+
+    Takes the hash rather than reading the file, because the question a record
+    asks is about bytes that no longer have to exist on disk.
+    """
+    entry = entry_for(path, registry)
+    if entry is None:
+        return UNPINNED, f"no canonical hash pinned for {normalise(path)}"
+    if not sha:
+        return UNPINNED, "no hash recorded to compare"
+    if sha == entry.get("sha256"):
+        return CANONICAL, None
+    for old in entry.get("superseded") or []:
+        if old.get("sha256") == sha:
+            return SUPERSEDED, (
+                f"{normalise(path)} was pinned at {sha[:12]}… until "
+                f"{old.get('retired_on', 'an unrecorded date')}; it is now "
+                f"{str(entry.get('sha256'))[:12]}…")
+    return UNCANONICAL, (
+        f"{normalise(path)} hashed {sha[:12]}…, which is neither the pinned "
+        f"{str(entry.get('sha256'))[:12]}… nor any hash it was pinned at "
+        "before; that file was not a published version of its condition")
+
+
+def disk_status(path: str | Path,
+                registry: Path = REGISTRY) -> tuple[str, str | None]:
+    """What the file *on disk* is, relative to its pin.
+
+    `uncanonical` here means the working tree carries a prompt that no pin
+    vouches for — an edit that has not been declared. This is the repo-state
+    check; `status_of_hash` is the record check, and they answer different
+    questions.
+    """
+    sha = sha256_of(Path(path))
+    if sha is None:
+        return UNPINNED, f"{normalise(path)} is not on disk"
+    return status_of_hash(path, sha, registry)
+
+
+def registered_paths(registry: Path = REGISTRY) -> list[str]:
+    return sorted(pins(registry))
+
+
+def prompt_files() -> list[Path]:
+    """Every prompt file a condition can consume, from the condition registry.
+
+    Derived rather than listed, for the reason `condition_of` records: a
+    written-out list knew only v1, v2 and tuned, and every v3 and v4 run fell
+    through it silently (#340). A new condition therefore arrives here already
+    pinnable, and `test_every_condition_prompt_is_pinned` fails until it is
+    actually pinned.
+    """
+    from data_sheets_schema.api_runner import (COMPONENTS, CONDITION_PROMPTS,
+                                               TUNED_PROMPT)
+
+    files = set(CONDITION_PROMPTS.values()) | {TUNED_PROMPT}
+    if COMPONENTS.is_dir():
+        files |= {p for p in COMPONENTS.glob("*.md") if p.name != "README.md"}
+    return sorted(files, key=lambda p: p.as_posix())
+
+
+def check_disk(paths: list[Path] | None = None,
+               registry: Path = REGISTRY) -> list[dict]:
+    """Every condition prompt on disk against its pin. One row each."""
+    rows = []
+    for path in paths if paths is not None else prompt_files():
+        status, why = disk_status(path, registry)
+        rows.append({"path": normalise(path), "status": status, "reason": why,
+                     "sha256": sha256_of(Path(path))})
+    return rows
+
+
+def _head_commit() -> str | None:
+    try:
+        out = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True,
+                             text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None if out.returncode == 0 else None
+
+
+def pin(path: str | Path, reason: str, registry: Path = REGISTRY,
+        today: str | None = None) -> dict:
+    """Declare the file's current bytes canonical, retiring the previous pin.
+
+    Rotation rather than overwrite. Dropping the old hash would make every
+    record written under it read `uncanonical` the moment a prompt is edited —
+    the same retroactive-failure error the live-provenance cutoff exists to
+    avoid, and it would push anyone hitting it toward silencing the check.
+
+    `reason` is required and not defaulted. A pin whose diff says only that a
+    hash changed records nothing a reviewer could not compute; the sentence
+    saying *why* the condition moved is the part worth versioning.
+    """
+    if not reason or not reason.strip():
+        raise ValueError("a pin needs a reason — see the docstring")
+    p = Path(path)
+    sha = sha256_of(p)
+    if sha is None:
+        raise FileNotFoundError(f"{p} is not on disk; nothing to pin")
+    today = today or _dt.date.today().isoformat()
+
+    data = load(registry)
+    data.setdefault("hash_algorithm", "sha256")
+    files = data.setdefault("files", {})
+    key = normalise(p)
+    prev = files.get(key)
+    if prev and prev.get("sha256") == sha:
+        return {"path": key, "status": "unchanged", "sha256": sha}
+
+    superseded = list((prev or {}).get("superseded") or [])
+    if prev and prev.get("sha256"):
+        superseded.append({"sha256": prev["sha256"],
+                           "pinned_on": prev.get("pinned_on"),
+                           "retired_on": today,
+                           "reason": prev.get("reason")})
+    files[key] = {"sha256": sha, "bytes": p.stat().st_size,
+                  "pinned_on": today, "pinned_at_commit": _head_commit(),
+                  "reason": reason.strip()}
+    if superseded:
+        files[key]["superseded"] = superseded
+
+    Path(registry).parent.mkdir(parents=True, exist_ok=True)
+    Path(registry).write_text(
+        _HEADER + yaml.safe_dump(data, sort_keys=True, width=88),
+        encoding="utf-8")
+    return {"path": key, "status": "pinned" if prev else "added",
+            "sha256": sha, "previous": (prev or {}).get("sha256")}
+
+
+_HEADER = """\
+# Canonical hashes for the prompt files the study's conditions are defined by.
+#
+# Written by `d4d api prompts pin`, read by `d4d api prompts check` (the repo
+# gate) and by `d4d runs check` (the record gate). See
+# src/data_sheets_schema/prompt_registry.py for what each status means and,
+# just as importantly, what this file does not prove.
+#
+# Editing a prompt file without rotating its pin fails
+# tests/test_prompt_registry.py. That is the point: the edit and the
+# declaration that it is the new canonical text are two acts, and the second
+# one is small enough to read.
+"""

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -998,13 +998,16 @@ def canonical_prompt_status(method: str, label: str, project: str,
     that catches it: is the hash the record already carries for each prompt
     file one this repo ever declared canonical for that condition?
 
-    Five outcomes; only one is a finding:
+    Six outcomes; two are findings:
 
     - ``canonical``   — every recorded prompt hash is the current pin.
     - ``superseded``  — one or more were pinned once and have since been
       rotated. Ordinary evolution; v4 exists, v5 will.
-    - ``uncanonical`` — a hash that was never pinned. The file that produced
-      this run was not a published version of its condition.
+    - ``uncanonical`` — a hash that was never pinned, or a labelled condition
+      whose record hashes no condition prompt at all (#436). The text that
+      produced this run was not a published version of its condition.
+    - ``missing``     — a pinned path the record hashed nothing for: the run
+      named a prompt file it did not read (#437).
     - ``unpinned``    — no pin covers one of the paths. Absence of evidence.
     - ``absent``      — the record hashes no prompt file at all, which is 88 of
       the corpus and predates the pin.
@@ -1019,15 +1022,40 @@ def canonical_prompt_status(method: str, label: str, project: str,
     data = _yaml.safe_load(p.read_text(encoding="utf-8")) or {}
     files = ((data.get("prompts") or {}).get("files")) or []
     seen: list[tuple[str, str | None]] = []
+    paths: set[str] = set()
     for entry in files:
         if not isinstance(entry, dict) or not entry.get("path"):
             continue
+        paths.add(_pr.normalise(entry["path"]))
         seen.append(_pr.status_of_hash(entry["path"], entry.get("sha256")))
     if not seen:
         return "absent", None
+
+    # Coverage, not just agreement (#436). The pin is keyed on the path, so a
+    # copy of a prompt at some other path is `unpinned` — reported, not fatal —
+    # and `condition_of` cannot name its condition either, because it matches on
+    # filename. Three checks, all silent, and the label still claims a
+    # condition. So: if the label claims one, the record must hash *some*
+    # pinned condition prompt.
+    #
+    # Deliberately not "the prompt of the condition the label claims". Sixteen
+    # records in the corpus are labelled `generic-v3` and hash the pinned v1 —
+    # that is #420, it is already reported by `prompt_condition_mismatch`, and
+    # it is reported and never fatal on purpose. Requiring the exact file would
+    # fail those retroactively through a side door.
+    from data_sheets_schema.api_runner import CONDITION_PROMPTS, TUNED_PROMPT
+    if condition_from_label(label):
+        known = {_pr.normalise(p) for p in
+                 (*CONDITION_PROMPTS.values(), TUNED_PROMPT)}
+        if not (paths & known):
+            return _pr.UNCANONICAL, (
+                f"the label claims condition {condition_from_label(label)!r} "
+                f"but the record hashes no condition prompt: {sorted(paths)}. "
+                "A prompt outside the registry is one nothing vouches for")
+
     # Worst-first: one uncanonical file is the verdict regardless of how many
     # of its neighbours are fine.
-    for wanted in (_pr.UNCANONICAL, _pr.UNPINNED, _pr.SUPERSEDED):
+    for wanted in (_pr.UNCANONICAL, _pr.MISSING, _pr.UNPINNED, _pr.SUPERSEDED):
         hits = [why for status, why in seen if status == wanted]
         if hits:
             return wanted, "; ".join(w for w in hits if w) or None

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -985,6 +985,55 @@ def _prompt_files_drifted(record: dict) -> bool | None:
     return False if seen else None
 
 
+def canonical_prompt_status(method: str, label: str, project: str,
+                            concat_dir: Path = CONCAT_DIR
+                            ) -> tuple[str, str | None]:
+    """Were the prompt files this run consumed published versions of their
+    condition? (#432)
+
+    The third comparison. `verify_request` re-renders the recorded spec and
+    compares it to the recorded instruction, which proves they agree *as the
+    files stand now* — so an instruction edited into the prompt file before
+    rendering re-renders to itself and reports `match`. This asks the question
+    that catches it: is the hash the record already carries for each prompt
+    file one this repo ever declared canonical for that condition?
+
+    Five outcomes; only one is a finding:
+
+    - ``canonical``   — every recorded prompt hash is the current pin.
+    - ``superseded``  — one or more were pinned once and have since been
+      rotated. Ordinary evolution; v4 exists, v5 will.
+    - ``uncanonical`` — a hash that was never pinned. The file that produced
+      this run was not a published version of its condition.
+    - ``unpinned``    — no pin covers one of the paths. Absence of evidence.
+    - ``absent``      — the record hashes no prompt file at all, which is 88 of
+      the corpus and predates the pin.
+    """
+    import yaml as _yaml
+    from data_sheets_schema import prompt_registry as _pr
+    from data_sheets_schema.provenance import record_path_for
+
+    p = record_path_for(project, method, label, concat_dir)
+    if not p.exists():
+        return "absent", "no provenance record"
+    data = _yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    files = ((data.get("prompts") or {}).get("files")) or []
+    seen: list[tuple[str, str | None]] = []
+    for entry in files:
+        if not isinstance(entry, dict) or not entry.get("path"):
+            continue
+        seen.append(_pr.status_of_hash(entry["path"], entry.get("sha256")))
+    if not seen:
+        return "absent", None
+    # Worst-first: one uncanonical file is the verdict regardless of how many
+    # of its neighbours are fine.
+    for wanted in (_pr.UNCANONICAL, _pr.UNPINNED, _pr.SUPERSEDED):
+        hits = [why for status, why in seen if status == wanted]
+        if hits:
+            return wanted, "; ".join(w for w in hits if w) or None
+    return _pr.CANONICAL, None
+
+
 def condition_from_label(label: str) -> str | None:
     """The prompt condition a label *claims*, or None if it names none.
 

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -1,0 +1,85 @@
+# Canonical hashes for the prompt files the study's conditions are defined by.
+#
+# Written by `d4d api prompts pin`, read by `d4d api prompts check` (the repo
+# gate) and by `d4d runs check` (the record gate). See
+# src/data_sheets_schema/prompt_registry.py for what each status means and,
+# just as importantly, what this file does not prove.
+#
+# Editing a prompt file without rotating its pin fails
+# tests/test_prompt_registry.py. That is the point: the edit and the
+# declaration that it is the new canonical text are two acts, and the second
+# one is small enough to read.
+files:
+  src/download/prompts/components/AI_READI.md:
+    bytes: 1203
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: 553f8d5b6a713d5e919fa33677c4d2bfeb209cd486a75db91851728f49c7b030
+  src/download/prompts/components/CHORUS.md:
+    bytes: 1233
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: f697cd7d78c2de0e88519e5d80894a35a6f3388042500ed60c567fd4b6fe61a2
+  src/download/prompts/components/CM4AI.md:
+    bytes: 1165
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: 849d68be5654ead54d5be8fad3646bbd809616f6d4abef0b2be78eae08ddcb79
+  src/download/prompts/components/VOICE.md:
+    bytes: 1294
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: 07b59ca750a1d24ef7c7eb42d310fbfa064ddf300b4cd118383aaaebb9074186
+  src/download/prompts/d4d_generic_arm_prompt.md:
+    bytes: 5754
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: 0fbc626bc3a51d74a8ba3d8e2813752f3bc5ce9366ee5f19c99089afdfd9e8dc
+  src/download/prompts/d4d_generic_arm_prompt_v2.md:
+    bytes: 9110
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: 4780613475ef2a629f98b69a934228b58eccd5fe93915fcd259a62cff6583de6
+  src/download/prompts/d4d_generic_arm_prompt_v3.md:
+    bytes: 7204
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: 2126da06d0834c2501c55fe9838720fe3ee33ab38c4775f2af329bc4759da45a
+  src/download/prompts/d4d_generic_arm_prompt_v4.md:
+    bytes: 7670
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
+  src/download/prompts/d4d_tuned_arm_prompt.md:
+    bytes: 2877
+    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
+    pinned_on: '2026-08-10'
+    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
+      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+      retroactively.'
+    sha256: 41dd2fd7e970abb0c54419b067d36bd77fdf1360dc17888ccb09f79f0d4f32c0
+hash_algorithm: sha256

--- a/tests/test_prompt_registry.py
+++ b/tests/test_prompt_registry.py
@@ -79,6 +79,23 @@ class TestStatusOfARecordedHash(unittest.TestCase):
         self.assertEqual(pr.UNCANONICAL, st)
         self.assertIn("arm.md", why)
 
+    def test_a_deleted_pinned_file_is_missing_not_unpinned(self):
+        """#437. A pinned file that is gone is evidence of an absence, not an
+        absence of evidence — the condition's declared text no longer exists."""
+        self.prompt.unlink()
+        st, why = pr.disk_status(self.prompt, self.reg)
+        self.assertEqual(pr.MISSING, st)
+        self.assertIn("pinned but not on disk", why)
+
+    def test_a_pinned_path_with_no_recorded_hash_is_missing(self):
+        st, why = pr.status_of_hash(self.prompt, None, self.reg)
+        self.assertEqual(pr.MISSING, st)
+        self.assertIn("did not read", why)
+
+    def test_an_unpinned_absent_path_stays_unpinned(self):
+        st, _ = pr.disk_status(self.root / "never-existed.md", self.reg)
+        self.assertEqual(pr.UNPINNED, st)
+
 
 class TestPinning(unittest.TestCase):
     def setUp(self):
@@ -145,6 +162,49 @@ class TestPinning(unittest.TestCase):
             pr.pin(self.root / "gone.md", "why", registry=self.reg)
 
 
+class TestPinningUncommittedBytes(unittest.TestCase):
+    """#438. `pinned_at_commit` is offered as the audit route — `git show
+    <commit>:<path>` should reproduce the pinned bytes. Pinning an uncommitted
+    edit would name a commit that hashes to something else, and be wrong for
+    exactly the case the registry exists to catch."""
+
+    def setUp(self):
+        import subprocess
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.cwd = os.getcwd()
+        self.addCleanup(os.chdir, self.cwd)
+        self.addCleanup(self.tmp.cleanup)
+        os.chdir(self.root)
+
+        def git(*a):
+            subprocess.run(["git", *a], check=True, capture_output=True)
+
+        git("init", "-q")
+        git("config", "user.email", "t@example.org")
+        git("config", "user.name", "t")
+        self.prompt = Path("arm.md")
+        self.prompt.write_text("committed\n")
+        git("add", "arm.md")
+        git("commit", "-qm", "add")
+        self.reg = Path("canonical.yaml")
+
+    def test_a_clean_file_pins_and_the_commit_reproduces_it(self):
+        import subprocess
+        res = pr.pin(self.prompt, "initial", registry=self.reg)
+        commit = pr.entry_for(self.prompt, self.reg)["pinned_at_commit"]
+        blob = subprocess.run(["git", "show", f"{commit}:arm.md"],
+                              capture_output=True, check=True).stdout
+        self.assertEqual(hashlib.sha256(blob).hexdigest(), res["sha256"])
+
+    def test_an_uncommitted_edit_is_refused(self):
+        self.prompt.write_text("uncommitted edit\n")
+        with self.assertRaises(ValueError) as ctx:
+            pr.pin(self.prompt, "trying", registry=self.reg)
+        self.assertIn("Commit the prompt first", str(ctx.exception))
+        self.assertFalse(self.reg.exists(), "nothing should have been written")
+
+
 class TestTheRealRegistry(unittest.TestCase):
     """The CI gate. Editing a prompt file without rotating its pin fails here —
     which is the whole mechanism: the edit and the declaration that it is now
@@ -173,6 +233,10 @@ class TestTheRecordGate(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.root = Path(self.tmp.name)
         self.cwd = os.getcwd()
+        # Registered before the chdir: a setUp that raises after it would
+        # otherwise skip tearDown and leave the whole suite in a temp dir.
+        self.addCleanup(os.chdir, self.cwd)
+        self.addCleanup(self.tmp.cleanup)
         os.chdir(self.root)
         # The registry path is repo-relative, so a temp root plus chdir gives a
         # self-contained registry without patching module constants.
@@ -186,9 +250,6 @@ class TestTheRecordGate(unittest.TestCase):
         self.dir = self.concat / f"{self.method}_core" / self.label
         self.dir.mkdir(parents=True)
 
-    def tearDown(self):
-        os.chdir(self.cwd)
-        self.tmp.cleanup()
 
     def _write_record(self, files, request=None):
         rec = {"record_mode": "live", "prompts": {"hash_algorithm": "sha256",
@@ -224,6 +285,44 @@ class TestTheRecordGate(unittest.TestCase):
 
     def test_a_missing_record_is_absent(self):
         self.assertEqual("absent", self._status()[0])
+
+    def test_a_prompt_copied_to_another_path_does_not_escape_the_pin(self):
+        """#436. The pin is keyed on path, so `cp` was the whole bypass: an
+        edited copy is `unpinned` (not fatal), `condition_of` cannot name its
+        condition, and the label still claims one. Coverage closes it."""
+        evil = Path("my_prompt_copy.md")
+        evil.write_text(self.prompt.read_text() + "\nCRITICAL SCOPE BOUNDARY\n")
+        self._write_record([{"path": str(evil), "sha256": pr.sha256_of(evil)}])
+        status, why = self._status()
+        self.assertEqual(pr.UNCANONICAL, status)
+        self.assertIn("hashes no condition prompt", why)
+
+    def test_a_label_naming_no_condition_is_not_second_guessed(self):
+        """Labels predating the convention name no condition. Failing them
+        would punish history for a rule that postdates it."""
+        from data_sheets_schema.runs import canonical_prompt_status
+        label = "2026-08-10_unlabelled_rep1"
+        d = self.concat / f"{self.method}_core" / label
+        d.mkdir(parents=True)
+        evil = Path("copy.md")
+        evil.write_text("anything\n")
+        (d / "P_provenance.yaml").write_text(yaml.safe_dump(
+            {"prompts": {"files": [{"path": str(evil),
+                                    "sha256": pr.sha256_of(evil)}]}}))
+        self.assertEqual(pr.UNPINNED,
+                         canonical_prompt_status(self.method, label, "P",
+                                                 self.concat)[0])
+
+    def test_the_known_label_condition_mismatch_stays_non_fatal(self):
+        """Sixteen corpus records are labelled `generic-v3` and hash the pinned
+        v1. That is #420, reported by `prompt_condition_mismatch` and never
+        fatal on purpose — requiring the *claimed* condition's exact file would
+        fail them retroactively through a side door."""
+        v1 = Path("src/download/prompts/d4d_generic_arm_prompt.md")
+        v1.write_text("# v1\n\n## Prompt body\nolder.\n")
+        pr.pin(v1, "v1", today="2026-08-10")
+        self._write_record([{"path": str(v1), "sha256": pr.sha256_of(v1)}])
+        self.assertEqual((pr.CANONICAL, None), self._status())
 
     def test_the_pre_render_edit_the_render_gate_cannot_see(self):
         """#432's reproduction, both gates side by side.
@@ -297,6 +396,8 @@ class TestTheCLI(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.root = Path(self.tmp.name)
         self.cwd = os.getcwd()
+        self.addCleanup(os.chdir, self.cwd)
+        self.addCleanup(self.tmp.cleanup)
         os.chdir(self.root)
         self.prompt = Path("src/download/prompts/d4d_generic_arm_prompt.md")
         self.prompt.parent.mkdir(parents=True)
@@ -306,9 +407,6 @@ class TestTheCLI(unittest.TestCase):
             p.write_text(f"# {name}\n\n## Prompt body\nbody\n")
         self.prompt.with_name("d4d_tuned_arm_prompt.md").write_text("# tuned\n")
 
-    def tearDown(self):
-        os.chdir(self.cwd)
-        self.tmp.cleanup()
 
     def _run(self, *args):
         from click.testing import CliRunner

--- a/tests/test_prompt_registry.py
+++ b/tests/test_prompt_registry.py
@@ -1,0 +1,356 @@
+"""#432 — a prompt file edited *before* rendering.
+
+The render gate re-renders a record's spec and compares it to the recorded
+instruction. That catches text edited after rendering. It cannot catch text
+edited into the prompt file first, because re-rendering reads the same edited
+file and reproduces the same bytes: `match`, honestly reported, about an
+instruction nobody published.
+
+`test_the_pre_render_edit_the_render_gate_cannot_see` is the issue's own
+reproduction, run against both gates at once. It is the test the rest of this
+file exists to support.
+"""
+
+import hashlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema import prompt_registry as pr
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class TestStatusOfARecordedHash(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.prompt = self.root / "arm.md"
+        self.prompt.write_text("# v3\n\n## Prompt body\nbody\n")
+        self.reg = self.root / "canonical.yaml"
+        pr.pin(self.prompt, "initial", registry=self.reg, today="2026-08-10")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _pinned(self):
+        return pr.entry_for(self.prompt, self.reg)["sha256"]
+
+    def test_the_pinned_hash_is_canonical(self):
+        st, why = pr.status_of_hash(self.prompt, self._pinned(), self.reg)
+        self.assertEqual(pr.CANONICAL, st)
+        self.assertIsNone(why)
+
+    def test_a_hash_that_was_never_pinned_is_the_finding(self):
+        st, why = pr.status_of_hash(self.prompt, _sha("something else"),
+                                    self.reg)
+        self.assertEqual(pr.UNCANONICAL, st)
+        self.assertIn("not a published version", why)
+
+    def test_a_previously_pinned_hash_is_superseded_not_a_finding(self):
+        """Conditions are allowed to move. Reporting every run made under the
+        prompt of the day as a defect would fail history for a rule that
+        postdates it — and push whoever hit it toward silencing the check."""
+        old = self._pinned()
+        self.prompt.write_text("# v3\n\n## Prompt body\nbody, plus a rule\n")
+        pr.pin(self.prompt, "added rule 4", registry=self.reg,
+               today="2026-08-11")
+
+        st, why = pr.status_of_hash(self.prompt, old, self.reg)
+        self.assertEqual(pr.SUPERSEDED, st)
+        self.assertIn("2026-08-11", why)
+        self.assertEqual(pr.CANONICAL,
+                         pr.status_of_hash(self.prompt, self._pinned(),
+                                           self.reg)[0])
+
+    def test_an_unregistered_path_is_reported_not_failed(self):
+        st, _ = pr.status_of_hash(self.root / "other.md", _sha("x"), self.reg)
+        self.assertEqual(pr.UNPINNED, st)
+
+    def test_disk_status_reads_the_file(self):
+        self.assertEqual(pr.CANONICAL, pr.disk_status(self.prompt, self.reg)[0])
+        self.prompt.write_text("edited\n")
+        st, why = pr.disk_status(self.prompt, self.reg)
+        self.assertEqual(pr.UNCANONICAL, st)
+        self.assertIn("arm.md", why)
+
+
+class TestPinning(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.prompt = self.root / "arm.md"
+        self.prompt.write_text("one\n")
+        self.reg = self.root / "canonical.yaml"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_a_pin_requires_a_reason(self):
+        """A diff that says only that a hash changed records nothing a reviewer
+        could not compute themselves."""
+        with self.assertRaises(ValueError):
+            pr.pin(self.prompt, "", registry=self.reg)
+        with self.assertRaises(ValueError):
+            pr.pin(self.prompt, "   ", registry=self.reg)
+
+    def test_rotation_keeps_the_previous_hash(self):
+        pr.pin(self.prompt, "first", registry=self.reg, today="2026-08-10")
+        first = pr.entry_for(self.prompt, self.reg)["sha256"]
+        self.prompt.write_text("two\n")
+        res = pr.pin(self.prompt, "second", registry=self.reg,
+                     today="2026-08-12")
+
+        entry = pr.entry_for(self.prompt, self.reg)
+        self.assertEqual(first, res["previous"])
+        self.assertNotEqual(first, entry["sha256"])
+        self.assertEqual([{"sha256": first, "pinned_on": "2026-08-10",
+                           "retired_on": "2026-08-12", "reason": "first"}],
+                         entry["superseded"])
+
+    def test_rotating_twice_keeps_both_ancestors(self):
+        hashes = []
+        for i, text in enumerate(("one\n", "two\n", "three\n")):
+            self.prompt.write_text(text)
+            pr.pin(self.prompt, f"v{i}", registry=self.reg,
+                   today=f"2026-08-1{i}")
+            hashes.append(_sha(text))
+        entry = pr.entry_for(self.prompt, self.reg)
+        self.assertEqual(hashes[:2],
+                         [s["sha256"] for s in entry["superseded"]])
+        for old in hashes[:2]:
+            self.assertEqual(pr.SUPERSEDED,
+                             pr.status_of_hash(self.prompt, old, self.reg)[0])
+
+    def test_repinning_unchanged_bytes_is_a_no_op(self):
+        """Otherwise a re-run of the pin command would retire a hash into the
+        superseded list and pin the identical value over it."""
+        pr.pin(self.prompt, "first", registry=self.reg)
+        res = pr.pin(self.prompt, "again", registry=self.reg)
+        self.assertEqual("unchanged", res["status"])
+        self.assertNotIn("superseded", pr.entry_for(self.prompt, self.reg))
+
+    def test_the_reason_is_stored_where_a_reviewer_will_read_it(self):
+        pr.pin(self.prompt, "carries the scalar-range rule", registry=self.reg)
+        self.assertIn("carries the scalar-range rule",
+                      self.reg.read_text(encoding="utf-8"))
+
+    def test_pinning_a_file_that_is_not_there_fails_loudly(self):
+        with self.assertRaises(FileNotFoundError):
+            pr.pin(self.root / "gone.md", "why", registry=self.reg)
+
+
+class TestTheRealRegistry(unittest.TestCase):
+    """The CI gate. Editing a prompt file without rotating its pin fails here —
+    which is the whole mechanism: the edit and the declaration that it is now
+    canonical are two acts, and the second is small enough to read."""
+
+    def test_every_condition_prompt_is_pinned_and_at_its_pin(self):
+        rows = pr.check_disk()
+        self.assertTrue(rows, "no condition prompts found to check")
+        bad = [r for r in rows if r["status"] != pr.CANONICAL]
+        self.assertEqual([], bad,
+                         "prompt file(s) not at their canonical hash; rotate "
+                         "with `d4d api prompts pin --file … --reason …`")
+
+    def test_every_condition_in_the_registry_has_a_prompt_pinned(self):
+        from data_sheets_schema.api_runner import CONDITION_PROMPTS
+        pinned = set(pr.registered_paths())
+        for condition, path in CONDITION_PROMPTS.items():
+            self.assertIn(pr.normalise(path), pinned,
+                          f"condition {condition!r} has no canonical pin")
+
+
+class TestTheRecordGate(unittest.TestCase):
+    """`canonical_prompt_status` over a provenance record on disk."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.cwd = os.getcwd()
+        os.chdir(self.root)
+        # The registry path is repo-relative, so a temp root plus chdir gives a
+        # self-contained registry without patching module constants.
+        self.prompt = Path("src/download/prompts/d4d_generic_arm_prompt_v3.md")
+        self.prompt.parent.mkdir(parents=True)
+        self.prompt.write_text(
+            "# header\n\n## Prompt body\nGenerate a record for {PROJECT}.\n")
+        pr.pin(self.prompt, "initial", today="2026-08-10")
+        self.concat = Path("data/d4d_concatenated")
+        self.label, self.method = "2026-08-10_generic-v3_rep1", "claudecode_agent"
+        self.dir = self.concat / f"{self.method}_core" / self.label
+        self.dir.mkdir(parents=True)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        self.tmp.cleanup()
+
+    def _write_record(self, files, request=None):
+        rec = {"record_mode": "live", "prompts": {"hash_algorithm": "sha256",
+                                                  "files": files}}
+        if request:
+            rec["prompts"]["request"] = request
+        (self.dir / "P_provenance.yaml").write_text(yaml.safe_dump(rec))
+
+    def _status(self):
+        from data_sheets_schema.runs import canonical_prompt_status
+        return canonical_prompt_status(self.method, self.label, "P",
+                                       self.concat)
+
+    def test_a_record_hashing_the_pinned_file_is_canonical(self):
+        self._write_record([{"path": str(self.prompt),
+                             "sha256": pr.sha256_of(self.prompt)}])
+        self.assertEqual((pr.CANONICAL, None), self._status())
+
+    def test_a_record_hashing_no_prompt_is_absent_not_a_finding(self):
+        (self.dir / "P_provenance.yaml").write_text(
+            yaml.safe_dump({"prompts": {"paths": None}}))
+        self.assertEqual("absent", self._status()[0])
+
+    def test_the_worst_status_across_several_files_wins(self):
+        other = Path("src/download/prompts/d4d_tuned_arm_prompt.md")
+        other.write_text("tuned\n")
+        self._write_record([
+            {"path": str(self.prompt), "sha256": pr.sha256_of(self.prompt)},
+            {"path": str(other), "sha256": _sha("who knows")},
+        ])
+        # One unpinned neighbour must not be hidden behind a canonical one.
+        self.assertEqual(pr.UNPINNED, self._status()[0])
+
+    def test_a_missing_record_is_absent(self):
+        self.assertEqual("absent", self._status()[0])
+
+    def test_the_pre_render_edit_the_render_gate_cannot_see(self):
+        """#432's reproduction, both gates side by side.
+
+        Add a project-specific paragraph to the generic prompt; render; run;
+        record. `verify_request` re-renders from the same edited file, gets the
+        same bytes, and says `match` — correctly, and uselessly. The pin is
+        what makes the edit a finding.
+        """
+        from data_sheets_schema.api_runner import RunSpec, resolve_prompt
+        from data_sheets_schema.runs import verify_request
+
+        self.prompt.write_text(
+            "# header\n\n## Prompt body\nGenerate a record for {PROJECT}.\n"
+            "CRITICAL SCOPE BOUNDARY: treat the pediatric cohort as out of "
+            "scope for this project.\n")
+
+        spec = RunSpec(project="P", arm="BASELINE", method=self.method,
+                       bundle=Path("b.txt"), label=self.label,
+                       condition="generic_v3", manifest_line="",
+                       run_date="2026-08-10", runtime="Claude Code",
+                       provider="Anthropic")
+        sent = resolve_prompt(spec)
+        self.assertIn("CRITICAL SCOPE BOUNDARY", sent)
+
+        self._write_record(
+            [{"path": str(self.prompt), "sha256": pr.sha256_of(self.prompt)}],
+            request={"sha256": _sha(sent), "bytes": len(sent.encode()),
+                     "spec": {"condition": "generic_v3", "arm": "BASELINE",
+                              "bundle": "b.txt", "manifest_line": "",
+                              "run_date": "2026-08-10",
+                              "runtime": "Claude Code",
+                              "provider": "Anthropic"}})
+
+        self.assertEqual("match",
+                         verify_request(self.method, self.label, "P",
+                                        self.concat)[0],
+                         "the render gate is expected to be satisfied here — "
+                         "that is why #432 exists")
+        status, why = self._status()
+        self.assertEqual(pr.UNCANONICAL, status)
+        self.assertIn("not a published version", why)
+
+    def test_the_same_run_under_the_published_prompt_passes_both(self):
+        """The negative control: without the edit, nothing is reported. A gate
+        that fires on the unedited case would be noise, not evidence."""
+        from data_sheets_schema.api_runner import RunSpec, resolve_prompt
+        from data_sheets_schema.runs import verify_request
+
+        spec = RunSpec(project="P", arm="BASELINE", method=self.method,
+                       bundle=Path("b.txt"), label=self.label,
+                       condition="generic_v3", manifest_line="",
+                       run_date="2026-08-10", runtime="Claude Code",
+                       provider="Anthropic")
+        sent = resolve_prompt(spec)
+        self._write_record(
+            [{"path": str(self.prompt), "sha256": pr.sha256_of(self.prompt)}],
+            request={"sha256": _sha(sent), "bytes": len(sent.encode()),
+                     "spec": {"condition": "generic_v3", "arm": "BASELINE",
+                              "bundle": "b.txt", "manifest_line": "",
+                              "run_date": "2026-08-10",
+                              "runtime": "Claude Code",
+                              "provider": "Anthropic"}})
+        self.assertEqual("match", verify_request(self.method, self.label, "P",
+                                                 self.concat)[0])
+        self.assertEqual((pr.CANONICAL, None), self._status())
+
+
+class TestTheCLI(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.cwd = os.getcwd()
+        os.chdir(self.root)
+        self.prompt = Path("src/download/prompts/d4d_generic_arm_prompt.md")
+        self.prompt.parent.mkdir(parents=True)
+        self.prompt.write_text("# v1\n\n## Prompt body\nbody\n")
+        for name in ("_v2", "_v3", "_v4"):
+            p = self.prompt.with_name(f"d4d_generic_arm_prompt{name}.md")
+            p.write_text(f"# {name}\n\n## Prompt body\nbody\n")
+        self.prompt.with_name("d4d_tuned_arm_prompt.md").write_text("# tuned\n")
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        self.tmp.cleanup()
+
+    def _run(self, *args):
+        from click.testing import CliRunner
+        from data_sheets_schema.cli.api import api
+        return CliRunner().invoke(api, ["prompts", *args])
+
+    def _pin_all(self):
+        for p in sorted(self.prompt.parent.glob("*.md")):
+            self._run("pin", "--file", str(p), "--reason", "initial")
+
+    def test_an_undeclared_prompt_file_fails_the_repo_gate(self):
+        """A condition prompt nobody pinned is text that was never declared —
+        the hole itself, not a gap in it. The record gate is more forgiving
+        because a record may name a prompt the registry does not cover; the
+        working tree has no such excuse."""
+        r = self._run("check", "--strict")
+        self.assertEqual(1, r.exit_code, r.output)
+        self.assertIn("unpinned", r.output)
+
+    def test_check_fails_strictly_once_a_pinned_file_is_edited(self):
+        self._pin_all()
+        self.assertEqual(0, self._run("check", "--strict").exit_code)
+
+        self.prompt.write_text("# v1\n\n## Prompt body\nbody, edited\n")
+        r = self._run("check", "--strict")
+        self.assertEqual(1, r.exit_code, r.output)
+        self.assertIn("uncanonical", r.output)
+        self.assertIn("d4d api prompts pin", r.output)
+
+    def test_pin_refuses_without_a_reason(self):
+        r = self._run("pin", "--file", str(self.prompt))
+        self.assertNotEqual(0, r.exit_code)
+
+    def test_pinning_the_edit_is_how_it_is_resolved(self):
+        self._pin_all()
+        self.prompt.write_text("# v1\n\n## Prompt body\nbody, edited\n")
+        r = self._run("pin", "--file", str(self.prompt), "--reason",
+                      "rule 4 added; re-baselines the arm")
+        self.assertEqual(0, r.exit_code, r.output)
+        self.assertIn("superseded", r.output)
+        self.assertEqual(0, self._run("check", "--strict").exit_code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #432.

## The hole

The render gate (#425, #429, #430) verifies that a record's `prompts.request.sha256` equals what re-rendering `prompts.request.spec` produces. That catches an instruction edited **after** rendering — the `CRITICAL SCOPE BOUNDARY` paragraph that started this thread.

It cannot catch one edited **before**:

1. add the paragraph to `d4d_generic_arm_prompt_v3.md`
2. render — the paragraph is now part of what the spec produces
3. run, record

`verify_request()` re-renders from the same file, gets the same bytes, and reports `match`. Correctly. The record is self-consistent and the condition label is a lie.

`tests/test_prompt_registry.py::TestTheRecordGate::test_the_pre_render_edit_the_render_gate_cannot_see` is that reproduction, asserting `match` from the render gate and `uncanonical` from the new one side by side. `test_the_same_run_under_the_published_prompt_passes_both` is the negative control.

## What is added

`src/download/prompts/canonical_hashes.yaml` — a pin per prompt file: sha256, byte count, `pinned_on`, `pinned_at_commit`, and a **required** reason. Rotation keeps the previous hash rather than dropping it, so runs made under the prompt of the day stay `superseded` rather than turning `uncanonical` the moment a condition moves.

Four verdicts for a hash: `canonical` / `superseded` / `uncanonical` (never pinned — the finding) / `unpinned`.

Three gates, at the three places a claim is made:

| where | asks | on failure |
|---|---|---|
| `d4d api prompts check --strict` + `tests/test_prompt_registry.py` | is the working tree at its pins? | fails, `unpinned` included |
| `d4d api run` / `batch` | is this run's condition declared? | refuses before the cost confirmation, no override |
| `d4d runs check --strict` | did this record hash a published prompt? | fatal on `uncanonical` only |

`render-prompt` and `provenance record` warn and proceed. Recording an uncanonical prompt is the honest act — it puts the evidence in the record for the check to fail on; refusing would reward not recording at all.

## What it does not do

**Not tamper-proofing, and the module docstring says so.** Whoever can edit a prompt can rotate its pin. What it buys: the two are separate deliberate acts, and a rotation leaves a dated line with a stated reason in a small file a reviewer reads, rather than a paragraph inside a 200-line prompt they do not. `pinned_at_commit` makes each pin re-derivable with `git show <commit>:<path>`.

## Blast radius

- Pinned from the files as they stand. **All 77 recorded prompt hashes in the corpus match** — nothing fails retroactively. `d4d runs check --strict`: 158 runs, 0 failing, before and after. `d4d api prompts check --strict`: 9 files, 0 off their pin.
- **Behaviour change:** `--condition tuned` for a project with no `components/{PROJECT}.md` (VOICE_PEDIATRIC) is now refused. Previously it silently produced a *generic* prompt under a tuned label, which is the same class of defect this thread is about — but it is a change, and it is the one thing here that could block a run someone expected to work.
- The playbook never told the agentic path to pass `--prompt` / `--prompt-text`, so a run following it recorded no prompt evidence at all — and as of today that fails `--strict` under #419. `.claude/commands/d4d-full-core.md` now passes both and says where to get the rendered text. That file is hashed into live records, so records made after this merge will carry a different playbook hash.

1450 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
