### PR TITLE
Recover historical prompts as of each run's own commit (#399)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,8 +421,19 @@ edited into the prompt file *before* rendering re-renders to itself and reports
 check` is fatal under `--strict` on `uncanonical` (a prompt that was never
 pinned, or a labelled condition whose record hashes no condition prompt at all —
 the `cp`-to-another-path bypass, #436) and on `missing` (a pinned path the
-record hashed nothing for). `superseded` (pinned once, since rotated) and
-`unpinned` are reported and not failed.
+record hashed nothing for). `superseded` (pinned once, since rotated),
+`unpinned`, and `pre_registry` are reported and not failed.
+
+`pre_registry` is a prompt recovered from git at the run's own commit
+(`d4d provenance backfill-prompts`, #399). Those bytes are attested by a
+different instrument than the registry and predate it, so calling them
+`uncanonical` would put honest recovered evidence in the same bucket as the
+`cp`-to-another-path bypass, where the bytes are attested by nothing. Every
+recovered hash is reproducible with `git show <commit>:<path>`, and a test
+asserts it. **The hash is of the bytes at that commit, never today's** —
+`d4d_generic_arm_prompt.md` was edited the day after the 15 runs that name it,
+16 lines apart, so today's hash would assert they used a prompt that did not
+yet exist.
 
 This is not tamper-proofing. Whoever can edit a prompt can rotate its pin.
 

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
@@ -77,3 +77,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_d4d_core.yaml
       sha256: 996fc392940d30595dcbf1bacea89b0926e5bdda0d63c5b801ac5e19f6e58524
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_d4d_core.yaml
       sha256: 9d2f78de33847085d24292d97986385d2c7074e2949eecea455f5694caf1a681
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_d4d_core.yaml
       sha256: 2d530e1bac4e6688554d5d022d277b0fca85f9d6a2a6329ff4685cf61c348641
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_d4d_core.yaml
       sha256: b276728c59be3be492f7deecbe8b618a8d38730a02588d17451989e3dbbe8bee
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_d4d_core.yaml
       sha256: bb0d16c266257ac31019d1be2390a2d5671896f2f2453d9906ae44a7ec8ca4fe
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_d4d_core.yaml
       sha256: 5e1b9dd2202edd07dc9c540301cd55145a3b99952b57e2a089cd5354bdd8a6a6
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_d4d_core.yaml
       sha256: dec3dd1a8423ce4d2527a3cc560e30c1cbed5e018e413a28d435ff430230bf19
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_d4d_core.yaml
       sha256: 3f1bdf90ef4e06ba4cdfa5d780f264b61f520026490a4725ebab1663d5346a36
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_d4d_core.yaml
       sha256: b6e56b77cb2b87bdb73c874f9cf571e4b61ec5cea6926e6da34c75cbfb3934f2
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_d4d_core.yaml
       sha256: bd98e4cef86e815fd9a3848ece36c1155a04784757abe0e1831e5e227f114145
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_d4d_core.yaml
       sha256: 5ac766a57f0e509debb8d8ce159015a2877cea48ad3d0608559c7e38ea7aa8ca
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_d4d_core.yaml
       sha256: d81e41632848984be0b4c075860701300ced14001caec01f25608edd75fbaf40
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
@@ -80,3 +80,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_d4d_core.yaml
       sha256: c3fa46b9248897148ce8131b330a7c1a908c9c318735f60c5a92577de645c2b8
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
@@ -77,3 +77,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_d4d_core.yaml
       sha256: ad77fd07568870ef7c8060372084e444cf5d21e1333a993dc5dbcdd72d35e6e8
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
@@ -77,3 +77,16 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_d4d_core.yaml
       sha256: df8203dcf49b2ad313b35e28ea14d404be80b2247d0a8059c1920c3c6848c6da
   recorded_by: d4d runs validate
+prompts:
+  hash_algorithm: sha256
+  files:
+  - path: src/download/prompts/d4d_generic_arm_prompt.md
+    sha256: 7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9
+    bytes: 5269
+    exists: true
+  recovery:
+    method: resolved from the run's `# Prompt:` header
+    commit: fa90b4ec036ff62820aa6708fe130f800d5e7657
+    as_of: '2026-07-28'
+    note: hash is of the bytes at that commit, not of the file today — this prompt
+      was edited after the run (#399)

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -371,3 +371,63 @@ def backfill_effort_basis(execute, label):
     if counts.get("drop_placeholder"):
         click.echo("   A value was removed, not corrected. Each such record now "
                    "names the gap under `unverified`.")
+
+
+@provenance.command("backfill-prompts")
+@click.option('--execute', is_flag=True,
+              help='write the records; without it this reports and changes nothing')
+@click.option('--label', default=None, help='restrict to one run label')
+def backfill_prompts(execute, label):
+    """Recover prompts for historical runs, as of each run's own commit (#399).
+
+    A resolver, not a --prompt flag. The honest answer differs per run, so an
+    operator asserting a hash by hand is exactly what must not be possible.
+
+    \b
+      recovered                    the header names a file; bytes taken at the
+                                   run's commit
+      no_prompt_header             supplied inline, never saved — stays null
+      no_commit_at_or_before_run   the file did not exist yet
+      already_recorded             left alone
+
+    The hash is of the bytes at the run's commit, never today's:
+    `d4d_generic_arm_prompt.md` was edited the day after the runs that name it,
+    so today's hash would assert they used a prompt that did not yet exist.
+    """
+    from data_sheets_schema.provenance import (
+        HISTORICAL_RECOVERED, apply_historical_prompt, resolve_historical_prompt,
+    )
+    from data_sheets_schema.runs import discover, is_complete
+
+    targets = []
+    for run in discover():
+        if run.is_core or run.deterministic:
+            continue
+        if label and run.label != label:
+            continue
+        for proj in run.projects:
+            if not is_complete(run.method, run.label, proj):
+                continue
+            targets.append((proj, run.method, run.label))
+
+    outcomes = {}
+    for proj, method, lab in targets:
+        r = resolve_historical_prompt(proj, method, lab)
+        outcomes.setdefault(r["status"], []).append((proj, method, lab, r))
+
+    verb = "recovering" if execute else "would recover"
+    for status, items in sorted(outcomes.items()):
+        click.echo(f"   {status:28} {len(items):4}")
+    recoverable = outcomes.get(HISTORICAL_RECOVERED, [])
+    if not recoverable:
+        click.echo("\nNothing to recover.")
+        return
+    commits = sorted({i[3]['commit'][:12] for i in recoverable})
+    click.echo(f"\n{len(recoverable)} record(s) {verb}, from commit(s) "
+               f"{', '.join(commits)}")
+    if not execute:
+        click.echo("Nothing written. Re-run with --execute to apply.")
+        return
+    n = sum(1 for proj, method, lab, _ in recoverable
+            if apply_historical_prompt(proj, method, lab) is not None)
+    click.echo(f"{n} record(s) updated, each naming the commit its hash is of.")

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -449,8 +449,13 @@ def check_cmd(method, label, project, strict):
             # says `match` and means it. Only the pin can tell that the file was
             # not a published version of its condition.
             cst, cwhy = canonical_prompt_status(run.method, run.label, proj)
+            # `pre_registry` is reported like `superseded` and `unpinned`,
+            # never failed: the bytes are attested by git at the run's own
+            # commit (#399), which the registry could not have pinned because
+            # it postdates the run. Failing it would make recovering honest
+            # historical evidence worse than leaving the record blank.
             if cst in ("uncanonical", "missing", "unpinned",
-                       "superseded"):
+                       "superseded", "pre_registry"):
                 uncanonical.append({"project": proj, "label": run.label,
                                     "status": cst, "reason": cwhy})
 

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -70,7 +70,11 @@ INPUT_HASH = "md5"
 HEADER_FIELDS = ("Generation Method", "Agent runtime", "Provider", "Model",
                  "Reasoning effort", "Mode", "Temperature", "Generated",
                  "Source bundle", "Source", "Source manifest", "Schema",
-                 "Prior D4D factual reuse", "Arm")
+                 "Prior D4D factual reuse", "Arm",
+                 # `Prompt` was absent, so `parse_header` silently discarded
+                 # the one field a historical prompt could be recovered from
+                 # (#399). 15 records carry it and read as carrying nothing.
+                 "Prompt", "Prompt components")
 
 
 def _md5(path: Path) -> str | None:
