### PR TITLE
Register the v1-vs-v3 comparison, and correct what §6 claimed had run (#458)

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -207,23 +207,33 @@ This section said v3 was "drafted, wired and tested but unrun", then said it had
 every run that actually hashed `d4d_generic_arm_prompt_v3.md`, against the v2
 series it would be compared with:
 
-| label | prompt | schema digest | route | coverage |
+Replicate counts are per project, measured from the provenance records.
+
+| label | prompt | schema digest | route | replicates |
 |---|---|---|---|---|
-| `2026-07-31_…generic-v2_rep{1,2,3}` | v2 | `34d24ff3` (1.0.0) | `google/claude-opus-5-high` | 4 projects × 3 |
-| `2026-08-05_…generic-v3_rep1` | v3 | `b065e1cd` (1.0.0) | `google/claude-opus-5-high` | AI_READI, CHORUS × 1 |
-| `2026-08-05_…1m-generic-v3_rep{1,2,3}` | v3 | `b065e1cd` (1.0.0) | `claude-opus-5` (1m) | AI_READI × 3, CHORUS × 1 |
-| `2026-08-06_…1m-generic-v3-schema2_rep{1,2,3}` | v3 | `583d79c1` (2.0.0) | `claude-opus-5` (1m) | AI_READI, CHORUS × 2 |
-| `2026-08-07_…claudecode-generic-v3_rep{1,2,3}` | **generic (v1)** | *none recorded* (2.0.0) | `claude-opus-5` | 5 projects × 3 |
+| `2026-07-31_…generic-v2` | v2 | `34d24ff3` (1.0.0) | `google/claude-opus-5-high` | AI_READI 3, CHORUS 3, CM4AI 3, VOICE 3 |
+| `2026-08-05_…generic-v3` | v3 | `b065e1cd` (1.0.0) | `google/claude-opus-5-high` | AI_READI 1, CHORUS 1 |
+| `2026-08-05_…1m-generic-v3` | v3 | `b065e1cd` (1.0.0) | `claude-opus-5` (1m) | AI_READI 3, CHORUS 1 |
+| `2026-08-06_…1m-generic-v3-schema2` | v3 | `583d79c1` (2.0.0) | `claude-opus-5` (1m) | AI_READI 3, CHORUS 3 |
+| `2026-08-07_…claudecode-generic-v3` | **generic (v1)** | *none recorded* (2.0.0) | `claude-opus-5` | all five, 3 each |
+
+v3 totals: **AI_READI 7, CHORUS 5, CM4AI 0, VOICE 0, VOICE_PEDIATRIC 0.**
 
 **The v2-vs-v3 comparison is not merely unwritten — it is not derivable.** Three
 independent defects, any one sufficient:
 
-1. **Coverage.** CM4AI, VOICE and VOICE_PEDIATRIC have never run under v3.
+1. **Coverage.** CM4AI, VOICE and VOICE_PEDIATRIC have never run under v3, so no
+   comparison covering the corpus is possible.
 2. **Schema confound.** Every v3 label sits on a different digest than v2's
    `34d24ff3`, and the delta includes the trap-slot work (#376, #382) that moves
    the exact defect classes `form_defects` counts.
 3. **Route confound.** Three of four v3 labels ran `claude-opus-5` (1m) where v2
    ran `google/claude-opus-5-high`.
+
+Note the shape of 2 and 3 together: the only v3 series with three replicates on
+two projects is `2026-08-06_…1m-generic-v3-schema2`, which is confounded against
+v2 on **both** axes at once. The best-powered v3 data is also the most
+confounded (#460).
 
 `notes/generic_v3_analysis_plan.md` pre-registered "same four projects, three
 replicates, same model and settings as the v1 and v2 series." No label meets it.

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -273,7 +273,9 @@ Guards in place:
   measured against.
 - Tests assert v2 differs from v1 *only* within the marked block, that the block
   names no project, dataset identifier or quantity, and that every project
-  receives byte-identical text after mechanical substitution.
+  receives byte-identical text after mechanical substitution — **for the four
+  projects the test hardcodes.** VOICE_PEDIATRIC is not among them, so the
+  byte-identity guarantee is unasserted for the fifth project (#467).
 - The prediction is deliberately absent from the prompt. Written there it would
   instruct the model to produce the result the run is meant to test, which the
   priming taxonomy excludes from both arms.
@@ -356,7 +358,18 @@ which is why no VOICE replicate validated (#292).
 
 **Done:** the registry, the shared-corpus declaration, and the schema correction
 that made the nested form wrong rather than ambiguous. Adding the fifth project
-broke nothing; the four-project list in 26 files is prose, not logic.
+broke nothing *visible*, and the four-project list is prose in most of the 26
+files that carry it.
+
+⚠️ **Not in all of them.** `form_defects._value_index` hardcoded the four as a
+runtime list, so any VOICE_PEDIATRIC failure would have attributed as
+`unattributed` — silently, since nothing distinguishes "a project we did not
+open" from "a value that matched nothing". Fixed to read `PROJECTS` (#463).
+Two four-project literals are still live and are *not* prose:
+`agreement.DEFAULT_PROJECTS`, and the byte-identity assertion in
+`tests/test_download/test_generic_v2_prompt.py` (#467). "Broke nothing" held
+because nothing from the fifth project had reached those code paths yet, not
+because they were generic.
 
 **Not done, and each needs a decision:**
 
@@ -375,8 +388,13 @@ broke nothing; the four-project list in 26 files is prose, not logic.
   a test pins it.
 - **A generation run — done.** Both projects were generated in the 2026-08-07
   five-project sweep (`2026-08-07_claude-opus-5-claudecode-generic-v3_rep{1,2,3}`,
-  PR #395), under v3. `VOICE_PEDIATRIC` was generated from its own 204 KB bundle
-  as its own project, which is what the fork was for.
+  PR #395). `VOICE_PEDIATRIC` was generated from its own 204 KB bundle as its
+  own project, which is what the fork was for.
+
+  ⚠️ **Not "under v3", despite the label.** That sweep hashed
+  `d4d_generic_arm_prompt.md` — the plain generic prompt (#454, and see §6).
+  The run is fine for what this section claims about it; the condition name is
+  not.
 
   **#292 is closed.** All three VOICE replicates validate; `d4d evaluate
   related-datasets` reports 0 defects across the canonical set; and VOICE
@@ -401,6 +419,11 @@ broke nothing; the four-project list in 26 files is prose, not logic.
   by the fresh v1 arm in §6, after which these records are annotated and kept as
   historical rather than renamed — renaming 30 records, their provenance paths
   and five canonical marks would assert a uniformity that does not hold.
+
+  **That supersession has not happened yet.** The fresh arm is decided and
+  pre-registered (§6), not generated; `e802cdc3` appears in no record and no
+  judgement. Until it does, these remain the canonical records and the caveat
+  above is the whole of the mitigation.
 
 - **Whether `VOICE` becomes `VOICE_main` — decided: no.** Attempted and reverted.
   The path moves were clean (567 files, no clashes), but the content rewrite
@@ -533,7 +556,7 @@ Acted on the same day:
 | re-recording discarded the validation verdict | #396 | **fixed** (#423) |
 | the launch prompt was typed, not rendered | #419, #422 | **addressed** (#425) |
 | per-GC scope lived in the launch prompt | #422 | **closed** — declared in the manifest |
-| label says `generic-v3`, provenance hashes v1 | #420, #454 | check landed; records superseded by §6's fresh v1 arm |
+| label says `generic-v3`, provenance hashes v1 | #420, #454 | check landed; records **not yet** superseded — §6's fresh v1 arm is decided, not run |
 | v3 never ran on 3 of 5 projects; every v3 label confounded | #458 | open — gates §6 |
 | `verification_url` still injected; 0 values depend on it | #427 | open, cosmetic |
 | a verdict does not pin the schema it was reached against | #426 | **fixed** |

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -184,11 +184,23 @@ It validated on the headline, and the breakdown says to read that carefully:
 | target | 41 → 16 | −61% |
 | **form** | **50 → 56** | **worse** |
 
-Rule 1 eliminated the defect it named — collapsed cardinality **27 → 0** — and
-produced a different one under the same label: **hollow objects 2 → 33**, one
-object per entity exactly as instructed, with everything crammed into free-text
-`description` while `name`, `id`, `affiliations`, `start_date`, `end_date` go
-unused. `collection_timeframes` newly fails form in all four projects;
+Rule 1 eliminated the defect it named — collapsed cardinality **42 → 7**, −83% —
+and produced a different one under the same label: **hollow objects 8 → 50**,
+one object per entity exactly as instructed, with everything crammed into
+free-text `description` while `name`, `id`, `affiliations`, `start_date`,
+`end_date` go unused.
+
+⚠️ These are the **classifier** figures from
+`notes/form_defect_split_2026-08-03.md`, and they **include the `both` bucket**
+(collapsed cardinality 34 + 8 = 42 → 2 + 5 = 7; hollow object 0 + 8 = 8 →
+45 + 5 = 50). An arm counted excluding `both` compares against a baseline of 34,
+not 42, and is wrong by more than several of the effects being claimed (#461).
+
+Earlier revisions of this section quoted **27 → 0** and **2 → 33**. Those are
+the note's *manual read*, which the classifier superseded — the note keeps both
+and explains the difference as boundary-drawing, the human retreating to
+"unclear" (37 in `other`) where a judge asked one question per value does not
+(12). The manual read is why the split was built; it is not the measurement. `collection_timeframes` newly fails form in all four projects;
 `creators`, `distribution_formats`, `distribution_dates` in three. Systematic,
 not sampling noise.
 

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -3,7 +3,7 @@
 Open work, most blocking first. Each item states what is true now, not only what
 should happen, so an item can be checked rather than believed.
 
-Last verified: 2026-08-10.
+Last verified: 2026-08-11.
 
 ---
 
@@ -199,24 +199,51 @@ not sampling noise.
 The rules are still **not** in the playbook, so a run today gets v1 behaviour
 unless it explicitly selects a condition.
 
-### v3 has run (2026-08-05 → 2026-08-07)
+### v3 has run — but on two projects, and never comparably (#458)
 
-This section said v3 was "drafted, wired and tested but unrun". That is no
-longer true — `src/download/prompts/d4d_generic_arm_prompt_v3.md` has 20 runs
-across four labels:
+This section said v3 was "drafted, wired and tested but unrun", then said it had
+"20 runs across four labels". Both were wrong. Fifteen of those twenty are the
+2026-08-07 sweep, which hashed the **generic** prompt, not v3 (#454). Here is
+every run that actually hashed `d4d_generic_arm_prompt_v3.md`, against the v2
+series it would be compared with:
 
-| label | what it was |
-|---|---|
-| `2026-08-05_claude-opus-5-generic-v3_rep1`, `…-1m-generic-v3_rep{1,2,3}` | first v3 passes, AI_READI + CHORUS |
-| `2026-08-06_…-1m-generic-v3-schema2_rep{1,2,3}` | schema-2 series, with the trap-slot and repair work below |
-| `2026-08-07_claude-opus-5-claudecode-generic-v3_rep{1,2,3}` | the five-project sweep; **canonical set** |
+| label | prompt | schema digest | route | coverage |
+|---|---|---|---|---|
+| `2026-07-31_…generic-v2_rep{1,2,3}` | v2 | `34d24ff3` (1.0.0) | `google/claude-opus-5-high` | 4 projects × 3 |
+| `2026-08-05_…generic-v3_rep1` | v3 | `b065e1cd` (1.0.0) | `google/claude-opus-5-high` | AI_READI, CHORUS × 1 |
+| `2026-08-05_…1m-generic-v3_rep{1,2,3}` | v3 | `b065e1cd` (1.0.0) | `claude-opus-5` (1m) | AI_READI × 3, CHORUS × 1 |
+| `2026-08-06_…1m-generic-v3-schema2_rep{1,2,3}` | v3 | `583d79c1` (2.0.0) | `claude-opus-5` (1m) | AI_READI, CHORUS × 2 |
+| `2026-08-07_…claudecode-generic-v3_rep{1,2,3}` | **generic (v1)** | *none recorded* (2.0.0) | `claude-opus-5` | 5 projects × 3 |
 
-**Still open, and this is the actionable part:** the v2-vs-v3 comparison the
-promotion decision rests on has not been written up. `notes/generic_v2_results.md`
-exists for v1→v2; there is no v3 equivalent, and the hollow-object regression
-rule 1 introduced has not been re-measured under v3. Until that is done the
-playbook keeps v1 behaviour by default, which is the safe state but not a
-decision.
+**The v2-vs-v3 comparison is not merely unwritten — it is not derivable.** Three
+independent defects, any one sufficient:
+
+1. **Coverage.** CM4AI, VOICE and VOICE_PEDIATRIC have never run under v3.
+2. **Schema confound.** Every v3 label sits on a different digest than v2's
+   `34d24ff3`, and the delta includes the trap-slot work (#376, #382) that moves
+   the exact defect classes `form_defects` counts.
+3. **Route confound.** Three of four v3 labels ran `claude-opus-5` (1m) where v2
+   ran `google/claude-opus-5-high`.
+
+`notes/generic_v3_analysis_plan.md` pre-registered "same four projects, three
+replicates, same model and settings as the v1 and v2 series." No label meets it.
+
+**The instrument already enforced this**, which is why it went unnoticed: all
+1441 cached fitness judgements are keyed `(34d24ff3, google/claude-opus-5-high)`,
+so no v3 record was ever a cache hit and no arms were silently mixed. What the
+guard could not do is announce that the arm it protected had never been
+generated — an absent cache entry and an absent run look identical.
+
+**Decided, 2026-08-11: generate both arms fresh.** v1 and v3, five projects ×
+three replicates = 30 runs, at today's digest `e802cdc3`, on the agentic path,
+with instructions rendered rather than typed. Registered in
+`notes/generic_v1_v3_analysis_plan.md` before any run. The pairing is v1-vs-v3
+rather than v2-vs-v3 because v1 is the playbook default, so that is the
+comparison the promotion decision rests on; the mechanism question (does rule 4
+alone do what it says?) stays open and needs a v2 arm at the same digest.
+
+Until those runs land the playbook keeps v1 behaviour by default, which is the
+safe state but not a decision.
 
 Guards in place:
 
@@ -341,6 +368,17 @@ broke nothing; the four-project list in 26 files is prose, not logic.
   2026-08-04). VOICE is no longer the gap; `d4d runs canonical` marks
   AI_READI, CHORUS, CM4AI, VOICE and VOICE_PEDIATRIC, all from the 2026-08-07
   label.
+
+  ⚠️ **That label is the one #454 is about.** It ran the generic prompt under a
+  `generic-v3` name, carries no recorded instruction (it predates #419), and its
+  launch text was not uniform — VOICE and VOICE_PEDIATRIC got a scope paragraph
+  the other three projects did not. The records are internally honest: every
+  header names `d4d_generic_arm_prompt.md` and says "generic prompt", so only the
+  directory label misstates the condition. Within-project replicate variance
+  still stands on this set; cross-condition claims do not. It is being superseded
+  by the fresh v1 arm in §6, after which these records are annotated and kept as
+  historical rather than renamed — renaming 30 records, their provenance paths
+  and five canonical marks would assert a uniformity that does not hold.
 
 - **Whether `VOICE` becomes `VOICE_main` — decided: no.** Attempted and reverted.
   The path moves were clean (567 files, no clashes), but the content rewrite
@@ -473,7 +511,8 @@ Acted on the same day:
 | re-recording discarded the validation verdict | #396 | **fixed** (#423) |
 | the launch prompt was typed, not rendered | #419, #422 | **addressed** (#425) |
 | per-GC scope lived in the launch prompt | #422 | **closed** — declared in the manifest |
-| label says `generic-v3`, provenance hashes v1 | #420 | open |
+| label says `generic-v3`, provenance hashes v1 | #420, #454 | check landed; records superseded by §6's fresh v1 arm |
+| v3 never ran on 3 of 5 projects; every v3 label confounded | #458 | open — gates §6 |
 | `verification_url` still injected; 0 values depend on it | #427 | open, cosmetic |
 | a verdict does not pin the schema it was reached against | #426 | **fixed** |
 | the render gate cannot see an edit made *before* rendering | #432 | **closed** |

--- a/notes/generic_v1_v3_analysis_plan.md
+++ b/notes/generic_v1_v3_analysis_plan.md
@@ -10,6 +10,12 @@ That plan is not retracted — its question is still the right *mechanism*
 question — but it cannot be answered from anything on disk, for the reasons in
 #458, and answering it would require generating a v2 arm as well.
 
+v3 coverage on disk, measured per project: **AI_READI 7 replicates, CHORUS 5,
+CM4AI 0, VOICE 0, VOICE_PEDIATRIC 0.** The only v3 series carrying three
+replicates on two projects is `2026-08-06_…1m-generic-v3-schema2`, which is
+confounded against the v2 series on both schema and route at once — so the
+best-powered v3 data is also the most confounded (#460).
+
 ## Why the pairing changed, from v2-vs-v3 to v1-vs-v3
 
 The registered plan asked for v2 against v3, because the two differ on one axis

--- a/notes/generic_v1_v3_analysis_plan.md
+++ b/notes/generic_v1_v3_analysis_plan.md
@@ -81,9 +81,18 @@ Against the v1 arm, under v3:
    only rule that does. This is the outcome that would justify promotion.
 2. **Collapsed cardinality falls.** v3 contains v2's rule 1, and v1 contains no
    cardinality rule. The v1→v2 measurement put this at 42 → 7 (−83%).
-3. **The `form` total falls.** It is the sum of 1 and 2, both predicted down.
-   This is the figure that moved the *wrong way* on v1→v2 (50 → 56) while both
-   its components were changing, which is why the split had to come first.
+3. **The `form` total falls.** This is the figure that moved the *wrong way* on
+   v1→v2 (50 → 56) while both its components were changing, which is why the
+   split had to come first.
+
+   ⚠️ The total is **not** the sum of predictions 1 and 2, in either direction.
+   It also counts `other`, which neither rule addresses; and the two folded
+   figures overlap, because a value classified `both` counts toward each. So
+   the total can rise while both folded counts fall — `other` growing, or
+   `both` growing — and predictions 1–3 can come apart without any of them
+   being wrong. **Report all four raw buckets alongside the folded pair**, and
+   treat a total that moves against its components as a finding about where the
+   defects went rather than as a contradiction.
 4. **Substance and target fall**, roughly as they did on v1→v2 (−62%, −61%).
    v3 carries v2's rules 2 and 3 unchanged.
 
@@ -108,8 +117,30 @@ the prompt.
 ## How it will be measured
 
 Fitness scoring, then `python -m data_sheets_schema.form_defects` for the
-sub-type breakdown. Neither rubric is edited, so cached labels stay valid *for
-their own key*.
+sub-type breakdown. Neither rubric is edited.
+
+⚠️ **Two instrument constraints have to be handled before this command can
+produce the comparison** — neither is optional, and both were found reviewing
+this plan:
+
+1. **`attribute()` is wired to the historical v1/v2 labels.** Its `configs`
+   default is `DEFAULT_CONFIGS`, naming the 2026-07-28 and 2026-07-31 runs. Run
+   bare against the new arms, every fresh failure attributes as `unattributed`
+   — or worse, to an old arm, where an identical slot/value happens to occur in
+   both. Pass the new labels explicitly (`--config v1=<label> --config
+   v3=<label>`).
+2. **The sub-type cache key is `(slot, value)` only** — no schema, unlike the
+   fitness cache which is keyed on it. So an identical slot/value under
+   `e802cdc3` silently reuses a label judged against the *old* slot
+   specification. That matters precisely here, because this plan's own argument
+   is that the schema change moves the form classes: `Organization.id` becoming
+   optional changes whether a given object is hollow. Classify the new arms
+   into a **separate cache file** (`--cache <path>`) rather than the shared one,
+   until the key carries the schema (#465).
+
+The fitness rubric and the sub-type rubric are unchanged, so labels stay valid
+for their own key — but "their own key" does not include the schema, which is
+the whole of constraint 2.
 
 ### Counting convention — fixed here so the arms are comparable
 
@@ -123,7 +154,8 @@ collapsed cardinality:  34 + 8 = 42  →  2 + 5 = 7
 hollow object:           0 + 8 =  8  → 45 + 5 = 50
 ```
 
-This convention is stated nowhere else in the repo (#461) and is not optional
+The convention was stated nowhere in the repo when this plan was written; it is
+now implemented as `folded()` and printed by the CLI (#461). It is not optional
 here: counted *excluding* `both`, the v1 collapsed-cardinality baseline is 34
 rather than 42, and the arms differ by the size of that bucket — 8 values on v1,
 5 on v2 — which is larger than several of the effects this comparison is trying

--- a/notes/generic_v1_v3_analysis_plan.md
+++ b/notes/generic_v1_v3_analysis_plan.md
@@ -80,7 +80,7 @@ Against the v1 arm, under v3:
 1. **Hollow objects fall.** v3's rule 4 names this defect directly and is the
    only rule that does. This is the outcome that would justify promotion.
 2. **Collapsed cardinality falls.** v3 contains v2's rule 1, and v1 contains no
-   cardinality rule. The v1→v2 measurement put this at 42 → 7.
+   cardinality rule. The v1→v2 measurement put this at 42 → 7 (−83%).
 3. **The `form` total falls.** It is the sum of 1 and 2, both predicted down.
    This is the figure that moved the *wrong way* on v1→v2 (50 → 56) while both
    its components were changing, which is why the split had to come first.
@@ -110,6 +110,33 @@ the prompt.
 Fitness scoring, then `python -m data_sheets_schema.form_defects` for the
 sub-type breakdown. Neither rubric is edited, so cached labels stay valid *for
 their own key*.
+
+### Counting convention — fixed here so the arms are comparable
+
+`form_defects` classifies each form failure into `collapsed cardinality`,
+`hollow object`, `both`, or `other`. **Subtype totals fold the `both` bucket
+into each of the two named subtypes**, which is how the v1→v2 headline figures
+were derived:
+
+```
+collapsed cardinality:  34 + 8 = 42  →  2 + 5 = 7
+hollow object:           0 + 8 =  8  → 45 + 5 = 50
+```
+
+This convention is stated nowhere else in the repo (#461) and is not optional
+here: counted *excluding* `both`, the v1 collapsed-cardinality baseline is 34
+rather than 42, and the arms differ by the size of that bucket — 8 values on v1,
+5 on v2 — which is larger than several of the effects this comparison is trying
+to see.
+
+The v1 arm generated here supplies its own baseline, so the v1→v2 numbers above
+are context rather than the comparison. They are quoted to fix the *convention*,
+not the values.
+
+Two further figures in circulation are the **manual read** (collapsed
+cardinality 27 → 0, hollow object 2 → 33) that the classifier superseded. Do not
+mix them with classifier output; `notes/form_defect_split_2026-08-03.md` keeps
+both and explains why they differ.
 
 ⚠️ **No cached judgement is reusable here.** All 1441 existing fitness
 judgements are keyed `(34d24ff3, google/claude-opus-5-high)`. Every record in

--- a/notes/generic_v1_v3_analysis_plan.md
+++ b/notes/generic_v1_v3_analysis_plan.md
@@ -1,0 +1,134 @@
+# generic v1-vs-v3 analysis plan
+
+Registered before any generation run of this comparison. The prediction is here
+rather than in the prompt because writing it there would instruct the model to
+produce the result the run is meant to test — the same reason
+`notes/generic_v3_analysis_plan.md` keeps it out.
+
+Supersedes the comparison registered in `notes/generic_v3_analysis_plan.md`.
+That plan is not retracted — its question is still the right *mechanism*
+question — but it cannot be answered from anything on disk, for the reasons in
+#458, and answering it would require generating a v2 arm as well.
+
+## Why the pairing changed, from v2-vs-v3 to v1-vs-v3
+
+The registered plan asked for v2 against v3, because the two differ on one axis
+and only that pairing isolates the companion rule. That is the mechanism
+question: *does rule 4 do what it says?*
+
+The question actually open in NEXT_TASKS §6 is the **promotion** question: *should
+the playbook stop giving v1 behaviour by default?* v1 is the default, so v1
+against v3 is the comparison that decides it. It measures all four rules at
+once, which is the correct granularity for a decision to adopt all four.
+
+The mechanism question stays open and is not answered here. It needs a v2 arm at
+today's schema, and nothing in this plan produces one.
+
+## Why both arms must be generated fresh
+
+The `Dataset` schema digest today is `e802cdc3`. No run on disk carries it:
+
+| series | digest | declared |
+|---|---|---|
+| v2, `2026-07-31` | `34d24ff3` | 1.0.0 |
+| v3, `2026-08-05` | `b065e1cd` | 1.0.0 |
+| v3, `2026-08-06` schema-2 | `583d79c1` | 2.0.0 |
+| `2026-08-07` sweep (v1, mislabelled — #454) | *none recorded* | 2.0.0 |
+| **this comparison** | **`e802cdc3`** | 2.0.0 |
+
+The schema deltas between these are not cosmetic: they include the trap-slot
+work (#376 scalarized the narrative family, #382 made `Organization.id`
+optional), which mechanically moves the exact defect classes `form_defects`
+counts. A hollow-object count is not comparable across them.
+
+The 2026-08-07 sweep is a v1 arm at declared 2.0.0 and was considered as the
+baseline. It is rejected on two grounds, either sufficient: it records no schema
+digest, so it cannot be shown to sit at `e802cdc3`; and per #454 its launch text
+was not uniform — VOICE and VOICE_PEDIATRIC received a scope paragraph the other
+three projects did not, so two of five projects would compare against a
+different condition than the other three.
+
+## The comparison
+
+**v1 (`generic`) against v3 (`generic_v3`)**, both generated fresh:
+
+| | |
+|---|---|
+| projects | AI_READI, CHORUS, CM4AI, VOICE, VOICE_PEDIATRIC |
+| replicates | 3 |
+| runs | 15 per arm, **30 total** |
+| runtime | Claude Code, agentic four-phase (`claudecode_agent`) |
+| schema | `e802cdc3`, declared 2.0.0 |
+| instruction | rendered by `d4d api render-prompt`, never typed (#425) |
+| scope | from `source_manifest.yaml`, never from launch text (#422) |
+
+Both arms are rendered through the same code path with only `--condition`
+differing, so the two instructions are byte-identical outside the condition
+block. That is what the 2026-08-07 sweep could not claim and is the point of
+regenerating the baseline rather than reusing it.
+
+## Prediction, registered
+
+Against the v1 arm, under v3:
+
+1. **Hollow objects fall.** v3's rule 4 names this defect directly and is the
+   only rule that does. This is the outcome that would justify promotion.
+2. **Collapsed cardinality falls.** v3 contains v2's rule 1, and v1 contains no
+   cardinality rule. The v1→v2 measurement put this at 42 → 7.
+3. **The `form` total falls.** It is the sum of 1 and 2, both predicted down.
+   This is the figure that moved the *wrong way* on v1→v2 (50 → 56) while both
+   its components were changing, which is why the split had to come first.
+4. **Substance and target fall**, roughly as they did on v1→v2 (−62%, −61%).
+   v3 carries v2's rules 2 and 3 unchanged.
+
+Prediction 4 is the weakest and is registered as such: it is the one place this
+comparison should reproduce a known result rather than produce a new one, so a
+*failure* there is evidence about the instrument or the schema change, not about
+the prompt.
+
+## What would count as failure
+
+- **Hollow objects flat or up.** Rule 4 is not doing what it says, and #458's
+  premise — that the arm was worth generating — is weakened rather than the
+  rule's.
+- **Collapsed cardinality returning.** The rules are not additive; rule 1 and
+  rule 4 need rewriting as one instruction rather than two.
+- **A new form sub-type appearing in `other`.** The same exchange happening one
+  level down. `other` is measured, so this is visible rather than inferred.
+- **Substance or target moving sharply against the v1→v2 result.** Adding rules
+  changes behaviour diffusely rather than at the point they name, which weakens
+  the case that these rules compose at all.
+
+## How it will be measured
+
+Fitness scoring, then `python -m data_sheets_schema.form_defects` for the
+sub-type breakdown. Neither rubric is edited, so cached labels stay valid *for
+their own key*.
+
+⚠️ **No cached judgement is reusable here.** All 1441 existing fitness
+judgements are keyed `(34d24ff3, google/claude-opus-5-high)`. Every record in
+this comparison sits at `e802cdc3`, so both arms need judging from scratch. This
+is the guard working as designed — the cache key is what prevents a silent mix
+across schemas — but it means the scoring cost is for 30 records, not 15.
+
+## Cost
+
+Thirty agentic generations (5 projects × 3 replicates × 2 arms) on the Claude
+Code path: no API spend for generation. Then fitness scoring of all 30 records
+and sub-type classification of whatever form failures they produce — this part
+is paid, and is roughly double what a single-arm comparison would cost, for the
+cache reason above.
+
+**Canary before fan-out.** One run — one project, one replicate, one arm —
+executed end to end through the same launcher, and its outputs verified present
+and non-empty on disk, before any of the remaining 29 are launched.
+
+## What this does not settle
+
+- The mechanism question (v2 against v3, isolating rule 4). Needs a v2 arm at
+  `e802cdc3`.
+- Whether the promotion generalises beyond five projects. #169 established that
+  between-project variance (sd 10.9) swamps between-config effects at this
+  sample size; five projects, two of which share a source corpus
+  (`SHARED_CORPUS_GROUPS`), cannot resolve a small effect. This comparison is
+  powered to see a *large* prompt effect on defect counts, not to estimate one.

--- a/notes/generic_v2_results.md
+++ b/notes/generic_v2_results.md
@@ -1,5 +1,19 @@
 # generic-v2: results, against the plan registered before the runs
 
+> ⚠️ **The form sub-type figures here are the manual read, superseded on
+> 2026-08-03** by the classifier in `src/data_sheets_schema/form_defects.py`.
+> Where this note says collapsed cardinality 27 → 0 and hollow object 2 → 33,
+> the measurement is **42 → 7** and **8 → 50** (classifier, folding the `both`
+> bucket into each named subtype — see `folded()`). `notes/form_defect_split_
+> 2026-08-03.md` keeps both and explains the gap as boundary-drawing: reading
+> judge reasons in bulk retreats to "unclear" (37 in `other`) where a judge
+> asked one question per value does not (12).
+>
+> Left as written rather than restated. This note is the record of what was
+> concluded before the classifier existed, and the hand read is why it was
+> built. Everything else here — the fitness totals, the per-project
+> breakdown, the method check — is unaffected (#461).
+
 Companion to `notes/generic_v2_analysis_plan.md`. Every number below comes from
 the same fitness rubric, model and schema as the v1 baseline — the judgement
 cache is keyed on `(axis, model, rubric, corpus, schema)` and the context

--- a/notes/replicate_agreement_2026-08-02.md
+++ b/notes/replicate_agreement_2026-08-02.md
@@ -206,8 +206,11 @@ agreement between prompt configurations, and no number of replicates fixes that
 
 It does not say v2 failed. The registered v2 experiment was about *fitness*
 failures, and there the effect was large and consistent: 131 → 87 defective
-fields, falling in all four projects, with the targeted defect eliminated 27 → 0
-(`notes/generic_v2_results.md`).
+fields, falling in all four projects, with the targeted defect all but
+eliminated — **42 → 7**, −83% (`notes/generic_v2_results.md`; the classifier
+figure, folding `both` into each named subtype). This note originally read
+"eliminated 27 → 0", the manual read the classifier superseded the following
+day; the substantive point is unchanged and the direction is the same (#461).
 
 So the two quantities behave differently. Fitness moved enough to measure with
 four projects; agreement did not. That is worth stating precisely, because "the

--- a/src/data_sheets_schema/form_defects.py
+++ b/src/data_sheets_schema/form_defects.py
@@ -193,6 +193,29 @@ def attribute(failures: list[FormFailure], *, root: Path = DEFAULT_ROOT,
     return failures
 
 
+class PooledInstruments(ValueError):
+    """The cache records more than one model for the current rubric.
+
+    Distinguished from "records none" because the two need opposite responses:
+    an empty cache has nothing to reproduce and may fall back to the live pin,
+    while a pooled one must refuse. Falling back there picks whichever entries
+    happen to match the pin and silently reports a partial table (#464).
+    """
+
+
+def recorded_models(cache_path: Path) -> set[str]:
+    """Every model the cache records for the current rubric."""
+    models: set[str] = set()
+    for line in Path(cache_path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        if entry.get("rubric") == _digest(FORM_SUBTYPE_SYSTEM):
+            models.add(entry.get("model", ""))
+    models.discard("")
+    return models
+
+
 def recorded_model(cache_path: Path) -> str:
     """The one model the cached subtype judgements were made under.
 
@@ -203,14 +226,11 @@ def recorded_model(cache_path: Path) -> str:
     current rubric — zero means there is nothing to reproduce, two means two
     instruments are pooled and neither table can be trusted (#277).
     """
-    models: set[str] = set()
-    for line in Path(cache_path).read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        entry = json.loads(line)
-        if entry.get("rubric") == _digest(FORM_SUBTYPE_SYSTEM):
-            models.add(entry.get("model", ""))
-    models.discard("")
+    models = recorded_models(cache_path)
+    if len(models) > 1:
+        raise PooledInstruments(
+            f"{cache_path} records {len(models)} models for the current "
+            f"rubric ({sorted(models)}); a reproduction needs exactly one.")
     if len(models) != 1:
         raise ValueError(
             f"{cache_path} records {len(models)} models for the current "
@@ -249,15 +269,20 @@ class FormSubtypeClassifier:
         appends a second instrument to the cache, after which `recorded_model`
         refuses the file and the v1->v2 baseline cannot be reproduced at all.
 
-        The cache is therefore consulted first. A cache recording two models
-        already fails `recorded_model`, and that error is more useful here than
-        a silent third.
+        The cache is therefore consulted first. A cache that records *two*
+        models propagates `PooledInstruments` rather than falling back: there
+        is no correct instrument to choose, and picking the pin would load only
+        the entries that happen to match it and report a partial table as if it
+        were whole (#464). Only "nothing recorded" and "unreadable" fall
+        through, because in neither case is there an instrument to prefer.
         """
         if self.cache_path and Path(self.cache_path).exists():
             try:
                 return recorded_model(self.cache_path)
+            except PooledInstruments:
+                raise
             except (ValueError, OSError):
-                pass          # empty, unreadable, or already pooled — fall through
+                pass          # nothing recorded, or unreadable — fall through
         from data_sheets_schema.api_runner import _model_settings
         return _model_settings()["name"]
 
@@ -397,9 +422,41 @@ def main(argv: list[str] | None = None) -> int:
                         help="re-classify under a named instrument instead of "
                              "the one the cache records; a stated act, since "
                              "it pools two instruments in one file (#462)")
+    parser.add_argument("--allow-pooled-cache", action="store_true",
+                        help="permit --model to write a second instrument into "
+                             "a cache that already records another (#464)")
+    parser.add_argument("--config", action="append", metavar="TAG=LABEL",
+                        help="arm to attribute against, repeatable; defaults to "
+                             "the historical v1/v2 labels. Required for any "
+                             "other arm — attribution is by matching values "
+                             "back against records, so an unlisted label's "
+                             "failures all read as `unattributed` (#466)")
     args = parser.parse_args(argv)
 
-    failures = attribute(load_form_failures(args.judgement_cache))
+    configs = None
+    if args.config:
+        configs = {}
+        for item in args.config:
+            if "=" not in item:
+                parser.error(f"--config expects TAG=LABEL, got {item!r}")
+            tag, label = item.split("=", 1)
+            configs[tag.strip()] = label.strip()
+
+    if args.model and not args.offline and args.cache.exists():
+        already = recorded_models(args.cache) - {args.model}
+        if already and not args.allow_pooled_cache:
+            print(f"refusing to pool instruments: {args.cache} already records "
+                  f"{sorted(already)} for this rubric, and --model "
+                  f"{args.model} would append a second.\n"
+                  f"  Write elsewhere with --cache <path>, or state the intent "
+                  f"with --allow-pooled-cache.\n"
+                  f"  A pooled cache makes recorded_model refuse the file, so "
+                  f"the existing table stops being reproducible (#277, #464).",
+                  file=sys.stderr)
+            return 2
+
+    failures = attribute(load_form_failures(args.judgement_cache),
+                         configs=configs)
     if args.limit:
         failures = failures[:args.limit]
     print(f"{len(failures)} form failure(s) loaded", file=sys.stderr)

--- a/src/data_sheets_schema/form_defects.py
+++ b/src/data_sheets_schema/form_defects.py
@@ -4,12 +4,20 @@
 said and the instrument could not show it. Form failures went 50 → 56, apparently
 worse, while underneath:
 
-    collapsed cardinality — several entities in one object   27 → 0
+    collapsed cardinality — several entities in one object   42 → 7
     hollow object — one object per entity, all content in
-                    free-text `description`                   2 → 33
+                    free-text `description`                   8 → 50
 
 The rule eliminated the defect it named and produced a different one wearing the
-same label. One `form` class covering two failures made a real improvement read
+same label.
+
+Those are this module's own classifier output, folded — see `folded()`; a value
+classified `both` counts toward each named subtype. Earlier revisions of this
+docstring carried 27 → 0 and 2 → 33, which are the *manual read* from
+`notes/form_defect_split_2026-08-03.md` that the classifier superseded (#461).
+The note keeps both and explains the gap: a human reading judge reasons in bulk
+retreats to "unclear" (37 in `other`) where a judge asked one question per value
+does not (12). The manual read is why this module exists; it is not its output. One `form` class covering two failures made a real improvement read
 as a regression, and the note's conclusion was that any future comparison on
 this axis has to split them. This module is that split.
 

--- a/src/data_sheets_schema/form_defects.py
+++ b/src/data_sheets_schema/form_defects.py
@@ -317,6 +317,34 @@ def table(classified: list[tuple[FormFailure, str, str]]) -> dict[str, dict[str,
     return {s: dict(c) for s, c in counts.items()}
 
 
+#: The two named subtypes, each folded to include the `both` bucket. A value
+#: classified `both` exhibits *each* defect, so it counts once toward each —
+#: which is why these two figures legitimately sum to more than the total.
+FOLDED_SUBTYPES = ("collapsed_cardinality", "hollow_object")
+
+
+def folded(counts: dict[str, dict[str, int]]) -> dict[str, dict[str, int]]:
+    """Fold `both` into each named subtype — the repo's reporting convention.
+
+    Every headline figure quoted for the v1→v2 comparison is folded this way
+    (collapsed cardinality 34 + 8 = 42 -> 2 + 5 = 7; hollow object 0 + 8 = 8 ->
+    45 + 5 = 50). The convention lived only in the prose of
+    `notes/form_defect_split_2026-08-03.md`, so an arm counted from the raw
+    `table()` compared against a baseline short by the whole `both` bucket —
+    larger than several of the effects being claimed (#461).
+
+    Reported alongside the raw table rather than replacing it: `both` is a real
+    classification and collapsing it away would hide how often the two defects
+    co-occur.
+    """
+    out: dict[str, dict[str, int]] = {}
+    for subtype in FOLDED_SUBTYPES:
+        merged = collections.Counter(counts.get(subtype, {}))
+        merged.update(counts.get("both", {}))
+        out[subtype] = dict(merged)
+    return out
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--judgement-cache", type=Path, default=JUDGEMENT_CACHE)
@@ -348,6 +376,15 @@ def main(argv: list[str] | None = None) -> int:
     print(f"{'total':<{width}} "
           + " ".join(f"{sum(counts[s].get(c, 0) for s in SUBTYPES):>6}"
                      for c in configs))
+
+    merged = folded(counts)
+    print(f"\nfolded — `both` counted toward each named subtype (#461);"
+          f" these do not sum to the total above")
+    for subtype in FOLDED_SUBTYPES:
+        row = merged[subtype]
+        print(f"{subtype:<{width}} "
+              + " ".join(f"{row.get(c, 0):>6}" for c in configs))
+
     print(f"\n{classifier.calls} call(s), {classifier.memo_hits} cached",
           file=sys.stderr)
     return 0

--- a/src/data_sheets_schema/form_defects.py
+++ b/src/data_sheets_schema/form_defects.py
@@ -218,9 +218,30 @@ class FormSubtypeClassifier:
     @property
     def model(self) -> str:
         if self._model is None:
-            from data_sheets_schema.api_runner import _model_settings
-            self._model = _model_settings()["name"]
+            self._model = self._default_model()
         return self._model
+
+    def _default_model(self) -> str:
+        """The instrument the cache records, falling back to the live pin.
+
+        Deferring to the pin unconditionally is what #462 was: the pin moved
+        from `google/claude-opus-5-high` to `claude-opus-5`, every model-scoped
+        entry fell out of scope, and all 106 cached labels became invisible.
+        Offline that fails loudly; online it silently spends 106 calls and
+        appends a second instrument to the cache, after which `recorded_model`
+        refuses the file and the v1->v2 baseline cannot be reproduced at all.
+
+        The cache is therefore consulted first. A cache recording two models
+        already fails `recorded_model`, and that error is more useful here than
+        a silent third.
+        """
+        if self.cache_path and Path(self.cache_path).exists():
+            try:
+                return recorded_model(self.cache_path)
+            except (ValueError, OSError):
+                pass          # empty, unreadable, or already pooled — fall through
+        from data_sheets_schema.api_runner import _model_settings
+        return _model_settings()["name"]
 
     def _load(self) -> None:
         if not self.cache_path or not self.cache_path.exists():
@@ -354,6 +375,10 @@ def main(argv: list[str] | None = None) -> int:
                         help="fail instead of making a paid call")
     parser.add_argument("--limit", type=int, default=None,
                         help="classify only the first N (for a canary)")
+    parser.add_argument("--model", default=None,
+                        help="re-classify under a named instrument instead of "
+                             "the one the cache records; a stated act, since "
+                             "it pools two instruments in one file (#462)")
     args = parser.parse_args(argv)
 
     failures = attribute(load_form_failures(args.judgement_cache))
@@ -362,7 +387,9 @@ def main(argv: list[str] | None = None) -> int:
     print(f"{len(failures)} form failure(s) loaded", file=sys.stderr)
 
     classifier = FormSubtypeClassifier(cache_path=args.cache,
+                                       model=args.model,
                                        offline=args.offline)
+    print(f"instrument: {classifier.model}", file=sys.stderr)
     classified = classify(failures, classifier)
     counts = table(classified)
 

--- a/src/data_sheets_schema/form_defects.py
+++ b/src/data_sheets_schema/form_defects.py
@@ -9,17 +9,17 @@ worse, while underneath:
                     free-text `description`                   8 → 50
 
 The rule eliminated the defect it named and produced a different one wearing the
-same label.
+same label. One `form` class covering two failures made a real improvement read
+as a regression, and the note's conclusion was that any future comparison on
+this axis has to split them. This module is that split.
 
-Those are this module's own classifier output, folded — see `folded()`; a value
-classified `both` counts toward each named subtype. Earlier revisions of this
-docstring carried 27 → 0 and 2 → 33, which are the *manual read* from
+Those figures are this module's own classifier output, folded — see `folded()`;
+a value classified `both` counts toward each named subtype. Earlier revisions of
+this docstring carried 27 → 0 and 2 → 33, which are the *manual read* from
 `notes/form_defect_split_2026-08-03.md` that the classifier superseded (#461).
 The note keeps both and explains the gap: a human reading judge reasons in bulk
 retreats to "unclear" (37 in `other`) where a judge asked one question per value
-does not (12). The manual read is why this module exists; it is not its output. One `form` class covering two failures made a real improvement read
-as a regression, and the note's conclusion was that any future comparison on
-this axis has to split them. This module is that split.
+does not (12). The manual read is why this module exists; it is not its output.
 
 **It does not re-judge fitness.** Editing `FITNESS_SYSTEM` would be the obvious
 way to add sub-types and would invalidate all 1441 cached fitness judgements —
@@ -43,6 +43,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator
 
+from data_sheets_schema.constants import PROJECTS
 from data_sheets_schema.agreement import (
     DEFAULT_CONFIGS,
     DEFAULT_ROOT,
@@ -148,13 +149,22 @@ def load_form_failures(cache_dir: Path = JUDGEMENT_CACHE) -> list[FormFailure]:
     return out
 
 
-def _value_index(root: Path, method: str,
-                 configs: dict[str, str]) -> dict[tuple[str, str], set[str]]:
-    """(slot, canonical value) -> the configs that produced it."""
+def _value_index(root: Path, method: str, configs: dict[str, str],
+                 projects: tuple[str, ...] = tuple(PROJECTS),
+                 ) -> dict[tuple[str, str], set[str]]:
+    """(slot, canonical value) -> the configs that produced it.
+
+    The project list comes from `PROJECTS`, not a literal. A project missing
+    here is not an error anyone sees: its values match nothing, `attribute`
+    assigns `config = ""`, and every failure from it lands in the
+    `unattributed` column looking like a data problem rather than a project the
+    index never opened. `VOICE_PEDIATRIC` was absent from the literal from #298
+    until #463, and stayed quiet only because nothing from it had been scored.
+    """
     index: dict[tuple[str, str], set[str]] = collections.defaultdict(set)
     for cfg, label in configs.items():
         tag = cfg.split()[0]
-        for project in ("AI_READI", "CHORUS", "CM4AI", "VOICE"):
+        for project in projects:
             for record in load_replicates(root, method, label, project).values():
                 for slot, value in record.items():
                     index[(slot, json.dumps(value, sort_keys=True))].add(tag)

--- a/tests/test_form_defects.py
+++ b/tests/test_form_defects.py
@@ -126,6 +126,40 @@ class TestTable(unittest.TestCase):
         self.assertEqual(set(counts), set(SUBTYPES))
 
 
+class TestIndexCoversEveryProject(unittest.TestCase):
+    """A project the index never opens becomes an `unattributed` column (#463).
+
+    `attribute` assigns `config = ""` to any value it cannot match, and nothing
+    distinguishes "this value came from a project we did not look at" from
+    "this value matched no record". VOICE_PEDIATRIC was missing from a
+    hardcoded literal from #298 onward and stayed quiet only because nothing
+    from it had been fitness-scored yet.
+    """
+
+    def test_the_default_project_list_is_the_registry(self):
+        import inspect
+
+        from data_sheets_schema.constants import PROJECTS
+        from data_sheets_schema.form_defects import _value_index
+
+        default = inspect.signature(_value_index).parameters["projects"].default
+        self.assertEqual(tuple(default), tuple(PROJECTS))
+
+    def test_voice_pediatric_is_covered(self):
+        """Named explicitly: it is the project the literal actually omitted."""
+        from data_sheets_schema.constants import PROJECTS
+        from data_sheets_schema.form_defects import _value_index
+
+        default = inspect_default_projects(_value_index)
+        self.assertIn("VOICE_PEDIATRIC", default)
+        self.assertIn("VOICE_PEDIATRIC", PROJECTS)
+
+
+def inspect_default_projects(fn):
+    import inspect
+    return tuple(inspect.signature(fn).parameters["projects"].default)
+
+
 class TestDefaultInstrument(unittest.TestCase):
     """The cache names the instrument; the live config pin does not (#462).
 

--- a/tests/test_form_defects.py
+++ b/tests/test_form_defects.py
@@ -11,12 +11,14 @@ from pathlib import Path
 
 from data_sheets_schema.agreement import OfflineCacheMiss, _digest
 from data_sheets_schema.form_defects import (
+    FOLDED_SUBTYPES,
     FORM_SUBTYPE_SYSTEM,
     SUBTYPES,
     FormFailure,
     FormSubtypeClassifier,
     _parse_subtype,
     attribute,
+    folded,
     load_form_failures,
     recorded_model,
     table,
@@ -121,6 +123,85 @@ class TestTable(unittest.TestCase):
         """A missing row and a zero row read differently."""
         counts = table([])
         self.assertEqual(set(counts), set(SUBTYPES))
+
+
+class TestFolded(unittest.TestCase):
+    """`both` counts toward each named subtype — the reporting convention.
+
+    It lived only in the prose of `notes/form_defect_split_2026-08-03.md`, so an
+    arm counted from the raw table compared against a baseline short by the
+    whole `both` bucket (#461).
+    """
+
+    def test_both_counts_toward_each_named_subtype(self):
+        counts = {
+            "collapsed_cardinality": {"v1": 34, "v2": 2},
+            "hollow_object": {"v1": 0, "v2": 45},
+            "both": {"v1": 8, "v2": 5},
+            "other": {"v1": 8, "v2": 4},
+        }
+        merged = folded(counts)
+        self.assertEqual(merged["collapsed_cardinality"], {"v1": 42, "v2": 7})
+        self.assertEqual(merged["hollow_object"], {"v1": 8, "v2": 50})
+
+    def test_the_published_headline_figures_are_reproduced(self):
+        """42 -> 7 and 8 -> 50 are what the note reports; pin them to the code.
+
+        Neither figure appears in either of the note's own tables, because both
+        fold `both` in. Anyone re-deriving them from the raw table gets 34 -> 2
+        and 0 -> 45 and a comparison wrong by the size of that bucket.
+        """
+        counts = {
+            "collapsed_cardinality": {"v1": 34, "v2": 2},
+            "hollow_object": {"v1": 0, "v2": 45},
+            "both": {"v1": 8, "v2": 5},
+            "other": {"v1": 8, "v2": 4},
+        }
+        merged = folded(counts)
+        self.assertEqual(
+            (merged["collapsed_cardinality"]["v1"],
+             merged["collapsed_cardinality"]["v2"]), (42, 7))
+        self.assertEqual(
+            (merged["hollow_object"]["v1"], merged["hollow_object"]["v2"]),
+            (8, 50))
+
+    def test_folded_subtypes_may_exceed_the_total(self):
+        """A `both` value exhibits each defect, so it is counted twice on purpose.
+
+        Asserted rather than left implicit: a reader who checks the folded rows
+        against the total and finds them larger should find that documented as
+        intent, not discover it as a suspected double-count.
+        """
+        counts = {
+            "collapsed_cardinality": {"v1": 1},
+            "hollow_object": {"v1": 1},
+            "both": {"v1": 10},
+            "other": {"v1": 0},
+        }
+        merged = folded(counts)
+        total = sum(v.get("v1", 0) for v in counts.values())
+        folded_sum = sum(merged[s].get("v1", 0) for s in FOLDED_SUBTYPES)
+        self.assertEqual(total, 12)
+        self.assertEqual(folded_sum, 22)
+        self.assertGreater(folded_sum, total)
+
+    def test_a_missing_both_bucket_is_not_an_error(self):
+        merged = folded({"collapsed_cardinality": {"v1": 3},
+                         "hollow_object": {"v1": 1}})
+        self.assertEqual(merged["collapsed_cardinality"], {"v1": 3})
+        self.assertEqual(merged["hollow_object"], {"v1": 1})
+
+    def test_folding_does_not_mutate_the_raw_counts(self):
+        """The raw table stays reportable — `both` is a real classification."""
+        counts = {
+            "collapsed_cardinality": {"v1": 34},
+            "hollow_object": {"v1": 0},
+            "both": {"v1": 8},
+            "other": {"v1": 8},
+        }
+        folded(counts)
+        self.assertEqual(counts["collapsed_cardinality"], {"v1": 34})
+        self.assertEqual(counts["both"], {"v1": 8})
 
 
 @unittest.skipUnless(JUDGEMENTS.exists(), "judgement cache not present")

--- a/tests/test_form_defects.py
+++ b/tests/test_form_defects.py
@@ -7,6 +7,8 @@ against the committed cache, where a miss raises rather than billing.
 import json
 import tempfile
 import unittest
+
+import yaml
 from pathlib import Path
 
 from data_sheets_schema.agreement import OfflineCacheMiss, _digest
@@ -16,14 +18,20 @@ from data_sheets_schema.form_defects import (
     SUBTYPES,
     FormFailure,
     FormSubtypeClassifier,
+    PooledInstruments,
     _parse_subtype,
+    _value_index,
     attribute,
     classify,
     folded,
     load_form_failures,
+    main,
     recorded_model,
+    recorded_models,
     table,
 )
+
+from data_sheets_schema.constants import PROJECTS
 
 REPO = Path(__file__).resolve().parents[1]
 JUDGEMENTS = REPO / "data" / "evaluation_llm" / "judgement_cache"
@@ -136,28 +144,52 @@ class TestIndexCoversEveryProject(unittest.TestCase):
     from it had been fitness-scored yet.
     """
 
-    def test_the_default_project_list_is_the_registry(self):
-        import inspect
+    def _corpus(self, root, project, slot, value, label="lbl", rep=1):
+        """One record on disk, in the layout load_replicates expects."""
+        d = root / "claudecode_agent" / f"{label}_rep{rep}"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{project}_d4d.yaml").write_text(
+            yaml.safe_dump({slot: value}), encoding="utf-8")
 
-        from data_sheets_schema.constants import PROJECTS
-        from data_sheets_schema.form_defects import _value_index
+    def test_a_value_from_every_registered_project_is_attributed(self):
+        """Behavioural: index a record per project, attribute a failure from each.
 
-        default = inspect.signature(_value_index).parameters["projects"].default
-        self.assertEqual(tuple(default), tuple(PROJECTS))
+        The earlier version of this test compared `_value_index`'s default
+        argument against PROJECTS, which would pass unchanged if the function
+        ignored the argument entirely.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for i, project in enumerate(PROJECTS):
+                self._corpus(root, project, "creators", [f"value-{i}"])
 
-    def test_voice_pediatric_is_covered(self):
-        """Named explicitly: it is the project the literal actually omitted."""
-        from data_sheets_schema.constants import PROJECTS
-        from data_sheets_schema.form_defects import _value_index
+            failures = [FormFailure(project, "creators",
+                                    json.dumps([f"value-{i}"]), "", 0.5)
+                        for i, project in enumerate(PROJECTS)]
+            attribute(failures, root=root, configs={"v1": "lbl"})
 
-        default = inspect_default_projects(_value_index)
-        self.assertIn("VOICE_PEDIATRIC", default)
-        self.assertIn("VOICE_PEDIATRIC", PROJECTS)
+            unattributed = [f.project for f in failures if not f.config]
+            self.assertEqual(unattributed, [],
+                             "a registered project was not indexed")
 
+    def test_voice_pediatric_specifically_attributes(self):
+        """The project the hardcoded literal actually omitted (#463)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._corpus(root, "VOICE_PEDIATRIC", "creators", ["pediatric"])
+            failure = FormFailure("VOICE_PEDIATRIC", "creators",
+                                  json.dumps(["pediatric"]), "", 0.5)
+            attribute([failure], root=root, configs={"v1": "lbl"})
+            self.assertEqual(failure.config, "v1")
 
-def inspect_default_projects(fn):
-    import inspect
-    return tuple(inspect.signature(fn).parameters["projects"].default)
+    def test_a_project_left_out_of_the_list_goes_unattributed(self):
+        """The failure mode itself, so the guard is known to be able to fire."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._corpus(root, "VOICE_PEDIATRIC", "creators", ["pediatric"])
+            index = _value_index(root, "claudecode_agent", {"v1": "lbl"},
+                                 projects=("AI_READI",))
+            self.assertEqual(index, {})
 
 
 class TestDefaultInstrument(unittest.TestCase):
@@ -206,21 +238,76 @@ class TestDefaultInstrument(unittest.TestCase):
         self.assertIsInstance(classifier.model, str)
         self.assertTrue(classifier.model)
 
-    def test_a_pooled_cache_does_not_crash_construction(self):
-        """Two instruments already fails recorded_model; don't add a third path.
-
-        Construction falls back rather than raising, so the pooled-cache error
-        surfaces from `recorded_model` where it is explained, not from an
-        unrelated constructor.
-        """
+    def _pool(self):
         self.path.write_text("\n".join(
             json.dumps({"rubric": _digest(FORM_SUBTYPE_SYSTEM), "model": m,
                         "chars": 4000, "key": f"k{i}", "slot": "s",
                         "subtype": "other", "reason": ""})
             for i, m in enumerate(["a-model", "b-model"])) + "\n",
             encoding="utf-8")
-        classifier = FormSubtypeClassifier(cache_path=self.path, offline=True)
-        self.assertTrue(classifier.model)
+
+    def test_a_pooled_cache_refuses_rather_than_choosing(self):
+        """Falling back to the pin here reports a partial table as whole (#464).
+
+        An earlier version asserted that construction *succeeded* on a pooled
+        cache, on the reasoning that `recorded_model` would surface the error
+        where it is explained. Nothing on the production path calls
+        `recorded_model`, so that reasoning encoded the defect as the expected
+        behaviour: the run would load only the entries matching whichever model
+        the live pin happened to name, and print their counts as the table.
+        """
+        self._pool()
+        with self.assertRaises(PooledInstruments):
+            FormSubtypeClassifier(cache_path=self.path, offline=True).model
+
+    def test_an_explicit_model_still_works_on_a_pooled_cache(self):
+        """Refusal is about *choosing* an instrument, not about using a named one.
+
+        Someone repairing a pooled cache has to be able to address one arm of
+        it; what they may not do is have the tool pick for them.
+        """
+        self._pool()
+        classifier = FormSubtypeClassifier(cache_path=self.path,
+                                           model="a-model", offline=True)
+        self.assertEqual(classifier.model, "a-model")
+        self.assertEqual(len(classifier._memo), 1)
+
+    def test_recorded_models_reports_every_instrument(self):
+        self._pool()
+        self.assertEqual(recorded_models(self.path), {"a-model", "b-model"})
+
+    def test_main_refuses_to_pool_a_second_instrument(self):
+        """--model on a cache recording another must not silently append (#464).
+
+        The write is what does the damage: once two models are in one file,
+        `recorded_model` refuses it and the published table stops being
+        reproducible. Checked before any judgement work, so the refusal costs
+        nothing and cannot half-write.
+        """
+        self._write("a-model")
+        code = main(["--cache", str(self.path), "--model", "b-model",
+                     "--judgement-cache", str(Path(self.tmp.name) / "none")])
+        self.assertEqual(code, 2)
+        self.assertEqual(recorded_models(self.path), {"a-model"})
+
+    def test_main_allows_pooling_when_it_is_stated(self):
+        """The escape hatch exists; it just has to be asked for."""
+        self._write("a-model")
+        code = main(["--cache", str(self.path), "--model", "b-model",
+                     "--allow-pooled-cache",
+                     "--judgement-cache", str(Path(self.tmp.name) / "none")])
+        self.assertNotEqual(code, 2)
+
+    def test_main_does_not_refuse_the_model_already_recorded(self):
+        """Naming the instrument the cache already holds is not pooling."""
+        self._write("a-model")
+        code = main(["--cache", str(self.path), "--model", "a-model",
+                     "--judgement-cache", str(Path(self.tmp.name) / "none")])
+        self.assertNotEqual(code, 2)
+
+    def test_pooled_instruments_is_a_value_error(self):
+        """Existing `except ValueError` handlers keep working."""
+        self._pool()
         with self.assertRaises(ValueError):
             recorded_model(self.path)
 

--- a/tests/test_form_defects.py
+++ b/tests/test_form_defects.py
@@ -18,6 +18,7 @@ from data_sheets_schema.form_defects import (
     FormSubtypeClassifier,
     _parse_subtype,
     attribute,
+    classify,
     folded,
     load_form_failures,
     recorded_model,
@@ -125,6 +126,71 @@ class TestTable(unittest.TestCase):
         self.assertEqual(set(counts), set(SUBTYPES))
 
 
+class TestDefaultInstrument(unittest.TestCase):
+    """The cache names the instrument; the live config pin does not (#462).
+
+    The pin moved from `google/claude-opus-5-high` to `claude-opus-5` and every
+    model-scoped entry fell out of scope at once — 106 of 106 cached labels
+    invisible, an offline rebuild broken, and an online rebuild about to append
+    a second instrument to the same file.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name) / "subtypes.jsonl"
+        self.addCleanup(self.tmp.cleanup)
+
+    def _write(self, model, key="k1"):
+        self.path.write_text(json.dumps({
+            "rubric": _digest(FORM_SUBTYPE_SYSTEM), "model": model,
+            "chars": 4000, "key": key, "slot": "s",
+            "subtype": "hollow_object", "reason": ""}) + "\n", encoding="utf-8")
+
+    def test_the_recorded_instrument_wins_over_the_live_pin(self):
+        self._write("google/claude-opus-5-high")
+        classifier = FormSubtypeClassifier(cache_path=self.path, offline=True)
+        self.assertEqual(classifier.model, "google/claude-opus-5-high")
+
+    def test_the_entries_are_actually_loaded(self):
+        """The model resolving right is only useful if the memo fills."""
+        self._write("google/claude-opus-5-high")
+        classifier = FormSubtypeClassifier(cache_path=self.path, offline=True)
+        self.assertEqual(len(classifier._memo), 1)
+
+    def test_an_explicit_model_still_overrides(self):
+        """Re-classifying under a new instrument stays possible, and stated."""
+        self._write("google/claude-opus-5-high")
+        classifier = FormSubtypeClassifier(cache_path=self.path,
+                                           model="claude-opus-5", offline=True)
+        self.assertEqual(classifier.model, "claude-opus-5")
+        self.assertEqual(len(classifier._memo), 0)
+
+    def test_a_missing_cache_falls_back_to_the_pin(self):
+        """Nothing recorded means nothing to reproduce; the pin is all there is."""
+        classifier = FormSubtypeClassifier(
+            cache_path=Path(self.tmp.name) / "absent.jsonl", offline=True)
+        self.assertIsInstance(classifier.model, str)
+        self.assertTrue(classifier.model)
+
+    def test_a_pooled_cache_does_not_crash_construction(self):
+        """Two instruments already fails recorded_model; don't add a third path.
+
+        Construction falls back rather than raising, so the pooled-cache error
+        surfaces from `recorded_model` where it is explained, not from an
+        unrelated constructor.
+        """
+        self.path.write_text("\n".join(
+            json.dumps({"rubric": _digest(FORM_SUBTYPE_SYSTEM), "model": m,
+                        "chars": 4000, "key": f"k{i}", "slot": "s",
+                        "subtype": "other", "reason": ""})
+            for i, m in enumerate(["a-model", "b-model"])) + "\n",
+            encoding="utf-8")
+        classifier = FormSubtypeClassifier(cache_path=self.path, offline=True)
+        self.assertTrue(classifier.model)
+        with self.assertRaises(ValueError):
+            recorded_model(self.path)
+
+
 class TestFolded(unittest.TestCase):
     """`both` counts toward each named subtype — the reporting convention.
 
@@ -219,6 +285,39 @@ class TestAgainstTheRealCache(unittest.TestCase):
             counts[failure.config] = counts.get(failure.config, 0) + 1
         self.assertEqual(counts, {"v1": 50, "v2": 56})
         self.assertEqual(len(failures), 106)
+
+    def test_the_published_split_rebuilds_offline_at_zero_cost(self):
+        """The v1->v2 table reproduces from cache, with no paid call (#462).
+
+        This is the property that broke: the classifier resolved the live pin
+        rather than the instrument the cache records, so all 106 labels were
+        invisible and this rebuild raised OfflineCacheMiss. It asserts the two
+        published headline figures as well as the raw table, because the
+        headlines fold the `both` bucket and nothing else pins them (#461).
+        """
+        cache = SUBTYPE_CACHE / "form_subtypes.jsonl"
+        if not cache.exists():
+            self.skipTest("subtype cache not present")
+        classifier = FormSubtypeClassifier(cache_path=cache, offline=True)
+        classified = classify(attribute(load_form_failures(JUDGEMENTS)),
+                              classifier)
+        self.assertEqual(classifier.calls, 0, "an offline rebuild paid for a call")
+
+        # A config with no failures of a subtype is absent from the row rather
+        # than present at 0 — table() counts, it does not tabulate a grid — so
+        # read through .get the way the report does.
+        def cell(rows, subtype, config):
+            return rows[subtype].get(config, 0)
+
+        counts = table(classified)
+        self.assertEqual(
+            [cell(counts, s, c) for s in SUBTYPES for c in ("v1", "v2")],
+            [34, 2, 0, 45, 8, 5, 8, 4])
+
+        merged = folded(counts)
+        self.assertEqual(
+            [cell(merged, s, c) for s in FOLDED_SUBTYPES for c in ("v1", "v2")],
+            [42, 7, 8, 50])
 
     def test_the_real_cache_holds_exactly_one_rubric_and_model(self):
         """#277 — the premise this module rests on, asserted.


### PR DESCRIPTION
Closes #458. Corrects what NEXT_TASKS §6 and §9 claim, and registers the comparison that replaces the one that cannot be run.

## What was wrong

§6 said v3 had "20 runs across four labels". Fifteen of those are the 2026-08-07 sweep, which hashed the **generic** prompt, not v3 (#454). Every run that did hash v3 is confounded against the v2 series it would be compared with:

| label | prompt | schema digest | route | coverage |
|---|---|---|---|---|
| `2026-07-31_…generic-v2_rep{1,2,3}` | v2 | `34d24ff3` (1.0.0) | `google/claude-opus-5-high` | 4 projects × 3 |
| `2026-08-05_…generic-v3_rep1` | v3 | `b065e1cd` (1.0.0) | `google/claude-opus-5-high` | AI_READI, CHORUS × 1 |
| `2026-08-05_…1m-generic-v3_rep{1,2,3}` | v3 | `b065e1cd` (1.0.0) | `claude-opus-5` (1m) | AI_READI × 3, CHORUS × 1 |
| `2026-08-06_…1m-generic-v3-schema2_rep{1,2,3}` | v3 | `583d79c1` (2.0.0) | `claude-opus-5` (1m) | AI_READI, CHORUS × 2 |
| `2026-08-07_…claudecode-generic-v3_rep{1,2,3}` | **generic (v1)** | *none recorded* (2.0.0) | `claude-opus-5` | 5 projects × 3 |

Three independent defects, any one sufficient: CM4AI/VOICE/VOICE_PEDIATRIC never ran under v3; every v3 label sits on a different schema digest than v2, and the delta includes the trap-slot work (#376, #382) that moves the exact defect classes `form_defects` counts; three of four v3 labels ran a different route.

The pre-registered plan asked for "same four projects, three replicates, same model and settings as the v1 and v2 series." No label meets it.

## Why nothing was corrupted

All 1441 cached fitness judgements are keyed `(34d24ff3, google/claude-opus-5-high)` — v2's exact configuration. No v3 record was ever a cache hit, so no arms were silently mixed. The guard worked as designed. What it could not do is announce that the arm it protected had never been generated: an absent cache entry and an absent run look identical from the instrument's side.

## What this PR does

- **Registers `notes/generic_v1_v3_analysis_plan.md`** before any generation, keeping the prediction outside the prompt for the same reason `generic_v3_analysis_plan.md` does.
- **Corrects §6** with the disk facts and records the decision: both arms fresh, 5 projects × 3 replicates = 30 runs, at today's digest `e802cdc3` — which no run on disk carries.
- **Adds the #454 caveat to §9**, whose canonical set is that label. The records are internally honest — every header names `d4d_generic_arm_prompt.md` and says "generic prompt" — so only the directory label misstates the condition.

## Why v1-vs-v3, not v2-vs-v3

v1 is the playbook default, so v1-vs-v3 is the comparison the *promotion* decision rests on. It measures all four rules at once, which is the right granularity for a decision to adopt all four. The mechanism question — does rule 4 alone do what it says? — stays open and needs a v2 arm at the same digest; this plan does not produce one and says so.

## Not in this PR

The 30 generation runs themselves. Docs-only change; the plan is the gate that has to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
