### PR TITLE
Cost the runs, and correct a Cost section left over from the agentic plan

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -295,6 +295,18 @@ canonical set needs replacing regardless (#454), and a fresh arm also clears the
 bundle drift on all five canonical records (#452). It answers replicate variance
 and corpus currency, not prompt promotion, and the two must not be conflated.
 
+**Staged and costed, not run.** Every free check is exhausted: `d4d api plan`
+renders all 10 project × condition combinations without error, each naming the
+expected prompt and the current digest `488bd7321fe5`, and `d4d api batch
+--dry-run` costs both arms at **~27.1M uncached input tokens** (v1 13.5M, v3
+13.6M; CM4AI and VOICE dominate at ~1.05M and ~1.21M per run, CHORUS cheapest at
+~200K). Phases 2–6 reuse a cached prefix, so billed input is materially lower;
+output tokens are extra.
+
+What remains is a spend decision. CHORUS is the natural canary — cheapest of the
+five, identical six-phase path — and the standing rule is one run verified on
+disk before any of the remaining 29.
+
 **No longer preconditions.** #385 and #380 were listed as pre-sweep decisions.
 Re-measured across the corpus, neither gates the run: the canonical agentic
 series is 971 `description` to 7 `notes` with 276 `source_caveats`, 692/692

--- a/notes/generic_v1_v3_analysis_plan.md
+++ b/notes/generic_v1_v3_analysis_plan.md
@@ -302,15 +302,58 @@ across schemas — but it means the scoring cost is for 30 records, not 15.
 
 ## Cost
 
-Thirty agentic generations (5 projects × 3 replicates × 2 arms) on the Claude
-Code path: no API spend for generation. Then fitness scoring of all 30 records
-and sub-type classification of whatever form failures they produce — this part
-is paid, and is roughly double what a single-arm comparison would cost, for the
-cache reason above.
+⚠️ **Corrected after the runtime moved to the API path.** This section read "no
+API spend for generation", which was true of the agentic path this plan
+originally specified and is not true of the one it now specifies (#479). The
+generation is the expensive part, not the scoring.
+
+Measured with `d4d api batch --dry-run`, which calls nothing:
+
+| arm | runs | input tokens (uncached) |
+|---|---|---|
+| v1 (`generic`) | 15 | ~13,535,730 |
+| v3 (`generic_v3`) | 15 | ~13,566,231 |
+| **total** | **30** | **~27.1M** |
+
+Per run, by project — the spread is the bundle, and CM4AI and VOICE dominate:
+
+```
+AI_READI          ~ 486,000     CM4AI            ~1,050,640
+CHORUS            ~ 199,637     VOICE            ~1,212,190
+VOICE_PEDIATRIC   ~ 706,578
+```
+
+Uncached is the pessimistic figure: each run's phases 2–6 reuse a cached prefix
+(`cached blocks=2` per phase), so the billed input is materially lower. Output
+tokens are extra and are not estimable in advance — and `max_tokens` must be
+sized for the reasoning rather than the answer, since a call can spend its
+whole budget thinking and return empty text.
+
+Then fitness scoring of all 30 records and sub-type classification of whatever
+form failures they produce, which is roughly double a single-arm comparison for
+the cache reason above.
+
+**This is a spend decision and belongs to whoever owns the budget.** The figure
+is here so it can be made on a number rather than an impression.
 
 **Canary before fan-out.** One run — one project, one replicate, one arm —
 executed end to end through the same launcher, and its outputs verified present
-and non-empty on disk, before any of the remaining 29 are launched.
+and non-empty on disk, before any of the remaining 29 are launched. CHORUS is
+the natural canary: at ~200K tokens it is the cheapest of the five and
+exercises the identical six-phase path.
+
+**Free checks already exhausted** (2026-08-11), per the standing canary rule
+that dry runs come before paid ones:
+
+- `d4d api plan` renders every phase for all 10 project × condition
+  combinations without error and without calling anything;
+- each plan names the expected prompt (`d4d_generic_arm_prompt_v3.md` for the
+  v3 arm) and the current schema digest `488bd7321fe5`;
+- `d4d api batch --dry-run` costs both arms in full.
+
+What those cannot exercise is the live call: credentials in the launching
+shell, rate limits under concurrency, and whether anything is actually written
+to disk. That is what the canary is for.
 
 ## What is no longer a precondition
 


### PR DESCRIPTION
The plan's Cost section still read *"no API spend for generation"* — true of the agentic path it originally specified, false of the API path it now specifies (#479). The generation is the expensive part, not the scoring, and the section said the opposite.

## Measured, with `--dry-run`, which calls nothing

| arm | runs | input tokens (uncached) |
|---|---|---|
| v1 (`generic`) | 15 | ~13,535,730 |
| v3 (`generic_v3`) | 15 | ~13,566,231 |
| **total** | **30** | **~27.1M** |

Per run the spread is the bundle:

```
AI_READI          ~ 486,000     CM4AI            ~1,050,640
CHORUS            ~ 199,637     VOICE            ~1,212,190
VOICE_PEDIATRIC   ~ 706,578
```

Uncached is the pessimistic figure — every run's phases 2–6 reuse a cached prefix (`cached blocks=2` per phase) — and output tokens are extra and not estimable in advance.

## Free checks exhausted first

Per the standing rule that dry runs precede paid ones:

- `d4d api plan` renders every phase for **all 10** project × condition combinations without error and without calling anything;
- each plan names the expected prompt (`d4d_generic_arm_prompt_v3.md` for the v3 arm) and the current schema digest `488bd7321fe5` — which independently confirms the #403 digest correction reached the launch path;
- `d4d api batch --dry-run` costs both arms in full.

**What those cannot exercise** is recorded as such rather than treated as verified: credentials in the launching shell, rate limits under concurrency, and whether anything is actually written to disk. That is what the canary is for, and **CHORUS is named as it** — cheapest of the five at ~200K, identical six-phase path.

The remaining decision is a spend decision. The figure is now on the page so it can be made on a number rather than an impression.

Full suite: **1688 passed, 4 skipped, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)