### PR TITLE
Report how many verdicts name no schema (#433)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -505,6 +505,25 @@ def check_cmd(method, label, project, strict):
         if st in (BUNDLE_DRIFTED, BUNDLE_ABSENT):
             drifted_bundles[Path(declared).name if declared else "unknown"] += 1
 
+    # Verdict schema pins (#433). `validation_status` leaves an unpinned
+    # verdict alone, correctly — but that means VALID means two things
+    # depending on when it was written, and `d4d runs validate` will not close
+    # the gap because it skips a run already VALID. Counted so the gap is a
+    # number someone can watch shrink rather than a property nobody can see.
+    from data_sheets_schema.runs import (
+        VERDICT_ABSENT, VERDICT_PINNED, VERDICT_UNPINNED, verdict_schema_pin,
+    )
+    pins: collections.Counter = collections.Counter()
+    for r in rows:
+        pins[verdict_schema_pin(r["method"], r["label"], r["project"])] += 1
+
+    if pins[VERDICT_UNPINNED]:
+        click.echo(f"\nⓘ  {pins[VERDICT_UNPINNED]} verdict(s) name no schema "
+                   f"({pins[VERDICT_PINNED]} pinned, {pins[VERDICT_ABSENT]} "
+                   "have no verdict at all).")
+        click.echo("   An unpinned verdict is not wrong; it is unfalsifiable "
+                   "by a schema change, so it cannot go STALE.")
+
     stale = drift[BUNDLE_DRIFTED] + drift[BUNDLE_ABSENT]
     if stale:
         click.echo(f"\nⓘ  {stale} record(s) name an input bundle whose bytes "

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -245,6 +245,53 @@ def validation_status(method: str, label: str, project: str,
     return VALID if v["passed"] else INVALID
 
 
+VERDICT_PINNED, VERDICT_UNPINNED, VERDICT_ABSENT = "pinned", "unpinned", "absent"
+
+
+def verdict_schema_pin(method: str, label: str, project: str,
+                       concat_dir: Path = CONCAT_DIR) -> str:
+    """Does this run's verdict say which schema it was reached against? (#433)
+
+    `validation_status` returns STALE when a pinned schema has moved, and
+    leaves an unpinned verdict alone — absent is not stale, and failing every
+    verdict written before the pin existed would discard evidence rather than
+    check it.
+
+    The cost of that correct choice is that `VALID` means two different things
+    depending on when it was written, and nothing distinguishes them without
+    reading the YAML. `d4d runs validate` will not close the gap on its own:
+    it skips a run already VALID, which is the whole point of caching a
+    verdict.
+
+    So this reports rather than repairs. Three outcomes:
+
+    - ``pinned``   — the verdict names the schema, and a schema change makes
+      it STALE.
+    - ``unpinned`` — a verdict exists and names no schema. It is not wrong; it
+      is unfalsifiable by a schema change.
+    - ``absent``   — no verdict at all, which is a different gap and counted
+      separately so the two cannot be confused.
+    """
+    import yaml as _yaml
+
+    from data_sheets_schema.provenance import record_path_for
+    path = record_path_for(project, method, label, concat_dir)
+    if not path.exists():
+        return VERDICT_ABSENT
+    try:
+        data = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (_yaml.YAMLError, OSError, UnicodeDecodeError):
+        return VERDICT_ABSENT
+    verdict = data.get("validation")
+    if not isinstance(verdict, dict) or "passed" not in verdict:
+        return VERDICT_ABSENT
+    pinned = verdict.get("schema")
+    if isinstance(pinned, dict) and any(
+            pinned.get(k) for k in ("full_sha256", "core_sha256")):
+        return VERDICT_PINNED
+    return VERDICT_UNPINNED
+
+
 class AmbiguousCanonical(RuntimeError):
     """A project carries a canonical mark under more than one configuration."""
 

--- a/tests/test_verdict_schema_pin.py
+++ b/tests/test_verdict_schema_pin.py
@@ -1,0 +1,124 @@
+"""Reporting which verdicts say what schema they were reached against (#433).
+
+`validation_status` returns STALE when a pinned schema moves, and leaves an
+unpinned verdict alone — absent is not stale, and failing every verdict written
+before the pin existed would discard evidence rather than check it (#426).
+
+The cost of that correct choice is that `VALID` means two different things
+depending on when it was written. `d4d runs validate` will not close the gap on
+its own, because it skips a run already VALID — which is the entire point of
+caching a verdict. So the gap is reported, not repaired.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.runs import (
+    VERDICT_ABSENT,
+    VERDICT_PINNED,
+    VERDICT_UNPINNED,
+    verdict_schema_pin,
+)
+
+METHOD, LABEL, PROJECT = "claudecode_agent", "2026-08-11_pin_rep1", "CHORUS"
+
+
+class TestVerdictSchemaPin(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.concat = Path(self.tmp.name) / "data/d4d_concatenated"
+        (self.concat / f"{METHOD}_core" / LABEL).mkdir(parents=True)
+
+    def _write(self, validation):
+        path = (self.concat / f"{METHOD}_core" / LABEL
+                / f"{PROJECT}_provenance.yaml")
+        body = {"record_version": 1}
+        if validation is not None:
+            body["validation"] = validation
+        path.write_text(yaml.safe_dump(body), encoding="utf-8")
+
+    def _status(self):
+        return verdict_schema_pin(METHOD, LABEL, PROJECT, self.concat)
+
+    def test_a_pinned_verdict_is_recognised(self):
+        self._write({"passed": True, "schema": {"full_sha256": "a" * 64}})
+        self.assertEqual(self._status(), VERDICT_PINNED)
+
+    def test_a_core_only_pin_counts(self):
+        """Either half is enough to make the verdict falsifiable."""
+        self._write({"passed": True, "schema": {"core_sha256": "b" * 64}})
+        self.assertEqual(self._status(), VERDICT_PINNED)
+
+    def test_a_verdict_with_no_schema_block_is_unpinned(self):
+        self._write({"passed": True, "recorded_by": "d4d runs validate"})
+        self.assertEqual(self._status(), VERDICT_UNPINNED)
+
+    def test_an_empty_schema_block_is_unpinned_not_pinned(self):
+        """A block with no hash in it pins nothing, and must not read as if it
+        did — that would be worse than an absent block, because it looks
+        checked."""
+        self._write({"passed": True, "schema": {}})
+        self.assertEqual(self._status(), VERDICT_UNPINNED)
+
+    def test_a_schema_block_with_empty_hashes_is_unpinned(self):
+        self._write({"passed": True,
+                     "schema": {"full_sha256": None, "core_sha256": ""}})
+        self.assertEqual(self._status(), VERDICT_UNPINNED)
+
+    def test_a_failing_verdict_can_still_be_pinned(self):
+        """The pin is about falsifiability, not about the outcome."""
+        self._write({"passed": False, "schema": {"full_sha256": "c" * 64}})
+        self.assertEqual(self._status(), VERDICT_PINNED)
+
+    def test_no_verdict_is_absent_not_unpinned(self):
+        """A different gap, counted separately so the two cannot be confused."""
+        self._write(None)
+        self.assertEqual(self._status(), VERDICT_ABSENT)
+
+    def test_a_verdict_without_passed_is_absent(self):
+        """A block that records no outcome is not a verdict."""
+        self._write({"recorded_by": "d4d runs validate"})
+        self.assertEqual(self._status(), VERDICT_ABSENT)
+
+    def test_a_missing_record_is_absent(self):
+        self.assertEqual(self._status(), VERDICT_ABSENT)
+
+    def test_an_unreadable_record_is_absent_not_raised(self):
+        """One bad record must not abort a corpus sweep — the #444 lesson."""
+        path = (self.concat / f"{METHOD}_core" / LABEL
+                / f"{PROJECT}_provenance.yaml")
+        path.write_bytes(b"\xff\xfe not utf-8")
+        self.assertEqual(self._status(), VERDICT_ABSENT)
+
+
+@unittest.skipUnless(Path("data/d4d_concatenated").exists(), "corpus absent")
+class TestAgainstTheRealCorpus(unittest.TestCase):
+    def test_the_corpus_gap_is_visible_and_counted(self):
+        """Pinned at the state #433 describes, so the number can be watched.
+
+        Every verdict in the corpus is unpinned, because the pin postdates them
+        all and `d4d runs validate` skips a run already VALID. This asserts the
+        gap exists rather than asserting a target — when it starts shrinking,
+        this test is where that shows up.
+        """
+        from data_sheets_schema.runs import discover, is_complete
+
+        counts = {VERDICT_PINNED: 0, VERDICT_UNPINNED: 0, VERDICT_ABSENT: 0}
+        for run in discover():
+            if run.is_core or run.deterministic:
+                continue
+            for project in run.projects:
+                if not is_complete(run.method, run.label, project):
+                    continue
+                counts[verdict_schema_pin(run.method, run.label, project)] += 1
+
+        self.assertGreater(counts[VERDICT_UNPINNED], 0,
+                           "if this is zero the corpus has converged — update "
+                           "the test and #433 rather than deleting it")
+        self.assertEqual(counts[VERDICT_ABSENT], 0,
+                         "a complete run with no verdict at all is a different "
+                         "and more serious gap than an unpinned one")


### PR DESCRIPTION
Closes #433. Implements **option 3** of the three the issue offers, and explains why option 2 is not honestly available.

`validation_status` returns STALE when a pinned schema moves and leaves an unpinned verdict alone (#426) — correctly: absent is not stale, and failing every verdict written before the pin existed would discard evidence rather than check it. The cost is that `VALID` means two different things depending on when it was written, and `d4d runs validate` will not close the gap because it **skips a run already VALID**, which is the entire point of caching a verdict.

So the gap is now a number rather than a property nobody can see:

```
ⓘ  158 verdict(s) name no schema (0 pinned, 0 have no verdict at all).
   An unpinned verdict is not wrong; it is unfalsifiable by a schema change,
   so it cannot go STALE.
```

**0 pinned of 158** — exactly the state the issue predicted.

## Why not option 2 as well

The issue recommends `--recheck` per label "where the schema demonstrably has not moved", noting the 2026-08-07 sweep as a candidate. That is no longer true: the schema files changed **today** under #456, after every run in the corpus. Re-validating now would produce a *new* verdict rather than pin an existing one, and the issue is explicit that those are different acts and the second must not be disguised as bookkeeping.

## Three outcomes, kept distinct

`pinned`, `unpinned` (a verdict exists and names no schema), and `absent` (no verdict at all — a different and more serious gap, never folded into the count). An **empty** `schema:` block reads as *unpinned* rather than pinned, which matters because a block with no hash in it looks checked and is not.

## Tests

Eleven. The corpus test asserts the gap *exists* rather than asserting a target, with a message telling the next reader to update it and the issue when it converges rather than delete it — and separately asserts **zero** `absent`, since a complete run with no verdict is the more serious condition.

Full suite: **1649 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)