### PR TITLE
Distinguish the three reasons a run has no reasoning log (#400)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,26 @@ d4d provenance reasoning --method claudecode_agent --label 2026-07-29_...
 d4d provenance reasoning --path some/log.jsonl
 ```
 
+⚠️ **The agentic path produces no reasoning log at all, and that is a runtime
+limit rather than a gap** (#400). A Claude Code subagent has no access to its
+own token accounting. Writing a log carrying only the effort level would be
+worse than writing none: `d4d provenance reasoning` would then report something
+that looks comparable with the API path's and is not.
+
+So the command distinguishes three empty cases rather than printing one message
+for all of them — currently **96 runs whose runtime cannot capture, 6 predating
+capture (before 2026-07-31), 0 missing**:
+
+| status | meaning |
+|---|---|
+| `runtime_cannot_capture` | agentic run; no log can exist |
+| `capture_postdates_run` | API run before capture; unrecoverable |
+| `missing` | API run after capture with no log — a **defect**, not a limit |
+
+**Any comparison of reasoning spend between the arms is one-sided.** A run with
+no log has not spent zero reasoning; it has no measurement. Do not average the
+two, and do not read an absent figure for the agentic arm as a low one.
+
 ⚠️ **Through CBORG the reasoning text is not available.** Verified 2026-07-29 on
 `google/claude-opus-5-high`: the thinking block arrives with a valid
 `signature` and `thinking: ''`, both streaming and non-streaming, and the stream

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -155,6 +155,10 @@ def reasoning_cmd(method, project, label, path):
         logs = [_Path(path)]
     else:
         for run in discover():
+            # `discover` yields the full and _core methods as separate runs
+            # over one reasoning log, so counting both doubles every figure.
+            if run.is_core or run.deterministic:
+                continue
             if method and run.method != method:
                 continue
             if label and run.label != label:
@@ -165,12 +169,54 @@ def reasoning_cmd(method, project, label, path):
                 logs.append(CONCAT_DIR / f"{run.method}_core" / run.label /
                             f"{proj}_reasoning.jsonl")
 
+    # Classify the runs that produced no log, rather than printing one message
+    # for three different situations (#400).
+    import collections as _collections
+
+    import yaml as _yaml
+
+    from data_sheets_schema import reasoning as _r
+    from data_sheets_schema.provenance import record_path_for
+    why: _collections.Counter = _collections.Counter()
+    for candidate in logs:
+        proj = candidate.name.replace("_reasoning.jsonl", "")
+        run_label = candidate.parent.name
+        base = candidate.parent.parent.name
+        runtime = None
+        rec = record_path_for(proj, base, run_label)
+        if rec.exists():
+            try:
+                data = _yaml.safe_load(rec.read_text(encoding="utf-8")) or {}
+                runtime = (data.get("model") or {}).get("agent_runtime")
+            except (_yaml.YAMLError, OSError, UnicodeDecodeError):
+                runtime = None
+        why[_r.log_status(runtime, run_label, candidate.exists())] += 1
+
     logs = [p for p in logs if p.exists()]
     if not logs:
-        click.echo("No reasoning logs found. They are written by `d4d api run`; "
-                   "runs generated before reasoning capture have none, and that "
-                   "is unrecoverable rather than unverified.")
+        click.echo("No reasoning logs found for the selection.")
+        if why[_r.NO_LOG_RUNTIME]:
+            click.echo(f"   {why[_r.NO_LOG_RUNTIME]} run(s): the Claude Code "
+                       "runtime cannot produce one — a subagent has no access "
+                       "to its own token accounting. Not a gap to fill: a log "
+                       "carrying only the effort level would look comparable "
+                       "with the API path's and would not be (#400).")
+        if why[_r.NO_LOG_PREDATES]:
+            click.echo(f"   {why[_r.NO_LOG_PREDATES]} run(s): predate reasoning "
+                       f"capture ({_r.CAPTURE_FROM}). Unrecoverable rather "
+                       "than unverified.")
+        if why[_r.NO_LOG_MISSING]:
+            click.echo(f"   ⚠️  {why[_r.NO_LOG_MISSING]} run(s): an API run "
+                       "after capture existed, with no log. That is a defect, "
+                       "not a limitation.")
         return
+    if why[_r.NO_LOG_RUNTIME] or why[_r.NO_LOG_PREDATES] or why[_r.NO_LOG_MISSING]:
+        click.echo(f"{len(logs)} log(s); "
+                   f"{why[_r.NO_LOG_RUNTIME]} run(s) whose runtime cannot "
+                   f"capture, {why[_r.NO_LOG_PREDATES]} predating capture, "
+                   f"{why[_r.NO_LOG_MISSING]} missing.")
+        click.echo("   A run with no log has not spent zero reasoning; it has "
+                   "no measurement. Do not average the two (#400).\n")
 
     total: list[dict] = []
     for p in sorted(logs):

--- a/src/data_sheets_schema/reasoning.py
+++ b/src/data_sheets_schema/reasoning.py
@@ -162,3 +162,44 @@ def summarise(entries: list[dict[str, Any]]) -> dict[str, Any]:
         "truncated": sum(1 for e in entries
                          if e.get("stop_reason") == "max_tokens"),
     }
+
+
+#: The first run whose phases wrote a reasoning log. Runs before this date are
+#: missing one because capture postdates them — a different claim from a run
+#: whose runtime cannot produce one, and from a run that should have written one
+#: and did not.
+CAPTURE_FROM = "2026-07-31"
+
+NO_LOG_RUNTIME = "runtime_cannot_capture"
+NO_LOG_PREDATES = "capture_postdates_run"
+NO_LOG_MISSING = "missing"
+HAS_LOG = "present"
+
+
+def log_status(runtime: str | None, label: str, log_exists: bool) -> str:
+    """Why does this run have no reasoning log? (#400)
+
+    `d4d provenance reasoning` printed one message for every empty case, which
+    conflated three different situations. They are not interchangeable:
+
+    - ``runtime_cannot_capture`` — a Claude Code agentic run. The subagent has
+      no access to its own token accounting, so no log can exist. Writing one
+      carrying only the effort level would be *worse* than writing none: it
+      would look comparable with the API path's and would not be, which is the
+      substitution #400 argues against.
+    - ``capture_postdates_run`` — an API run from before ``CAPTURE_FROM``.
+      Unrecoverable, and nobody's fault.
+    - ``missing`` — an API run from after capture existed, with no log. That is
+      a defect rather than a limitation, and is the only one of the three worth
+      chasing.
+
+    The distinction matters wherever arms are compared: a missing reasoning
+    figure for the agentic arm must not be read as zero spend.
+    """
+    if log_exists:
+        return HAS_LOG
+    if (runtime or "").strip().lower() == "claude code":
+        return NO_LOG_RUNTIME
+    if label[:10] < CAPTURE_FROM:
+        return NO_LOG_PREDATES
+    return NO_LOG_MISSING

--- a/tests/test_reasoning_log_status.py
+++ b/tests/test_reasoning_log_status.py
@@ -1,0 +1,115 @@
+"""Why a run has no reasoning log — three answers, not one (#400).
+
+`d4d provenance reasoning` printed a single message for every empty case, which
+conflated a runtime limit, an unrecoverable gap, and a defect. They license
+completely different responses, and only the third is worth chasing.
+
+The distinction matters most where arms are compared: a run with no log has not
+spent zero reasoning, it has no measurement.
+"""
+
+import unittest
+
+from data_sheets_schema.reasoning import (
+    CAPTURE_FROM,
+    HAS_LOG,
+    NO_LOG_MISSING,
+    NO_LOG_PREDATES,
+    NO_LOG_RUNTIME,
+    log_status,
+)
+
+
+class TestLogStatus(unittest.TestCase):
+    def test_an_existing_log_is_present_whatever_the_runtime(self):
+        for runtime in ("Claude Code", "Claude API (direct)", None):
+            with self.subTest(runtime=runtime):
+                self.assertEqual(
+                    log_status(runtime, "2026-08-07_x_rep1", True), HAS_LOG)
+
+    def test_an_agentic_run_cannot_capture(self):
+        """No log can exist: a subagent has no access to its token accounting.
+
+        Not a gap to fill. A log carrying only the effort level would look
+        comparable with the API path's and would not be — the substitution
+        #400 argues against.
+        """
+        self.assertEqual(
+            log_status("Claude Code", "2026-08-07_x_rep1", False),
+            NO_LOG_RUNTIME)
+
+    def test_the_runtime_check_is_case_and_space_insensitive(self):
+        for spelling in ("claude code", "  Claude Code  ", "CLAUDE CODE"):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(
+                    log_status(spelling, "2026-08-07_x_rep1", False),
+                    NO_LOG_RUNTIME)
+
+    def test_an_api_run_before_capture_is_unrecoverable(self):
+        self.assertEqual(
+            log_status("Claude API (direct)", "2026-07-29_x_rep1", False),
+            NO_LOG_PREDATES)
+
+    def test_an_api_run_after_capture_with_no_log_is_a_defect(self):
+        """The only one of the three worth chasing."""
+        self.assertEqual(
+            log_status("Claude API (direct)", "2026-08-05_x_rep1", False),
+            NO_LOG_MISSING)
+
+    def test_the_boundary_is_inclusive_of_the_capture_date(self):
+        """A run *on* CAPTURE_FROM should have written one."""
+        self.assertEqual(
+            log_status("Claude API (direct)", f"{CAPTURE_FROM}_x_rep1", False),
+            NO_LOG_MISSING)
+        earlier = "2026-07-30"
+        self.assertLess(earlier, CAPTURE_FROM)
+        self.assertEqual(
+            log_status("Claude API (direct)", f"{earlier}_x_rep1", False),
+            NO_LOG_PREDATES)
+
+    def test_an_unknown_runtime_is_not_excused_as_a_runtime_limit(self):
+        """Only Claude Code is known to be unable to capture.
+
+        Treating an unrecorded runtime as incapable would quietly absolve a
+        real defect, which is the direction that loses information.
+        """
+        self.assertEqual(
+            log_status(None, "2026-08-05_x_rep1", False), NO_LOG_MISSING)
+
+
+class TestAgainstTheRealCorpus(unittest.TestCase):
+    def test_no_api_run_after_capture_is_missing_its_log(self):
+        """0 missing today: every empty case is a limit, not a defect.
+
+        Fails if an API run lands without a log, which is the condition this
+        classification exists to make visible.
+        """
+        from pathlib import Path
+
+        import yaml
+
+        from data_sheets_schema.api_runner import CONCAT_DIR
+        from data_sheets_schema.provenance import record_path_for
+        from data_sheets_schema.runs import discover
+
+        if not Path("data/d4d_concatenated").exists():
+            self.skipTest("corpus absent")
+
+        missing = []
+        for run in discover():
+            if run.is_core or run.deterministic:
+                continue
+            for project in run.projects:
+                log = (CONCAT_DIR / f"{run.method}_core" / run.label /
+                       f"{project}_reasoning.jsonl")
+                rec = record_path_for(project, run.method, run.label)
+                runtime = None
+                if rec.exists():
+                    try:
+                        data = yaml.safe_load(rec.read_text("utf-8")) or {}
+                        runtime = (data.get("model") or {}).get("agent_runtime")
+                    except Exception:            # noqa: BLE001
+                        runtime = None
+                if log_status(runtime, run.label, log.exists()) == NO_LOG_MISSING:
+                    missing.append(f"{run.label}/{project}")
+        self.assertEqual(missing, [])


### PR DESCRIPTION
Closes #400. Both things the issue asked for, and deliberately **not** the thing it warned against.

The command printed one message for every empty case — *"runs generated before reasoning capture have none"* — which conflated a runtime limit, an unrecoverable gap, and a defect. They license completely different responses, and only the third is worth chasing.

| status | meaning |
|---|---|
| `runtime_cannot_capture` | agentic run; a subagent has no access to its own token accounting, so no log can exist |
| `capture_postdates_run` | API run before 2026-07-31; unrecoverable |
| `missing` | API run *after* capture with no log — a **defect**, not a limitation |

Corpus today:

```
61 log(s); 96 run(s) whose runtime cannot capture, 6 predating capture, 0 missing.
   A run with no log has not spent zero reasoning; it has no measurement.
   Do not average the two (#400).
```

**Every empty case is a limitation and none is a defect** — a claim nobody could previously make.

## Not a substitute

The issue is explicit that writing an agentic log carrying only the effort level would be worse than writing none, because `d4d provenance reasoning` would then report something that *looks* comparable with the API path's and is not. Nothing is synthesized here; the gap is named.

An **unrecorded** runtime classifies as `missing`, not as a runtime limit. Only Claude Code is known to be unable to capture, and treating unknown as incapable would quietly absolve a real defect.

## A double count, found while wiring it in

`discover` yields the full and `_core` methods as separate runs over one log. The first version reported 96/96/76 against a corpus of 158, and claimed a label with two logs also had two missing. Fixed with the same `is_core or deterministic` filter the sibling commands use.

## The second half of the issue

CLAUDE.md now records the limitation where arms are compared, with the three-way table and the warning that an absent figure for the agentic arm is not a low one.

Eight tests, including the boundary at `CAPTURE_FROM` and a corpus test asserting **zero** `missing`, which fails if an API run ever lands without a log.

Full suite: **1657 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)