### PR TITLE
Record prompt paths as this repository names them (#398)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -45,6 +45,7 @@ from data_sheets_schema import reasoning, schema_digest
 from data_sheets_schema.provenance import (
     DETERMINISTIC_CONFIG,
     load_generation_config,
+    repo_relative,
 )
 
 PROMPTS = Path("src/download/prompts")
@@ -594,7 +595,7 @@ def plan(spec: RunSpec) -> dict[str, Any]:
         "bundle": str(spec.bundle), "bundle_bytes": spec.bundle.stat().st_size,
         "model": settings,
         "runtime": RUNTIME,
-        "prompt_files": [str(p) for p in spec.prompt_files],
+        "prompt_files": [repo_relative(p) for p in spec.prompt_files],
         "schema_digest_md5": schema_digest.fingerprint(
             schema_digest.digest_text("Dataset")),
         "phases": phases,

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -119,6 +119,41 @@ AGENT_PLAYBOOKS = (
 )
 
 
+def repo_relative(path: Path | str) -> str:
+    """A path as this repository names it, whatever the caller passed (#398).
+
+    Every other path-like field in a record is repo-relative by construction —
+    `inputs.bundle_path`, `schema.full_path`, `outputs.*.path` — because they
+    are built from module constants. Prompt paths came from the command line
+    and were recorded verbatim, so the same file recorded as
+    `src/download/prompts/d4d_generic_arm_prompt.md` and as
+    `/Users/…/data-sheets-schema/src/download/prompts/d4d_generic_arm_prompt.md`
+    describes one condition under two strings. The sha256 still matches, so
+    integrity is unaffected — but anything grouping runs *by prompt path* sees
+    two conditions where there is one, and the absolute form leaks a local
+    filesystem layout into a checked-in artifact.
+
+    A path outside the repository keeps its absolute form: rewriting it would
+    assert a location that does not exist here, which is worse than a long
+    string. Callers can tell the two apart because only the latter is absolute.
+
+    Resolved either way, not just when it turns out to be inside. Resolving one
+    branch and not the other would leave the same class of defect in place for
+    outside paths — `/var/…` and `/private/var/…` are one file on macOS — and a
+    function that normalises inconsistently is harder to reason about than one
+    that does not normalise at all.
+    """
+    p = Path(path)
+    try:
+        resolved = p.resolve()
+    except OSError:
+        return str(p)
+    try:
+        return str(resolved.relative_to(Path(__file__).resolve().parents[2]))
+    except (ValueError, OSError):
+        return str(resolved)
+
+
 def playbook_facts(paths: tuple[Path, ...] = AGENT_PLAYBOOKS) -> dict[str, Any]:
     """Hash the instruction files an agentic run follows.
 
@@ -135,7 +170,7 @@ def playbook_facts(paths: tuple[Path, ...] = AGENT_PLAYBOOKS) -> dict[str, Any]:
     out = []
     for p in paths:
         p = Path(p)
-        out.append({"path": str(p), "sha256": _sha256(p),
+        out.append({"path": repo_relative(p), "sha256": _sha256(p),
                     "bytes": p.stat().st_size if p.exists() else None,
                     "exists": p.exists()})
     return {"hash_algorithm": PROMPT_HASH, "files": out}
@@ -172,7 +207,7 @@ def prompt_facts(prompt_paths: list[Path] | None,
         out = []
         for p in prompt_paths:
             p = Path(p)
-            out.append({"path": str(p), "sha256": _sha256(p),
+            out.append({"path": repo_relative(p), "sha256": _sha256(p),
                         "bytes": p.stat().st_size if p.exists() else None,
                         "exists": p.exists()})
         facts = {"hash_algorithm": PROMPT_HASH, "files": out}

--- a/tests/test_cli/test_provenance_prompt.py
+++ b/tests/test_cli/test_provenance_prompt.py
@@ -91,7 +91,11 @@ class TestProvenancePromptFlag(unittest.TestCase):
         self.assertEqual(prompts["hash_algorithm"], "sha256")
         self.assertEqual(len(prompts["files"]), 1)
         entry = prompts["files"][0]
-        self.assertEqual(entry["path"], str(self.prompt))
+        # Normalised, not verbatim (#398). These fixtures live outside the
+        # repository, so the recorded path stays absolute — but it is resolved,
+        # which on macOS turns /var/... into /private/var/... . One file must
+        # not be recordable under two strings, inside the repo or out.
+        self.assertEqual(entry["path"], str(self.prompt.resolve()))
         self.assertTrue(entry["exists"])
         self.assertEqual(entry["bytes"], self.prompt.stat().st_size)
         self.assertEqual(len(entry["sha256"]), 64)
@@ -106,7 +110,7 @@ class TestProvenancePromptFlag(unittest.TestCase):
 
         files = self._written()["prompts"]["files"]
         self.assertEqual([f["path"] for f in files],
-                         [str(self.prompt), str(second)])
+                         [str(self.prompt.resolve()), str(second.resolve())])
         # The tuned condition is prompt + component; two files that hash the
         # same would mean the component never made it into the record.
         self.assertNotEqual(files[0]["sha256"], files[1]["sha256"])

--- a/tests/test_repo_relative_paths.py
+++ b/tests/test_repo_relative_paths.py
@@ -1,0 +1,114 @@
+"""Prompt paths are recorded as this repository names them (#398).
+
+Every other path-like field in a record is repo-relative by construction —
+`inputs.bundle_path`, `schema.full_path`, `outputs.*.path` — because they are
+built from module constants. Prompt paths came from the command line and were
+recorded verbatim, so one prompt could appear under two strings. The sha256
+still matched, so integrity was never at risk; what broke is any analysis that
+groups runs *by prompt path*, which then sees two conditions where there is one.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from data_sheets_schema.provenance import (
+    playbook_facts,
+    prompt_facts,
+    repo_relative,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+A_PROMPT = "src/download/prompts/d4d_generic_arm_prompt.md"
+
+
+class TestRepoRelative(unittest.TestCase):
+    def test_a_relative_path_is_unchanged(self):
+        self.assertEqual(repo_relative(A_PROMPT), A_PROMPT)
+
+    def test_an_absolute_path_inside_the_repo_is_shortened(self):
+        """The defect itself: the same file under two strings."""
+        self.assertEqual(repo_relative(REPO / A_PROMPT), A_PROMPT)
+
+    def test_both_spellings_agree(self):
+        self.assertEqual(repo_relative(A_PROMPT), repo_relative(REPO / A_PROMPT))
+
+    def test_a_path_outside_the_repo_keeps_its_absolute_form(self):
+        """Rewriting it would assert a location that does not exist here.
+
+        A long string is better than a wrong one, and the caller can still tell
+        the cases apart because only this one comes back absolute.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            outside = Path(d) / "elsewhere.md"
+            self.assertEqual(repo_relative(outside), str(outside.resolve()))
+            self.assertTrue(Path(repo_relative(outside)).is_absolute())
+
+    def test_an_outside_path_is_resolved_too(self):
+        """Both branches resolve, or the same defect survives outside the repo.
+
+        On macOS `/var` is a symlink to `/private/var`, so an unresolved
+        outside path reproduces exactly the two-strings-one-file problem this
+        function exists to remove — just beyond the repo boundary. Caught by
+        the test above failing on that difference.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            a = repo_relative(Path(d) / "x.md")
+            b = repo_relative(Path(d).resolve() / "x.md")
+            self.assertEqual(a, b)
+
+    def test_a_nonexistent_path_inside_the_repo_still_normalises(self):
+        """Recording is not gated on the file existing — `exists` is its own
+        field, and a missing prompt should still be named consistently."""
+        self.assertEqual(repo_relative(REPO / "src/download/prompts/nope.md"),
+                         "src/download/prompts/nope.md")
+
+    def test_a_traversal_is_resolved_not_preserved(self):
+        self.assertEqual(
+            repo_relative(REPO / "src/download/../download/prompts" /
+                          "d4d_generic_arm_prompt.md"),
+            A_PROMPT)
+
+
+class TestRecordedFacts(unittest.TestCase):
+    def test_prompt_facts_records_the_repo_relative_path(self):
+        facts = prompt_facts([REPO / A_PROMPT])
+        self.assertEqual([f["path"] for f in facts["files"]], [A_PROMPT])
+
+    def test_prompt_facts_agrees_across_spellings(self):
+        """Two records of one run must not describe two conditions."""
+        absolute = prompt_facts([REPO / A_PROMPT])
+        relative = prompt_facts([Path(A_PROMPT)])
+        self.assertEqual([f["path"] for f in absolute["files"]],
+                         [f["path"] for f in relative["files"]])
+        self.assertEqual([f["sha256"] for f in absolute["files"]],
+                         [f["sha256"] for f in relative["files"]])
+
+    def test_playbook_facts_are_normalised_too(self):
+        """Same writer, same defect — and playbooks are hashed for every run."""
+        for entry in playbook_facts()["files"]:
+            with self.subTest(path=entry["path"]):
+                self.assertFalse(Path(entry["path"]).is_absolute())
+
+    def test_no_recorded_path_leaks_a_home_directory(self):
+        facts = prompt_facts([REPO / A_PROMPT])
+        for entry in facts["files"]:
+            self.assertNotIn("/Users/", entry["path"])
+            self.assertNotIn("/home/", entry["path"])
+
+
+class TestPlanFacts(unittest.TestCase):
+    def test_the_plan_records_repo_relative_prompt_files(self):
+        """`api_runner.plan` is the third writer and was not normalised either."""
+        from data_sheets_schema.api_runner import RunSpec, plan
+
+        bundle = Path("data/preprocessed/concatenated/CHORUS_preprocessed.txt")
+        if not bundle.exists():
+            self.skipTest("bundle not present")
+        spec = RunSpec(project="CHORUS", arm="BASELINE (input documents only)",
+                       method="claudecode_agent", bundle=bundle, label="L",
+                       condition="generic", runtime="Claude API (direct)",
+                       provider="Anthropic")
+        for recorded in plan(spec)["prompt_files"]:
+            with self.subTest(path=recorded):
+                self.assertFalse(Path(recorded).is_absolute())


### PR DESCRIPTION
Closes #398.

Every other path-like field in a record is repo-relative by construction — `inputs.bundle_path`, `schema.full_path`, `outputs.*.path` — because they are built from module constants. Prompt paths came from the command line and were recorded **verbatim**, so the same file could be recorded as:

```
src/download/prompts/d4d_generic_arm_prompt.md
/Users/…/data-sheets-schema/src/download/prompts/d4d_generic_arm_prompt.md
```

The sha256 still matches, so integrity was never at risk. What breaks is any analysis that groups runs *by prompt path* — it sees two conditions where there is one — and the absolute form leaks a local filesystem layout into a checked-in artifact.

## One normaliser, three writers

`repo_relative` is applied at `prompt_facts`, `playbook_facts`, and `api_runner.plan`'s `prompt_files` — the third of which the issue noted was not normalised either.

A path **outside** the repository keeps its absolute form: rewriting it would assert a location that does not exist here, which is worse than a long string. Only that case comes back absolute, so callers can still tell them apart.

## A test caught an inconsistency in the fix

The first implementation resolved only the inside branch. That leaves the *same defect* beyond the repo boundary — on macOS `/var` and `/private/var` are one directory, so an unresolved outside path reproduces two-strings-one-file exactly. Both branches now resolve.

## No migration needed

All **77** recorded prompt paths in the corpus are already relative, so this prevents divergence rather than repairing it. Two existing tests asserted the verbatim behaviour on temp-dir fixtures and now assert the normalised contract.

Twelve tests, including that both spellings of one file agree, that a `..` traversal is resolved, that a nonexistent path inside the repo still normalises (recording is not gated on existence — `exists` is its own field), and that no recorded path leaks a home directory.

Full suite: **1638 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)