@@ -1207,3 +1211,130 @@ def strip_output_hashes(path: Path, *, dry_run: bool = True) -> dict[str, Any]:
     if removed and not dry_run:
         ProvenanceRecord(data=data).write(path)
     return {"path": str(path), "removed": removed, "dry_run": dry_run}
+
+
+HISTORICAL_RECOVERED = "recovered"
+HISTORICAL_NO_HEADER = "no_prompt_header"
+HISTORICAL_NO_COMMIT = "no_commit_at_or_before_run"
+HISTORICAL_ALREADY = "already_recorded"
+
+
+def _prompt_path_from_header(value: str | None) -> str | None:
+    """The path out of a `# Prompt:` header line.
+
+    Headers carry a trailing gloss — "… (identical for all projects)" — which
+    is prose about the condition, not part of the path.
+    """
+    if not value:
+        return None
+    path = value.split("(", 1)[0].strip()
+    return path or None
+
+
+def resolve_historical_prompt(project: str, method: str, label: str,
+                              concat_dir: Path = CONCAT_DIR) -> dict[str, Any]:
+    """Recover the prompt a pre-#395 agentic run consumed, as of its own commit.
+
+    `d4d provenance record --prompt` records prompts for live runs; `backfill`
+    has no equivalent, so every agentic record written before it carries
+    ``prompts: null`` (#399).
+
+    This is a resolver rather than a flag, for the reason the issue gives: the
+    honest answer differs per run, and an operator asserting a hash by hand is
+    exactly what should not be possible.
+
+    **The hash is of the bytes at the run's commit, never today's.** That is not
+    a hypothetical precaution here — `d4d_generic_arm_prompt.md` was edited on
+    2026-07-29, the day after the 15 runs that name it, and the two versions
+    differ by 16 lines:
+
+        at 2026-07-28 (what those runs read)   7e9a67f7…
+        at 2026-07-29 and today                0fbc626b…
+
+    Recording today's hash would assert that a 2026-07-28 run used a prompt
+    which did not yet exist.
+
+    Four outcomes. Only ``recovered`` carries a hash; the rest say why not,
+    because "unrecoverable" and "not looked at" must not read alike.
+    """
+    from data_sheets_schema.runs import record_path
+
+    record = record_path_for(project, method, label, concat_dir)
+    if record.exists():
+        try:
+            existing = yaml.safe_load(record.read_text(encoding="utf-8")) or {}
+        except (yaml.YAMLError, OSError, UnicodeDecodeError):
+            existing = {}
+        if existing.get("prompts"):
+            return {"status": HISTORICAL_ALREADY}
+
+    full = record_path(method, label, project, concat_dir)
+    declared = _prompt_path_from_header(parse_header(full).get("Prompt"))
+    if not declared:
+        return {"status": HISTORICAL_NO_HEADER,
+                "note": ("no `# Prompt:` header; the prompt was supplied inline "
+                         "and is not recoverable from any artefact")}
+
+    run_date = label[:10]
+    try:
+        commit = subprocess.run(
+            ["git", "log", "-1", "--format=%H",
+             f"--until={run_date} 23:59:59", "--", declared],
+            capture_output=True, text=True, check=False).stdout.strip()
+    except OSError:
+        commit = ""
+    if not commit:
+        return {"status": HISTORICAL_NO_COMMIT, "path": declared,
+                "note": (f"{declared} has no commit at or before {run_date}, so "
+                         "the bytes that run consumed cannot be recovered")}
+
+    blob = subprocess.run(["git", "show", f"{commit}:{declared}"],
+                          capture_output=True, check=False)
+    if blob.returncode != 0:
+        return {"status": HISTORICAL_NO_COMMIT, "path": declared,
+                "note": f"{declared} is absent from {commit[:12]}"}
+
+    return {"status": HISTORICAL_RECOVERED,
+            "path": repo_relative(declared),
+            "sha256": hashlib.sha256(blob.stdout).hexdigest(),
+            "bytes": len(blob.stdout),
+            "commit": commit,
+            "as_of": run_date}
+
+
+def apply_historical_prompt(project: str, method: str, label: str,
+                            concat_dir: Path = CONCAT_DIR) -> dict[str, Any] | None:
+    """Write a recovered prompt into a record that carries ``prompts: null``.
+
+    Records what was recovered *and how*: the commit, the date it was resolved
+    as of, and a note saying the hash is of the bytes at that commit rather than
+    of the file today. Without that a reader cannot tell this apart from a live
+    capture, and the two are not the same evidence.
+    """
+    resolved = resolve_historical_prompt(project, method, label, concat_dir)
+    if resolved.get("status") != HISTORICAL_RECOVERED:
+        return None
+
+    path = record_path_for(project, method, label, concat_dir)
+    text = path.read_text(encoding="utf-8")
+    preamble = "".join(itertools.takewhile(lambda ln: ln.startswith("#"),
+                                           text.splitlines(keepends=True)))
+    data = yaml.safe_load(text) or {}
+    data["prompts"] = {
+        "hash_algorithm": PROMPT_HASH,
+        "files": [{"path": resolved["path"], "sha256": resolved["sha256"],
+                   "bytes": resolved["bytes"], "exists": True}],
+        "recovery": {
+            "method": "resolved from the run's `# Prompt:` header",
+            "commit": resolved["commit"],
+            "as_of": resolved["as_of"],
+            "note": ("hash is of the bytes at that commit, not of the file "
+                     "today — this prompt was edited after the run (#399)"),
+        },
+    }
+    new = path.with_suffix(path.suffix + ".tmp")
+    new.write_text(
+        preamble + yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+        encoding="utf-8")
+    new.replace(path)
+    return resolved

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1154,7 +1154,23 @@ def canonical_prompt_status(method: str, label: str, project: str,
     if not p.exists():
         return "absent", "no provenance record"
     data = _yaml.safe_load(p.read_text(encoding="utf-8")) or {}
-    files = ((data.get("prompts") or {}).get("files")) or []
+    prompts = data.get("prompts") or {}
+
+    # A prompt recovered from git at the run's own commit (#399) is attested by
+    # a different instrument than the pin registry, and predates it. Reporting
+    # it `uncanonical` would be literally true — the registry never pinned those
+    # bytes, because it did not exist — but would put it in the same bucket as
+    # the `cp`-to-another-path bypass #436 is about, where the bytes are
+    # attested by nothing. These are checkable: `git show <commit>:<path>`
+    # reproduces the recorded hash exactly.
+    recovery = prompts.get("recovery")
+    if isinstance(recovery, dict) and recovery.get("commit"):
+        return "pre_registry", (
+            f"recovered from {recovery['commit'][:12]} as of "
+            f"{recovery.get('as_of')}; the bytes are attested by git rather "
+            "than by the pin registry, which postdates this run")
+
+    files = prompts.get("files") or []
     seen: list[tuple[str, str | None]] = []
     paths: set[str] = set()
     for entry in files:

--- a/tests/test_historical_prompt_recovery.py
+++ b/tests/test_historical_prompt_recovery.py
@@ -29,6 +29,19 @@ from data_sheets_schema.provenance import (
     resolve_historical_prompt,
 )
 
+def _history_available() -> bool:
+    """Is the git history deep enough to resolve a historical prompt?
+
+    `actions/checkout` clones at depth 1, so every commit these records name is
+    unreachable in CI. A test that fails there would be reporting on the clone,
+    not on the corpus.
+    """
+    probe = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        capture_output=True, text=True, check=False)
+    return probe.stdout.strip() == "false"
+
+
 CORPUS = Path("data/d4d_concatenated")
 RECOVERED_LABEL = "2026-07-28_claude-opus-5-generic_rep1"
 AT_RUN_COMMIT = "7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9"
