### PR TITLE
Say where every recorded reasoning effort came from (#470)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,7 +441,9 @@ simply lacked it — 12 of the 2026-08 API runs. Three sources, in order:
    launcher, and still listed under `unverified`;
 3. nothing — the field is left absent and the gap is named.
 
-Never write "default", "unspecified" or a guess. A run that did not choose an
+Never write "default", "unspecified" or a guess — `d4d provenance
+backfill-effort-basis` removes such a value and names the gap it leaves, rather
+than relabelling it (#470). A run that did not choose an
 effort is a different claim from a run whose effort is unknown, and neither is
 a run at high. The fix lives in the recorder because adding a header line to a
 generic prompt would re-baseline that condition for every project and require a

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
@@ -15,7 +15,6 @@ model:
   agent_runtime: Claude Code
   provider: Anthropic
   model: claude-opus-5[1m]
-  reasoning_effort: default
   mode: four-phase project agent
   temperature: '0.0'
 schema:
@@ -75,3 +74,9 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_d4d_core.yaml
       sha256: 7d689413e4c5a095de6e996b16d6f6fbcdb41f2e736bf1d65ca599d92f97eaa2
   recorded_by: d4d runs validate
+unverified:
+- field: model.reasoning_effort
+  value: null
+  reason: 'the record carried ''default'', which names no effort; the route ''claude-opus-5[1m]''
+    exposes no effort ladder, so nothing was chosen. Removed rather than kept: a run
+    that did not choose an effort is a different claim from one at any level (#470).'

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/AI_READI_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/CHORUS_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/CM4AI_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/VOICE_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/AI_READI_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/CHORUS_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/CM4AI_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/VOICE_PEDIATRIC_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/VOICE_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/AI_READI_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/CHORUS_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/CM4AI_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/VOICE_PEDIATRIC_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/VOICE_provenance.yaml
@@ -24,6 +24,7 @@ model:
     name: claude-opus-5
     temperature: 0.0
     max_tokens: 16000
+  reasoning_effort_basis: asserted by the generating agent, not observed
 prompts:
   hash_algorithm: sha256
   files:
@@ -86,6 +87,11 @@ unverified:
   reason: the Claude Code runtime does not expose a temperature setting to the agent
     or to this recorder; the header value restates the prompt template rather than
     a measured parameter. A direct API run can observe it.
+- field: model.reasoning_effort
+  value: high
+  reason: 'recorded from the generation header; the basis field postdates this run,
+    so nothing observed the value at the time. The runtime does expose CLAUDE_EFFORT,
+    so it is confirmable in principle but was not confirmed here (#449, #470).'
 notes: null
 validation:
   passed: true

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
@@ -15,7 +15,6 @@ model:
   agent_runtime: Claude Code
   provider: Anthropic
   model: claude-opus-5[1m]
-  reasoning_effort: default
   mode: four-phase project agent
   temperature: '0.0'
 schema:
@@ -75,3 +74,9 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_d4d_core.yaml
       sha256: 10139e1d5857d6205d1415108c3fb4ac2767eb2370ce5326c334e0bfca8aad7f
   recorded_by: d4d runs validate
+unverified:
+- field: model.reasoning_effort
+  value: null
+  reason: 'the record carried ''default'', which names no effort; the route ''claude-opus-5[1m]''
+    exposes no effort ladder, so nothing was chosen. Removed rather than kept: a run
+    that did not choose an effort is a different claim from one at any level (#470).'

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -260,3 +260,68 @@ def backfill_effort(execute, method, label):
     click.echo(f"\n{written} record(s) updated. The value is observed — read "
                "from the route the record already carried — so it is not "
                "listed under `unverified`.")
+
+
+@provenance.command("backfill-effort-basis")
+@click.option('--execute', is_flag=True,
+              help='write the records; without it this reports and changes nothing')
+@click.option('--label', default=None, help='restrict to one run label')
+def backfill_effort_basis(execute, label):
+    """Say where each recorded reasoning effort came from (#470).
+
+    Every honestly-derived effort carries a basis — read from the route,
+    observed against CLAUDE_EFFORT, or asserted by the generating agent. A value
+    with no basis cannot be placed on that ladder, and anything grouping runs by
+    effort reads it as a third condition alongside `high` and absent.
+
+    Two actions, reported separately because they are opposite:
+
+    \b
+      record_basis      the value is real and stays; the basis is added
+      drop_placeholder  the value names no effort ('default') and is removed
+
+    The second is a deletion. It is never bundled into the first's count, and it
+    writes an `unverified` entry naming the gap it leaves.
+    """
+    from pathlib import Path
+
+    from data_sheets_schema.provenance import (
+        CONCAT_DIR, apply_effort_basis, effort_basis_gap,
+    )
+
+    paths = sorted(CONCAT_DIR.glob("*_core/*/*_provenance.yaml"))
+    if label:
+        paths = [p for p in paths if p.parts[-2] == label]
+
+    gaps = [g for g in (effort_basis_gap(Path(p)) for p in paths) if g]
+    if not gaps:
+        click.echo(f"{len(paths)} record(s) examined; every recorded effort "
+                   "already says where it came from.")
+        return
+
+    by_action: dict[str, list] = {}
+    for g in gaps:
+        by_action.setdefault(g["action"], []).append(g)
+
+    verb = "applying" if execute else "would apply"
+    click.echo(f"{len(paths)} record(s) examined, {len(gaps)} {verb}:")
+    for action, items in sorted(by_action.items()):
+        routes = sorted({str(i["route"]) for i in items})
+        click.echo(f"   {action:18} {len(items):3}   "
+                   f"effort={sorted({str(i['effort']) for i in items})}   "
+                   f"route={routes}")
+
+    if not execute:
+        click.echo("\nNothing written. Re-run with --execute to apply.")
+        return
+
+    counts: dict[str, int] = {}
+    for g in gaps:
+        applied = apply_effort_basis(g["path"])
+        if applied:
+            counts[applied["action"]] = counts.get(applied["action"], 0) + 1
+    for action, n in sorted(counts.items()):
+        click.echo(f"\n{n} record(s): {action}")
+    if counts.get("drop_placeholder"):
+        click.echo("   A value was removed, not corrected. Each such record now "
+                   "names the gap under `unverified`.")

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -311,6 +311,110 @@ def apply_observed_effort(path: Path) -> dict[str, Any] | None:
     return change
 
 
+#: Values that name no effort. CLAUDE.md forbids writing any of them: "a run
+#: that did not choose an effort is a different claim from a run whose effort is
+#: unknown, and neither is a run at high." The correct state is an absent field
+#: and a named gap.
+PLACEHOLDER_EFFORTS = {"default", "unspecified", "n/a", "none", "unknown"}
+
+
+def effort_basis_gap(path: Path) -> dict[str, Any] | None:
+    """Does this record state an effort without saying where it came from? (#470)
+
+    Every honestly-derived effort carries a `reasoning_effort_basis` — read from
+    the route, observed against `CLAUDE_EFFORT`, or asserted by the generating
+    agent. A value with no basis cannot be placed on that ladder, and anything
+    grouping runs by effort reads it as a third condition.
+
+    Two distinct defects, returned with different `action`s because they need
+    opposite fixes:
+
+    - ``record_basis`` — the value is a real ladder value with no basis. The
+      2026-08-07 sweep's 15 records are this: their header says `high`, the
+      runtime does expose `CLAUDE_EFFORT` (#449), and the basis field simply
+      postdates them. The value stays; what is added is where it came from.
+    - ``drop_placeholder`` — the value is one of `PLACEHOLDER_EFFORTS`, which
+      names no effort at all. The value goes and the gap is named. This is a
+      deletion, so it is reported separately and never bundled with the above.
+    """
+    if not path.exists():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (yaml.YAMLError, OSError, UnicodeDecodeError):
+        return None
+    model = data.get("model")
+    if not isinstance(model, dict):
+        return None
+    effort = model.get("reasoning_effort")
+    if not effort or str(effort).strip().lower() == "not applicable":
+        return None
+    if model.get("reasoning_effort_basis"):
+        return None
+
+    value = str(effort).strip().lower()
+    if value in PLACEHOLDER_EFFORTS:
+        return {"path": path, "action": "drop_placeholder", "effort": effort,
+                "route": model.get("model")}
+    return {"path": path, "action": "record_basis", "effort": effort,
+            "route": model.get("model")}
+
+
+def apply_effort_basis(path: Path) -> dict[str, Any] | None:
+    """Record the missing basis, or drop the placeholder that names none (#470).
+
+    The basis written for a surviving value is the same string `build_record`
+    writes in the same situation — "asserted by the generating agent, not
+    observed" — because that is exactly what is known: the header carries the
+    value and nothing here observed it. Claiming more would be the fabrication
+    the recorder exists to prevent.
+    """
+    change = effort_basis_gap(path)
+    if change is None:
+        return None
+    text = path.read_text(encoding="utf-8")
+    preamble = "".join(itertools.takewhile(lambda ln: ln.startswith("#"),
+                                           text.splitlines(keepends=True)))
+    data = yaml.safe_load(text) or {}
+    model = data["model"]
+    unverified = data.setdefault("unverified", []) or []
+    if not isinstance(unverified, list):
+        unverified = []
+
+    if change["action"] == "drop_placeholder":
+        dropped = model.pop("reasoning_effort")
+        model.pop("reasoning_effort_basis", None)
+        unverified.append({
+            "field": "model.reasoning_effort",
+            "value": None,
+            "reason": (f"the record carried {dropped!r}, which names no effort; "
+                       f"the route {change['route'] or 'unknown'!r} exposes no "
+                       "effort ladder, so nothing was chosen. Removed rather "
+                       "than kept: a run that did not choose an effort is a "
+                       "different claim from one at any level (#470)."),
+        })
+    else:
+        model["reasoning_effort_basis"] = (
+            "asserted by the generating agent, not observed")
+        unverified.append({
+            "field": "model.reasoning_effort",
+            "value": model["reasoning_effort"],
+            "reason": ("recorded from the generation header; the basis field "
+                       "postdates this run, so nothing observed the value at "
+                       "the time. The runtime does expose CLAUDE_EFFORT, so it "
+                       "is confirmable in principle but was not confirmed here "
+                       "(#449, #470)."),
+        })
+
+    data["unverified"] = unverified
+    new = path.with_suffix(path.suffix + ".tmp")
+    new.write_text(
+        preamble + yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+        encoding="utf-8")
+    new.replace(path)
+    return change
+
+
 def parse_header(path: Path) -> dict[str, str]:
     out: dict[str, str] = {}
     if not path.exists():

--- a/tests/test_observed_effort_backfill.py
+++ b/tests/test_observed_effort_backfill.py
@@ -17,7 +17,9 @@ from pathlib import Path
 import yaml
 
 from data_sheets_schema.provenance import (
+    apply_effort_basis,
     apply_observed_effort,
+    effort_basis_gap,
     observed_effort_gap,
 )
 
@@ -204,11 +206,30 @@ class TestAgainstTheRealCorpus(unittest.TestCase):
             if not model.get("reasoning_effort_basis"):
                 without_basis.append(str(p))
 
-        self.assertLessEqual(
-            len(without_basis), 17,
-            "a new record carries an effort with no basis; every effort must "
-            "say whether it was read from the route, asserted by the launcher, "
-            "or observed from the runtime (#397, #470)")
+        self.assertEqual(
+            without_basis, [],
+            "a record carries an effort with no basis; every effort must say "
+            "whether it was read from the route, asserted by the generating "
+            "agent, or observed from the runtime (#397, #470)")
+
+    def test_no_record_states_an_effort_that_names_none(self):
+        """`default` and kin are forbidden values, not null (#470).
+
+        Anything grouping runs by effort reads them as a third condition
+        alongside `high` and absent. Two records carried `default`; the value
+        was removed rather than corrected, because a run that did not choose an
+        effort is a different claim from one at any level.
+        """
+        from data_sheets_schema.provenance import PLACEHOLDER_EFFORTS
+
+        offenders = []
+        for p in Path("data/d4d_concatenated").glob(
+                "*_core/*/*_provenance.yaml"):
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            effort = (data.get("model") or {}).get("reasoning_effort")
+            if effort and str(effort).strip().lower() in PLACEHOLDER_EFFORTS:
+                offenders.append((str(p), effort))
+        self.assertEqual(offenders, [])
 
     def test_the_backfilled_records_all_carry_their_basis(self):
         """The 49 this pass wrote are the well-formed case, asserted as such."""
@@ -223,3 +244,104 @@ class TestAgainstTheRealCorpus(unittest.TestCase):
                               model.get("reasoning_effort_basis") or "", str(p))
                 n += 1
         self.assertEqual(n, 49)
+
+
+class TestEffortBasis(unittest.TestCase):
+    """Every recorded effort must say where it came from (#470).
+
+    A value with no basis cannot be placed on the ladder #397 defines — route
+    (observed), launcher/agent (asserted), or absent (gap named) — and anything
+    grouping runs by effort reads it as a third condition.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "X_provenance.yaml"
+
+    def _write(self, model, unverified=None):
+        data = {"record_version": 1, "model": model,
+                "unverified": unverified if unverified is not None else []}
+        self.path.write_text(
+            PREAMBLE + yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    def _load(self):
+        return yaml.safe_load(self.path.read_text(encoding="utf-8"))
+
+    def test_a_real_value_without_a_basis_gets_one(self):
+        self._write({"model": "claude-opus-5", "reasoning_effort": "high"})
+        change = apply_effort_basis(self.path)
+        self.assertEqual(change["action"], "record_basis")
+        model = self._load()["model"]
+        self.assertEqual(model["reasoning_effort"], "high")
+        self.assertIn("asserted by the generating agent",
+                      model["reasoning_effort_basis"])
+
+    def test_recording_a_basis_keeps_the_value(self):
+        """The value is right; only its provenance was missing."""
+        self._write({"model": "claude-opus-5", "reasoning_effort": "high"})
+        apply_effort_basis(self.path)
+        self.assertEqual(self._load()["model"]["reasoning_effort"], "high")
+
+    def test_a_placeholder_is_removed_not_relabelled(self):
+        """`default` names no effort, so no basis can be honest about it."""
+        self._write({"model": "claude-opus-5[1m]", "reasoning_effort": "default"})
+        change = apply_effort_basis(self.path)
+        self.assertEqual(change["action"], "drop_placeholder")
+        model = self._load()["model"]
+        self.assertNotIn("reasoning_effort", model)
+        self.assertNotIn("reasoning_effort_basis", model)
+
+    def test_a_dropped_placeholder_names_the_gap(self):
+        """Deleting a value silently would be worse than keeping it."""
+        self._write({"model": "claude-opus-5[1m]", "reasoning_effort": "default"})
+        apply_effort_basis(self.path)
+        entries = [e for e in self._load()["unverified"]
+                   if e["field"] == "model.reasoning_effort"]
+        self.assertEqual(len(entries), 1)
+        self.assertIsNone(entries[0]["value"])
+        self.assertIn("names no effort", entries[0]["reason"])
+
+    def test_every_placeholder_spelling_is_caught(self):
+        for value in ("default", "unspecified", "n/a", "none", "unknown",
+                      "DEFAULT", " Default "):
+            with self.subTest(value=value):
+                self._write({"model": "m", "reasoning_effort": value})
+                self.assertEqual(effort_basis_gap(self.path)["action"],
+                                 "drop_placeholder")
+
+    def test_an_existing_basis_is_left_alone(self):
+        self._write({"model": "m", "reasoning_effort": "high",
+                     "reasoning_effort_basis": "read from the model route"})
+        self.assertIsNone(effort_basis_gap(self.path))
+        self.assertIsNone(apply_effort_basis(self.path))
+
+    def test_not_applicable_is_not_a_gap(self):
+        """A run that declares the field inapplicable has already answered."""
+        self._write({"model": "m", "reasoning_effort": "not applicable"})
+        self.assertIsNone(effort_basis_gap(self.path))
+
+    def test_an_absent_effort_is_not_a_gap(self):
+        """Absent is the honest state for a route with no ladder."""
+        self._write({"model": "claude-opus-5"})
+        self.assertIsNone(effort_basis_gap(self.path))
+
+    def test_applying_twice_is_a_no_op(self):
+        self._write({"model": "m", "reasoning_effort": "high"})
+        self.assertIsNotNone(apply_effort_basis(self.path))
+        first = self.path.read_text(encoding="utf-8")
+        self.assertIsNone(apply_effort_basis(self.path))
+        self.assertEqual(self.path.read_text(encoding="utf-8"), first)
+
+    def test_existing_unverified_entries_survive(self):
+        self._write({"model": "m", "reasoning_effort": "high"},
+                    unverified=[{"field": "model.temperature", "value": None,
+                                 "reason": "pre-existing"}])
+        apply_effort_basis(self.path)
+        fields = [e["field"] for e in self._load()["unverified"]]
+        self.assertIn("model.temperature", fields)
+        self.assertIn("model.reasoning_effort", fields)
+
+    def test_unreadable_records_are_skipped_not_raised(self):
+        self.path.write_bytes(b"\xff\xfe bad")
+        self.assertIsNone(effort_basis_gap(self.path))


### PR DESCRIPTION
Closes #470.

Seventeen records stated an effort with no `reasoning_effort_basis`, so the value could not be placed on the ladder #397 defines — route (observed), agent (asserted), or absent (gap named). Anything grouping runs by effort read them as a third condition alongside `high` and absent.

```
record_basis      15  effort=high     route=claude-opus-5
drop_placeholder   2  effort=default  route=claude-opus-5[1m]
```

Two defects needing **opposite** fixes, kept separate throughout.

## The 15: the value is right, its provenance was missing

The 2026-08-07 sweep. Header says `high`, the runtime does expose `CLAUDE_EFFORT` (#449), and only the basis field postdates them. The basis written is the same string `build_record` writes in the same situation — *"asserted by the generating agent, not observed"* — because that is exactly what is known: the header carries the value and nothing here observed it. Claiming more would be the fabrication the recorder exists to prevent, so each also gains an `unverified` entry.

## The 2: the value names no effort, so no basis can be honest about it

`default` is forbidden outright by CLAUDE.md, on a route with no effort ladder. **Removed rather than relabelled**, with the gap named:

```yaml
unverified:
- field: model.reasoning_effort
  value: null
  reason: 'the record carried ''default'', which names no effort; the route
    ''claude-opus-5[1m]'' exposes no effort ladder, so nothing was chosen.
    Removed rather than kept: a run that did not choose an effort is a
    different claim from one at any level (#470).'
```

That is a deletion, so it is reported separately and never folded into the other count.

## Canaried per action before the batch

`drop_placeholder`: one line removed, gap named, nothing reformatted. `record_basis`: one line added to `model`, one `unverified` entry, nothing else. Then the remaining 15. The whole diff is **17 files, 102 insertions, 2 deletions**, and every touched line concerns `reasoning_effort`.

## Corpus after

```
49  ('high', 'read from the model route; the provider expo…')
15  ('high', 'asserted by the generating agent, not observ…')
```

No record carries a placeholder. `d4d runs check --strict` still exits 0.

The guard added with #448 pinned this debt at ≤17 so it could only shrink; **it now asserts zero**, and a second guard asserts no record states an effort that names none.

Full suite: **1623 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)