### PR TITLE
Record the reasoning effort 49 records' own routes already named (#448)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,7 +433,10 @@ prompt header (#397). No generic prompt names it, so records made before this
 simply lacked it — 12 of the 2026-08 API runs. Three sources, in order:
 
 1. the model route, where the provider expresses effort as a name suffix
-   (`google/claude-opus-5-high`) — recorded as observed;
+   (`google/claude-opus-5-high`) — recorded as observed. `d4d provenance
+   backfill-effort` applies this retroactively; it reports by default and
+   writes only under `--execute`, and has already populated the 49 records
+   whose route named an effort they did not carry (#448);
 2. `d4d provenance record --reasoning-effort <x>` — recorded as asserted by the
    launcher, and still listed under `unverified`;
 3. nothing — the field is left absent and the gap is named.

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_canary_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_canary_rep1/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
@@ -25,6 +25,9 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
 prompts:
   hash_algorithm: sha256
   files:

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -197,3 +197,66 @@ def reasoning_cmd(method, project, label, path):
         click.echo("\nNo reasoning text was available in any entry. The blocks "
                    "are signed but empty — the endpoint strips the plaintext. "
                    "Runs made directly against the Anthropic API capture it.")
+
+
+@provenance.command("backfill-effort")
+@click.option('--execute', is_flag=True,
+              help='write the records; without it this reports and changes nothing')
+@click.option('--method', default=None, help='restrict to one method directory')
+@click.option('--label', default=None, help='restrict to one run label')
+def backfill_effort(execute, method, label):
+    """Record the reasoning effort a run's own model route already names (#448).
+
+    `_effort_from_route` runs only when a record is built, so records written
+    before it existed name `google/claude-opus-5-high` and carry no
+    `reasoning_effort`. The information was in the route all along; nothing read
+    it.
+
+    This adds no claim the record was not already making — the route is in the
+    record, and the effort is read off it — so the value is recorded as
+    **observed** and does not enter `unverified`. That is what makes a bulk pass
+    defensible here and not, say, for temperature.
+
+    Reports by default and writes only under --execute, because rewriting
+    records should be a deliberate reviewable commit rather than a side effect.
+    """
+    from pathlib import Path
+
+    from data_sheets_schema.provenance import (
+        CONCAT_DIR, apply_observed_effort, observed_effort_gap,
+    )
+
+    paths = sorted(CONCAT_DIR.glob("*_core/*/*_provenance.yaml"))
+    if method:
+        base = method[:-5] if method.endswith("_core") else method
+        paths = [p for p in paths if p.parts[-3] == f"{base}_core"]
+    if label:
+        paths = [p for p in paths if p.parts[-2] == label]
+
+    gaps = [g for g in (observed_effort_gap(Path(p)) for p in paths) if g]
+    if not gaps:
+        click.echo(f"{len(paths)} record(s) examined; none has an effort its "
+                   "route names but it does not carry.")
+        return
+
+    by_route: dict[str, int] = {}
+    for g in gaps:
+        by_route[f"{g['route']} -> {g['effort']}"] = (
+            by_route.get(f"{g['route']} -> {g['effort']}", 0) + 1)
+
+    verb = "updating" if execute else "would update"
+    click.echo(f"{len(paths)} record(s) examined, {len(gaps)} {verb}:")
+    for route, n in sorted(by_route.items()):
+        click.echo(f"   {route:44} {n}")
+
+    if not execute:
+        click.echo("\nNothing written. Re-run with --execute to apply.")
+        return
+
+    written = 0
+    for g in gaps:
+        if apply_observed_effort(g["path"]) is not None:
+            written += 1
+    click.echo(f"\n{written} record(s) updated. The value is observed — read "
+               "from the route the record already carried — so it is not "
+               "listed under `unverified`.")

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -21,6 +21,7 @@ with the reason, never silently filled.
 from __future__ import annotations
 
 import hashlib
+import itertools
 import os
 import platform
 import subprocess
@@ -223,6 +224,76 @@ def _effort_from_route(model_name: str | None) -> tuple[str | None, str | None]:
             return effort, ("read from the model route; the provider exposes "
                             "effort as a model-name suffix, not a parameter")
     return None, None
+
+
+def observed_effort_gap(path: Path) -> dict[str, Any] | None:
+    """Could this record carry an effort its own route already names? (#448)
+
+    `_effort_from_route` only runs when a record is *built*, so 49 records
+    written before it existed name `google/claude-opus-5-high` and carry no
+    `reasoning_effort`. The information was in the route all along; nothing read
+    it. They are not wrong today — an absent field is the honest state — but
+    they are less placeable than they need to be, and #400 wants exactly this
+    field to compare the agentic and API arms on reasoning spend.
+
+    Returns None when there is nothing to do, which covers three distinct
+    situations that must not be conflated:
+
+    - the route names no effort (`claude-opus-5`, `claude-opus-5[1m]`). Not
+      "default" — a route on which no ladder was offered, which stays a gap.
+    - the record already carries an effort.
+    - there is no model block to read.
+
+    Returns a dict describing the change otherwise. Never writes: a pass that
+    rewrites 49 records should be a deliberate, reviewable commit rather than a
+    side effect of some other command.
+    """
+    if not path.exists():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return None
+    model = data.get("model")
+    if not isinstance(model, dict):
+        return None
+    if model.get("reasoning_effort"):
+        return None
+    effort, basis = _effort_from_route(model.get("model"))
+    if not effort:
+        return None
+    return {"path": path, "route": model.get("model"),
+            "effort": effort, "basis": basis}
+
+
+def apply_observed_effort(path: Path) -> dict[str, Any] | None:
+    """Write the route-derived effort into a record that lacks it (#448).
+
+    Rewrites only `model.reasoning_effort` and `model.reasoning_effort_basis`,
+    and only where `observed_effort_gap` says the route names an effort the
+    record does not carry.
+
+    The value is **observed**, not asserted: it is read off the route the record
+    itself already records, so it is not new evidence and does not belong in
+    `unverified`. That is the whole reason this pass is safe to run in bulk —
+    it adds no claim the record was not already making, it makes an existing
+    one legible.
+    """
+    change = observed_effort_gap(path)
+    if change is None:
+        return None
+    text = path.read_text(encoding="utf-8")
+    # Preserve the leading comment block verbatim. It carries record_version and
+    # a pointer to this module, and safe_dump would silently drop it.
+    preamble = "".join(itertools.takewhile(lambda ln: ln.startswith("#"),
+                                           text.splitlines(keepends=True)))
+    data = yaml.safe_load(text) or {}
+    data["model"]["reasoning_effort"] = change["effort"]
+    data["model"]["reasoning_effort_basis"] = change["basis"]
+    path.write_text(
+        preamble + yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+        encoding="utf-8")
+    return change
 
 
 def parse_header(path: Path) -> dict[str, str]:

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -252,7 +252,13 @@ def observed_effort_gap(path: Path) -> dict[str, Any] | None:
         return None
     try:
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except yaml.YAMLError:
+    except (yaml.YAMLError, OSError, UnicodeDecodeError):
+        # All three, not just YAMLError (#472). This runs once per record over
+        # 162 records, so one unreadable file aborting the pass is the failure
+        # #444 fixed for the scope sweep — and it is worse under --execute,
+        # which writes as it goes and would stop partway with no report of
+        # where. `read_text` raises OSError and UnicodeDecodeError, neither of
+        # which YAMLError covers.
         return None
     model = data.get("model")
     if not isinstance(model, dict):
@@ -290,9 +296,18 @@ def apply_observed_effort(path: Path) -> dict[str, Any] | None:
     data = yaml.safe_load(text) or {}
     data["model"]["reasoning_effort"] = change["effort"]
     data["model"]["reasoning_effort_basis"] = change["basis"]
-    path.write_text(
+
+    # Written atomically, unlike `Record.write`, and the difference is the
+    # point: that method creates a record for a run that just happened, so a
+    # failed write loses something not yet relied on. This mutates 49 records
+    # that already exist and are already attested — a truncated write here
+    # destroys provenance rather than failing to add it. Rename is atomic
+    # within a filesystem, so a record is either its old bytes or its new ones.
+    new = path.with_suffix(path.suffix + ".tmp")
+    new.write_text(
         preamble + yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
         encoding="utf-8")
+    new.replace(path)
     return change
 
 

--- a/tests/test_observed_effort_backfill.py
+++ b/tests/test_observed_effort_backfill.py
@@ -1,0 +1,195 @@
+"""Recording the effort a run's own model route already names (#448).
+
+`_effort_from_route` runs only when a record is built, so 49 records written
+before it existed named `google/claude-opus-5-high` and carried no
+`reasoning_effort`. The information was in the route all along.
+
+The property that makes a bulk pass defensible: this adds no claim the record
+was not already making. The route is in the record; the effort is read off it.
+So the value is **observed**, and must not appear in `unverified` — unlike an
+effort asserted by a launcher, which must.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.provenance import (
+    apply_observed_effort,
+    observed_effort_gap,
+)
+
+PREAMBLE = ("# D4D generation provenance record\n"
+            "# record_version 1 — see src/data_sheets_schema/provenance.py\n")
+
+
+class TestObservedEffortBackfill(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "X_provenance.yaml"
+
+    def _write(self, model, extra=None):
+        data = {"record_version": 1, "model": model,
+                "unverified": [{"field": "model.temperature"}]}
+        data.update(extra or {})
+        self.path.write_text(
+            PREAMBLE + yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    def _load(self):
+        return yaml.safe_load(self.path.read_text(encoding="utf-8"))
+
+    def test_a_suffixed_route_is_recoverable(self):
+        self._write({"model": "google/claude-opus-5-high"})
+        gap = observed_effort_gap(self.path)
+        self.assertEqual(gap["effort"], "high")
+        self.assertIn("model route", gap["basis"])
+
+    def test_a_route_with_no_ladder_yields_nothing(self):
+        """`claude-opus-5` is not "default" — it is a route offering no ladder.
+
+        Filling it would invent the distinction CLAUDE.md forbids: a run that
+        did not choose an effort is a different claim from one whose effort is
+        unknown, and neither is a run at high.
+        """
+        for route in ("claude-opus-5", "claude-opus-5[1m]",
+                      "google/claude-opus-5"):
+            with self.subTest(route=route):
+                self._write({"model": route})
+                self.assertIsNone(observed_effort_gap(self.path))
+
+    def test_an_existing_effort_is_never_overwritten(self):
+        self._write({"model": "google/claude-opus-5-high",
+                     "reasoning_effort": "low",
+                     "reasoning_effort_basis": "asserted by the launcher"})
+        self.assertIsNone(observed_effort_gap(self.path))
+        self.assertIsNone(apply_observed_effort(self.path))
+        self.assertEqual(self._load()["model"]["reasoning_effort"], "low")
+
+    def test_applying_writes_the_effort_and_its_basis(self):
+        self._write({"model": "google/claude-opus-5-high"})
+        apply_observed_effort(self.path)
+        model = self._load()["model"]
+        self.assertEqual(model["reasoning_effort"], "high")
+        self.assertIn("model route", model["reasoning_effort_basis"])
+
+    def test_the_value_is_observed_so_it_does_not_enter_unverified(self):
+        """The whole reason a bulk pass is safe here.
+
+        An effort asserted by a launcher belongs in `unverified`; one read off
+        the route the record already carries does not, because it is not a new
+        claim. Recording it as unverified would understate what is known.
+        """
+        self._write({"model": "google/claude-opus-5-high"})
+        apply_observed_effort(self.path)
+        fields = [e.get("field") for e in self._load().get("unverified") or []]
+        self.assertEqual(fields, ["model.temperature"])
+        self.assertNotIn("model.reasoning_effort", fields)
+
+    def test_the_comment_preamble_survives(self):
+        """It carries record_version and a pointer to the module; safe_dump
+        would drop it silently."""
+        self._write({"model": "google/claude-opus-5-high"})
+        apply_observed_effort(self.path)
+        text = self.path.read_text(encoding="utf-8")
+        self.assertTrue(text.startswith("# D4D generation provenance record"))
+        self.assertIn("record_version 1", text)
+
+    def test_every_other_field_is_left_alone(self):
+        """A 49-record rewrite must change only what it claims to change."""
+        extra = {"run": {"label": "L", "project": "P"},
+                 "validation": {"passed": True, "artifacts": {"full": {}}},
+                 "inputs": {"bundle_md5": "abc", "bundle_path": "b.txt"}}
+        self._write({"model": "google/claude-opus-5-high"}, extra)
+        before = self._load()
+        apply_observed_effort(self.path)
+        after = self._load()
+        for key in ("run", "validation", "inputs", "unverified",
+                    "record_version"):
+            self.assertEqual(after[key], before[key], key)
+        self.assertEqual(set(after) , set(before))
+
+    def test_a_record_with_no_model_block_is_skipped(self):
+        self.path.write_text(PREAMBLE + yaml.safe_dump({"record_version": 1}),
+                             encoding="utf-8")
+        self.assertIsNone(observed_effort_gap(self.path))
+
+    def test_a_missing_file_is_skipped(self):
+        self.assertIsNone(observed_effort_gap(self.path / "nope.yaml"))
+
+    def test_unparseable_yaml_is_skipped_not_raised(self):
+        """One bad record must not abort a corpus-wide pass — the failure #444
+        fixed for the scope sweep."""
+        self.path.write_text("this: [is: not: valid", encoding="utf-8")
+        self.assertIsNone(observed_effort_gap(self.path))
+
+    def test_applying_twice_is_a_no_op(self):
+        self._write({"model": "google/claude-opus-5-high"})
+        self.assertIsNotNone(apply_observed_effort(self.path))
+        first = self.path.read_text(encoding="utf-8")
+        self.assertIsNone(apply_observed_effort(self.path))
+        self.assertEqual(self.path.read_text(encoding="utf-8"), first)
+
+
+@unittest.skipUnless(Path("data/d4d_concatenated").exists(), "corpus absent")
+class TestAgainstTheRealCorpus(unittest.TestCase):
+    def test_no_recoverable_effort_is_left_unrecorded(self):
+        """The 49 are done, and nothing has regressed.
+
+        Fails if a new record lands whose route names an effort it does not
+        carry — which is the state #448 was filed about.
+        """
+        gaps = [g for g in
+                (observed_effort_gap(p) for p in
+                 Path("data/d4d_concatenated").glob(
+                     "*_core/*/*_provenance.yaml"))
+                if g]
+        self.assertEqual(gaps, [], f"{len(gaps)} record(s) still recoverable")
+
+    def test_every_recorded_effort_says_where_it_came_from(self):
+        """A value with no basis cannot be placed on the ladder #397 defines.
+
+        The invariant is *not* "the route must name it" — that was this test's
+        first premise and it was wrong. CLAUDE.md gives three sources in order:
+        the route (observed), `--reasoning-effort` (asserted by the launcher),
+        and nothing (absent, gap named). The agentic path legitimately records
+        `high` on a ladderless route because the runtime exposes `CLAUDE_EFFORT`
+        (#449). What distinguishes those cases is the *basis*, so that is what
+        is asserted.
+
+        17 records predate the basis field and are pinned by count, not
+        excused: 15 from the 2026-08-07 sweep carrying `high` with no basis, and
+        2 carrying the forbidden `default` (#470). The number may only go down.
+        """
+        without_basis = []
+        for p in Path("data/d4d_concatenated").glob(
+                "*_core/*/*_provenance.yaml"):
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            model = data.get("model") or {}
+            effort = model.get("reasoning_effort")
+            if not effort or effort == "not applicable":
+                continue
+            if not model.get("reasoning_effort_basis"):
+                without_basis.append(str(p))
+
+        self.assertLessEqual(
+            len(without_basis), 17,
+            "a new record carries an effort with no basis; every effort must "
+            "say whether it was read from the route, asserted by the launcher, "
+            "or observed from the runtime (#397, #470)")
+
+    def test_the_backfilled_records_all_carry_their_basis(self):
+        """The 49 this pass wrote are the well-formed case, asserted as such."""
+        n = 0
+        for p in Path("data/d4d_concatenated").glob(
+                "*_core/*/*_provenance.yaml"):
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            model = data.get("model") or {}
+            if (model.get("model") or "").endswith("-high"):
+                self.assertEqual(model.get("reasoning_effort"), "high", str(p))
+                self.assertIn("model route",
+                              model.get("reasoning_effort_basis") or "", str(p))
+                n += 1
+        self.assertEqual(n, 49)

--- a/tests/test_observed_effort_backfill.py
+++ b/tests/test_observed_effort_backfill.py
@@ -125,6 +125,36 @@ class TestObservedEffortBackfill(unittest.TestCase):
         self.path.write_text("this: [is: not: valid", encoding="utf-8")
         self.assertIsNone(observed_effort_gap(self.path))
 
+    def test_undecodable_bytes_are_skipped_too(self):
+        """A different code path from bad YAML, and only one was covered (#472).
+
+        `read_text` raises UnicodeDecodeError before the parser is reached, so
+        a `except yaml.YAMLError` guard lets it through and the sweep dies on
+        record N of 162 — under --execute, partway through writing.
+        """
+        self.path.write_bytes(b"\xff\xfe\x00 model: not utf-8")
+        self.assertIsNone(observed_effort_gap(self.path))
+
+    def test_an_unreadable_path_is_skipped(self):
+        """A directory where a file is expected raises OSError, not YAMLError."""
+        directory = Path(self.tmp.name) / "a_directory.yaml"
+        directory.mkdir()
+        self.assertIsNone(observed_effort_gap(directory))
+
+    def test_the_write_leaves_no_temp_file_behind(self):
+        """Atomic via rename, so a record is its old bytes or its new ones.
+
+        Unlike `Record.write`, which creates a record for a run that just
+        happened, this mutates records that already exist and are attested — a
+        truncated write here destroys provenance rather than failing to add it.
+        """
+        self._write({"model": "google/claude-opus-5-high"})
+        apply_observed_effort(self.path)
+        strays = [p.name for p in Path(self.tmp.name).iterdir()
+                  if p.name != self.path.name]
+        self.assertEqual(strays, [])
+        self.assertEqual(self._load()["model"]["reasoning_effort"], "high")
+
     def test_applying_twice_is_a_no_op(self):
         self._write({"model": "google/claude-opus-5-high"})
         self.assertIsNotNone(apply_observed_effort(self.path))


### PR DESCRIPTION
Closes #448.

`_effort_from_route` runs only when a record is *built*, so records written before it existed name `google/claude-opus-5-high` and carry no `reasoning_effort`. The information was in the route all along; nothing read it.

Adds `d4d provenance backfill-effort` — reports by default, writes only under `--execute`, because rewriting 49 records should be a deliberate reviewable commit rather than a side effect of some other command.

```
162 record(s) examined, 49 would update:
   google/claude-opus-5-high -> high            49
```

## Why a bulk pass is defensible here

The value is **observed, not asserted**, so it does not enter `unverified`. The route is already in the record and the effort is read off it — this adds no claim the record was not already making, it makes an existing one legible. The same pass would not be defensible for temperature, which no record carries evidence for.

## Canaried before the batch

One record first, per the standing rule. Diff inspected: **+3 lines**, no reformatting, comment preamble intact, validation block carried forward, `unverified` still naming only `model.temperature`, and `d4d runs check --strict` still exit 0. Then the remaining 48.

The full 49-file diff is **147 insertions, 0 deletions**, containing only:

```
+  reasoning_effort: high
+  reasoning_effort_basis: read from the model route; the provider exposes effort as
+    a model-name suffix, not a parameter
```

No record was reformatted on the way past.

## What is deliberately left alone

Routes with no ladder — `claude-opus-5`, `claude-opus-5[1m]`, `google/claude-opus-5` — stay absent. A run that was never offered an effort is a different claim from one at high, and filling it would invent exactly the distinction CLAUDE.md forbids.

## What the tests found

Fourteen tests. One pins that no recoverable effort is left unrecorded, so #448's state cannot return.

Another asserts that **every recorded effort says where it came from**, and that turned up more than was filed. Its first premise — "the route must name it" — was wrong: the agentic path legitimately records `high` on a ladderless route because the runtime exposes `CLAUDE_EFFORT` (#449). The real invariant is the *basis*, and 17 records lack one:

```
  49  ('google/claude-opus-5-high', 'high', 'read from the model route; ...')
  15  ('claude-opus-5',             'high', 'NO BASIS')
   2  ('claude-opus-5[1m]',      'default', 'NO BASIS')
```

Two different defects: the 15 have the right value and no record of its provenance; the 2 carry a value CLAUDE.md forbids. Pinned at ≤17 so the debt can only shrink, and reported on #470.

Full suite: **1588 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)