### PR TITLE
Report records whose declared input bundle has since changed (#452)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,6 +354,25 @@ bundles embed the document bundle verbatim, and after #421 stripped curator
 prose they were not rebuilt — so the de novo arm read 9 curation notes the
 baseline arm no longer saw, for a day, with nothing to detect it.
 
+**One layer up, `d4d runs check` reports bundle drift** (#452): does the file at
+a record's `inputs.bundle_path` still hash to the `bundle_md5` that record
+pinned? Currently **64 records drifted, 12 current, 82 with no hash recorded**.
+
+The two checks are mirror images. `audit-bundles` asks whether a *bundle* still
+matches what its inputs produce; this asks whether a *record's declared input*
+still matches what that record consumed. A drifted record is not wrong — it
+correctly states the bytes it read — but the path it names no longer resolves
+to them, so anyone re-reading its declared input reads something else.
+
+Reported and never fatal, for the same reason as the unobserved-values counter
+(#447): these records stay usable, they just cannot be re-derived from the path
+they name. #421 caused most of the drift by stripping curator notes and #445
+added to it by stripping `verification_url`; **both strips were correct**. The
+defect was that the corpus absorbed a corpus-wide input change with no report.
+
+Derived records (`record_mode: derived`) are out of scope by construction: they
+consume replicates rather than a bundle and declare `bundle_md5` not-applicable.
+
 Each entry names the `referent_id` and any `related_but_distinct` dataset, with
 the slot that carries the relation (`express_as: related_datasets`) and, where
 the related dataset's documentation is legitimately in the bundle, the source id

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -384,8 +384,13 @@ because they were generic.
   including them would import adult facts into a pediatric datasheet, which is
   the failure the fitness axis calls `target`.
 
-  The VOICE bundle is byte-identical (md5 `e637eb75`, what 49 runs attest), and
-  a test pins it.
+  The VOICE bundle was byte-identical across the fork at md5 `e637eb75`, which
+  49 runs attest. **It is now `dcd71717`** — #421 stripped curator prose from
+  every bundle after those runs. `tests/test_voice_pediatric_bundle.py` pins
+  both, current and `_PRE_421`, so the transition is recorded rather than
+  overwritten. The sentence here previously named only `e637eb75` as the
+  bundle's hash, which stopped being true when the strip landed and was found
+  by the drift check below (#452).
 - **A generation run — done.** Both projects were generated in the 2026-08-07
   five-project sweep (`2026-08-07_claude-opus-5-claudecode-generic-v3_rep{1,2,3}`,
   PR #395). `VOICE_PEDIATRIC` was generated from its own 204 KB bundle as its
@@ -424,6 +429,23 @@ because they were generic.
   pre-registered (§6), not generated; `e802cdc3` appears in no record and no
   judgement. Until it does, these remain the canonical records and the caveat
   above is the whole of the mitigation.
+
+  ⚠️ **All five canonical records are also bundle-drifted** (#452). Every one
+  pins a bundle md5 the file no longer has:
+
+  | project | pinned | now |
+  |---|---|---|
+  | AI_READI | `8aadffca` | `20150c10` |
+  | CHORUS | `1ce7d891` | `9b2ef4b6` |
+  | CM4AI | `3694e188` | `1dfd34e5` |
+  | VOICE | `e637eb75` | `dcd71717` |
+  | VOICE_PEDIATRIC | `327c2920` | `008212ac` |
+
+  Caused by #421 and #445, both correct strips. The records remain accurate
+  about what they read; what no longer holds is that re-reading their declared
+  inputs reproduces it. So the canonical set carries two independent caveats —
+  a label that names the wrong condition, and inputs that cannot be re-fetched
+  — and the fresh arm in §6 clears both at once.
 
 - **Whether `VOICE` becomes `VOICE_main` — decided: no.** Attempted and reverted.
   The path moves were clean (567 files, no clashes), but the content rewrite

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -486,6 +486,35 @@ def check_cmd(method, label, project, strict):
         for field, n in unobserved.most_common():
             click.echo(f"     {field:28} {n}")
 
+    # Bundle drift (#452). The mirror of `audit-bundles` one layer up: that asks
+    # whether a derived bundle still matches what its inputs produce, this asks
+    # whether a record's *declared input* still matches what the record
+    # consumed. Reported, never fatal, for the same reason as the counter above
+    # — a drifted record is still usable, it just cannot be re-derived from the
+    # path it names, and a gate would collapse that distinction.
+    from data_sheets_schema.runs import (
+        BUNDLE_ABSENT, BUNDLE_CURRENT, BUNDLE_DRIFTED, BUNDLE_UNRECORDED,
+        bundle_drift_detail,
+    )
+    drift: collections.Counter = collections.Counter()
+    drifted_bundles: collections.Counter = collections.Counter()
+    for r in rows:
+        st, _why, declared = bundle_drift_detail(
+            r["method"], r["label"], r["project"])
+        drift[st] += 1
+        if st in (BUNDLE_DRIFTED, BUNDLE_ABSENT):
+            drifted_bundles[Path(declared).name if declared else "unknown"] += 1
+
+    stale = drift[BUNDLE_DRIFTED] + drift[BUNDLE_ABSENT]
+    if stale:
+        click.echo(f"\nⓘ  {stale} record(s) name an input bundle whose bytes "
+                   f"have since changed ({drift[BUNDLE_CURRENT]} still match, "
+                   f"{drift[BUNDLE_UNRECORDED]} record no hash):")
+        for name, n in drifted_bundles.most_common():
+            click.echo(f"     {name:44} {n}")
+        click.echo("   Each record correctly states the bytes it consumed; the "
+                   "path no longer resolves to them.")
+
     # Reported separately from the provenance verdict, and never fatal. A
     # label naming a condition its prompt does not match is a real defect
     # (#420) — but it is a defect in records that already exist, and failing

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1039,6 +1039,15 @@ def bundle_drift_detail(method: str, label: str, project: str,
     the provenance record or parse the path back out of a human-readable
     reason string.
     """
+    # Deliberately un-memoised (#469). Hashing once per record rather than once
+    # per bundle is ~20x redundant — 158 records against 12 distinct bundles —
+    # and costs 0.77s for a full sweep. A path-keyed cache would report
+    # `current` for a file that drifted after its first read, which is the exact
+    # failure this function exists to detect; `(path, size, mtime_ns)` narrows
+    # that window without closing it, since a same-size edit within one
+    # filesystem tick is both plausible for generated bundles and silent. If the
+    # corpus ever makes this cost real, scope a cache to a single sweep and pass
+    # it in, so it cannot outlive the invocation that built it.
     import hashlib
 
     from data_sheets_schema.provenance import record_path_for

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -985,6 +985,84 @@ def _prompt_files_drifted(record: dict) -> bool | None:
     return False if seen else None
 
 
+BUNDLE_CURRENT, BUNDLE_DRIFTED = "current", "drifted"
+BUNDLE_ABSENT, BUNDLE_UNRECORDED = "absent", "unrecorded"
+
+
+def bundle_drift(method: str, label: str, project: str,
+                 concat_dir: Path = CONCAT_DIR) -> tuple[str, str | None]:
+    """Does the file at ``inputs.bundle_path`` still hash to ``bundle_md5``? (#452)
+
+    A record pins the md5 of the bytes it consumed and asserts ``hash_basis:
+    verified identical to the bytes consumed``. Nothing ever re-checked that
+    against the file. The record is not wrong — it correctly states what *it*
+    read — but the path it names no longer resolves to those bytes, so anyone
+    re-reading a record's declared input reads something else.
+
+    This is the mirror of ``d4d download audit-bundles`` (#446), one layer up.
+    That command asks whether a derived bundle still matches what its inputs
+    produce; this asks whether a *record's* declared input still matches what
+    the record consumed. #421 caused most of the current drift by stripping
+    curator notes and #445 added to it by stripping ``verification_url``. Both
+    strips were correct. The defect is that the corpus absorbed a corpus-wide
+    input change with no report.
+
+    Four outcomes, kept distinct because they license different actions:
+
+    - ``current``    — the file still hashes to what the record pinned.
+    - ``drifted``    — it does not. The record stays usable and stops being
+      re-derivable from the path it names.
+    - ``absent``     — the path no longer exists at all.
+    - ``unrecorded`` — no ``bundle_md5``, so there is nothing to compare. A
+      different claim from ``current`` and never counted as one.
+
+    Scope note. Callers iterating ``discover()`` see 158 runs against 162
+    provenance records on disk. The four extra are the ``guarded-union``
+    derived merges, which are not runs and which declare ``bundle_md5``
+    not-applicable by design (§3) — a derived record consumes replicates, not a
+    bundle, so it has no input that could drift. All four fall in
+    ``unrecorded``, which is why the drifted and current counts are unaffected
+    by the difference and only the ``unrecorded`` denominator moves (82 here
+    against the 86 counted over every record in #452).
+    """
+    status, reason, _declared = bundle_drift_detail(method, label, project,
+                                                    concat_dir)
+    return status, reason
+
+
+def bundle_drift_detail(method: str, label: str, project: str,
+                        concat_dir: Path = CONCAT_DIR
+                        ) -> tuple[str, str | None, str | None]:
+    """``bundle_drift``, plus the path the record declared.
+
+    Separate so a caller grouping drift *by bundle* does not have to re-read
+    the provenance record or parse the path back out of a human-readable
+    reason string.
+    """
+    import hashlib
+
+    from data_sheets_schema.provenance import record_path_for
+    path = record_path_for(project, method, label, concat_dir)
+    if not path.exists():
+        return BUNDLE_UNRECORDED, "no provenance record", None
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    inputs = data.get("inputs") or {}
+    recorded = inputs.get("bundle_md5")
+    declared = inputs.get("bundle_path")
+    if not recorded or not declared:
+        return BUNDLE_UNRECORDED, "no bundle hash recorded", declared
+
+    bundle = Path(declared)
+    if not bundle.exists():
+        return BUNDLE_ABSENT, f"{declared} does not exist", declared
+
+    current = hashlib.md5(bundle.read_bytes()).hexdigest()
+    if current == recorded:
+        return BUNDLE_CURRENT, None, declared
+    return BUNDLE_DRIFTED, (f"{declared} now hashes {current[:8]}, "
+                            f"record pinned {recorded[:8]}"), declared
+
+
 def canonical_prompt_status(method: str, label: str, project: str,
                             concat_dir: Path = CONCAT_DIR
                             ) -> tuple[str, str | None]:

--- a/tests/test_cli/test_bundle_drift.py
+++ b/tests/test_cli/test_bundle_drift.py
@@ -1,0 +1,155 @@
+"""Does a record's declared input still hash to what the record consumed? (#452)
+
+The mirror of `d4d download audit-bundles` (#446) one layer up. That command
+asks whether a derived bundle still matches what its inputs produce; this asks
+whether a *record's* declared input still matches what the record read.
+
+The distinction the whole check rests on: a drifted record is not wrong. It
+correctly states the bytes it consumed. What it has lost is the ability to be
+re-derived from the path it names, which is a caveat rather than a defect —
+hence reported and never fatal, like the unobserved-values counter (#447).
+"""
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.runs import (
+    BUNDLE_ABSENT,
+    BUNDLE_CURRENT,
+    BUNDLE_DRIFTED,
+    BUNDLE_UNRECORDED,
+    bundle_drift,
+    bundle_drift_detail,
+)
+
+
+class TestBundleDrift(unittest.TestCase):
+    LABEL, METHOD, PROJECT = "2026-08-11_drift_rep1", "claudecode_agent", "VOICE"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.concat = self.root / "data/d4d_concatenated"
+        (self.concat / f"{self.METHOD}_core" / self.LABEL).mkdir(parents=True)
+        self.bundle = self.root / "bundle.txt"
+
+    def _write(self, *, content=b"the bytes the run consumed", md5=None,
+               path=None, omit_hash=False, omit_record=False):
+        if content is not None:
+            self.bundle.write_bytes(content)
+        if omit_record:
+            return
+        inputs = {"bundle_path": str(path if path is not None else self.bundle)}
+        if not omit_hash:
+            inputs["bundle_md5"] = md5 or hashlib.md5(content).hexdigest()
+        record = (self.concat / f"{self.METHOD}_core" / self.LABEL
+                  / f"{self.PROJECT}_provenance.yaml")
+        record.write_text(yaml.safe_dump({"inputs": inputs}), encoding="utf-8")
+
+    def _status(self):
+        return bundle_drift(self.METHOD, self.LABEL, self.PROJECT, self.concat)
+
+    def test_an_unchanged_bundle_is_current(self):
+        self._write()
+        status, reason = self._status()
+        self.assertEqual(status, BUNDLE_CURRENT)
+        self.assertIsNone(reason)
+
+    def test_a_changed_bundle_drifts(self):
+        """The case the corpus is in: #421 stripped curator notes from bundles
+        55 records already pinned."""
+        self._write()
+        self.bundle.write_bytes(b"the bytes after a later, correct strip")
+        status, reason = self._status()
+        self.assertEqual(status, BUNDLE_DRIFTED)
+        self.assertIn("now hashes", reason)
+
+    def test_a_single_byte_is_enough(self):
+        """Not a heuristic — the record pins an md5, so any edit drifts it."""
+        self._write(content=b"aaaa")
+        self.bundle.write_bytes(b"aaab")
+        self.assertEqual(self._status()[0], BUNDLE_DRIFTED)
+
+    def test_a_missing_bundle_is_absent_not_drifted(self):
+        """Distinct because the remedies differ: a drifted path can still be
+        read and diffed, a deleted one cannot."""
+        self._write()
+        self.bundle.unlink()
+        status, reason = self._status()
+        self.assertEqual(status, BUNDLE_ABSENT)
+        self.assertIn("does not exist", reason)
+
+    def test_no_recorded_hash_is_not_a_pass(self):
+        """`unrecorded` must never be counted as `current`.
+
+        86 records carry no bundle hash. Folding them into the matching count
+        would report the corpus as far healthier than it is — the same error as
+        treating an absent cache entry as a hit.
+        """
+        self._write(omit_hash=True)
+        self.assertEqual(self._status()[0], BUNDLE_UNRECORDED)
+
+    def test_a_missing_provenance_record_is_unrecorded(self):
+        self._write(omit_record=True)
+        self.assertEqual(self._status()[0], BUNDLE_UNRECORDED)
+
+    def test_the_detail_form_returns_the_declared_path(self):
+        """So a caller grouping by bundle need not parse the reason string."""
+        self._write()
+        status, _reason, declared = bundle_drift_detail(
+            self.METHOD, self.LABEL, self.PROJECT, self.concat)
+        self.assertEqual(status, BUNDLE_CURRENT)
+        self.assertEqual(declared, str(self.bundle))
+
+    def test_the_declared_path_survives_a_missing_hash(self):
+        """Grouping still works for records that recorded a path but no hash."""
+        self._write(omit_hash=True)
+        _status, _reason, declared = bundle_drift_detail(
+            self.METHOD, self.LABEL, self.PROJECT, self.concat)
+        self.assertEqual(declared, str(self.bundle))
+
+    def test_the_record_is_read_not_the_live_config(self):
+        """The comparison is against the path the *record* declares.
+
+        A check that resolved the bundle from the current project config would
+        report `current` for a record whose declared path had since been
+        repointed — the drift it exists to find.
+        """
+        other = self.root / "somewhere_else.txt"
+        other.write_bytes(b"a different bundle entirely")
+        self._write(content=b"original", path=other,
+                    md5=hashlib.md5(b"original").hexdigest())
+        self.assertEqual(self._status()[0], BUNDLE_DRIFTED)
+
+
+@unittest.skipUnless(Path("data/d4d_concatenated").exists(), "corpus absent")
+class TestAgainstTheRealCorpus(unittest.TestCase):
+    def test_the_corpus_drift_is_what_the_issue_measured(self):
+        """64 drifted / 12 current, the figures #452 was filed on.
+
+        Pinned so the next corpus-wide input change is a visible test failure
+        rather than an unreported absorption — which is the whole defect: #421
+        and #445 both changed bundles correctly and neither was detected.
+        """
+        from data_sheets_schema.runs import discover, is_complete
+
+        counts = {BUNDLE_CURRENT: 0, BUNDLE_DRIFTED: 0,
+                  BUNDLE_ABSENT: 0, BUNDLE_UNRECORDED: 0}
+        for run in discover():
+            # The same filter `d4d runs check` applies. `discover` yields the
+            # full and _core methods as separate runs over one provenance
+            # record, so counting both doubles every figure.
+            if run.is_core or run.deterministic:
+                continue
+            for project in run.projects:
+                if not is_complete(run.method, run.label, project):
+                    continue
+                counts[bundle_drift(run.method, run.label, project)[0]] += 1
+
+        self.assertEqual(counts[BUNDLE_DRIFTED] + counts[BUNDLE_ABSENT], 64)
+        self.assertEqual(counts[BUNDLE_CURRENT], 12)

--- a/tests/test_cli/test_bundle_drift.py
+++ b/tests/test_cli/test_bundle_drift.py
@@ -69,6 +69,20 @@ class TestBundleDrift(unittest.TestCase):
         self.assertEqual(status, BUNDLE_DRIFTED)
         self.assertIn("now hashes", reason)
 
+    def test_a_change_after_a_first_read_is_still_detected(self):
+        """Guards the decision not to memoise the hash (#469).
+
+        The obvious optimisation is to cache the md5 by path — 158 records hash
+        12 distinct bundles. A path-keyed cache would answer `current` here on
+        the second call, which is precisely the drift the function exists to
+        detect. Two calls either side of an edit, so the guard fires if anyone
+        adds one.
+        """
+        self._write(content=b"before")
+        self.assertEqual(self._status()[0], BUNDLE_CURRENT)
+        self.bundle.write_bytes(b"after!")          # same length, new bytes
+        self.assertEqual(self._status()[0], BUNDLE_DRIFTED)
+
     def test_a_single_byte_is_enough(self):
         """Not a heuristic — the record pins an md5, so any edit drifts it."""
         self._write(content=b"aaaa")


### PR DESCRIPTION
Closes #452.

A provenance record pins `inputs.bundle_md5` and asserts `hash_basis: verified identical to the bytes consumed`. Nothing ever re-checked that against the file at `inputs.bundle_path`. `d4d runs check` now does:

```
ⓘ  64 record(s) name an input bundle whose bytes have since changed
   (12 still match, 82 record no hash):
     CHORUS_preprocessed.txt                      18
     AI_READI_preprocessed.txt                    16
     CM4AI_preprocessed.txt                        9
     VOICE_preprocessed.txt                        9
     VOICE_PEDIATRIC_preprocessed.txt             3
     CHORUS_preprocessed_with_crate.txt           3
     CM4AI_preprocessed_with_crate.txt            3
     VOICE_preprocessed_with_crate.txt            3
   Each record correctly states the bytes it consumed; the path no longer resolves to them.
```

That reproduces both the counts and the per-bundle breakdown the issue was filed on.

## The shape of it

The mirror of `audit-bundles` (#446) one layer up. That command asks whether a derived **bundle** still matches what its inputs produce; this asks whether a **record's declared input** still matches what that record consumed.

**Reported, never fatal** — verified `--strict` still exits 0. A drifted record is not wrong: it correctly states the bytes it read, and has only lost the ability to be re-derived from the path it names. That is a caveat, not a defect, and a gate would collapse the distinction — the same reasoning as the unobserved-values counter (#447).

#421 caused most of the drift by stripping curator notes; #445 added to it by stripping `verification_url`. **Both strips were correct.** The defect is that the corpus absorbed a corpus-wide input change with no report.

## Four outcomes, kept distinct

`current`, `drifted`, `absent` (the path is gone, so it cannot even be diffed), `unrecorded`. `unrecorded` is never counted as `current` — folding 82 hashless records into the matching count would report the corpus far healthier than it is, the same error as treating an absent cache entry as a hit.

## On 82 vs the issue's 86

Scope, not disagreement, and documented on the function. The four extra are the `guarded-union` derived merges: not runs, and they declare `bundle_md5` not-applicable by design (§3), because a derived record consumes replicates rather than a bundle and so has no input that can drift. All four are hashless, so the drifted and current counts are unaffected.

## Tests

Ten, including one pinning 64/12 against the real corpus — so the next corpus-wide input change is a visible test failure rather than a silent absorption, which is the entire defect. Also asserts that a check resolving the bundle from live config rather than from the record would miss the drift it exists to find.

Full suite: **1573 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)