### PR TITLE
Stop the byte-identity guard shadowing PROJECTS, and state why agreement's default is four (#467)

### DIFF
--- a/src/data_sheets_schema/agreement.py
+++ b/src/data_sheets_schema/agreement.py
@@ -548,6 +548,21 @@ def compare_records(records: dict[str, dict[str, Any]], *,
 DEFAULT_METHOD = "claudecode_agent"
 DEFAULT_CONFIGS = {"v1  (2026-07-28 generic)": "2026-07-28_claude-opus-5-generic",
                    "v2  (2026-07-31 generic-v2)": "2026-07-31_claude-opus-5-generic-v2"}
+#: Four, not `PROJECTS`, and deliberately so (#467). This is the project set
+#: §7's published agreement figures were computed over — 261/540 shared slots,
+#: 48.3%, and the between-config effect of −2.9 against a per-project delta sd
+#: of 10.9. Widening the default would silently change what a bare invocation
+#: reports against what was published, which is a decision about the figures
+#: rather than a lint fix.
+#:
+#: VOICE_PEDIATRIC is reachable with `--projects`; it is excluded from the
+#: default because it and VOICE share a source corpus, so counting them as two
+#: samples overstates the independent n that §7's power argument rests on. See
+#: `SHARED_CORPUS_GROUPS`.
+#:
+#: Unlike `form_defects._value_index`, whose omission of the fifth project was
+#: an oversight that silently produced an `unattributed` column, an absent
+#: project here is visible: it simply has no row.
 DEFAULT_PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
 DEFAULT_ROOT = Path("data/d4d_concatenated")
 DEFAULT_CACHE = Path("data/evaluation_llm/agreement_cache")

--- a/tests/test_download/test_generic_v2_prompt.py
+++ b/tests/test_download/test_generic_v2_prompt.py
@@ -13,8 +13,14 @@ from pathlib import Path
 from data_sheets_schema.api_runner import (
     GENERIC_PROMPT, GENERIC_PROMPT_V2, RunSpec, prompt_body, resolve_prompt,
 )
+from data_sheets_schema.constants import PROJECTS
 
-PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
+# PROJECTS is imported, not restated. This file previously shadowed it with a
+# four-project literal, so the assertion "every project receives identical
+# text" excluded VOICE_PEDIATRIC from the day it became a project (#298) — a
+# guard whose stated scope was wider than its actual scope, in exactly the area
+# #419 and #422 were about. A fifth project now fails this file rather than
+# passing it by omission (#467).
 MARK_START = "--- ADDED IN v2 ---"
 MARK_END = "--- END ADDED IN v2 ---"
 

--- a/tests/test_download/test_generic_v3_prompt.py
+++ b/tests/test_download/test_generic_v3_prompt.py
@@ -19,8 +19,12 @@ from data_sheets_schema.api_runner import (
     condition_delta,
     prompt_body,
 )
+from data_sheets_schema.constants import PROJECTS
 
-PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
+# PROJECTS is imported, not restated. A four-project literal here made
+# the per-project assertions below exclude VOICE_PEDIATRIC from the day
+# #298 made it a project, so a guard that reads as covering every
+# project covered four of five (#467).
 MARK_START = "--- ADDED IN v3 ---"
 MARK_END = "--- END ADDED IN v3 ---"
 

--- a/tests/test_download/test_generic_v4_prompt.py
+++ b/tests/test_download/test_generic_v4_prompt.py
@@ -25,8 +25,12 @@ from data_sheets_schema.api_runner import (
     condition_delta,
     prompt_body,
 )
+from data_sheets_schema.constants import PROJECTS
 
-PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
+# PROJECTS is imported, not restated. A four-project literal here made
+# the per-project assertions below exclude VOICE_PEDIATRIC from the day
+# #298 made it a project, so a guard that reads as covering every
+# project covered four of five (#467).
 MARK_START = "--- ADDED IN v4 ---"
 MARK_END = "--- END ADDED IN v4 ---"
 

--- a/tests/test_download/test_prompt_components.py
+++ b/tests/test_download/test_prompt_components.py
@@ -13,12 +13,25 @@ These tests are cheap and catch that.
 import re
 import unittest
 from pathlib import Path
+from data_sheets_schema.constants import PROJECTS
 
 PROMPTS = Path("src/download/prompts")
 GENERIC = PROMPTS / "d4d_generic_arm_prompt.md"
 TUNED = PROMPTS / "d4d_tuned_arm_prompt.md"
 COMPONENTS = PROMPTS / "components"
-PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
+# PROJECTS is imported, not restated. A four-project literal here made
+# the per-project assertions below exclude VOICE_PEDIATRIC from the day
+# #298 made it a project, so a guard that reads as covering every
+# project covered four of five (#467).
+#
+# Widening it immediately found the gap the narrowing had hidden:
+# VOICE_PEDIATRIC has no component file, so the `tuned` condition cannot be run
+# for it (#478). Authoring one is content and a judgement call — it must state
+# what distinguishes the pediatric cohort without importing adult-cohort facts —
+# so the gap is pinned by name rather than papered over. The other four projects
+# stay guarded, and this list may only shrink.
+WITHOUT_COMPONENT = {"VOICE_PEDIATRIC"}
+COMPONENT_PROJECTS = tuple(p for p in PROJECTS if p not in WITHOUT_COMPONENT)
 
 ALLOWED_TYPES = {"fact", "decision-rule", "referent-pin"}
 HEADING = re.compile(r"^##\s+([a-z-]+)\s*$", re.MULTILINE)
@@ -74,19 +87,23 @@ class TestGenericPromptIsGeneric(unittest.TestCase):
 
 class TestComponentFiles(unittest.TestCase):
     def test_every_project_has_a_component_file(self):
-        for p in PROJECTS:
-            self.assertTrue((COMPONENTS / f"{p}.md").exists(),
-                            f"missing component file for {p}")
+        missing = [p for p in PROJECTS
+                   if not (COMPONENTS / f"{p}.md").exists()]
+        self.assertEqual(
+            set(missing), WITHOUT_COMPONENT,
+            "the set of projects without a component file has changed; a new "
+            "gap must be filed like #478, and a filled one removed from "
+            "WITHOUT_COMPONENT")
 
     def test_only_permitted_component_types_are_declared(self):
-        for p in PROJECTS:
+        for p in COMPONENT_PROJECTS:
             for kind in HEADING.findall((COMPONENTS / f"{p}.md").read_text("utf-8")):
                 self.assertIn(kind, ALLOWED_TYPES,
                               f"{p}.md declares disallowed component {kind!r}")
 
     def test_expectation_components_are_absent(self):
         """The one category with measured harm must not reappear."""
-        for p in PROJECTS:
+        for p in COMPONENT_PROJECTS:
             text = (COMPONENTS / f"{p}.md").read_text("utf-8")
             self.assertNotIn("## expectation", text,
                              f"{p}.md declares an expectation component")
@@ -96,7 +113,7 @@ class TestComponentFiles(unittest.TestCase):
         banned = ("expected to be", "should be largely", "sparse output",
                   "do not manufacture", "is the correct result",
                   "target slot", "aim for")
-        for p in PROJECTS:
+        for p in COMPONENT_PROJECTS:
             text = (COMPONENTS / f"{p}.md").read_text("utf-8").lower()
             for phrase in banned:
                 self.assertNotIn(phrase, text,


### PR DESCRIPTION
Closes #467. Two four-project literals that NEXT_TASKS §9 counted as "prose, not logic". They are not.

## 1. The byte-identity guard was narrower than it claimed

`tests/test_download/test_generic_v2_prompt.py` declared its own `PROJECTS` tuple, shadowing the registry. So the assertion its own module docstring opens with —

> The arm's whole value is that **every project** receives identical text.

— excluded VOICE_PEDIATRIC from the day #298 made it a project. A guard whose stated scope is wider than its actual scope, in precisely the area #419 and #422 were about: per-project prompt divergence.

Now imports `PROJECTS`, so a sixth dataset fails this file rather than passing it by omission.

**The guarantee did hold.** All 18 tests pass unchanged with the fifth project included, and `VOICE_PEDIATRIC_preprocessed.txt` is present so the case is genuinely exercised rather than silently skipped. It simply was not being asserted — which is the difference between a property and a checked property.

## 2. `agreement.DEFAULT_PROJECTS` stays four, and now says why

Not a mechanical widening, as the issue argued. This is the project set §7's published agreement figures were computed over — 261/540 shared slots, 48.3%, between-config effect −2.9 against a per-project delta sd of 10.9. Changing the default would silently alter what a bare invocation reports against what was published: a decision about the figures, not a lint fix.

VOICE_PEDIATRIC is reachable with `--projects`, and is excluded from the *default* because it and VOICE share a source corpus — counting them as two samples overstates the independent n that §7's power argument rests on (`SHARED_CORPUS_GROUPS`).

## The two omissions are not the same kind

`form_defects._value_index` (#463, fixed) silently produced an `unattributed` column that read as a data problem. An absent project here simply has no row, which is visible. Recorded in the comment so the next reader does not "fix" it.

Full suite: **1600 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)