### PR TITLE
Declare dataset scope in the manifest, where the next dataset inherits it (#422)

### DIFF
--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -64,6 +64,28 @@ neither, because a prompt written for one path was reused verbatim by another.
 - Full schema: `src/data_sheets_schema/schema/data_sheets_schema_all.yaml` (class `Dataset`)
 - Core schema: `src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml` (class `CoreDataset`)
 
+### Scope: what the record is about
+
+The bundle is the evidence. What the record is *about* is declared in the
+`scope:` block of `data/preprocessed/source_manifest.yaml` — the referent, and
+any dataset that is related to it but distinct from it, with the slot that
+carries the relation. Read it with `d4d download scope --project {PROJECT}`.
+
+**A scope constraint goes in the manifest, never in the launch text.** The VOICE
+run of 2026-08-07 was sent a paragraph naming the project, the companion
+pediatric dataset, a file not to read, and the issue number of the last time it
+went wrong (#422). It worked, and it was per-GC adaptation invisible to every
+prompt test, because it lived in the message rather than in a file. If a run
+seems to need a constraint the bundle and the manifest cannot express, that is a
+manifest bug — fix it there, where the next dataset inherits it.
+
+A bundle may legitimately contain sources *about* a related dataset: VOICE's
+does, and the manifest says so (`in_bundle: physionet_pediatric_1_1_0`).
+Represent the relation through the declared slot — `related_datasets` — rather
+than merging the two, and never as a nested object standing in for the other
+dataset's own record. `d4d download scope --check` verifies afterwards that no
+record identifies itself as a dataset its project declares distinct.
+
 ## Outputs (per project)
 
 - Full: `data/d4d_concatenated/claudecode_agent/{VERSION}/{PROJECT}_d4d.yaml`
@@ -487,6 +509,9 @@ reconciliation report rather than pinning the edit to make the check pass.
 - The core file header names both its source-document bundle and full YAML input.
 - Both headers state that prior D4D factual reuse is prohibited.
 - The provenance audit confirms that no older full/core YAML was used.
+- `d4d download scope --check --project {PROJECT}` reports the record in
+  scope: it does not identify itself as a dataset the manifest declares
+  distinct from this project.
 - The core header contains `Phase 4 reconciliation: completed`.
 - The Phase 3/4 reconciliation report is present.
 - The live provenance record is present and its `record_mode` is `live`, and it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,33 @@ make gen-d4d-html
 make d4d-pipeline-{individual|concatenated|full}-gpt5
 ```
 
+## Dataset Scope (what a record is about)
+
+Declared per project in the `scope:` block of
+`data/preprocessed/source_manifest.yaml`, not in any prompt or launch message.
+
+```bash
+d4d download scope --project VOICE        # show the declaration
+d4d download scope --check --strict       # check every record against it
+```
+
+Each entry names the `referent_id` and any `related_but_distinct` dataset, with
+the slot that carries the relation (`express_as: related_datasets`) and, where
+the related dataset's documentation is legitimately in the bundle, the source id
+that carries it (`in_bundle`).
+
+**A scope constraint belongs in the manifest, never in the launch text** (#422).
+The VOICE run of 2026-08-07 was sent a paragraph naming the project, the
+companion pediatric dataset and a file not to read; it worked, and it was per-GC
+adaptation that no future dataset inherits and no prompt test can see. The
+manifest declaration is checkable (`check_record` catches a record that
+identifies itself as a dataset its project declares distinct) and inherited by
+any project that declares one.
+
+The check reads the record's `id` only. A record can stay in scope by its
+identifier and still discuss the related dataset in prose — which is legitimate,
+and is what `related_datasets` is for.
+
 ## Canonical Prompt Registry
 
 Each condition's prompt files are pinned by hash in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,9 +359,15 @@ manifest declaration is checkable (`check_record` catches a record that
 identifies itself as a dataset its project declares distinct) and inherited by
 any project that declares one.
 
-The check reads the record's `id` only. A record can stay in scope by its
-identifier and still discuss the related dataset in prose — which is legitimate,
-and is what `related_datasets` is for.
+`--check` reports two things. The **verdict** is on the record's `id`:
+`out_of_scope` when a record identifies itself as a dataset its project declares
+distinct. Separately and never fatally, it lists values where a related-but-
+distinct dataset's identifiers appear **outside** the declared slot (#441) — 32
+records place the pediatric release inside VOICE's own `resources`,
+`distribution_formats[].access_urls` and `file_collections[].download_url`.
+Citing the related dataset's page is legitimate; absorbing it into this
+dataset's distribution is not, and the line between them is a judgement the
+check surfaces rather than settles.
 
 ## Canonical Prompt Registry
 

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -472,6 +472,7 @@ Acted on the same day:
 | bundles carried curator prose, unequally per project | #421 | **fixed** (#424) |
 | re-recording discarded the validation verdict | #396 | **fixed** (#423) |
 | the launch prompt was typed, not rendered | #419, #422 | **addressed** (#425) |
+| per-GC scope lived in the launch prompt | #422 | **closed** — declared in the manifest |
 | label says `generic-v3`, provenance hashes v1 | #420 | open |
 | `verification_url` still injected; 0 values depend on it | #427 | open, cosmetic |
 | a verdict does not pin the schema it was reached against | #426 | **fixed** |

--- a/data/preprocessed/source_manifest.yaml
+++ b/data/preprocessed/source_manifest.yaml
@@ -51,6 +51,91 @@ bundle_hash_history:
       before: e637eb752ee8cab5f9f7a52782250469
       after: 3e5c24df7b46d97204cb007c43b99e92
 
+scope:
+  # What each project's record is *about* (#422). The bundle is the evidence;
+  # this is the referent, and it is declared here because scope is a property
+  # of the dataset rather than of the prompt.
+  #
+  # The VOICE launch prompt for the 2026-08-07 sweep carried a paragraph naming
+  # the project, the pediatric dataset, a file not to read, and the issue number
+  # of the last time it went wrong. It worked, and it was the clearest per-GC
+  # intervention in the pipeline: a quality warning, at the wrong layer, that no
+  # future dataset inherits. This block is the same statement as data, checkable
+  # by `d4d download scope --check` and inherited by every project that declares
+  # one.
+  #
+  # `referent_id` is the identifier a record of this project should carry. Where
+  # a project has no minted dataset DOI its landing page is the identifier, which
+  # is what those records already use. It is documentation, not a naming rule:
+  # nothing fails a record for citing a release DOI instead.
+  #
+  # `related_but_distinct` is the load-bearing part. An empty list means the
+  # question was asked and the answer was none.
+  #
+  # Adding this block changes the manifest's md5, which provenance records under
+  # `inputs.source_manifest`. Nothing re-verifies that field against disk, and
+  # no bundle changed: this is metadata about the selection, not part of it, and
+  # the preprocessor writes no top-level manifest key into a bundle.
+  AI_READI:
+    referent: AI-READI dataset
+    referent_id: https://doi.org/10.60775/fairhub.3
+    referent_note: >-
+      fairhub.1 and fairhub.2 are earlier releases of the same dataset, both
+      documented in the bundle, not separate datasets.
+    related_but_distinct: []
+  CHORUS:
+    referent: CHoRUS dataset
+    referent_id: https://chorus4ai.org/
+    referent_note: >-
+      No dataset DOI appears in any CHORUS source document; the project site is
+      the identifier the records themselves use.
+    related_but_distinct: []
+  CM4AI:
+    referent: CM4AI (Cell Maps for Artificial Intelligence) dataset
+    referent_id: https://cm4ai.org/
+    referent_note: >-
+      The four Dataverse releases in the bundle (B35XWX, F3TD5R, K7TGEM and the
+      June 2026 release) are releases of this dataset, not separate datasets.
+    related_but_distinct: []
+  VOICE:
+    referent: Bridge2AI-Voice dataset (adult)
+    referent_id: https://doi.org/10.13026/37yb-1t42
+    referent_note: >-
+      PhysioNet project-level DOI, recorded in the bundle as "DOI (latest
+      version)". Per-version DOIs for the same dataset: 10.13026/8xbn-nq66
+      (3.1.0), 10.13026/k81f-qr68 (3.0.0), 10.13026/249v-w155 (1.1).
+    related_but_distinct:
+      - id: https://doi.org/10.13026/mf9s-5r03
+        name: Bridge2AI-Voice Pediatric Dataset
+        also_known_as:
+          - https://doi.org/10.13026/h995-bt35
+          - https://physionet.org/content/b2ai-voice-pediatric/1.1.0/
+        manifest_key: VOICE_PEDIATRIC
+        why: >-
+          a separate PhysioNet project with its own DOI, protocol and ethics
+          approval, collected from a distinct cohort at a different site — not a
+          version of the adult dataset
+        in_bundle: physionet_pediatric_1_1_0
+        express_as: related_datasets
+  VOICE_PEDIATRIC:
+    referent: Bridge2AI-Voice Pediatric Dataset
+    referent_id: https://doi.org/10.13026/mf9s-5r03
+    referent_note: >-
+      PhysioNet project-level DOI. Release 1.1.0 is 10.13026/h995-bt35.
+    related_but_distinct:
+      - id: https://doi.org/10.13026/37yb-1t42
+        name: Bridge2AI-Voice dataset (adult)
+        also_known_as:
+          - https://doi.org/10.13026/8xbn-nq66
+          - https://doi.org/10.13026/k81f-qr68
+          - https://doi.org/10.13026/249v-w155
+        manifest_key: VOICE
+        why: >-
+          the adult cohort is a separate PhysioNet project under its own
+          protocol; the pediatric bundle shares five of its six sources with it,
+          so the overlap is in the evidence, not in the referent
+        express_as: related_datasets
+
 default_minimum_characters: 500
 
 projects:

--- a/src/data_sheets_schema/cli/download.py
+++ b/src/data_sheets_schema/cli/download.py
@@ -317,9 +317,16 @@ def scope_cmd(project, do_check, strict, manifest):
     bad = []
     if do_check:
         from data_sheets_schema.api_runner import CONCAT_DIR
+        from data_sheets_schema.scope import foreign_references
         checked = 0
-        for rec in sorted(CONCAT_DIR.glob("*/*/*_d4d.yaml")):
-            name = rec.name.replace("_d4d.yaml", "")
+        unreadable, absorbed = [], []
+        # Core records too. Sweeping only `*_d4d.yaml` reported 16 records
+        # where the corpus holds 32: a core record is a record, and the
+        # pediatric identifiers appear in both halves of the pair.
+        records = sorted([*CONCAT_DIR.glob("*/*/*_d4d.yaml"),
+                          *CONCAT_DIR.glob("*/*/*_d4d_core.yaml")])
+        for rec in records:
+            name = rec.name.replace("_d4d_core.yaml", "").replace("_d4d.yaml", "")
             if project and name != project:
                 continue
             if name not in scopes:
@@ -328,12 +335,36 @@ def scope_cmd(project, do_check, strict, manifest):
             status, why = check_record(name, rec, m)
             if status == "out_of_scope":
                 bad.append((rec, why))
+            elif status == "unreadable":
+                unreadable.append((rec, why))
+                continue
+            refs = foreign_references(name, rec, m)
+            if refs:
+                absorbed.append((rec, refs))
         click.echo(f"\n{checked} record(s) checked against the declaration")
         for rec, why in bad:
             click.echo(f"   ❌ {rec}\n      {why}")
         if not bad:
             click.echo("   ✓ none is about a dataset its project declares "
                        "distinct")
+        for rec, why in unreadable:
+            click.echo(f"   ⚠️  unreadable {rec}: {why}")
+
+        # Reported, never fatal (#441). `check_record` settles what a record is
+        # *about*; this is the shape one level down — the other dataset placed
+        # inside this one's resources or distribution. Citing the related
+        # dataset's page is legitimate, absorbing it is not, and the line
+        # between them is a judgement this surfaces rather than settles.
+        if absorbed:
+            n = sum(len(r) for _, r in absorbed)
+            click.echo(f"\n⚠️  {len(absorbed)} record(s), {n} value(s) place a "
+                       "related-but-distinct dataset outside its declared slot:")
+            for rec, refs in absorbed:
+                click.echo(f"   {rec}")
+                for r in refs[:4]:
+                    click.echo(f"      {r['path']} = {r['value']}")
+                if len(refs) > 4:
+                    click.echo(f"      … {len(refs) - 4} more")
         # Say what the check does not cover. A record can stay in scope by its
         # `id` and still describe the other cohort in its prose, which is what
         # #292 actually looked like; the identifier is the part a rule can

--- a/src/data_sheets_schema/cli/download.py
+++ b/src/data_sheets_schema/cli/download.py
@@ -268,3 +268,80 @@ def audit_manifest(project, manifest):
                    f"and cannot be re-fetched by any means")
     if not a['missing_raw'] and not a['missing_processed']:
         click.echo("\n✓ local corpus matches the manifest")
+
+
+@download.command('scope')
+@click.option('--project', type=click.Choice(PROJECTS),
+              help='Limit to one project (default: all)')
+@click.option('--check', 'do_check', is_flag=True,
+              help='Also check generated records against the declaration.')
+@click.option('--strict', is_flag=True,
+              help='Exit non-zero if any record is about a related-but-'
+                   'distinct dataset.')
+@click.option('--manifest', type=click.Path(exists=True),
+              default='data/preprocessed/source_manifest.yaml', show_default=True)
+def scope_cmd(project, do_check, strict, manifest):
+    """What each project's record is about, and whether the records agree.
+
+    Scope is a property of the dataset, not of the prompt (#422). The VOICE
+    launch prompt of 2026-08-07 carried a paragraph naming the project, the
+    pediatric dataset and a file not to read; declaring the same thing here
+    makes it checkable and makes every future dataset inherit the check
+    instead of needing its own paragraph.
+    """
+    require_repo_context("d4d download scope")
+    setup_repo_imports()
+    from data_sheets_schema.scope import (all_scopes, check_manifest,
+                                          check_record, related_ids)
+
+    m = Path(manifest)
+    scopes = all_scopes(m)
+    names = [project] if project else sorted(scopes)
+    for name in names:
+        s = scopes.get(name)
+        if not s:
+            click.echo(f"{name:16} no scope declared", err=True)
+            continue
+        click.echo(f"{name}")
+        click.echo(f"   about     {s.get('referent')}  <{s.get('referent_id')}>")
+        for entry in s.get("related_but_distinct") or []:
+            click.echo(f"   not about {entry.get('name')}  <{entry.get('id')}>")
+            click.echo(f"             express as `{entry.get('express_as')}`"
+                       + (f"; in this bundle as {entry['in_bundle']}"
+                          if entry.get("in_bundle") else ""))
+
+    problems = check_manifest(m)
+    for p in problems:
+        click.echo(f"❌ {p['project']:16} {p['problem']}", err=True)
+
+    bad = []
+    if do_check:
+        from data_sheets_schema.api_runner import CONCAT_DIR
+        checked = 0
+        for rec in sorted(CONCAT_DIR.glob("*/*/*_d4d.yaml")):
+            name = rec.name.replace("_d4d.yaml", "")
+            if project and name != project:
+                continue
+            if name not in scopes:
+                continue
+            checked += 1
+            status, why = check_record(name, rec, m)
+            if status == "out_of_scope":
+                bad.append((rec, why))
+        click.echo(f"\n{checked} record(s) checked against the declaration")
+        for rec, why in bad:
+            click.echo(f"   ❌ {rec}\n      {why}")
+        if not bad:
+            click.echo("   ✓ none is about a dataset its project declares "
+                       "distinct")
+        # Say what the check does not cover. A record can stay in scope by its
+        # `id` and still describe the other cohort in its prose, which is what
+        # #292 actually looked like; the identifier is the part a rule can
+        # settle, and claiming more would be the same overreach as the
+        # paragraph this replaces.
+        if any(related_ids(n, m) for n in names):
+            click.echo("   (checked on the record's `id`; prose that discusses "
+                       "a related dataset is legitimate and not inspected)")
+
+    if problems or (strict and bad):
+        sys.exit(1)

--- a/src/data_sheets_schema/scope.py
+++ b/src/data_sheets_schema/scope.py
@@ -45,6 +45,7 @@ the record did and what validated.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -83,17 +84,27 @@ def related_ids(project: str, manifest: Path = MANIFEST) -> dict[str, dict]:
     return out
 
 
-def _norm(identifier: Any) -> str:
-    """Compare identifiers without tripping over trailing slashes or scheme.
+_BARE_DOI = re.compile(r"^10\.\d{4,9}/\S+$")
+_DOI_PREFIXES = ("https://doi.org/", "http://doi.org/",
+                 "https://dx.doi.org/", "http://dx.doi.org/", "doi:")
 
-    `https://doi.org/10.13026/h995-bt35` and `doi:10.13026/h995-bt35` name the
-    same dataset, and a check that answered "no match" for the second would be
-    an invitation to write the second.
+
+def _norm(identifier: Any) -> str:
+    """Compare identifiers without tripping over spelling.
+
+    `https://doi.org/10.13026/h995-bt35`, `doi:10.13026/h995-bt35`, the
+    `dx.doi.org` form and the bare `10.13026/h995-bt35` all name the same
+    dataset, and a check that answered "no match" for any of them would be an
+    invitation to write that one (#442). Bare DOIs are not hypothetical: #402
+    found 42% of nested ids in one clean-validating record are neither URI nor
+    CURIE.
     """
     s = str(identifier or "").strip().rstrip("/").lower()
-    for prefix in ("https://doi.org/", "http://doi.org/", "doi:"):
+    for prefix in _DOI_PREFIXES:
         if s.startswith(prefix):
             return "doi:" + s[len(prefix):]
+    if _BARE_DOI.match(s):
+        return "doi:" + s
     return s
 
 
@@ -108,9 +119,17 @@ def check_record(project: str, record: dict | Path,
     - ``out_of_scope`` — the record's `id` is a dataset the manifest declares
       distinct from this project. The #292 failure.
     - ``undeclared``  — the project declares no scope. Reported, not failed.
+    - ``unreadable``  — the file could not be parsed (#444). Reported so a
+      sweep of 171 records is not aborted by one of them.
     """
     if isinstance(record, Path):
-        record = yaml.safe_load(record.read_text(encoding="utf-8")) or {}
+        # One unparseable record must not abort a sweep of 171 (#444): report
+        # the file and carry on, which is more useful than a traceback naming
+        # the same file.
+        try:
+            record = yaml.safe_load(record.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            return "unreadable", f"{type(exc).__name__}: {exc}"
     if not isinstance(record, dict):
         return "undeclared", "record is not a mapping"
 
@@ -129,6 +148,65 @@ def check_record(project: str, record: dict | Path,
                 + f"{entry.get('manifest_key', 'its own project')}; this one "
                 + f"may reference it through `{entry.get('express_as', 'related_datasets')}`")
     return "ok", None
+
+
+def _walk(node: Any, trail: str = ""):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from _walk(v, f"{trail}.{k}" if trail else str(k))
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from _walk(v, f"{trail}[{i}]")
+    else:
+        yield trail, node
+
+
+def foreign_references(project: str, record: dict | Path,
+                       manifest: Path = MANIFEST) -> list[dict]:
+    """Where a related-but-distinct dataset's identifiers appear outside the
+    slot the manifest declares for them (#441).
+
+    `check_record` reads the record's `id`, which settles what the record is
+    *about*. It said 171 of 171 in scope while 32 of them placed the pediatric
+    release inside VOICE's own `resources`, `distribution_formats[].access_urls`
+    and `file_collections[].download_url` — the #292 shape one level down: not a
+    record about the wrong dataset, but a record absorbing the other dataset
+    into its own distribution.
+
+    Reported, never a verdict. A record may legitimately cite the related
+    dataset's page as a resource — that page is in its bundle — and the line
+    between citing and absorbing is a judgement this surfaces rather than
+    settles. `express_as` names where the relation belongs; anything under that
+    slot is excluded.
+    """
+    if isinstance(record, Path):
+        try:
+            record = yaml.safe_load(record.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError) as exc:              # noqa: PERF203
+            return [{"path": str(record), "value": None,
+                     "unreadable": f"{type(exc).__name__}: {exc}"}]
+    if not isinstance(record, dict):
+        return []
+
+    wanted = {}
+    for ident, entry in related_ids(project, manifest).items():
+        wanted[_norm(ident)] = entry
+    if not wanted:
+        return []
+
+    out = []
+    for trail, value in _walk(record):
+        if not isinstance(value, str):
+            continue
+        entry = wanted.get(_norm(value))
+        if entry is None:
+            continue
+        slot = entry.get("express_as") or "related_datasets"
+        if slot and slot in trail:
+            continue
+        out.append({"path": trail, "value": value,
+                    "dataset": entry.get("name"), "express_as": slot})
+    return out
 
 
 def check_manifest(manifest: Path = MANIFEST) -> list[dict]:
@@ -170,4 +248,23 @@ def check_manifest(manifest: Path = MANIFEST) -> list[dict]:
             problems.append({"project": project,
                              "problem": "the referent is also listed as "
                                         "related-but-distinct"})
+
+        # Symmetry (#443). A one-directional declaration checks one direction:
+        # a pediatric record identifying itself by the adult DOI would pass and
+        # the asymmetry would be invisible. Only required when the other side
+        # has a scope block at all — a related dataset outside this corpus
+        # legitimately has no entry here.
+        for entry in scope.get("related_but_distinct") or []:
+            other = entry.get("manifest_key")
+            other_scope = (data.get("scope") or {}).get(other)
+            if not other or not other_scope:
+                continue
+            back = {e.get("manifest_key")
+                    for e in other_scope.get("related_but_distinct") or []}
+            if project not in back:
+                problems.append({
+                    "project": project,
+                    "problem": f"declares {other} related-but-distinct, but "
+                               f"{other} does not say the same of {project}; "
+                               "the check would then run in one direction only"})
     return problems

--- a/src/data_sheets_schema/scope.py
+++ b/src/data_sheets_schema/scope.py
@@ -1,0 +1,173 @@
+"""What each project's record is *about*, declared in the manifest (#422).
+
+The VOICE launch prompt for the 2026-08-07 sweep carried a paragraph naming the
+project, the pediatric dataset, a file not to read, and the issue number of the
+last time it went wrong. It worked, and it is the single clearest per-GC
+intervention in the pipeline: the wrong layer (the bundle is the scope), the
+wrong kind of statement (a quality warning, which the priming taxonomy excludes
+from the generic arm), and not generalisable (every new dataset with a companion
+cohort needs someone to notice and write another paragraph).
+
+The scope is a property of the dataset, not of the prompt. So it is declared
+where the other properties of the input set live — `source_manifest.yaml` — as
+data:
+
+```yaml
+scope:
+  VOICE:
+    referent: Bridge2AI-Voice adult dataset
+    referent_id: https://doi.org/10.13026/37yb-1t42
+    related_but_distinct:
+      - id: https://doi.org/10.13026/h995-bt35
+        manifest_key: VOICE_PEDIATRIC
+        in_bundle: physionet_pediatric_1_1_0
+        express_as: related_datasets
+```
+
+Two things follow that a paragraph could not do.
+
+**It is checkable.** `check_record` reads the declaration and reports a record
+whose referent is a dataset its own project declares related-but-distinct —
+which is the #292 failure exactly, caught after the fact by a rule rather than
+before the fact by a warning nobody can generalise.
+
+**It is inherited.** A new dataset with a companion cohort declares two lines in
+the manifest and gets the same check. Nobody has to remember the prose.
+
+`in_bundle` is deliberate: VOICE's bundle *does* contain the pediatric PhysioNet
+record, because the current VOICE documentation advertises the two releases
+together. Pretending otherwise by dropping the source would make the bundle a
+worse description of the evidence in order to make a rule easier to state. The
+declaration says the source is there and what it means — and
+`express_as: related_datasets` names the slot that carries it, which is what
+the record did and what validated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+MANIFEST = Path("data/preprocessed/source_manifest.yaml")
+
+
+def load_manifest(manifest: Path = MANIFEST) -> dict[str, Any]:
+    if not Path(manifest).exists():
+        return {}
+    return yaml.safe_load(Path(manifest).read_text(encoding="utf-8")) or {}
+
+
+def all_scopes(manifest: Path = MANIFEST) -> dict[str, dict]:
+    return (load_manifest(manifest).get("scope") or {})
+
+
+def scope_of(project: str, manifest: Path = MANIFEST) -> dict | None:
+    return all_scopes(manifest).get(project)
+
+
+def related_ids(project: str, manifest: Path = MANIFEST) -> dict[str, dict]:
+    """Identifier -> declaration, for datasets this project is *not* about.
+
+    `also_known_as` is listed alongside `id` because PhysioNet mints a DOI per
+    version as well as one for the project, and a check that knew only the
+    project-level DOI would pass a record that named the version.
+    """
+    scope = scope_of(project, manifest) or {}
+    out = {}
+    for entry in scope.get("related_but_distinct") or []:
+        for ident in [entry.get("id"), *(entry.get("also_known_as") or [])]:
+            if ident:
+                out[str(ident).strip()] = entry
+    return out
+
+
+def _norm(identifier: Any) -> str:
+    """Compare identifiers without tripping over trailing slashes or scheme.
+
+    `https://doi.org/10.13026/h995-bt35` and `doi:10.13026/h995-bt35` name the
+    same dataset, and a check that answered "no match" for the second would be
+    an invitation to write the second.
+    """
+    s = str(identifier or "").strip().rstrip("/").lower()
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi:"):
+        if s.startswith(prefix):
+            return "doi:" + s[len(prefix):]
+    return s
+
+
+def check_record(project: str, record: dict | Path,
+                 manifest: Path = MANIFEST) -> tuple[str, str | None]:
+    """Is this record about the dataset its project declares it is about?
+
+    - ``ok``          — the referent is not a declared related-but-distinct
+      dataset. Silent on whether it *equals* `referent_id`: records legitimately
+      identify themselves by a release DOI, a landing page or an ARK, and
+      failing that variety would be a naming rule wearing a scope rule's coat.
+    - ``out_of_scope`` — the record's `id` is a dataset the manifest declares
+      distinct from this project. The #292 failure.
+    - ``undeclared``  — the project declares no scope. Reported, not failed.
+    """
+    if isinstance(record, Path):
+        record = yaml.safe_load(record.read_text(encoding="utf-8")) or {}
+    if not isinstance(record, dict):
+        return "undeclared", "record is not a mapping"
+
+    scope = scope_of(project, manifest)
+    if not scope:
+        return "undeclared", f"no scope declared for {project} in the manifest"
+
+    got = _norm(record.get("id"))
+    for ident, entry in related_ids(project, manifest).items():
+        if got and got == _norm(ident):
+            return "out_of_scope", (
+                f"the record identifies itself as {record.get('id')}, which "
+                f"{project}'s manifest scope declares a distinct dataset"
+                + (f" ({entry['why']})" if entry.get("why") else "")
+                + ". A record about it belongs under "
+                + f"{entry.get('manifest_key', 'its own project')}; this one "
+                + f"may reference it through `{entry.get('express_as', 'related_datasets')}`")
+    return "ok", None
+
+
+def check_manifest(manifest: Path = MANIFEST) -> list[dict]:
+    """Is every scope declaration internally consistent? One row per problem.
+
+    A declaration that names a project or a source that does not exist is worse
+    than none: it reads as a control and enforces nothing.
+    """
+    data = load_manifest(manifest)
+    projects = data.get("projects") or {}
+    problems: list[dict] = []
+    for project, scope in (data.get("scope") or {}).items():
+        if project not in projects:
+            problems.append({"project": project,
+                             "problem": "scope declared for a project the "
+                                        "manifest has no sources for"})
+        if not scope.get("referent_id"):
+            problems.append({"project": project,
+                             "problem": "no referent_id: the scope says what "
+                                        "the record is about in prose only"})
+        ids = {e.get("id") for e in scope.get("related_but_distinct") or []}
+        for entry in scope.get("related_but_distinct") or []:
+            key = entry.get("manifest_key")
+            if key and key not in projects:
+                problems.append({"project": project,
+                                 "problem": f"related dataset names manifest "
+                                            f"key {key!r}, which does not exist"})
+            src = entry.get("in_bundle")
+            if src:
+                known = {e.get("id") for e in projects.get(project) or []
+                         if isinstance(e, dict)}
+                if src not in known:
+                    problems.append({
+                        "project": project,
+                        "problem": f"related dataset claims source {src!r} is "
+                                   f"in this bundle; the manifest lists no "
+                                   f"such source for {project}"})
+        if scope.get("referent_id") in ids:
+            problems.append({"project": project,
+                             "problem": "the referent is also listed as "
+                                        "related-but-distinct"})
+    return problems

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -99,18 +99,40 @@ class TestCheckingARecord(unittest.TestCase):
         self.assertEqual("ok", scope.check_record(
             "AI_READI", {"id": "https://doi.org/10.60775/fairhub.2"})[0])
 
+    def test_bare_and_dx_doi_spellings_do_not_slip_through(self):
+        """#442. `uriorcurie` slots accept bare tokens (#402), so a bare DOI is
+        a form records actually take — and one the check answered `ok` for."""
+        for spelling in ("10.13026/h995-bt35",
+                         "http://dx.doi.org/10.13026/h995-bt35",
+                         "https://dx.doi.org/10.13026/h995-bt35"):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(
+                    "out_of_scope",
+                    scope.check_record("VOICE", {"id": spelling})[0])
+
+    def test_an_unreadable_record_is_reported_not_raised(self):
+        """#444. One unparseable file must not abort a sweep of 329."""
+        bad = Path(tempfile.mkstemp(suffix=".yaml")[1])
+        self.addCleanup(lambda: bad.unlink(missing_ok=True))
+        bad.write_text("id: [unclosed\n")
+        status, why = scope.check_record("VOICE", bad)
+        self.assertEqual("unreadable", status)
+        self.assertIn("Error", why)
+
     def test_a_project_with_no_declaration_is_reported_not_failed(self):
         status, why = scope.check_record("NOT_A_PROJECT", {"id": "x"})
         self.assertEqual("undeclared", status)
         self.assertIn("no scope declared", why)
 
     def test_the_whole_corpus_agrees_with_the_declaration(self):
-        """171 records at the time of writing, none about the other cohort.
-        The paragraph was belt-and-braces; this is the braces."""
+        """329 records at the time of writing (full and core), none about the
+        other cohort. The paragraph was belt-and-braces; this is the braces."""
         from data_sheets_schema.api_runner import CONCAT_DIR
         bad = []
-        for rec in CONCAT_DIR.glob("*/*/*_d4d.yaml"):
-            project = rec.name.replace("_d4d.yaml", "")
+        for rec in [*CONCAT_DIR.glob("*/*/*_d4d.yaml"),
+                    *CONCAT_DIR.glob("*/*/*_d4d_core.yaml")]:
+            project = (rec.name.replace("_d4d_core.yaml", "")
+                       .replace("_d4d.yaml", ""))
             if project not in ALL_PROJECTS:
                 continue
             try:
@@ -120,6 +142,50 @@ class TestCheckingARecord(unittest.TestCase):
             if scope.check_record(project, data)[0] == "out_of_scope":
                 bad.append(str(rec))
         self.assertEqual([], bad)
+
+
+class TestTheOtherCohortAbsorbedOneLevelDown(unittest.TestCase):
+    """#441. `check_record` settles what a record is *about* and said 329 of 329
+    were fine, while 32 of them placed the pediatric release inside VOICE's own
+    resources and distribution. Not a record about the wrong dataset — a record
+    absorbing the other dataset into its own."""
+
+    def test_an_identifier_in_the_declared_slot_is_not_reported(self):
+        refs = scope.foreign_references("VOICE", {
+            "id": "https://doi.org/10.13026/37yb-1t42",
+            "related_datasets": [
+                {"target_dataset": "https://doi.org/10.13026/h995-bt35"}]})
+        self.assertEqual([], refs)
+
+    def test_an_identifier_in_the_distribution_is_reported(self):
+        refs = scope.foreign_references("VOICE", {
+            "id": "https://doi.org/10.13026/37yb-1t42",
+            "distribution_formats": [
+                {"access_urls": ["https://physionet.org/content/"
+                                 "b2ai-voice-pediatric/1.1.0/"]}]})
+        self.assertEqual(1, len(refs))
+        self.assertEqual("distribution_formats[0].access_urls[0]",
+                         refs[0]["path"])
+
+    def test_a_bare_doi_nested_deep_is_reported(self):
+        refs = scope.foreign_references("VOICE", {
+            "resources": [{"version_access":
+                           {"latest_version_doi": "10.13026/mf9s-5r03"}}]})
+        self.assertEqual(["resources[0].version_access.latest_version_doi"],
+                         [r["path"] for r in refs])
+
+    def test_a_project_with_nothing_declared_distinct_reports_nothing(self):
+        self.assertEqual([], scope.foreign_references(
+            "AI_READI", {"id": "x", "resources": [{"id": "y"}]}))
+
+    def test_it_is_reported_and_never_a_verdict(self):
+        """32 records carry these placements. Failing them would be the
+        retroactive-failure error the live-provenance cutoff exists to avoid,
+        and some placements are legitimate citations."""
+        record = {"id": "https://doi.org/10.13026/37yb-1t42",
+                  "resources": [{"id": "https://doi.org/10.13026/h995-bt35"}]}
+        self.assertEqual(("ok", None), scope.check_record("VOICE", record))
+        self.assertEqual(1, len(scope.foreign_references("VOICE", record)))
 
 
 class TestAMalformedDeclarationIsCaught(unittest.TestCase):
@@ -155,6 +221,28 @@ class TestAMalformedDeclarationIsCaught(unittest.TestCase):
                                   [{"id": "y", "in_bundle": "src_missing"}]}})
         self.assertTrue(any("no such source" in p["problem"]
                             for p in scope.check_manifest(m)))
+
+    def test_a_one_directional_declaration_is_caught(self):
+        """#443. A declaration in one direction checks in one direction: a
+        pediatric record identifying itself by the adult DOI would pass."""
+        m = self._manifest({
+            "P": {"referent_id": "x", "related_but_distinct":
+                  [{"id": "y", "manifest_key": "Q"}]},
+            "Q": {"referent_id": "y", "related_but_distinct": []},
+        })
+        # Q must exist in `projects` for the first check to stay quiet.
+        data = yaml.safe_load(m.read_text())
+        data["projects"]["Q"] = [{"id": "src_b"}]
+        m.write_text(yaml.safe_dump(data))
+        self.assertTrue(any("one direction only" in p["problem"]
+                            for p in scope.check_manifest(m)))
+
+    def test_a_related_dataset_outside_the_corpus_needs_no_back_reference(self):
+        """An upstream cohort or partner registry legitimately has no scope
+        block here, and requiring one would force fictional entries."""
+        m = self._manifest({"P": {"referent_id": "x", "related_but_distinct":
+                                  [{"id": "y", "manifest_key": None}]}})
+        self.assertEqual([], scope.check_manifest(m))
 
     def test_a_referent_that_is_also_declared_distinct_from_itself(self):
         m = self._manifest({"P": {"referent_id": "x", "related_but_distinct":

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,254 @@
+"""#422 — scope belongs in the manifest, not in the launch prompt.
+
+The VOICE launch prompt for the 2026-08-07 sweep carried a paragraph naming the
+project, the pediatric dataset, a file not to read, and the issue number of the
+last time it went wrong. It worked. It was also the wrong layer, the wrong kind
+of statement, and inherited by nothing: any new dataset with a companion cohort
+needs someone to notice and write another one.
+
+These tests hold the replacement in place from both ends — the declaration is
+consistent and checkable, and the instruction that goes out carries no
+project-specific text that could quietly become load-bearing again.
+"""
+
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema import scope
+from data_sheets_schema.constants import PROJECTS
+
+ALL_PROJECTS = (*PROJECTS, "VOICE_PEDIATRIC")
+
+
+class TestTheDeclarationItself(unittest.TestCase):
+    def test_every_project_declares_a_scope(self):
+        """A new dataset declares two lines and inherits the check. One that
+        declares nothing is the state this issue is about."""
+        declared = scope.all_scopes()
+        for project in ALL_PROJECTS:
+            with self.subTest(project=project):
+                self.assertIn(project, declared)
+                self.assertTrue(declared[project].get("referent_id"))
+
+    def test_the_declaration_is_internally_consistent(self):
+        """A declaration naming a project or a source that does not exist is
+        worse than none: it reads as a control and enforces nothing."""
+        self.assertEqual([], scope.check_manifest())
+
+    def test_the_voice_pair_declares_each_other(self):
+        self.assertIn("VOICE_PEDIATRIC",
+                      [e.get("manifest_key")
+                       for e in scope.scope_of("VOICE")["related_but_distinct"]])
+        self.assertIn("VOICE",
+                      [e.get("manifest_key") for e in
+                       scope.scope_of("VOICE_PEDIATRIC")["related_but_distinct"]])
+
+    def test_the_pediatric_source_is_declared_as_present_in_voices_bundle(self):
+        """VOICE's bundle really does contain the pediatric PhysioNet record,
+        because the current VOICE documentation advertises the two together.
+        Dropping the source to make the rule easier to state would make the
+        bundle a worse description of the evidence."""
+        entry = scope.scope_of("VOICE")["related_but_distinct"][0]
+        self.assertEqual("physionet_pediatric_1_1_0", entry["in_bundle"])
+        self.assertEqual("related_datasets", entry["express_as"])
+
+    def test_version_dois_are_covered_not_only_the_project_doi(self):
+        """PhysioNet mints a DOI per version as well as one per project. A
+        check that knew only the project-level DOI would pass a record that
+        named the version — which is the form the records actually use."""
+        ids = scope.related_ids("VOICE")
+        self.assertIn("https://doi.org/10.13026/h995-bt35", ids)
+        self.assertIn("https://doi.org/10.13026/mf9s-5r03", ids)
+
+
+class TestCheckingARecord(unittest.TestCase):
+    def test_a_record_about_the_companion_cohort_is_caught(self):
+        status, why = scope.check_record(
+            "VOICE", {"id": "https://doi.org/10.13026/h995-bt35"})
+        self.assertEqual("out_of_scope", status)
+        self.assertIn("related_datasets", why)
+
+    def test_identifier_spelling_does_not_let_it_through(self):
+        """`doi:10.…` and `https://doi.org/10.…` name the same dataset, and a
+        check that answered "no match" for one would be an invitation to write
+        that one."""
+        for spelling in ("doi:10.13026/h995-bt35",
+                         "https://doi.org/10.13026/h995-bt35/",
+                         "HTTPS://DOI.ORG/10.13026/H995-BT35"):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(
+                    "out_of_scope",
+                    scope.check_record("VOICE", {"id": spelling})[0])
+
+    def test_the_adult_dataset_is_in_scope_for_voice(self):
+        for ident in ("https://doi.org/10.13026/37yb-1t42",
+                      "https://doi.org/10.13026/8xbn-nq66",
+                      "https://b2ai-voice.org/"):
+            with self.subTest(ident=ident):
+                self.assertEqual(
+                    ("ok", None), scope.check_record("VOICE", {"id": ident}))
+
+    def test_a_release_doi_is_not_failed_for_not_being_the_referent(self):
+        """Records legitimately identify themselves by a release DOI, a landing
+        page or an ARK. Failing that variety would be a naming rule wearing a
+        scope rule's coat."""
+        self.assertEqual("ok", scope.check_record(
+            "AI_READI", {"id": "https://doi.org/10.60775/fairhub.2"})[0])
+
+    def test_a_project_with_no_declaration_is_reported_not_failed(self):
+        status, why = scope.check_record("NOT_A_PROJECT", {"id": "x"})
+        self.assertEqual("undeclared", status)
+        self.assertIn("no scope declared", why)
+
+    def test_the_whole_corpus_agrees_with_the_declaration(self):
+        """171 records at the time of writing, none about the other cohort.
+        The paragraph was belt-and-braces; this is the braces."""
+        from data_sheets_schema.api_runner import CONCAT_DIR
+        bad = []
+        for rec in CONCAT_DIR.glob("*/*/*_d4d.yaml"):
+            project = rec.name.replace("_d4d.yaml", "")
+            if project not in ALL_PROJECTS:
+                continue
+            try:
+                data = yaml.safe_load(rec.read_text(encoding="utf-8"))
+            except yaml.YAMLError:
+                continue
+            if scope.check_record(project, data)[0] == "out_of_scope":
+                bad.append(str(rec))
+        self.assertEqual([], bad)
+
+
+class TestAMalformedDeclarationIsCaught(unittest.TestCase):
+    """`check_manifest` is the reason the declaration can be trusted; if it
+    passed anything, the block would be prose again."""
+
+    def _manifest(self, scope_block):
+        tmp = tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False)
+        yaml.safe_dump({"projects": {"P": [{"id": "src_a"}]},
+                        "scope": scope_block}, tmp)
+        tmp.close()
+        self.addCleanup(lambda: Path(tmp.name).unlink(missing_ok=True))
+        return Path(tmp.name)
+
+    def test_a_scope_for_an_unknown_project(self):
+        m = self._manifest({"Q": {"referent_id": "x"}})
+        self.assertTrue(any("no sources for" in p["problem"]
+                            for p in scope.check_manifest(m)))
+
+    def test_a_referent_stated_only_in_prose(self):
+        m = self._manifest({"P": {"referent": "a dataset"}})
+        self.assertTrue(any("prose only" in p["problem"]
+                            for p in scope.check_manifest(m)))
+
+    def test_a_related_dataset_naming_a_project_that_does_not_exist(self):
+        m = self._manifest({"P": {"referent_id": "x", "related_but_distinct":
+                                  [{"id": "y", "manifest_key": "NOPE"}]}})
+        self.assertTrue(any("does not exist" in p["problem"]
+                            for p in scope.check_manifest(m)))
+
+    def test_a_related_dataset_claiming_a_source_the_bundle_lacks(self):
+        m = self._manifest({"P": {"referent_id": "x", "related_but_distinct":
+                                  [{"id": "y", "in_bundle": "src_missing"}]}})
+        self.assertTrue(any("no such source" in p["problem"]
+                            for p in scope.check_manifest(m)))
+
+    def test_a_referent_that_is_also_declared_distinct_from_itself(self):
+        m = self._manifest({"P": {"referent_id": "x", "related_but_distinct":
+                                  [{"id": "x"}]}})
+        self.assertTrue(any("also listed as" in p["problem"]
+                            for p in scope.check_manifest(m)))
+
+
+class TestTheInstructionCarriesNoProjectSpecificScope(unittest.TestCase):
+    """The mirror of the existing test that the prompt *file* names no project
+    (`test_generic_v2_prompt.py`), moved to the artifact that is actually sent.
+
+    A file can be generic and the instruction still not be: substitution
+    happens in between, and on the agentic path a human used to compose the
+    launch text by hand.
+    """
+
+    def _rendered(self, project, condition):
+        from data_sheets_schema.api_runner import RunSpec, resolve_prompt
+        return resolve_prompt(RunSpec(
+            project=project, arm="BASELINE", method="claudecode_agent",
+            bundle=Path(f"data/preprocessed/concatenated/{project}"
+                        f"_preprocessed.txt"),
+            label="L", condition=condition, manifest_line="",
+            run_date="2026-08-11"))
+
+    def test_no_rendered_instruction_names_another_project(self):
+        from data_sheets_schema.api_runner import CONDITION_PROMPTS
+        for condition in sorted(CONDITION_PROMPTS):
+            for project in ALL_PROJECTS:
+                text = self._rendered(project, condition)
+                for other in ALL_PROJECTS:
+                    if other == project:
+                        continue
+                    with self.subTest(condition=condition, project=project,
+                                      other=other):
+                        # Word-bounded: `VOICE` is a prefix of
+                        # `VOICE_PEDIATRIC`, so a substring test would report
+                        # the pediatric name as the adult one and pass the
+                        # exact case this exists to catch.
+                        self.assertIsNone(
+                            re.search(rf"\b{other}\b", text),
+                            f"the {condition} instruction for {project} names "
+                            f"{other}")
+
+    def test_a_rendered_instruction_names_only_its_own_bundle(self):
+        """The paragraph's operative sentence was *"Do not read
+        `data/preprocessed/concatenated/VOICE_PEDIATRIC_preprocessed.txt`"* — a
+        second bundle named in an instruction that declares one.
+
+        Banning directive phrases outright would be wrong: the prompt's uniform
+        rules are directives (`OUTPUTS — do not write outside these three`) and
+        they apply to every project identically. What must not appear is
+        another dataset's bundle.
+        """
+        from data_sheets_schema.api_runner import CONDITION_PROMPTS
+        pattern = re.compile(r"data/preprocessed/concatenated/[\w.-]+")
+        for condition in sorted(CONDITION_PROMPTS):
+            for project in ALL_PROJECTS:
+                text = self._rendered(project, condition)
+                named = set(pattern.findall(text))
+                expected = {f"data/preprocessed/concatenated/{project}"
+                            f"_preprocessed.txt"}
+                with self.subTest(condition=condition, project=project):
+                    self.assertEqual(expected, named)
+
+
+class TestThePlaybooksCarryNoPerProjectScope(unittest.TestCase):
+    """`.claude/` is the launch template on the agentic path — the one place a
+    per-GC paragraph could live and still be invisible to the prompt-condition
+    tests, which inspect the prompt file."""
+
+    DIRECTIVES = ("do not read", "must not read", "never read", "out of scope",
+                  "separate project", "scope boundary", "only covers")
+
+    def test_no_playbook_line_scopes_a_named_project(self):
+        offenders = []
+        for path in sorted(Path(".claude").rglob("*.md")):
+            for n, line in enumerate(path.read_text(encoding="utf-8")
+                                     .splitlines(), 1):
+                named = any(re.search(rf"\b{p}\b", line) for p in ALL_PROJECTS)
+                directs = any(d in line.lower() for d in self.DIRECTIVES)
+                if named and directs:
+                    offenders.append(f"{path}:{n}: {line.strip()[:110]}")
+        self.assertEqual([], offenders,
+                         "a per-project scope directive belongs in the "
+                         "manifest's `scope:` block, not in a playbook")
+
+    def test_the_playbook_says_where_scope_goes(self):
+        text = Path(".claude/commands/d4d-full-core.md").read_text(
+            encoding="utf-8")
+        self.assertIn("scope", text.lower())
+        self.assertIn("source_manifest.yaml", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #422.

## The finding

The VOICE launch prompt for the 2026-08-07 sweep carried this:

> CRITICAL SCOPE BOUNDARY: this run covers the adult/main Bridge2AI-Voice dataset ONLY. `VOICE_PEDIATRIC` is a separate project … Do not read `data/preprocessed/concatenated/VOICE_PEDIATRIC_preprocessed.txt` … doing so is what previously caused every VOICE replicate to fail validation (issue #292).

It worked, and it was per-GC adaptation at the wrong layer, of a kind the priming taxonomy excludes from the generic arm, that no future dataset inherits and no prompt test can see.

## The replacement

`source_manifest.yaml` gains a `scope:` block per project — `referent_id`, and any `related_but_distinct` dataset with `express_as` (the slot that carries the relation) and `in_bundle` (the source id, where its documentation is legitimately in the bundle):

```yaml
VOICE:
  referent_id: https://doi.org/10.13026/37yb-1t42
  related_but_distinct:
    - id: https://doi.org/10.13026/mf9s-5r03
      also_known_as: [https://doi.org/10.13026/h995-bt35, …]
      manifest_key: VOICE_PEDIATRIC
      in_bundle: physionet_pediatric_1_1_0
      express_as: related_datasets
```

```bash
d4d download scope --project VOICE      # show it
d4d download scope --check --strict     # check every record against it
```

**Checkable:** a record that identifies itself as a dataset its own project declares distinct is the #292 failure, now caught by a rule rather than prevented by a warning. 171 records checked, none out of scope. `check_manifest` refuses a declaration naming a project or a source that does not exist — a declaration that reads as a control and enforces nothing is worse than none.

**Inherited:** a new dataset declares two lines and gets the same check. An empty `related_but_distinct` means the question was asked and the answer was none.

## The issue's three asks

1. **Delete the paragraph from the launch template** — nothing in the repo held it; it lived in the launch message (`grep` finds it only in notes and tests). Since #429 an instruction that does not match its rendered spec fails `d4d runs check --strict`, so it can no longer arrive unrecorded. What was missing was somewhere legitimate for the information to live, which is this.
2. **Decide at the manifest level** — the pediatric PhysioNet record **stays** in VOICE's sources. Current VOICE documentation advertises the two releases together; dropping the source would make the bundle a worse description of the evidence in order to make a rule easier to state. The manifest now says the source is there and what it means.
3. **A test that the launch template names no project** — moved to the artifact actually sent: no rendered instruction, under any condition, names another project or another project's bundle. Banning directive phrases outright would be wrong (the prompt's uniform rules *are* directives, applied identically to every project); what must not appear is a second dataset. Plus a test that no `.claude/` playbook line carries a scope directive against a named project.

## Facts, and where they came from

Checked against the source documents, not against prior records: `10.13026/37yb-1t42` is the adult project-level DOI and `10.13026/mf9s-5r03` the pediatric one, both recorded in the bundle as "DOI (latest version)"; `h995-bt35` is pediatric 1.1.0; `8xbn-nq66` / `k81f-qr68` / `249v-w155` are adult 3.1.0 / 3.0.0 / 1.1. Version DOIs go under `also_known_as` — a check that knew only the project DOI would pass a record naming the version, which is the form the records actually use.

## Blast radius

- No bundle changed; `d4d download audit-manifest` still reports 41 sources.
- The manifest md5 that provenance records under `inputs.source_manifest` changes for future records. Nothing re-verifies that field, and the preprocessor writes no top-level manifest key into a bundle.
- `.claude/commands/d4d-full-core.md` gains a Scope section and a completion criterion, so its playbook hash changes again.
- The scope check reads the record's `id` only. A record can stay in scope by its identifier and still discuss the related dataset in prose — legitimate, and what `related_datasets` is for. Stated in the command's output rather than implied.

1478 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
