### PR TITLE
Banner the four per-rubric reports, the most citable form of the archived scores (#286)

### DIFF
--- a/data/evaluation_llm/rubric10/concatenated/scores_summary.txt
+++ b/data/evaluation_llm/rubric10/concatenated/scores_summary.txt
@@ -1,4 +1,6 @@
-# rubric10 scores — publication exemplar run 2026-07-22 (claude-fable-5)
+# [HISTORICAL] rubric10 scores — publication exemplar run 2026-07-22 (claude-fable-5)
+# These score the archived 2026-04-10_sonnet-4.6 label, set aside
+# as unattestable. Do not cite as current. See #286.
 
 [claudecode]
   AI_READI   34/50  (68.0%)

--- a/data/evaluation_llm/rubric10/concatenated/summary_report.md
+++ b/data/evaluation_llm/rubric10/concatenated/summary_report.md
@@ -1,4 +1,15 @@
-# rubric10 Evaluation Summary (Publication Exemplar Run 2026-07-22)
+# [HISTORICAL] rubric10 Evaluation Summary (Publication Exemplar Run 2026-07-22)
+
+> ⚠️  **Historical. These figures score records the study has since excluded.**
+>
+> The inputs were `data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/` and the
+> flat pre-run-label layout. That label was archived as **unattestable** by
+> `d4d runs archive --unattested` — its bundles were first committed after the
+> runs executed, so the bytes those runs consumed cannot be verified. The records
+> survive under `data/ATTIC/d4d_concatenated_archived/`, so every number here
+> remains traceable to its input; none of it describes the current corpus.
+>
+> Do not cite these as current results. See #286.
 
 Rubric: `rubric10` | Run: `2026-07-22` | Model (agent/core rows): `claude-fable-5`
 

--- a/data/evaluation_llm/rubric10_semantic/concatenated/scores_summary.txt
+++ b/data/evaluation_llm/rubric10_semantic/concatenated/scores_summary.txt
@@ -1,4 +1,6 @@
-# rubric10_semantic scores — publication exemplar run 2026-07-22 (claude-fable-5)
+# [HISTORICAL] rubric10_semantic scores — publication exemplar run 2026-07-22 (claude-fable-5)
+# These score the archived 2026-04-10_sonnet-4.6 label, set aside
+# as unattestable. Do not cite as current. See #286.
 
 [claudecode_agent]
   AI_READI   37/50  (74.0%)

--- a/data/evaluation_llm/rubric10_semantic/concatenated/summary_report.md
+++ b/data/evaluation_llm/rubric10_semantic/concatenated/summary_report.md
@@ -1,4 +1,15 @@
-# rubric10_semantic Evaluation Summary (Publication Exemplar Run 2026-07-22)
+# [HISTORICAL] rubric10_semantic Evaluation Summary (Publication Exemplar Run 2026-07-22)
+
+> ⚠️  **Historical. These figures score records the study has since excluded.**
+>
+> The inputs were `data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/` and the
+> flat pre-run-label layout. That label was archived as **unattestable** by
+> `d4d runs archive --unattested` — its bundles were first committed after the
+> runs executed, so the bytes those runs consumed cannot be verified. The records
+> survive under `data/ATTIC/d4d_concatenated_archived/`, so every number here
+> remains traceable to its input; none of it describes the current corpus.
+>
+> Do not cite these as current results. See #286.
 
 Rubric: `rubric10_semantic` | Run: `2026-07-22` | Model (agent/core rows): `claude-fable-5`
 

--- a/data/evaluation_llm/rubric20/concatenated/scores_summary.txt
+++ b/data/evaluation_llm/rubric20/concatenated/scores_summary.txt
@@ -1,4 +1,6 @@
-# rubric20 scores — publication exemplar run 2026-07-22 (claude-fable-5)
+# [HISTORICAL] rubric20 scores — publication exemplar run 2026-07-22 (claude-fable-5)
+# These score the archived 2026-04-10_sonnet-4.6 label, set aside
+# as unattestable. Do not cite as current. See #286.
 
 [claudecode]
   AI_READI   49/84  (58.3%)

--- a/data/evaluation_llm/rubric20/concatenated/summary_report.md
+++ b/data/evaluation_llm/rubric20/concatenated/summary_report.md
@@ -1,4 +1,15 @@
-# rubric20 Evaluation Summary (Publication Exemplar Run 2026-07-22)
+# [HISTORICAL] rubric20 Evaluation Summary (Publication Exemplar Run 2026-07-22)
+
+> ⚠️  **Historical. These figures score records the study has since excluded.**
+>
+> The inputs were `data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/` and the
+> flat pre-run-label layout. That label was archived as **unattestable** by
+> `d4d runs archive --unattested` — its bundles were first committed after the
+> runs executed, so the bytes those runs consumed cannot be verified. The records
+> survive under `data/ATTIC/d4d_concatenated_archived/`, so every number here
+> remains traceable to its input; none of it describes the current corpus.
+>
+> Do not cite these as current results. See #286.
 
 Rubric: `rubric20` | Run: `2026-07-22` | Model (agent/core rows): `claude-fable-5`
 

--- a/data/evaluation_llm/rubric20_semantic/concatenated/scores_summary.txt
+++ b/data/evaluation_llm/rubric20_semantic/concatenated/scores_summary.txt
@@ -1,4 +1,6 @@
-# rubric20_semantic scores — publication exemplar run 2026-07-22 (claude-fable-5)
+# [HISTORICAL] rubric20_semantic scores — publication exemplar run 2026-07-22 (claude-fable-5)
+# These score the archived 2026-04-10_sonnet-4.6 label, set aside
+# as unattestable. Do not cite as current. See #286.
 
 [claudecode_agent]
   AI_READI   76/84  (90.5%)

--- a/data/evaluation_llm/rubric20_semantic/concatenated/summary_report.md
+++ b/data/evaluation_llm/rubric20_semantic/concatenated/summary_report.md
@@ -1,4 +1,15 @@
-# rubric20_semantic Evaluation Summary (Publication Exemplar Run 2026-07-22)
+# [HISTORICAL] rubric20_semantic Evaluation Summary (Publication Exemplar Run 2026-07-22)
+
+> ⚠️  **Historical. These figures score records the study has since excluded.**
+>
+> The inputs were `data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/` and the
+> flat pre-run-label layout. That label was archived as **unattestable** by
+> `d4d runs archive --unattested` — its bundles were first committed after the
+> runs executed, so the bytes those runs consumed cannot be verified. The records
+> survive under `data/ATTIC/d4d_concatenated_archived/`, so every number here
+> remains traceable to its input; none of it describes the current corpus.
+>
+> Do not cite these as current results. See #286.
 
 Rubric: `rubric20_semantic` | Run: `2026-07-22` | Model (agent/core rows): `claude-fable-5`
 

--- a/scripts/publication_summary_2026-07-22.py
+++ b/scripts/publication_summary_2026-07-22.py
@@ -107,7 +107,13 @@ def per_rubric_report(rubric, scores):
         lines.append("| " + " | ".join(row) + " |")
     lines.append("")
 
-    txt = [f"# {rubric} scores — publication run {RUN_DATE}", ""]
+    # Plain text gets the same warning in its own comment style. The .tsv
+    # sibling has carried TSV_BANNER since #286 was filed and this did not, so
+    # the most machine-greppable form was the one left unmarked (#476).
+    txt = [f"# [HISTORICAL] {rubric} scores — publication run {RUN_DATE}",
+           "# These score the archived 2026-04-10_sonnet-4.6 label, set aside",
+           "# as unattestable. Do not cite as current. See #286.",
+           ""]
     for m in methods:
         txt.append(f"[{m}]")
         for p in PROJECTS:
@@ -125,8 +131,9 @@ def per_rubric_report(rubric, scores):
 def publication_table(all_scores):
     """Headline table: rows = projects, columns = 4 rubrics × 2 variants."""
     lines = [
-        f"# D4D Publication Summary — Rerun {RUN_DATE}",
+        f"# [HISTORICAL] D4D Publication Summary — Rerun {RUN_DATE}",
         "",
+        *HISTORICAL_BANNER,
         "Final claudecode_agent scores across the four rubrics for both full D4D and",
         "D4D-core outputs, per Grand Challenge project. All 32 evaluations produced by",
         "the four `d4d-rubric*` agents at git commit `0e19e85f` (PR #154 merged).",

--- a/scripts/publication_summary_2026-07-22.py
+++ b/scripts/publication_summary_2026-07-22.py
@@ -47,11 +47,40 @@ def pick_pct(score):
     return score.get("normalized_percentage", score.get("percentage"))
 
 
+#: Emitted into every generated report, not only the two headline summaries.
+#: The per-rubric reports carry the most citable form of the figures — a bare
+#: method x project table — and carried no indication of what they scored, so
+#: they were the easiest thing in the directory to quote as current (#286).
+#: Written by the generator rather than added by hand so a regeneration cannot
+#: drop it, which is how `d4d runs archive` deleted the ATTIC rationale (#412).
+HISTORICAL_BANNER = [
+    "> ⚠️  **Historical. These figures score records the study has since "
+    "excluded.**",
+    ">",
+    "> The inputs were "
+    "`data/d4d_concatenated/claudecode_agent/2026-04-10_sonnet-4.6/` and the",
+    "> flat pre-run-label layout. That label was archived as **unattestable** "
+    "by",
+    "> `d4d runs archive --unattested` — its bundles were first committed "
+    "after the",
+    "> runs executed, so the bytes those runs consumed cannot be verified. The "
+    "records",
+    "> survive under `data/ATTIC/d4d_concatenated_archived/`, so every number "
+    "here",
+    "> remains traceable to its input; none of it describes the current corpus.",
+    ">",
+    "> Do not cite these as current results. See #286.",
+    "",
+]
+
+
 def per_rubric_report(rubric, scores):
     methods = sorted({m for (_, m) in scores.keys()})
     lines = [
-        f"# {rubric} Evaluation Summary (Publication Run {RUN_DATE})",
+        f"# [HISTORICAL] {rubric} Evaluation Summary "
+        f"(Publication Run {RUN_DATE})",
         "",
+        *HISTORICAL_BANNER,
         f"Rubric: `{rubric}` | Run: `{RUN_DATE}` | Model: `claude-sonnet-4-5-20250929`",
         "",
         "## Overall Scores by Method × Project",


### PR DESCRIPTION
Closes #286.

Items 1 and 2 were already done — all three headline documents carry a `[HISTORICAL]` banner, `notes/semantic_evaluation_corpus_2026-08-03.md` describes the problem, and the generator script's docstring says so.

Item 3 was *"worth checking whether any other document in `data/evaluation_llm/` cites these tables."* It does — four generated per-rubric reports, with no framing at all:

```
rubric10/concatenated/summary_report.md
rubric10_semantic/concatenated/summary_report.md
rubric20/concatenated/summary_report.md
rubric20_semantic/concatenated/summary_report.md
```

## Why these are the worst case, not a leftover

They present the headline figure in its **most quotable form** — a bare method × project table:

```
| `claudecode_agent` | 46/50 (92.0%) | 41/50 (82.0%) | 46/50 (92.0%) | 49/50 (98.0%) | 91.0% |
```

— with nothing indicating it scores the archived `2026-04-10_sonnet-4.6` label. The two documents that *did* carry warnings are the discursive ones nobody copies a number out of. The unlabelled ones were the ones a reader would actually cite.

## Emitted by the generator, not added by hand

`HISTORICAL_BANNER` lives in `scripts/publication_summary_2026-07-22.py` and is written into every report, so a regeneration cannot drop it.

That is the #412 lesson: `d4d runs archive` rebuilt the ATTIC README on every invocation, and four archiving runs deleted the rationale for the 2026-04 and 2026-07-23 series — because the documentation lived outside the writer. Verified the generator emits it.

Full suite: **1600 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)