### PR TITLE
Give prompt rendering a home its audience will look in (#428)

### DIFF
--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -495,9 +495,19 @@ exists to prevent.
 
 **The prompt is an input like the bundle.** `--prompt` may repeat; pass every
 file the condition is built from. `--prompt-text` takes the instruction as
-actually sent — render it with `d4d api render-prompt --condition {CONDITION}
---out <file>` rather than retyping it, so the text and its hash come from the
-same place. From 2026-08-10 a run without a recorded instruction fails
+actually sent — render it with
+
+```bash
+d4d prompt render --project {PROJECT} --label {LABEL} \
+                  --condition {CONDITION} --runtime 'Claude Code' --out <file>
+```
+
+rather than retyping it, so the text and its hash come from the same place.
+
+`d4d prompt render` is the same command as `d4d api render-prompt` (#428). The
+top-level spelling exists because this path is not the API path, and a launcher
+following this playbook has no reason to look under a group named for the
+runtime it is not using. From 2026-08-10 a run without a recorded instruction fails
 `d4d runs check --strict` (#419): the gate was otherwise opt-in by omission,
 since a launcher that simply passes neither flag records nothing and nothing
 says so.

--- a/src/data_sheets_schema/cli/__init__.py
+++ b/src/data_sheets_schema/cli/__init__.py
@@ -18,7 +18,7 @@ def cli():
     pass
 
 # Import and register subcommands
-from . import download, evaluate, utils, rocrate, schema, render, healthsheet, runs, provenance, api, enrich
+from . import download, evaluate, utils, rocrate, schema, render, healthsheet, runs, provenance, api, enrich, prompt
 
 cli.add_command(download.download)
 cli.add_command(evaluate.evaluate)
@@ -31,6 +31,7 @@ cli.add_command(provenance.provenance)
 cli.add_command(schema.schema)
 cli.add_command(render.render)
 cli.add_command(api.api)
+cli.add_command(prompt.prompt)
 
 if __name__ == "__main__":
     cli()

--- a/src/data_sheets_schema/cli/prompt.py
+++ b/src/data_sheets_schema/cli/prompt.py
@@ -1,0 +1,33 @@
+"""Top-level home for prompt rendering.
+
+`d4d api render-prompt` exists so the **agentic** path can obtain its
+instruction rather than compose one by hand — but it lives under `d4d api`,
+the group for generating records through the Anthropic API. So the command an
+agentic run needs was filed under the path it is not taking, and `d4d api
+--help` describes a group its audience is deliberately not using (#428).
+
+The rendering machinery genuinely is the API runner's — `resolve_prompt`,
+`RunSpec` and `CONDITION_PROMPTS` all live in `api_runner` — so this aliases
+rather than moves. One implementation, two entry points, and the discoverable
+one is named in `.claude/commands/d4d-full-core.md`, which is what an agentic
+run actually reads.
+
+Moving `resolve_prompt` and `RunSpec` into a shared module is the larger fix
+the issue describes as option 2; it touches the module every API run goes
+through, and is worth doing only if this shared surface grows.
+"""
+
+import click
+
+from data_sheets_schema.cli.api import render_prompt_cmd
+
+
+@click.group()
+def prompt():
+    """Render the instruction a run should receive, for any runtime."""
+
+
+# The same command object, not a reimplementation: a copy would be free to
+# drift, and two renderers that disagree is precisely the failure #425 was
+# built to remove.
+prompt.add_command(render_prompt_cmd, name="render")

--- a/tests/test_prompt_render_alias.py
+++ b/tests/test_prompt_render_alias.py
@@ -1,0 +1,67 @@
+"""`d4d prompt render` — the rendering command, where its audience will look.
+
+`d4d api render-prompt` exists so the *agentic* path can obtain its instruction
+rather than compose one by hand, and it lived under the group for generating
+records through the API. The command an agentic run needs was filed under the
+path it is not taking (#428).
+
+Aliased rather than reimplemented. Two renderers free to disagree is exactly the
+failure #425 was built to remove.
+"""
+
+import unittest
+
+from click.testing import CliRunner
+
+from data_sheets_schema.cli import cli
+
+
+class TestPromptRenderAlias(unittest.TestCase):
+    ARGS = ["--project", "CHORUS", "--label", "2026-08-11_alias_rep1",
+            "--condition", "generic"]
+
+    def _run(self, *argv):
+        return CliRunner().invoke(cli, list(argv))
+
+    def test_the_group_is_discoverable_from_the_top_level(self):
+        result = self._run("--help")
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("prompt", result.output)
+
+    def test_render_produces_an_instruction(self):
+        result = self._run("prompt", "render", *self.ARGS)
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("rendered generic for CHORUS", result.output)
+
+    def test_both_spellings_produce_identical_output(self):
+        """One implementation. A copy would be free to drift, and two
+        renderers that disagree is the failure #425 removed."""
+        alias = self._run("prompt", "render", *self.ARGS)
+        original = self._run("api", "render-prompt", *self.ARGS)
+        self.assertEqual(alias.exit_code, 0, alias.output)
+        self.assertEqual(original.exit_code, 0, original.output)
+        self.assertEqual(alias.output, original.output)
+
+    def test_it_is_the_same_command_object(self):
+        """Not merely equal today — the same object, so it cannot diverge."""
+        from data_sheets_schema.cli.api import api, render_prompt_cmd
+        from data_sheets_schema.cli.prompt import prompt
+
+        self.assertIs(prompt.commands["render"], render_prompt_cmd)
+        self.assertIs(api.commands["render-prompt"], render_prompt_cmd)
+
+    def test_the_original_still_works(self):
+        """Aliasing must not move it: labels, scripts and the API playbook
+        already name the original."""
+        result = self._run("api", "render-prompt", *self.ARGS)
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_the_agentic_playbook_names_the_discoverable_spelling(self):
+        """The playbook is what an agentic run reads, so it is where the
+        command has to be named for the fix to reach its audience."""
+        from pathlib import Path
+
+        playbook = Path(".claude/commands/d4d-full-core.md")
+        if not playbook.exists():
+            self.skipTest("playbook absent")
+        self.assertIn("d4d prompt render", playbook.read_text(encoding="utf-8"))


### PR DESCRIPTION
Closes #428.

`d4d api render-prompt` exists so the **agentic** path can obtain its instruction rather than compose one by hand — and it lived under the group for generating records through the Anthropic API. The command an agentic run needs was filed under the path it is *not* taking, and `d4d api --help` describes a group its audience is deliberately not using.

```
$ d4d --help
  prompt       Render the instruction a run should receive, for any runtime.
```

## An alias, not a move

Option 1 of the three the issue offers. The rendering machinery genuinely is the API runner's — `resolve_prompt`, `RunSpec` and `CONDITION_PROMPTS` all live in `api_runner` — and moving them into a shared module touches the code path every API run goes through. Worth doing only if that surface grows, which the docstring records.

**The same command object, not a reimplementation**, asserted by test rather than left to convention:

```python
self.assertIs(prompt.commands["render"], render_prompt_cmd)
self.assertIs(api.commands["render-prompt"], render_prompt_cmd)
```

A copy would be free to drift, and two renderers that disagree is precisely the failure #425 was built to remove. Verified both spellings emit byte-identical output.

## The part that makes it reach its audience

`.claude/commands/d4d-full-core.md` now names `d4d prompt render` in the block about recording `--prompt-text`. The issue's own note was that whichever option was taken, the playbook had to name the command — it is what an agentic run actually reads. A test asserts it stays named there.

The original spelling still works; labels, scripts and the API-side documentation already use it, and aliasing must not move it.

Full suite: **1680 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)