### PR TITLE
Author and pin the VOICE_PEDIATRIC prompt component (#478)

### DIFF
--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -42,6 +42,16 @@ files:
       recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
       retroactively.'
     sha256: 07b59ca750a1d24ef7c7eb42d310fbfa064ddf300b4cd118383aaaebb9074186
+  src/download/prompts/components/VOICE_PEDIATRIC.md:
+    bytes: 1887
+    pinned_at_commit: 5f1ab65796518f355eec7b5bb1afc8822a79640e
+    pinned_on: '2026-08-11'
+    reason: "First canonical text for the pediatric tuned condition (#478). States the adult\
+      \ figures present in the pediatric bundle \u2014 833 instances against this dataset's\
+      \ 300 participants \u2014 so each is attributed to the cohort its source names. Mirrors\
+      \ the VOICE cohort fact, which is the study's largest measured single effect. The referent\
+      \ is left to the manifest scope declaration rather than restated here (#422)."
+    sha256: b7db067c2852b57287cb68bd1fd4f3bfc229496cc2a4bd33065bb9558a35b215
   src/download/prompts/d4d_generic_arm_prompt.md:
     bytes: 5754
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/components/VOICE_PEDIATRIC.md
+++ b/src/download/prompts/components/VOICE_PEDIATRIC.md
@@ -1,0 +1,36 @@
+# VOICE_PEDIATRIC — GC-specific prompt components
+
+## fact
+
+The input bundle is scoped to the **pediatric** cohort, but it also carries
+programme-level documents that state **adult** figures, and at the point where
+they appear the cohort is not named.
+
+- **This dataset** — Bridge2AI-Voice Pediatric, PhysioNet `b2ai-voice-pediatric`
+  release 1.1.0, DOI `10.13026/h995-bt35`. Derived audio features for **23,533
+  recordings collected from 300 participants aged 2–18**, recruited at the
+  Hospital for Sick Children. Raw audio is distributed via Synapse rather than
+  the PhysioNet route.
+- **Also present in the bundle** — the Bridge2AI-Voice adult dataset,
+  PhysioNet `b2ai-voice`, release 3.1.0. The programme documents state "there
+  are currently around **833** instances", which is the adult count.
+
+Attribute each figure to the cohort its source states it for. The adult figures
+are in the bundle because the programme documents that cover this release also
+cover the adult one, not because they describe this dataset.
+
+Note the version numbers invite the error in both directions: adult `3.1.0` and
+pediatric `1.1.0` are different datasets, and a release string alone does not
+distinguish them.
+
+Rationale: this is the mirror of the fact supplied to the adult project, which
+moved three-way agreement from 76.7% to 92.4% — the largest single effect
+measured in the study. Where the adult bundle risks absorbing pediatric figures,
+this one risks absorbing adult figures, and `833` against this dataset's 300 is
+the specific value at risk.
+
+The referent itself is **not** restated here. It is declared in the `scope:`
+block of `data/preprocessed/source_manifest.yaml`, where `d4d download scope
+--check` can verify it and where the next dataset inherits the mechanism (#422).
+A component that repeated it would be a second copy that could drift from the
+checkable one.

--- a/tests/test_download/test_prompt_components.py
+++ b/tests/test_download/test_prompt_components.py
@@ -24,13 +24,13 @@ COMPONENTS = PROMPTS / "components"
 # #298 made it a project, so a guard that reads as covering every
 # project covered four of five (#467).
 #
-# Widening it immediately found the gap the narrowing had hidden:
-# VOICE_PEDIATRIC has no component file, so the `tuned` condition cannot be run
-# for it (#478). Authoring one is content and a judgement call — it must state
-# what distinguishes the pediatric cohort without importing adult-cohort facts —
-# so the gap is pinned by name rather than papered over. The other four projects
-# stay guarded, and this list may only shrink.
-WITHOUT_COMPONENT = {"VOICE_PEDIATRIC"}
+# Widening it immediately found the gap the narrowing had hidden: VOICE_PEDIATRIC
+# had no component file, so the `tuned` condition could not be run for it (#478).
+# Filled — the set is now empty and every project is guarded. Kept as a named set
+# rather than deleted, because the README makes "no legitimate component" a valid
+# outcome: such a project would get an *empty block*, which is a different state
+# from a missing file and belongs here rather than as a silent absence.
+WITHOUT_COMPONENT: set[str] = set()
 COMPONENT_PROJECTS = tuple(p for p in PROJECTS if p not in WITHOUT_COMPONENT)
 
 ALLOWED_TYPES = {"fact", "decision-rule", "referent-pin"}

--- a/tests/test_download/test_prompt_components.py
+++ b/tests/test_download/test_prompt_components.py
@@ -152,5 +152,58 @@ class TestTunedPromptIsGenericPlusBlock(unittest.TestCase):
         self.assertIn("nothing about what the output should contain", text)
 
 
+class TestTunedRendersForEveryProject(unittest.TestCase):
+    """The tuned condition must be runnable for every project (#478).
+
+    File existence is not the property that matters — reaching the instruction
+    is. VOICE_PEDIATRIC had no component, so `--condition tuned` could not be
+    rendered for it at all, and nothing said so because the only check declared
+    its own project list.
+    """
+
+    def _render(self, project):
+        from data_sheets_schema.api_runner import RunSpec, resolve_prompt
+        bundle = Path(f"data/preprocessed/concatenated/{project}_preprocessed.txt")
+        if not bundle.exists():
+            self.skipTest(f"{project} bundle not present")
+        return resolve_prompt(RunSpec(
+            project=project, arm="BASELINE (input documents only)",
+            method="claudecode_agent", bundle=bundle, label="L",
+            condition="tuned", runtime="Claude API (direct)",
+            provider="Anthropic"))
+
+    def test_every_project_renders_under_tuned(self):
+        for project in PROJECTS:
+            with self.subTest(project=project):
+                self.assertTrue(self._render(project).strip())
+
+    def test_the_component_body_reaches_the_instruction(self):
+        """Substituted in, not merely present on disk."""
+        for project in COMPONENT_PROJECTS:
+            with self.subTest(project=project):
+                rendered = flat(self._render(project))
+                component = flat(body(COMPONENTS / f"{project}.md"))
+                probe = next((ln for ln in component.split(".")
+                              if len(ln.strip()) > 40), None)
+                self.assertIsNotNone(probe, f"{project}.md has no prose to probe")
+                self.assertIn(probe.strip()[:60], rendered)
+
+    def test_tuned_is_longer_than_generic_where_a_component_exists(self):
+        """A component that renders to nothing would pass every other check."""
+        from data_sheets_schema.api_runner import RunSpec, resolve_prompt
+        for project in COMPONENT_PROJECTS:
+            with self.subTest(project=project):
+                bundle = Path(f"data/preprocessed/concatenated/"
+                              f"{project}_preprocessed.txt")
+                if not bundle.exists():
+                    self.skipTest(f"{project} bundle not present")
+                generic = resolve_prompt(RunSpec(
+                    project=project, arm="BASELINE (input documents only)",
+                    method="claudecode_agent", bundle=bundle, label="L",
+                    condition="generic", runtime="Claude API (direct)",
+                    provider="Anthropic"))
+                self.assertGreater(len(self._render(project)), len(generic))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #478. VOICE_PEDIATRIC has had no component since the fork, so the `tuned` condition could not be run for it. Found by widening a test that declared its own project list (#467) — which is why it hid for months.

## This was a decision, not a hole to fill

The components README is explicit:

> A project with no legitimate component gets an empty block, and its tuned condition is then identical to generic. **That is a valid result, not a gap to fill.**

So the question was empirical: does the pediatric bundle actually carry content that could be conflated? It does, and the offending line is unlabelled:

```
line 1786:  "There are currently around 833 instances."
line  391:  "23,533 recordings collected from 300 participants aged 2-18"
```

**833 is the adult count**, sitting in the pediatric bundle with no cohort attached, against this dataset's own **300**. That is exactly the conflation VOICE's component prevents in the other direction — the fact that moved three-way agreement from **76.7% to 92.4%**, the largest single effect measured in the study. The mirror of it is legitimate here.

## Everything is quoted from the bundle

23,533 recordings, 300 participants aged 2–18, DOI `10.13026/h995-bt35`, Hospital for Sick Children, Synapse for raw audio, adult release `3.1.0` — each checked against `VOICE_PEDIATRIC_preprocessed.txt` rather than copied from `VOICE.md`.

## The referent is deliberately not restated

It is declared in the manifest's `scope:` block, where `d4d download scope --check` verifies it and where the next dataset inherits the mechanism (#422). A component repeating it would be a second copy free to drift from the checkable one — the risk named when this issue was filed.

## Registry

The registry correctly refused the new file as `unpinned`, which is what #432 built it to do: a prompt never declared canonical is not a condition's text, just a file someone added. Pinned **after** committing, never before — a pin records the commit it was taken at, so pinning uncommitted bytes is refused by design.

```
10 prompt file(s), 0 not at their pin
```

`WITHOUT_COMPONENT` is now empty and all five projects are guarded by the four content assertions. Kept as a named set rather than deleted: a project with no legitimate component gets an *empty block*, which is a different state from a missing file and belongs recorded.

Full suite: **1623 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)