### PR TITLE
Check AGENT_PLAYBOOKS against the files a run is told to read (#431)

### DIFF
--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -24,6 +24,7 @@ import hashlib
 import itertools
 import os
 import platform
+import re
 import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
@@ -1338,3 +1339,51 @@ def apply_historical_prompt(project: str, method: str, label: str,
         encoding="utf-8")
     new.replace(path)
     return resolved
+
+
+_PLAYBOOK_REF = re.compile(r"\.claude/[A-Za-z0-9_/.-]*\.md")
+
+#: Where the reference chain starts. The launch instruction's first lines name
+#: the guard and the playbook; everything else is reached from those.
+PLAYBOOK_ROOTS = (Path("src/download/prompts/d4d_generic_arm_prompt.md"),)
+
+
+def referenced_playbooks(roots: tuple[Path, ...] = PLAYBOOK_ROOTS
+                         ) -> tuple[Path, ...]:
+    """Every `.claude/*.md` reachable from the launch instruction (#431).
+
+    `AGENT_PLAYBOOKS` is a claim about which files carry decision rules, and it
+    was maintained by hand with nothing checking it against the tree. Two
+    failures follow. A **renamed** playbook silently becomes `exists: false`,
+    so the record attests that a file the agent actually read was absent. A
+    **new** playbook is invisible: add a fourth instruction file, tell the
+    agent to read it, and no record mentions it.
+
+    Both are the original problem one level up — instructions reaching the
+    model through files nobody tracks — which is what hashing playbooks exists
+    to stop.
+
+    Derived by following references rather than globbing `.claude/`: a glob
+    would hash files no run reads, and a record's playbook list would then
+    change whenever an unrelated command was added. The prompt body names the
+    guard and the playbook; the playbook names the agent file. That closure is
+    the set, and a test asserts `AGENT_PLAYBOOKS` equals it.
+
+    Sorted for determinism — a record's playbook list must not depend on
+    filesystem or traversal order.
+    """
+    seen: set[str] = set()
+    queue = [Path(r) for r in roots]
+    while queue:
+        current = queue.pop()
+        if not current.exists():
+            continue
+        try:
+            text = current.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for ref in _PLAYBOOK_REF.findall(text):
+            if ref not in seen:
+                seen.add(ref)
+                queue.append(Path(ref))
+    return tuple(Path(p) for p in sorted(seen))

--- a/tests/test_agent_playbooks.py
+++ b/tests/test_agent_playbooks.py
@@ -1,0 +1,76 @@
+"""AGENT_PLAYBOOKS must match the files a run is actually told to read (#431).
+
+The list is a claim about which files carry decision rules, and it was
+maintained by hand with nothing checking it against the tree. Two failures
+follow, and they are the same defect:
+
+- a **renamed** playbook silently becomes `exists: false`, so the record
+  attests that a file the agent actually read was absent;
+- a **new** playbook is invisible — add a fourth instruction file, tell the
+  agent to read it, and no record mentions it.
+
+Both reproduce the original problem one level up: instructions reaching the
+model through files nobody tracks, which is what hashing playbooks exists to
+stop (#394, #420).
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from data_sheets_schema.provenance import (
+    AGENT_PLAYBOOKS,
+    playbook_facts,
+    referenced_playbooks,
+)
+
+
+class TestPlaybookClosure(unittest.TestCase):
+    def test_the_declared_list_is_the_referenced_closure(self):
+        """The assertion the whole issue asks for."""
+        self.assertEqual(set(AGENT_PLAYBOOKS), set(referenced_playbooks()))
+
+    def test_every_declared_playbook_exists(self):
+        """A renamed playbook would otherwise be recorded `exists: false`,
+        which is an attestation that the agent read nothing."""
+        missing = [str(p) for p in AGENT_PLAYBOOKS if not Path(p).exists()]
+        self.assertEqual(missing, [])
+
+    def test_the_closure_is_sorted_for_determinism(self):
+        derived = [str(p) for p in referenced_playbooks()]
+        self.assertEqual(derived, sorted(derived))
+
+    def test_a_new_reference_is_picked_up(self):
+        """The invisible-fourth-playbook case, exercised rather than argued."""
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d) / "root.md"
+            root.write_text(
+                "read `.claude/commands/d4d-full-core.md` and also "
+                "`.claude/commands/d4d-brand-new.md`\n", encoding="utf-8")
+            derived = [str(p) for p in referenced_playbooks((root,))]
+        self.assertIn(".claude/commands/d4d-brand-new.md", derived)
+
+    def test_references_are_followed_transitively(self):
+        """d4d-agent.md is reached only through d4d-full-core.md, so a
+        one-level scan would miss the file carrying the slot-filling rules."""
+        self.assertIn(Path(".claude/commands/d4d-agent.md"),
+                      referenced_playbooks())
+
+    def test_a_missing_root_does_not_raise(self):
+        self.assertEqual(referenced_playbooks((Path("nope/absent.md"),)), ())
+
+    def test_the_facts_record_the_declared_set_not_the_derived_one(self):
+        """Records stay stable while the closure is the *check*.
+
+        Deriving at record time would make a record's playbook list change
+        whenever the prompt's wording changed, which is not what it attests.
+        """
+        recorded = {f["path"] for f in playbook_facts()["files"]}
+        self.assertEqual(recorded, {str(p) for p in AGENT_PLAYBOOKS})
+
+    def test_the_slot_filling_playbook_is_tracked(self):
+        """`.claude/commands/d4d-agent.md` is where v2/v3 behaviour reaches the
+        agentic path (#394). It is the file this whole mechanism exists for, so
+        its presence is asserted by name rather than only by closure."""
+        tracked = {str(p) for p in AGENT_PLAYBOOKS}
+        self.assertIn(".claude/commands/d4d-agent.md", tracked)


### PR DESCRIPTION
Closes #431.

`AGENT_PLAYBOOKS` is a claim about which files carry decision rules, maintained by hand with nothing checking it against the tree. Two failures follow, and they are the same defect:

- a **renamed** playbook silently becomes `exists: false`, so the record attests that a file the agent actually read was absent;
- a **new** playbook is invisible — add a fourth instruction file, tell the agent to read it, and no record mentions it.

Both reproduce the original problem one level up: instructions reaching the model through files nobody tracks, which is exactly what hashing playbooks exists to stop (#394, #420). This is the file where `d4d-agent.md` carries the slot-filling contract that gives the agentic path its v2/v3 behaviour — established this session as the reason a v1 prompt there already produces v3-quality structure.

## Option 1: follow the references

`referenced_playbooks` walks `.claude/*.md` references transitively from the launch instruction, and a test asserts the tuple equals that closure:

```
derived : ['.claude/agents/d4d-provenance-guard.md',
           '.claude/commands/d4d-agent.md',
           '.claude/commands/d4d-full-core.md']
equal   : True
```

**Not a glob of `.claude/`** — the issue's option 2. Globbing would hash files no run reads, and a record's playbook list would then change whenever an unrelated command was added.

**Transitivity is the point, not an incidental.** `d4d-agent.md` is reached *only* through `d4d-full-core.md`, so a one-level scan would miss the very file this mechanism exists for. Asserted both ways — by closure and by name.

## Records still write the declared set

Deriving at record time would make a record's playbook list shift whenever the prompt's wording changed, which is not what it attests. The closure is the **check**, not the content.

Verified the guard fires: a fabricated root naming a fourth playbook produces a set that fails the equality test.

Eight tests. Full suite: **1688 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)