### PR TITLE
Match core distributions against nested resources, not just collections (#401)

### DIFF
--- a/src/data_sheets_schema/d4d_pair_consistency.py
+++ b/src/data_sheets_schema/d4d_pair_consistency.py
@@ -419,7 +419,15 @@ def _append_distribution_relation_issues(
             distribution, mapping_collections
         )
         level = "collection"
-        if collection is None:
+        if collection is None and match_basis is None:
+            # Only on a *clean* miss. `_related_match` returns
+            # (None, "ambiguous <key>") when two collections share an
+            # identifier, which is a data defect; descending past it and
+            # finding one nested file would report a tidy resource-level match
+            # and delete the ambiguity from the output (#474). That would make
+            # the defect less visible than before this change, inverting what
+            # #401 is for.
+            #
             # Descend into each collection's nested `resources` (#401).
             # `FileCollection` is collection-level — total_bytes, file_count,
             # collection_type — while `CoreDistribution` is file-level — bytes,

--- a/src/data_sheets_schema/d4d_pair_consistency.py
+++ b/src/data_sheets_schema/d4d_pair_consistency.py
@@ -330,6 +330,26 @@ def _append_resource_projection_errors(
             )
 
 
+def _nested_resources(
+    collections: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    """Every `File` nested under a collection's `resources` (#401).
+
+    Flattened across collections rather than searched per collection, because
+    a core distribution names the file, not the collection it sits in — and
+    `_related_match` already refuses an ambiguous match, so two files sharing
+    an id anywhere in the record are reported rather than silently resolved to
+    whichever came first.
+    """
+    out: list[Mapping[str, Any]] = []
+    for collection in collections:
+        resources = collection.get("resources")
+        if not isinstance(resources, list):
+            continue
+        out.extend(item for item in resources if isinstance(item, Mapping))
+    return out
+
+
 def _related_match(
     distribution: Mapping[str, Any],
     collections: Sequence[Mapping[str, Any]],
@@ -381,7 +401,9 @@ def _append_distribution_relation_issues(
     mapping_collections = [
         item for item in collections if isinstance(item, Mapping)
     ]
+    nested_files = _nested_resources(mapping_collections)
     matched = 0
+    matched_nested = 0
     unmatched = []
     for index, distribution in enumerate(distributions):
         if not isinstance(distribution, Mapping):
@@ -396,10 +418,24 @@ def _append_distribution_relation_issues(
         collection, match_basis = _related_match(
             distribution, mapping_collections
         )
+        level = "collection"
+        if collection is None:
+            # Descend into each collection's nested `resources` (#401).
+            # `FileCollection` is collection-level — total_bytes, file_count,
+            # collection_type — while `CoreDistribution` is file-level — bytes,
+            # hash, md5, sha256, path, media_type. So a core record that
+            # enumerates one distribution per *file* is doing the correct
+            # thing, and matching only at the top level reported all 12 of
+            # VOICE_PEDIATRIC's as unmatched when every one matched a nested
+            # File by id, with name, path and bytes agreeing and zero conflicts.
+            collection, match_basis = _related_match(distribution, nested_files)
+            level = "resource"
         if collection is None:
             unmatched.append(index)
             continue
         matched += 1
+        if level == "resource":
+            matched_nested += 1
         relation_path = f"$.distributions[{index}]"
         for field_name in ("path", "compression"):
             if (
@@ -418,10 +454,14 @@ def _append_distribution_relation_issues(
                         ),
                     )
                 )
+        # A collection carries `total_bytes`; a nested File carries `bytes`.
+        # Comparing a file-level size against a collection total would be a
+        # category error, so the counterpart field follows the match level.
+        size_field = "total_bytes" if level == "collection" else "bytes"
         if (
             "bytes" in distribution
-            and "total_bytes" in collection
-            and distribution["bytes"] != collection["total_bytes"]
+            and size_field in collection
+            and distribution["bytes"] != collection[size_field]
         ):
             report.errors.append(
                 ConsistencyIssue(
@@ -429,20 +469,23 @@ def _append_distribution_relation_issues(
                     path=f"{relation_path}.bytes",
                     message=(
                         "value conflicts with matched "
-                        "file_collection.total_bytes: "
-                        f"full={collection['total_bytes']!r}, "
+                        f"file_collection.{size_field}: "
+                        f"full={collection[size_field]!r}, "
                         f"core={distribution['bytes']!r}"
                     ),
                 )
             )
 
+    at_collection = matched - matched_nested
     report.warnings.append(
         ConsistencyIssue(
             code="semantic-review-required",
             path="$.file_collections <-> $.distributions",
             message=(
                 "Phase 4 must semantically review related distribution "
-                f"content; deterministic matches={matched}, "
+                f"content; deterministic matches={matched} "
+                f"({at_collection} at collection level, "
+                f"{matched_nested} at nested resource level), "
                 f"unmatched core distributions={unmatched}"
             ),
         )

--- a/tests/test_d4d_pair_consistency.py
+++ b/tests/test_d4d_pair_consistency.py
@@ -181,6 +181,172 @@ class TestD4DPairConsistency(unittest.TestCase):
             {issue.code for issue in report.errors},
         )
 
+    # --- nested resource matching (#401) -------------------------------
+    #
+    # `FileCollection` is collection-level (total_bytes, file_count,
+    # collection_type, nested resources); `CoreDistribution` is file-level
+    # (bytes, hash, md5, sha256, path, media_type). A core record that
+    # enumerates one distribution per file is therefore doing the correct
+    # thing, and matching only at the top level reported all 12 of
+    # VOICE_PEDIATRIC's as unmatched while every one matched a nested File.
+
+    def _nested_pair(self, *, core_bytes=10, core_path="data/a.csv"):
+        full = {
+            "id": "https://example.org/dataset",
+            "file_collections": [
+                {
+                    "id": "https://example.org/collection",
+                    "name": "Collection",
+                    "total_bytes": 100,
+                    "resources": [
+                        {
+                            "id": "https://example.org/file-a",
+                            "name": "a.csv",
+                            "path": "data/a.csv",
+                            "bytes": 10,
+                        }
+                    ],
+                }
+            ],
+        }
+        core = {
+            "id": "https://example.org/dataset",
+            "distributions": [
+                {
+                    "id": "https://example.org/file-a",
+                    "name": "a.csv",
+                    "path": core_path,
+                    "bytes": core_bytes,
+                }
+            ],
+        }
+        return full, core
+
+    def _relation_warning(self, report):
+        for issue in report.warnings:
+            if issue.path == "$.file_collections <-> $.distributions":
+                return issue.message
+        self.fail("no distribution relation warning emitted")
+
+    def test_a_file_level_distribution_matches_a_nested_resource(self):
+        full, core = self._nested_pair()
+        report = validate_pair_data(full, core, self.pair_schema)
+        message = self._relation_warning(report)
+        self.assertIn("unmatched core distributions=[]", message)
+        self.assertIn("1 at nested resource level", message)
+        self.assertIn("0 at collection level", message)
+
+    def test_a_nested_match_is_not_an_error(self):
+        """The record was correct; only the instrument disagreed."""
+        full, core = self._nested_pair()
+        report = validate_pair_data(full, core, self.pair_schema)
+        self.assertEqual(
+            [i for i in report.errors
+             if i.code == "distribution-related-content"], [])
+
+    def test_bytes_is_compared_against_the_nested_file_not_the_total(self):
+        """A file size against a collection total is a category error.
+
+        The nested File is 10 bytes and its collection is 100. Comparing the
+        core distribution's 10 against 100 would report a conflict on a record
+        that agrees exactly.
+        """
+        full, core = self._nested_pair(core_bytes=10)
+        report = validate_pair_data(full, core, self.pair_schema)
+        self.assertEqual(
+            [i for i in report.errors
+             if i.code == "distribution-related-content"], [])
+
+    def test_a_real_conflict_against_a_nested_file_is_still_caught(self):
+        """Descending must not turn the check off."""
+        full, core = self._nested_pair(core_bytes=999, core_path="wrong/")
+        report = validate_pair_data(full, core, self.pair_schema)
+        codes = {i.code for i in report.errors}
+        self.assertIn("distribution-related-content", codes)
+
+    def test_collection_level_matching_still_wins_and_is_reported_as_such(self):
+        """The pre-existing behaviour, unchanged and now labelled."""
+        full = {
+            "id": "https://example.org/dataset",
+            "file_collections": [
+                {"id": "https://example.org/files", "name": "Files",
+                 "total_bytes": 100},
+            ],
+        }
+        core = {
+            "id": "https://example.org/dataset",
+            "distributions": [
+                {"id": "https://example.org/files", "name": "Files",
+                 "bytes": 100},
+            ],
+        }
+        report = validate_pair_data(full, core, self.pair_schema)
+        message = self._relation_warning(report)
+        self.assertIn("1 at collection level", message)
+        self.assertIn("0 at nested resource level", message)
+
+    def test_a_genuinely_absent_distribution_is_still_unmatched(self):
+        """The signal the fix exists to make meaningful.
+
+        Before #401 this warning looked identical to the benign nested case,
+        so the alarming reading was routine. It must survive.
+        """
+        full = {
+            "id": "https://example.org/dataset",
+            "file_collections": [
+                {"id": "https://example.org/collection", "name": "C",
+                 "resources": [{"id": "https://example.org/file-a",
+                                "name": "a.csv"}]},
+            ],
+        }
+        core = {
+            "id": "https://example.org/dataset",
+            "distributions": [
+                {"id": "https://example.org/nowhere", "name": "ghost.csv"},
+            ],
+        }
+        report = validate_pair_data(full, core, self.pair_schema)
+        self.assertIn("unmatched core distributions=[0]",
+                      self._relation_warning(report))
+
+    def test_an_id_duplicated_across_collections_is_not_resolved_silently(self):
+        """Ambiguity is reported, not settled by iteration order."""
+        full = {
+            "id": "https://example.org/dataset",
+            "file_collections": [
+                {"id": "https://example.org/c1", "name": "C1",
+                 "resources": [{"id": "https://example.org/dup", "name": "x"}]},
+                {"id": "https://example.org/c2", "name": "C2",
+                 "resources": [{"id": "https://example.org/dup", "name": "y"}]},
+            ],
+        }
+        core = {
+            "id": "https://example.org/dataset",
+            "distributions": [
+                {"id": "https://example.org/dup", "name": "z"},
+            ],
+        }
+        report = validate_pair_data(full, core, self.pair_schema)
+        self.assertIn("unmatched core distributions=[0]",
+                      self._relation_warning(report))
+
+    def test_a_collection_without_resources_is_handled(self):
+        full = {
+            "id": "https://example.org/dataset",
+            "file_collections": [
+                {"id": "https://example.org/c", "name": "C"},
+                {"id": "https://example.org/c2", "name": "C2",
+                 "resources": "not a list"},
+            ],
+        }
+        core = {
+            "id": "https://example.org/dataset",
+            "distributions": [{"id": "https://example.org/x", "name": "x"}],
+        }
+        report = validate_pair_data(full, core, self.pair_schema)
+        self.assertIn("unmatched core distributions=[0]",
+                      self._relation_warning(report))
+
     def test_synchronize_core_uses_full_as_canonical_content(self):
         full = {
             "id": "https://example.org/dataset",

--- a/tests/test_d4d_pair_consistency.py
+++ b/tests/test_d4d_pair_consistency.py
@@ -330,6 +330,35 @@ class TestD4DPairConsistency(unittest.TestCase):
         self.assertIn("unmatched core distributions=[0]",
                       self._relation_warning(report))
 
+    def test_an_ambiguous_collection_match_is_not_rescued_by_descending(self):
+        """Two collections sharing an id is a defect; descending would hide it.
+
+        `_related_match` reports ambiguity distinctly from absence. If the
+        descent treated them alike, this record would report a tidy
+        `1 at nested resource level` match and the duplicate collection id
+        would vanish from the output — less visible than before #401, which
+        exists to make `unmatched` mean what it says (#474).
+        """
+        full = {
+            "id": "https://example.org/dataset",
+            "file_collections": [
+                {"id": "https://example.org/dup", "name": "C1",
+                 "resources": [{"id": "https://example.org/dup",
+                                "name": "nested"}]},
+                {"id": "https://example.org/dup", "name": "C2"},
+            ],
+        }
+        core = {
+            "id": "https://example.org/dataset",
+            "distributions": [
+                {"id": "https://example.org/dup", "name": "d"},
+            ],
+        }
+        report = validate_pair_data(full, core, self.pair_schema)
+        message = self._relation_warning(report)
+        self.assertIn("unmatched core distributions=[0]", message)
+        self.assertIn("0 at nested resource level", message)
+
     def test_a_collection_without_resources_is_handled(self):
         full = {
             "id": "https://example.org/dataset",


### PR DESCRIPTION
Closes #401.

`FileCollection` is collection-level — `total_bytes`, `file_count`, `collection_type`, nested `resources` — while `CoreDistribution` is file-level — `bytes`, `hash`, `md5`, `sha256`, `path`, `media_type`. A core record that enumerates one distribution per *file* is therefore doing the correct thing, and matching only against top-level collections reported it as broken.

On VOICE_PEDIATRIC in the canonical label, the record #401 was filed on and hand-verified:

```
before: deterministic matches=1, unmatched core distributions=[0..11]

after:  deterministic matches=13 (1 at collection level,
        12 at nested resource level), unmatched core distributions=[]
        0 errors
```

All 12 match a nested `File` by id, with `name`, `path` and `bytes` agreeing and zero conflicts — which is what the issue verified by hand.

## The size field follows the match level

A collection carries `total_bytes`; a nested `File` carries `bytes`. Comparing a file-level size against a collection total is a category error, and would have reported a conflict on the very record that agrees exactly. Tested both directions.

## Why this matters beyond the noise

The warning now names which level each match came from, so **`unmatched` means what it says**. Previously a genuinely unmatched core distribution — one asserting a file that exists nowhere in full — produced an identical warning to the benign case, so the signal that should alarm was routine.

## Corpus swept for regressions

158 pairs. **3** now match at nested level (the three VOICE_PEDIATRIC replicates); **29** still report unmatched. Sampled two of the 29: both have *zero* nested files, and their distribution ids sit in a different namespace from their collection ids (`distribution:adult-v3-1-0-parquet-features` against `filecollection:adult-v3-1-0-features`). They legitimately have no counterpart at either level — real cases for semantic review, which is now what the warning means.

## Tests

Nine, including that a real conflict against a nested file is still caught (descending must not turn the check off), that an id duplicated across two collections is *reported* rather than settled by iteration order, and that a genuinely absent distribution still reports unmatched.

Full suite: **1599 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)