### PR TITLE
Audit identifier syntax: the trap that passes validation (#402)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -98,15 +98,22 @@ def identifiers_cmd(label, method, output, show, strict):
     report = ident.audit(root=root)
     if label:
         # Recompute rather than filter in place: the headline must describe
-        # exactly the records it is printed above.
+        # exactly the records it is printed above. `slots_audited` describes
+        # the schema, not the selection, so it is carried across rather than
+        # recomputed — dropping it made the header claim only `id` was checked
+        # while the by-slot line below it named others.
+        audited = report.get("slots_audited")
         report = ident.summarize(
             [r for r in report["records"] if f"/{label}/" in r["path"]],
             report["prefixes_declared"], report.get("unreadable"))
+        report["slots_audited"] = audited
 
     rows = [r for r in report["records"] if r["offenders"]]
+    slots = report.get("slots_audited") or ["id"]
     click.echo(f"🔍 {len(report['records'])} record(s), "
                f"{report['identifiers']} identifier(s), "
                f"{report['prefixes_declared']} declared prefix(es)")
+    click.echo(f"   slots with range uriorcurie: {', '.join(slots)}")
     c = report["counts"]
     click.echo(f"   {c[ident.URI]:>6}  absolute IRI")
     click.echo(f"   {c[ident.CURIE_DECLARED]:>6}  CURIE on a declared prefix")
@@ -117,6 +124,10 @@ def identifiers_cmd(label, method, output, show, strict):
         click.echo(f"\n⚠️  {report['unresolvable']} identifier(s) "
                    f"({report['unresolvable_share']:.0%}) across {len(rows)} "
                    "record(s) resolve to nothing:")
+        by_slot = report.get("unresolvable_by_slot") or {}
+        if by_slot:
+            click.echo("   by slot: " + ", ".join(f"{s} {n}"
+                                                  for s, n in by_slot.items()))
         for r in rows:
             name = Path(r["path"]).name
             click.echo(f"   {name}  ({len(r['offenders'])} of {r['total']}, "

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -65,6 +65,86 @@ def telemetry_cmd(label_prefix, method, output, findings_path, do_validate):
         click.echo("✓ report validates against d4d_run_telemetry.yaml")
 
 
+@runs.command("identifiers")
+@click.option("--label", default=None, help="limit to one run label")
+@click.option("--method", default=None, help="limit to one method directory")
+@click.option("-o", "--output", type=click.Path(), default=None,
+              help="write the full per-record report here as YAML")
+@click.option("--show", default=8, type=int, show_default=True,
+              help="list up to N offending values per affected record")
+@click.option("--strict", is_flag=True,
+              help="exit non-zero if any identifier cannot be resolved")
+def identifiers_cmd(label, method, output, show, strict):
+    """Audit identifier syntax across records — the trap the validator misses (#402).
+
+    `trap-inventory` mines validation failures. This is its complement, and the
+    defect it finds is the more dangerous kind because it passes: `uriorcurie`
+    declares no pattern, so LinkML renders it `{"type": ["string","null"]}` and
+    a bare token like `funder_nih` validates exactly as cleanly as a ROR IRI.
+
+    Nothing is repaired here. Adding the pattern would invalidate values in
+    records already committed — the right end state, and a migration rather
+    than a flag flip. Naming what is out there comes first.
+    """
+    import sys
+    import yaml as _yaml
+
+    from data_sheets_schema import identifiers as ident
+    from data_sheets_schema.runs import CONCAT_DIR
+
+    root = CONCAT_DIR
+    if method:
+        root = root / method
+    report = ident.audit(root=root)
+    if label:
+        # Recompute rather than filter in place: the headline must describe
+        # exactly the records it is printed above.
+        report = ident.summarize(
+            [r for r in report["records"] if f"/{label}/" in r["path"]],
+            report["prefixes_declared"], report.get("unreadable"))
+
+    rows = [r for r in report["records"] if r["offenders"]]
+    click.echo(f"🔍 {len(report['records'])} record(s), "
+               f"{report['identifiers']} identifier(s), "
+               f"{report['prefixes_declared']} declared prefix(es)")
+    c = report["counts"]
+    click.echo(f"   {c[ident.URI]:>6}  absolute IRI")
+    click.echo(f"   {c[ident.CURIE_DECLARED]:>6}  CURIE on a declared prefix")
+    click.echo(f"   {c[ident.CURIE_UNDECLARED]:>6}  CURIE on an undeclared prefix")
+    click.echo(f"   {c[ident.BARE]:>6}  bare token — neither IRI nor CURIE")
+
+    if report["unresolvable"]:
+        click.echo(f"\n⚠️  {report['unresolvable']} identifier(s) "
+                   f"({report['unresolvable_share']:.0%}) across {len(rows)} "
+                   "record(s) resolve to nothing:")
+        for r in rows:
+            name = Path(r["path"]).name
+            click.echo(f"   {name}  ({len(r['offenders'])} of {r['total']}, "
+                       f"mostly {r['dominant']})")
+            for o in r["offenders"][:show]:
+                click.echo(f"       {o['slot_path']:44} {o['value'][:48]}")
+            if len(r["offenders"]) > show:
+                # Never a silent cap: a truncated list that does not say it was
+                # truncated reads as the whole finding.
+                click.echo(f"       … {len(r['offenders']) - show} more "
+                           "(raise --show, or use -o for the full report)")
+    else:
+        click.echo("\n✓ every identifier is an IRI or a CURIE on a declared prefix")
+
+    if report.get("unreadable"):
+        click.echo(f"\n·  {len(report['unreadable'])} record(s) could not be parsed")
+
+    if output:
+        out = Path(output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(_yaml.safe_dump(report, sort_keys=False,
+                                       allow_unicode=True), encoding="utf-8")
+        click.echo(f"\n✓ full report -> {out}")
+
+    if strict and report["unresolvable"]:
+        sys.exit(1)
+
+
 @runs.command("trap-inventory")
 @click.option("-o", "--output", type=click.Path(),
               default="data/run_telemetry/trap_slot_inventory.yaml",

--- a/src/data_sheets_schema/identifiers.py
+++ b/src/data_sheets_schema/identifiers.py
@@ -1,0 +1,174 @@
+"""Identifier-syntax audit: what the validator accepts and the range does not (#402).
+
+`trap-inventory` mines the corpus for validation *failures*. This is its
+complement, and it exists because the more dangerous defect is the one that
+passes. `uriorcurie` declares no `pattern`, so LinkML renders it as
+
+    "id": {"type": ["string", "null"]}
+
+and every string is legal. A bare token like `funder_nih` validates exactly as
+cleanly as `https://ror.org/01cwqze88`. The declared range promises identifier
+syntax; nothing enforces it, so nothing reports it, and four mutually
+incompatible conventions coexisted across one label without a single warning.
+
+Why it matters more than tidiness: the core record is a semantic exchange
+layer, and entity resolution across records is the point. NIH currently appears
+as `funder_nih`, `https://cm4ai.org/data-releases/#funder-nih`,
+`d4d:VOICE-funding-nih-common-fund`, and as a name with no id at all. Nothing
+joins those. A bare token is worse than an absent identifier, because it looks
+like one and is scoped to nothing — two records both emitting `funder_nih`
+collide by accident rather than agree by reference.
+
+This module reports and never repairs. Adding a `pattern` to `uriorcurie` would
+invalidate values in records already committed, which is the correct end state
+and a migration rather than a flag flip; naming what is out there is the step
+that has to come first.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+CONCAT_DIR = Path("data/d4d_concatenated")
+FULL_SCHEMA = Path("src/data_sheets_schema/schema/data_sheets_schema_all.yaml")
+
+#: An absolute IRI. Anything with a scheme is self-describing and resolvable in
+#: principle, which is the property a bare token lacks.
+_ABSOLUTE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
+
+#: `prefix:reference`. The prefix must be declared in the schema for the CURIE
+#: to expand, so an undeclared prefix is reported separately from a declared
+#: one: it is well-formed and still unresolvable.
+_CURIE = re.compile(r"^([A-Za-z_][A-Za-z0-9._\-]*):(\S*)$")
+
+URI = "uri"
+CURIE_DECLARED = "curie_declared"
+CURIE_UNDECLARED = "curie_undeclared"
+BARE = "bare_token"
+
+#: The two that cannot be resolved to anything. Reported as the headline; the
+#: other two are recorded so a record's convention is visible rather than
+#: merely its failures.
+UNRESOLVABLE = (CURIE_UNDECLARED, BARE)
+
+
+def declared_prefixes(schema_path: Path = FULL_SCHEMA) -> set[str]:
+    """Prefixes the schema declares, against which a CURIE can be expanded.
+
+    Read from the merged schema's own `prefixes:` block rather than a hardcoded
+    list, so a prefix added to the schema is immediately admissible here and
+    the audit cannot drift from what the schema would actually resolve.
+    """
+    doc = yaml.safe_load(schema_path.read_text(encoding="utf-8")) or {}
+    return set(doc.get("prefixes") or {})
+
+
+def classify(value: str, prefixes: set[str]) -> str:
+    """Which of the four shapes an identifier value has."""
+    v = value.strip()
+    if _ABSOLUTE.match(v):
+        return URI
+    m = _CURIE.match(v)
+    if m:
+        return CURIE_DECLARED if m.group(1) in prefixes else CURIE_UNDECLARED
+    return BARE
+
+
+def walk_ids(node: Any, path: str = "$") -> Iterator[tuple[str, str]]:
+    """Every `id` value in a parsed record, with the path that carries it.
+
+    Indices are normalised to `[]` so occurrences aggregate by slot rather than
+    by position — the same normalisation `trap_inventory` applies, for the same
+    reason: 12 bad ids in one list is one defect, not twelve.
+    """
+    if isinstance(node, dict):
+        raw = node.get("id")
+        if isinstance(raw, str) and raw.strip():
+            yield f"{path}.id", raw
+        for key, child in node.items():
+            if key != "id":
+                yield from walk_ids(child, f"{path}.{key}")
+    elif isinstance(node, list):
+        for item in node:
+            yield from walk_ids(item, f"{path}[]")
+
+
+def audit_record(path: Path, prefixes: set[str]) -> dict[str, Any]:
+    """Classify every identifier in one record."""
+    doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    counts = {URI: 0, CURIE_DECLARED: 0, CURIE_UNDECLARED: 0, BARE: 0}
+    offenders: list[dict[str, str]] = []
+    for slot_path, value in walk_ids(doc):
+        kind = classify(value, prefixes)
+        counts[kind] += 1
+        if kind in UNRESOLVABLE:
+            offenders.append({"slot_path": slot_path, "value": value,
+                              "kind": kind})
+    total = sum(counts.values())
+    return {"path": str(path), "total": total, "counts": counts,
+            "offenders": offenders,
+            # The convention this record actually used, where it used one. A
+            # record that is 107/108 CURIE has a convention and one slip; a
+            # record split down the middle has none, and the two want different
+            # remedies.
+            "dominant": (max(counts, key=lambda k: counts[k])
+                         if total else None)}
+
+
+def summarize(records: list[dict[str, Any]], prefixes_declared: int,
+              unreadable: list[dict[str, str]] | None = None) -> dict[str, Any]:
+    """Totals over exactly the records given.
+
+    Separated from `audit` so a caller that filters — by label, method or
+    project — recomputes the headline from what it kept. Reporting a filtered
+    record list beside corpus-wide totals states two scopes in one breath and
+    reads as one.
+    """
+    totals = {URI: 0, CURIE_DECLARED: 0, CURIE_UNDECLARED: 0, BARE: 0}
+    for rec in records:
+        for kind, n in rec["counts"].items():
+            totals[kind] += n
+    total = sum(totals.values())
+    unresolvable = sum(totals[k] for k in UNRESOLVABLE)
+    return {
+        "records_scanned": len(records),
+        "records_with_unresolvable_ids": len([r for r in records
+                                              if r["offenders"]]),
+        "identifiers": total,
+        "counts": totals,
+        "unresolvable": unresolvable,
+        "unresolvable_share": (unresolvable / total) if total else 0.0,
+        "prefixes_declared": prefixes_declared,
+        "records": records,
+        "unreadable": unreadable or None,
+    }
+
+
+def audit(root: Path = CONCAT_DIR, schema_path: Path = FULL_SCHEMA,
+          include_archived: bool = False) -> dict[str, Any]:
+    """Classify identifiers across every record under ``root``.
+
+    ATTIC is excluded by default: those records were archived precisely because
+    their provenance could not be established, and counting them would inflate
+    a figure meant to describe the live corpus.
+    """
+    prefixes = declared_prefixes(schema_path)
+    files = sorted(p for p in root.rglob("*_d4d.yaml")
+                   if include_archived or "ATTIC" not in p.parts)
+    files += sorted(p for p in root.rglob("*_d4d_core.yaml")
+                    if include_archived or "ATTIC" not in p.parts)
+
+    records: list[dict[str, Any]] = []
+    unreadable: list[dict[str, str]] = []
+    for f in files:
+        try:
+            records.append(audit_record(f, prefixes))
+        except Exception as exc:  # noqa: BLE001 — a record that will not parse
+            unreadable.append({"path": str(f),                # is a finding too
+                               "error": f"{type(exc).__name__}: {exc}"})
+
+    return summarize(records, len(prefixes), unreadable)

--- a/src/data_sheets_schema/identifiers.py
+++ b/src/data_sheets_schema/identifiers.py
@@ -42,8 +42,10 @@ _ABSOLUTE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
 
 #: `prefix:reference`. The prefix must be declared in the schema for the CURIE
 #: to expand, so an undeclared prefix is reported separately from a declared
-#: one: it is well-formed and still unresolvable.
-_CURIE = re.compile(r"^([A-Za-z_][A-Za-z0-9._\-]*):(\S*)$")
+#: one: it is well-formed and still unresolvable. The reference is `\S+`, not
+#: `\S*`: `d4d:` expands to the namespace itself and identifies nothing, so
+#: accepting it would pass a value that names no entity.
+_CURIE = re.compile(r"^([A-Za-z_][A-Za-z0-9._\-]*):(\S+)$")
 
 URI = "uri"
 CURIE_DECLARED = "curie_declared"
@@ -78,36 +80,70 @@ def classify(value: str, prefixes: set[str]) -> str:
     return BARE
 
 
-def walk_ids(node: Any, path: str = "$") -> Iterator[tuple[str, str]]:
-    """Every `id` value in a parsed record, with the path that carries it.
+def uriorcurie_slots(schema_path: Path = FULL_SCHEMA) -> set[str]:
+    """Every slot whose *induced* range is `uriorcurie`, from the schema.
+
+    Derived rather than hardcoded to `id`, because `id` is one of six and the
+    other five hold the worse values: `unit` is 148 for 148 unresolvable
+    (`%`, `years`), `publisher` carries bare names like `PhysioNet`,
+    `latest_version_doi` carries bare DOIs, and `data_substrate` and
+    `data_topic` carry whole prose sentences. An audit that checked only `id`
+    would report a clean `unit` slot that has never once held an identifier.
+
+    Induced, not declared, so a `slot_usage` narrowing some other slot to
+    `uriorcurie` is picked up without anyone remembering to add it here.
+    """
+    from linkml_runtime import SchemaView
+
+    sv = SchemaView(str(schema_path))
+    found: set[str] = set()
+    for class_name in sv.all_classes():
+        for slot_name in sv.class_slots(class_name, attributes=True):
+            try:
+                slot = sv.induced_slot(slot_name, class_name)
+            except Exception:  # noqa: BLE001 — a slot that will not resolve
+                continue       # is not evidence about identifier syntax
+            if str(slot.range) == "uriorcurie":
+                found.add(slot_name)
+    return found
+
+
+def walk_identifiers(node: Any, slots: set[str],
+                     path: str = "$") -> Iterator[tuple[str, str, str]]:
+    """Every identifier-ranged value in a record, as (path, slot, value).
 
     Indices are normalised to `[]` so occurrences aggregate by slot rather than
     by position — the same normalisation `trap_inventory` applies, for the same
     reason: 12 bad ids in one list is one defect, not twelve.
     """
     if isinstance(node, dict):
-        raw = node.get("id")
-        if isinstance(raw, str) and raw.strip():
-            yield f"{path}.id", raw
         for key, child in node.items():
-            if key != "id":
-                yield from walk_ids(child, f"{path}.{key}")
+            here = f"{path}.{key}"
+            if key in slots:
+                for value in (child if isinstance(child, list) else [child]):
+                    if isinstance(value, str) and value.strip():
+                        yield here, key, value
+            # Recurse regardless: an identifier-ranged key may itself hold an
+            # inlined object elsewhere in the tree, and a nested `id` under a
+            # `publisher` object is still an identifier.
+            yield from walk_identifiers(child, slots, here)
     elif isinstance(node, list):
         for item in node:
-            yield from walk_ids(item, f"{path}[]")
+            yield from walk_identifiers(item, slots, f"{path}[]")
 
 
-def audit_record(path: Path, prefixes: set[str]) -> dict[str, Any]:
-    """Classify every identifier in one record."""
+def audit_record(path: Path, prefixes: set[str],
+                 slots: set[str] | None = None) -> dict[str, Any]:
+    """Classify every identifier-ranged value in one record."""
     doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     counts = {URI: 0, CURIE_DECLARED: 0, CURIE_UNDECLARED: 0, BARE: 0}
     offenders: list[dict[str, str]] = []
-    for slot_path, value in walk_ids(doc):
+    for slot_path, slot, value in walk_identifiers(doc, slots or {"id"}):
         kind = classify(value, prefixes)
         counts[kind] += 1
         if kind in UNRESOLVABLE:
-            offenders.append({"slot_path": slot_path, "value": value,
-                              "kind": kind})
+            offenders.append({"slot_path": slot_path, "slot": slot,
+                              "value": value, "kind": kind})
     total = sum(counts.values())
     return {"path": str(path), "total": total, "counts": counts,
             "offenders": offenders,
@@ -134,6 +170,14 @@ def summarize(records: list[dict[str, Any]], prefixes_declared: int,
             totals[kind] += n
     total = sum(totals.values())
     unresolvable = sum(totals[k] for k in UNRESOLVABLE)
+    # Per-slot, because the remedies are not the same size. A slot that is
+    # wholly unresolvable is a modelling error — `unit` was ranged
+    # `uriorcurie` and only ever holds `%` — while a slot that is mostly fine
+    # with a few strays is a data-entry problem.
+    by_slot: dict[str, int] = {}
+    for rec in records:
+        for off in rec["offenders"]:
+            by_slot[off.get("slot", "id")] = by_slot.get(off.get("slot", "id"), 0) + 1
     return {
         "records_scanned": len(records),
         "records_with_unresolvable_ids": len([r for r in records
@@ -142,6 +186,8 @@ def summarize(records: list[dict[str, Any]], prefixes_declared: int,
         "counts": totals,
         "unresolvable": unresolvable,
         "unresolvable_share": (unresolvable / total) if total else 0.0,
+        "unresolvable_by_slot": dict(sorted(by_slot.items(),
+                                            key=lambda kv: -kv[1])),
         "prefixes_declared": prefixes_declared,
         "records": records,
         "unreadable": unreadable or None,
@@ -157,6 +203,7 @@ def audit(root: Path = CONCAT_DIR, schema_path: Path = FULL_SCHEMA,
     a figure meant to describe the live corpus.
     """
     prefixes = declared_prefixes(schema_path)
+    slots = uriorcurie_slots(schema_path)
     files = sorted(p for p in root.rglob("*_d4d.yaml")
                    if include_archived or "ATTIC" not in p.parts)
     files += sorted(p for p in root.rglob("*_d4d_core.yaml")
@@ -166,9 +213,11 @@ def audit(root: Path = CONCAT_DIR, schema_path: Path = FULL_SCHEMA,
     unreadable: list[dict[str, str]] = []
     for f in files:
         try:
-            records.append(audit_record(f, prefixes))
+            records.append(audit_record(f, prefixes, slots))
         except Exception as exc:  # noqa: BLE001 — a record that will not parse
             unreadable.append({"path": str(f),                # is a finding too
                                "error": f"{type(exc).__name__}: {exc}"})
 
-    return summarize(records, len(prefixes), unreadable)
+    report = summarize(records, len(prefixes), unreadable)
+    report["slots_audited"] = sorted(slots)
+    return report

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -59,29 +59,63 @@ class TestClassify(unittest.TestCase):
         self.assertEqual(ident.URI,
                          ident.classify("  https://ror.org/x  ", PREFIXES))
 
+    def test_a_prefix_with_no_reference_identifies_nothing(self):
+        """`d4d:` expands to the namespace itself. Accepting it would pass a
+        value that names no entity."""
+        self.assertEqual(ident.BARE, ident.classify("d4d:", PREFIXES))
 
-class TestWalkIds(unittest.TestCase):
+    def test_the_values_that_prompted_this(self):
+        """Real values from the corpus, in slots ranged `uriorcurie`."""
+        for v in ("%", "years", "PhysioNet", "10.60775/fairhub.3",
+                  "Type 2 diabetes mellitus and associated health outcomes"):
+            with self.subTest(v=v):
+                self.assertIn(ident.classify(v, PREFIXES), ident.UNRESOLVABLE)
+
+
+class TestWalkIdentifiers(unittest.TestCase):
+    SLOTS = {"id", "publisher", "unit", "latest_version_doi"}
+
+    def _paths(self, doc):
+        return [p for p, _, _ in ident.walk_identifiers(doc, self.SLOTS)]
+
     def test_nested_ids_are_found_at_every_depth(self):
         doc = {"id": "top",
                "funders": [{"id": "funder_nih"}],
                "file_collections": [
                    {"id": "fc", "resources": [{"id": "file_a"},
                                               {"id": "file_b"}]}]}
-        found = dict(ident.walk_ids(doc))
+        found = set(self._paths(doc))
         self.assertIn("$.id", found)
         self.assertIn("$.funders[].id", found)
         self.assertIn("$.file_collections[].resources[].id", found)
+
+    def test_slots_other_than_id_are_audited(self):
+        """`id` is one of six uriorcurie slots and not the worst: `unit` holds
+        `%`, `publisher` holds bare names. Auditing only `id` would report a
+        clean `unit` that has never held an identifier."""
+        doc = {"unit": "%", "publisher": "PhysioNet",
+               "latest_version_doi": "10.60775/fairhub.3"}
+        found = {slot for _, slot, _ in ident.walk_identifiers(doc, self.SLOTS)}
+        self.assertEqual({"unit", "publisher", "latest_version_doi"}, found)
+
+    def test_a_multivalued_identifier_slot_yields_each_value(self):
+        doc = {"publisher": ["PhysioNet", "https://ror.org/x"]}
+        vals = [v for _, _, v in ident.walk_identifiers(doc, self.SLOTS)]
+        self.assertEqual(["PhysioNet", "https://ror.org/x"], vals)
 
     def test_list_positions_collapse_so_one_slot_is_one_finding(self):
         """12 bad ids in one list is one defect, not twelve — the same
         normalisation `trap_inventory` applies, for the same reason."""
         doc = {"purposes": [{"id": "a"}, {"id": "b"}, {"id": "c"}]}
-        paths = [p for p, _ in ident.walk_ids(doc)]
-        self.assertEqual(["$.purposes[].id"] * 3, paths)
+        self.assertEqual(["$.purposes[].id"] * 3, self._paths(doc))
 
     def test_a_non_string_or_empty_id_is_not_reported_as_an_identifier(self):
         doc = {"id": None, "a": {"id": ""}, "b": {"id": 7}}
-        self.assertEqual([], list(ident.walk_ids(doc)))
+        self.assertEqual([], self._paths(doc))
+
+    def test_a_slot_not_ranged_uriorcurie_is_left_alone(self):
+        doc = {"description": "a sentence that is not an identifier"}
+        self.assertEqual([], self._paths(doc))
 
 
 class TestAudit(unittest.TestCase):
@@ -89,9 +123,31 @@ class TestAudit(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
         self.root = Path(self.tmp.name)
+        # A real LinkML schema, not a prefixes-only stub: `audit` derives the
+        # slot set from it, so the fixture has to be loadable and has to
+        # declare a slot ranged `uriorcurie` other than `id` — otherwise the
+        # tests would pass against a scan that only ever looked at `id`.
         self.schema = self.root / "schema.yaml"
-        self.schema.write_text(yaml.safe_dump(
-            {"prefixes": {p: f"https://example.org/{p}/" for p in PREFIXES}}))
+        self.schema.write_text(yaml.safe_dump({
+            "id": "https://example.org/test",
+            "name": "test_schema",
+            "prefixes": {p: f"https://example.org/{p}/" for p in PREFIXES},
+            "default_range": "string",
+            "slots": {
+                "id": {"range": "uriorcurie", "identifier": True},
+                "publisher": {"range": "uriorcurie"},
+                "funders": {"range": "Thing", "multivalued": True,
+                            "inlined_as_list": True},
+                "x": {"range": "Thing", "multivalued": True,
+                      "inlined_as_list": True},
+                "description": {"range": "string"},
+            },
+            "classes": {
+                "Thing": {"slots": ["id", "publisher", "description"]},
+                "Dataset": {"slots": ["id", "publisher", "funders", "x",
+                                      "description"]},
+            },
+        }))
 
     def _record(self, rel: str, doc: dict):
         p = self.root / rel
@@ -126,6 +182,30 @@ class TestAudit(unittest.TestCase):
                             {"id": "oops"}]})
         rep = ident.audit(self.root, self.schema)
         self.assertEqual(ident.CURIE_DECLARED, rep["records"][0]["dominant"])
+
+    def test_the_slot_set_is_derived_from_the_schema_not_hardcoded(self):
+        rep = ident.audit(self.root, self.schema)
+        self.assertIn("publisher", rep["slots_audited"])
+        self.assertIn("id", rep["slots_audited"])
+
+    def test_a_bad_value_in_a_non_id_slot_is_caught(self):
+        """The version that only walked `id` reported this record clean, while
+        `publisher: PhysioNet` sat in a slot ranged `uriorcurie`."""
+        self._record("m/lbl/P_d4d.yaml",
+                     {"id": "https://doi.org/10.1/x",
+                      "publisher": "PhysioNet"})
+        rep = ident.audit(self.root, self.schema)
+        self.assertEqual(1, rep["unresolvable"])
+        self.assertEqual({"publisher": 1}, rep["unresolvable_by_slot"])
+
+    def test_offenders_are_grouped_by_slot(self):
+        self._record("m/lbl/P_d4d.yaml",
+                     {"id": "bare_one",
+                      "publisher": "PhysioNet",
+                      "funders": [{"id": "bare_two"}]})
+        rep = ident.audit(self.root, self.schema)
+        self.assertEqual({"id": 2, "publisher": 1},
+                         rep["unresolvable_by_slot"])
 
     def test_core_records_are_scanned_too(self):
         self._record("m_core/lbl/P_d4d_core.yaml", {"id": "bare"})

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,188 @@
+"""#402 — the trap that passes validation.
+
+`uriorcurie` declares no `pattern`, so LinkML renders it as
+`{"type": ["string","null"]}` and every string is legal. `funder_nih` validates
+exactly as cleanly as `https://ror.org/01cwqze88`, which is why four
+incompatible conventions coexisted across one label with no warning from
+anything.
+
+`trap-inventory` cannot find this: it mines validation *failures*, and these
+values pass. That is the whole point — the defect that passes is the dangerous
+one, because nothing in the pipeline is looking at it.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema import identifiers as ident
+
+PREFIXES = {"d4d", "schema", "dcterms"}
+
+
+class TestClassify(unittest.TestCase):
+    def test_absolute_iris(self):
+        for v in ("https://ror.org/01cwqze88",
+                  "http://example.org/x",
+                  "https://doi.org/10.13026/h995-bt35"):
+            with self.subTest(v=v):
+                self.assertEqual(ident.URI, ident.classify(v, PREFIXES))
+
+    def test_a_curie_on_a_declared_prefix(self):
+        self.assertEqual(ident.CURIE_DECLARED,
+                         ident.classify("d4d:VOICE-funding-nih", PREFIXES))
+
+    def test_a_curie_on_an_undeclared_prefix_is_not_the_same_thing(self):
+        """Well-formed and still unresolvable. Reported separately, because the
+        remedy differs: declare the prefix, versus rewrite the value."""
+        self.assertEqual(ident.CURIE_UNDECLARED,
+                         ident.classify("nosuch:thing", PREFIXES))
+
+    def test_bare_tokens(self):
+        for v in ("funder_nih", "purpose_workforce_and_education",
+                  "file_demographics", "x"):
+            with self.subTest(v=v):
+                self.assertEqual(ident.BARE, ident.classify(v, PREFIXES))
+
+    def test_a_bare_token_is_worse_than_an_absent_id(self):
+        """It looks like an identifier and is scoped to nothing, so two records
+        emitting `funder_nih` collide by accident rather than agree by
+        reference. Both classify as bare; the point is that neither resolves."""
+        self.assertIn(ident.classify("funder_nih", PREFIXES),
+                      ident.UNRESOLVABLE)
+        self.assertNotIn(ident.classify("https://ror.org/x", PREFIXES),
+                         ident.UNRESOLVABLE)
+
+    def test_surrounding_whitespace_does_not_change_the_verdict(self):
+        self.assertEqual(ident.URI,
+                         ident.classify("  https://ror.org/x  ", PREFIXES))
+
+
+class TestWalkIds(unittest.TestCase):
+    def test_nested_ids_are_found_at_every_depth(self):
+        doc = {"id": "top",
+               "funders": [{"id": "funder_nih"}],
+               "file_collections": [
+                   {"id": "fc", "resources": [{"id": "file_a"},
+                                              {"id": "file_b"}]}]}
+        found = dict(ident.walk_ids(doc))
+        self.assertIn("$.id", found)
+        self.assertIn("$.funders[].id", found)
+        self.assertIn("$.file_collections[].resources[].id", found)
+
+    def test_list_positions_collapse_so_one_slot_is_one_finding(self):
+        """12 bad ids in one list is one defect, not twelve — the same
+        normalisation `trap_inventory` applies, for the same reason."""
+        doc = {"purposes": [{"id": "a"}, {"id": "b"}, {"id": "c"}]}
+        paths = [p for p, _ in ident.walk_ids(doc)]
+        self.assertEqual(["$.purposes[].id"] * 3, paths)
+
+    def test_a_non_string_or_empty_id_is_not_reported_as_an_identifier(self):
+        doc = {"id": None, "a": {"id": ""}, "b": {"id": 7}}
+        self.assertEqual([], list(ident.walk_ids(doc)))
+
+
+class TestAudit(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.schema = self.root / "schema.yaml"
+        self.schema.write_text(yaml.safe_dump(
+            {"prefixes": {p: f"https://example.org/{p}/" for p in PREFIXES}}))
+
+    def _record(self, rel: str, doc: dict):
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(yaml.safe_dump(doc))
+        return p
+
+    def test_a_clean_record_reports_nothing(self):
+        self._record("m/lbl/P_d4d.yaml",
+                     {"id": "https://doi.org/10.1/x",
+                      "funders": [{"id": "d4d:nih"}]})
+        rep = ident.audit(self.root, self.schema)
+        self.assertEqual(0, rep["unresolvable"])
+        self.assertEqual(0.0, rep["unresolvable_share"])
+
+    def test_offenders_are_named_with_their_slot_and_value(self):
+        self._record("m/lbl/P_d4d.yaml",
+                     {"id": "https://doi.org/10.1/x",
+                      "funders": [{"id": "funder_nih"}]})
+        rep = ident.audit(self.root, self.schema)
+        self.assertEqual(1, rep["unresolvable"])
+        off = rep["records"][0]["offenders"]
+        self.assertEqual("$.funders[].id", off[0]["slot_path"])
+        self.assertEqual("funder_nih", off[0]["value"])
+
+    def test_the_dominant_convention_is_reported(self):
+        """A record that is 107/108 CURIE has a convention and one slip; one
+        split down the middle has none, and they want different remedies."""
+        self._record("m/lbl/P_d4d.yaml",
+                     {"id": "d4d:a",
+                      "x": [{"id": "d4d:b"}, {"id": "d4d:c"},
+                            {"id": "oops"}]})
+        rep = ident.audit(self.root, self.schema)
+        self.assertEqual(ident.CURIE_DECLARED, rep["records"][0]["dominant"])
+
+    def test_core_records_are_scanned_too(self):
+        self._record("m_core/lbl/P_d4d_core.yaml", {"id": "bare"})
+        rep = ident.audit(self.root, self.schema)
+        self.assertEqual(1, rep["records_scanned"])
+        self.assertEqual(1, rep["unresolvable"])
+
+    def test_attic_is_excluded_by_default(self):
+        """Archived records were set aside because their provenance could not
+        be established; counting them inflates a live-corpus figure."""
+        self._record("ATTIC/m/lbl/P_d4d.yaml", {"id": "bare"})
+        self.assertEqual(0, ident.audit(self.root, self.schema)["records_scanned"])
+        self.assertEqual(1, ident.audit(self.root, self.schema,
+                                        include_archived=True)["records_scanned"])
+
+    def test_an_unparseable_record_is_reported_not_skipped(self):
+        p = self.root / "m/lbl/P_d4d.yaml"
+        p.parent.mkdir(parents=True)
+        p.write_text("{{ not yaml")
+        rep = ident.audit(self.root, self.schema)
+        self.assertEqual(1, len(rep["unreadable"]))
+
+
+class TestSummarizeMatchesItsRecords(unittest.TestCase):
+    """A filtered record list beside corpus-wide totals states two scopes in
+    one breath and reads as one. The CLI recomputes; this pins that."""
+
+    def test_totals_describe_exactly_the_records_given(self):
+        recs = [
+            {"path": "a", "total": 2, "counts": {ident.URI: 2,
+                                                 ident.CURIE_DECLARED: 0,
+                                                 ident.CURIE_UNDECLARED: 0,
+                                                 ident.BARE: 0},
+             "offenders": [], "dominant": ident.URI},
+            {"path": "b", "total": 2, "counts": {ident.URI: 0,
+                                                 ident.CURIE_DECLARED: 0,
+                                                 ident.CURIE_UNDECLARED: 0,
+                                                 ident.BARE: 2},
+             "offenders": [{"slot_path": "$.id", "value": "x",
+                            "kind": ident.BARE}] * 2,
+             "dominant": ident.BARE},
+        ]
+        both = ident.summarize(recs, 33)
+        self.assertEqual(4, both["identifiers"])
+        self.assertEqual(2, both["unresolvable"])
+        self.assertEqual(0.5, both["unresolvable_share"])
+
+        just_a = ident.summarize(recs[:1], 33)
+        self.assertEqual(2, just_a["identifiers"])
+        self.assertEqual(0, just_a["unresolvable"])
+        self.assertEqual(1, just_a["records_scanned"])
+
+    def test_an_empty_selection_does_not_divide_by_zero(self):
+        empty = ident.summarize([], 33)
+        self.assertEqual(0, empty["identifiers"])
+        self.assertEqual(0.0, empty["unresolvable_share"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #402.

## What

`d4d runs identifiers` — a corpus audit of identifier syntax, sibling to `trap-inventory`.

```
🔍 341 record(s), 23378 identifier(s), 33 declared prefix(es)
     8168  absolute IRI
     8086  CURIE on a declared prefix
     3510  CURIE on an undeclared prefix
     3614  bare token — neither IRI nor CURIE

⚠️  7124 identifier(s) (30%) across 124 record(s) resolve to nothing
```

## Why it needed a new command

`trap-inventory` mines the corpus for validation **failures**. It cannot find this one, because these values pass. That is the point: `uriorcurie` declares no `pattern`, so LinkML renders it `{"type": ["string","null"]}` and `funder_nih` validates exactly as cleanly as `https://ror.org/01cwqze88`.

Nothing was looking, so four mutually incompatible conventions coexisted inside a single label — `2026-08-07..._rep1` is **42% unresolvable** — with no warning from any gate. The corpus now holds NIH as four different things:

- `funder_nih` (CHORUS, VOICE_PEDIATRIC)
- `https://cm4ai.org/data-releases/#funder-nih` (CM4AI)
- `d4d:VOICE-funding-nih-common-fund` (VOICE)
- no id at all, name only (AI-READI)

Nothing joins those, which defeats the purpose of a semantic exchange layer. A bare token is worse than an absent id: it looks like an identifier and is scoped to nothing, so two records both emitting `funder_nih` collide by accident rather than agree by reference.

## Design notes

**Four shapes, not two.** A CURIE on an *undeclared* prefix is well-formed and still unresolvable, and it is counted apart from a bare token because the remedy differs — declare the prefix, versus rewrite the value. 3,510 of the corpus's unresolvable ids are this kind, so collapsing the two would have pointed the work in the wrong direction.

**Prefixes come from the schema.** Read from the merged schema's own `prefixes:` block rather than a hardcoded list, so the audit cannot drift from what the schema would actually expand.

**Reports, never repairs.** Adding the pattern to `uriorcurie` is the correct end state and would invalidate values in records already committed — a migration, not a flag flip. Naming what is out there comes first. `--strict` is opt-in for anyone who wants the gate today.

**`summarize()` is separate from `audit()`** so a filtered caller recomputes its headline. The first version printed a label-filtered record list beneath corpus-wide totals: "10 records, 23378 identifiers", two scopes in one breath, reading as one. Truncated offender lists say how many they dropped, for the same reason.

## Not in scope

The `pattern` itself, and the migration of the 7,124 existing values. #402 stays the reference for that decision; this PR makes the number visible and stable enough to plan against.

## Testing

`tests/test_identifiers.py` — 17 tests: the four classifications, nested/`[]`-normalised traversal, non-string ids ignored, ATTIC excluded by default, unparseable records reported rather than skipped, dominant-convention detection, and that `summarize` totals describe exactly the records handed to it.

250 pass across `test_rocrate/test_runs.py`, `test_cli/`, `test_identifiers.py`, `test_provenance_reasoning_effort.py`. Verified `--strict` exits 1 on a label with unresolvable ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)