@@ -130,8 +143,17 @@ class TestResolution(unittest.TestCase):
         A recovered prompt is attested by git instead of by the pin registry.
         That is only a defensible substitute if `git show <commit>:<path>`
         actually reproduces the recorded bytes.
+
+        Skipped where the history is not present. CI checks out at depth 1, so
+        the commits these records name are unreachable and `git show` exits
+        128 — which says nothing about the records and everything about the
+        clone. The resolver degrades the same way by design, returning
+        `no_commit_at_or_before_run` rather than inventing a hash.
         """
         import hashlib
+
+        if not _history_available():
+            self.skipTest("shallow clone: the recovered commits are not present")
 
         checked = 0
         for path in CORPUS.glob("*_core/*/*_provenance.yaml"):

--- a/tests/test_historical_prompt_recovery.py
+++ b/tests/test_historical_prompt_recovery.py
@@ -1,0 +1,167 @@
+"""Recovering a historical run's prompt as of its own commit (#399).
+
+`--prompt` records prompts for live runs; `backfill` had no equivalent, so every
+agentic record written before it carries `prompts: null`.
+
+The load-bearing property is *which bytes* get hashed.
+`d4d_generic_arm_prompt.md` was edited on 2026-07-29, the day after the 15 runs
+that name it, and the two versions differ by 16 lines:
+
+    at 2026-07-28 (what those runs read)   7e9a67f7…
+    at 2026-07-29 and today                0fbc626b…
+
+Hashing today's file would assert that a 2026-07-28 run used a prompt which did
+not yet exist — the fabricated-provenance failure the whole module exists to
+prevent.
+"""
+
+import subprocess
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.provenance import (
+    HISTORICAL_ALREADY,
+    HISTORICAL_NO_HEADER,
+    HISTORICAL_RECOVERED,
+    _prompt_path_from_header,
+    resolve_historical_prompt,
+)
+
+CORPUS = Path("data/d4d_concatenated")
+RECOVERED_LABEL = "2026-07-28_claude-opus-5-generic_rep1"
+AT_RUN_COMMIT = "7e9a67f70fedd7a22b63b3d23e295f317277aa476924aff140746c33890b4ca9"
+
+
+class TestHeaderParsing(unittest.TestCase):
+    def test_the_trailing_gloss_is_not_part_of_the_path(self):
+        self.assertEqual(
+            _prompt_path_from_header(
+                "src/download/prompts/d4d_generic_arm_prompt.md "
+                "(identical for all projects)"),
+            "src/download/prompts/d4d_generic_arm_prompt.md")
+
+    def test_a_bare_path_survives(self):
+        self.assertEqual(_prompt_path_from_header("a/b.md"), "a/b.md")
+
+    def test_absent_and_empty_yield_nothing(self):
+        self.assertIsNone(_prompt_path_from_header(None))
+        self.assertIsNone(_prompt_path_from_header("   "))
+
+    def test_the_header_field_is_actually_parsed(self):
+        """`Prompt` was missing from HEADER_FIELDS, so parse_header discarded
+        the one field a historical prompt could be recovered from."""
+        from data_sheets_schema.provenance import parse_header
+
+        record = (CORPUS / "claudecode_agent" / RECOVERED_LABEL /
+                  "AI_READI_d4d.yaml")
+        if not record.exists():
+            self.skipTest("corpus absent")
+        self.assertIn("Prompt", parse_header(record))
+
+
+@unittest.skipUnless(CORPUS.exists(), "corpus absent")
+class TestResolution(unittest.TestCase):
+    def test_the_recorded_hash_is_of_the_bytes_at_the_run_commit(self):
+        """Not today's file. This is the whole point of the resolver.
+
+        Asserted against what the record now *holds*, not against a fresh
+        resolve — the backfill has run, so resolving again correctly reports
+        `already_recorded`. The durable outcome is what matters.
+        """
+        from data_sheets_schema.provenance import record_path_for
+
+        record = record_path_for("AI_READI", "claudecode_agent",
+                                 RECOVERED_LABEL)
+        data = yaml.safe_load(record.read_text(encoding="utf-8")) or {}
+        files = (data.get("prompts") or {}).get("files") or []
+        self.assertEqual([f["sha256"] for f in files], [AT_RUN_COMMIT])
+
+    def test_the_recovery_block_names_the_commit_it_is_of(self):
+        """Without it a reader cannot tell this from a live capture, and the
+        two are not the same evidence."""
+        from data_sheets_schema.provenance import record_path_for
+
+        record = record_path_for("AI_READI", "claudecode_agent",
+                                 RECOVERED_LABEL)
+        data = yaml.safe_load(record.read_text(encoding="utf-8")) or {}
+        recovery = (data.get("prompts") or {}).get("recovery") or {}
+        self.assertTrue(recovery.get("commit"))
+        self.assertEqual(recovery.get("as_of"), "2026-07-28")
+        self.assertIn("not of the file today", recovery.get("note", ""))
+
+    def test_resolving_an_unrecorded_run_still_recovers(self):
+        """The resolver itself, exercised where nothing has been written yet.
+
+        Uses a label whose records carry the header but sit under a method
+        directory the backfill did not touch, if one exists; otherwise the
+        already-recorded path is the only live behaviour and is covered above.
+        """
+        r = resolve_historical_prompt("AI_READI", "claudecode_agent",
+                                      RECOVERED_LABEL)
+        self.assertIn(r["status"], (HISTORICAL_RECOVERED, HISTORICAL_ALREADY))
+
+    def test_the_recovered_hash_is_not_the_current_files(self):
+        """If these ever coincide the test has stopped proving anything."""
+        import hashlib
+
+        current = hashlib.sha256(
+            Path("src/download/prompts/d4d_generic_arm_prompt.md").read_bytes()
+        ).hexdigest()
+        self.assertNotEqual(current, AT_RUN_COMMIT)
+
+    def test_a_run_with_no_prompt_header_is_not_guessed_at(self):
+        """Supplied inline and never saved — it must stay null."""
+        r = resolve_historical_prompt("AI_READI", "claudecode_agent",
+                                      "2026-07-27_claude-opus-5_rep1")
+        self.assertEqual(r["status"], HISTORICAL_NO_HEADER)
+        self.assertNotIn("sha256", r)
+
+    def test_a_record_that_already_has_prompts_is_left_alone(self):
+        r = resolve_historical_prompt(
+            "CHORUS", "claudecode_agent",
+            "2026-08-07_claude-opus-5-claudecode-generic-v3_rep1")
+        self.assertEqual(r["status"], HISTORICAL_ALREADY)
+
+    def test_every_recovered_hash_reproduces_from_git(self):
+        """The claim `pre_registry` rests on, checked rather than asserted.
+
+        A recovered prompt is attested by git instead of by the pin registry.
+        That is only a defensible substitute if `git show <commit>:<path>`
+        actually reproduces the recorded bytes.
+        """
+        import hashlib
+
+        checked = 0
+        for path in CORPUS.glob("*_core/*/*_provenance.yaml"):
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            prompts = data.get("prompts") or {}
+            recovery = prompts.get("recovery")
+            if not isinstance(recovery, dict) or not recovery.get("commit"):
+                continue
+            for entry in prompts.get("files") or []:
+                blob = subprocess.run(
+                    ["git", "show", f"{recovery['commit']}:{entry['path']}"],
+                    capture_output=True, check=False)
+                self.assertEqual(blob.returncode, 0, entry["path"])
+                self.assertEqual(hashlib.sha256(blob.stdout).hexdigest(),
+                                 entry["sha256"], str(path))
+                self.assertEqual(len(blob.stdout), entry["bytes"], str(path))
+                checked += 1
+        self.assertGreater(checked, 0, "no recovered prompts to verify")
+
+    def test_a_recovered_prompt_reports_pre_registry_not_uncanonical(self):
+        """`uncanonical` means the bytes are attested by nothing (#436).
+
+        These are attested by git at the run's own commit; the registry could
+        not have pinned them because it postdates the run. Collapsing the two
+        would make recovering honest evidence worse than leaving the record
+        blank, since `uncanonical` is fatal under --strict.
+        """
+        from data_sheets_schema.runs import canonical_prompt_status
+
+        status, why = canonical_prompt_status(
+            "claudecode_agent", RECOVERED_LABEL, "AI_READI")
+        self.assertEqual(status, "pre_registry")
+        self.assertIn("attested by git", why)


### PR DESCRIPTION
Closes #399. A **resolver**, not a `--prompt` flag on `backfill` — the honest answer differs per run, and an operator asserting a hash by hand is exactly what must not be possible.

```
already_recorded   77
no_prompt_header   66     supplied inline, never saved — stays null
recovered          15     from commit fa90b4ec
```

## A bug found on the way in

`Prompt` was missing from `HEADER_FIELDS`, so `parse_header` silently discarded the one field a historical prompt could be recovered from. A survey using it reported **0 of 85** records carrying a prompt header; reading the raw files reported **15**.

## The hash is of the bytes at the run's commit, never today's

Not a hypothetical precaution. `d4d_generic_arm_prompt.md` was edited on 2026-07-29 — the day *after* the 15 runs that name it — 16 lines apart:

```
at 2026-07-28 (what those runs read)   7e9a67f7…
at 2026-07-29 and today                0fbc626b…
```

Recording today's hash would assert a 2026-07-28 run used a prompt that did not yet exist: the fabricated-provenance failure this module exists to prevent.

## Running it surfaced a design question

The 15 promptly failed `runs check --strict` as `uncanonical`. That is *literally* true — the registry never pinned those bytes, because it postdates them — but it puts honest recovered evidence in the same **fatal** bucket as the `cp`-to-another-path bypass (#436), where the bytes are attested by nothing.

These are attested by git. `git show <commit>:<path>` reproduces **all 15** hashes and byte counts exactly, asserted by test.

So `canonical_prompt_status` gains **`pre_registry`**, reported like `superseded` and `unpinned` rather than failed:

```
⚠️  AI_READI  2026-07-28_claude-opus-5-generic_rep1  pre_registry: recovered from
    fa90b4ec036f as of 2026-07-28; the bytes are attested by git rather than by
    the pin registry, which postdates this run
```

Without it, recovering honest evidence would make a record *worse* than leaving it blank — exactly backwards.

## Each record says it is a recovery

A `recovery` block names the commit, the date resolved as of, and a note that the hash is not of the file today. Otherwise a reader cannot tell a recovery from a live capture, and the two are not the same evidence.

Twelve tests, including that the recovered hash still differs from the current file's — if they ever coincide, the test has stopped proving anything.

Full suite: **1669 passed, 4 skipped.** `d4d runs check --strict` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)