### PR TITLE
Make a running sweep findable and stoppable (#513)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ data/poster_assets/
 
 # Resume scaffolding for `d4d api` runs — deleted on success, never a record.
 *_api_progress.json
+
+# Run locks for in-flight API sweeps (#513) — process state, not artifacts
+data/.run_locks/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,6 +401,27 @@ check surfaces rather than settles.
 Each condition's prompt files are pinned by hash in
 `src/download/prompts/canonical_hashes.yaml`.
 
+### Stopping a sweep
+
+A running `d4d api batch` **cannot be found by name** — a console-script entry
+point runs as `python -c import sys; …` and carries none of its own name, so
+`pgrep -f "d4d api"` returns nothing while the sweep is still spending. On
+2026-08-11 that cost roughly two hours of unobserved generation after the batch
+was reported stopped (#513).
+
+```bash
+d4d api status                          # which sweeps are running, and their pids
+d4d api stop --label-prefix <prefix>    # stop one; --force for SIGKILL
+```
+
+A sweep writes a lock under `data/.run_locks/` naming its pid, label and
+projects, and **refuses to start while a live lock holds the same prefix** —
+two batches writing one label directory produce a record that is a mixture of
+both runs with provenance describing neither. Stopping is safe: each run
+resumes from its progress file, so the cost is the unfinished phases of the
+current run. `status` reports a stale lock rather than deleting it, because a
+lock outliving its process is evidence a sweep died without cleaning up.
+
 ```bash
 d4d api prompts check --strict          # working tree vs the pins (CI gate)
 d4d api prompts pin --file <path> --reason '<why this is the text>'

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -302,6 +302,17 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
         click.echo("aborted")
         return
 
+    # Claim the label prefix before spending anything (#513). Two batches
+    # writing the same label directories is not a tolerable race: each writes
+    # phase snapshots and a progress file under the same names, so the
+    # survivor's record can be a mixture of both runs while its provenance
+    # describes neither. That happened on 2026-08-11.
+    from data_sheets_schema import run_lock
+    try:
+        lock_path = run_lock.acquire(label_prefix, names)
+    except run_lock.AlreadyRunning as exc:
+        raise click.ClickException(str(exc)) from exc
+
     ok, failed, spent_in, spent_out = [], [], 0, 0
     for i, s in enumerate(specs, 1):
         click.echo(f"\n[{i}/{len(specs)}] {s.project} {s.label}")
@@ -335,12 +346,75 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
                 click.echo("stopping; re-run to resume unfinished phases", err=True)
                 break
 
+    # Released even when the sweep failed or was interrupted mid-loop: a lock
+    # outliving its process would make the next attempt refuse to start, which
+    # turns a crash into a permanent block. `live()` also checks the pid, so a
+    # lock left by a hard kill is recognised as stale rather than believed.
+    run_lock.release(lock_path)
+
     click.echo(f"\n{len(ok)} succeeded, {len(failed)} failed")
     click.echo(f"tokens: {spent_in:,} in, {spent_out:,} out")
     for p, lbl, err in failed:
         click.echo(f"   {p} {lbl}: {err[:90]}")
     if failed:
         sys.exit(1)
+
+
+@api.command("status")
+def api_status_cmd():
+    """Which sweeps are running, and under what pid (#513).
+
+    Exists because a batch cannot be found by name: a console-script entry
+    point runs as `python -c import sys; …`, so `pgrep -f "d4d api"` returns
+    nothing while the sweep is still spending. The lock is the answer that
+    string matching cannot give.
+    """
+    from data_sheets_schema import run_lock
+
+    running = run_lock.live()
+    stale = run_lock.stale()
+    if not running and not stale:
+        click.echo("No sweep is running.")
+        return
+    for lock in running:
+        click.echo(f"▶  pid {lock.pid}  {lock.label_prefix}  "
+                   f"since {lock.started}  ({', '.join(lock.projects)})")
+    for lock in stale:
+        click.echo(f"·  stale lock for {lock.label_prefix} (pid {lock.pid} is "
+                   f"gone) — a sweep died without releasing it: {lock.path}")
+    if running:
+        click.echo("\nStop one with `d4d api stop --label-prefix <prefix>`.")
+
+
+@api.command("stop")
+@click.option("--label-prefix", required=True)
+@click.option("--force", is_flag=True, help="SIGKILL instead of SIGTERM")
+def api_stop_cmd(label_prefix, force):
+    """Stop a running sweep by the label it holds (#513).
+
+    Stopping mid-run is safe: each run resumes from its progress file, so the
+    cost of stopping is the unfinished phases of the current run and nothing
+    more. What is *not* safe is believing a sweep has stopped when it has not,
+    which is what this command exists to prevent.
+    """
+    import signal as _signal
+
+    from data_sheets_schema import run_lock
+
+    matches = [l for l in run_lock.live() if l.label_prefix == label_prefix]
+    if not matches:
+        click.echo(f"No running sweep holds {label_prefix!r}.")
+        stale = [l for l in run_lock.stale() if l.label_prefix == label_prefix]
+        if stale:
+            click.echo("A stale lock exists; its process is already gone.")
+        return
+    for lock in matches:
+        sig = _signal.SIGKILL if force else _signal.SIGTERM
+        sent = run_lock.stop(lock, sig)
+        click.echo(f"{'signalled' if sent else 'could not signal'} pid "
+                   f"{lock.pid} ({'KILL' if force else 'TERM'})")
+    click.echo("Re-run `d4d api status` to confirm it is gone — a signal sent "
+               "is not a process stopped.")
 
 
 @api.group("prompts")

--- a/src/data_sheets_schema/run_lock.py
+++ b/src/data_sheets_schema/run_lock.py
@@ -1,0 +1,164 @@
+"""A sweep must be findable and stoppable without guessing a `pkill` pattern (#513).
+
+On 2026-08-11 a `d4d api batch` was asked to stop. `pkill -f "d4d api"` matched
+nothing and `pgrep -f "d4d api"` returned 0, so it was reported stopped. It ran
+for about two more hours, because a console-script entry point does not carry
+its own name in `argv`:
+
+    /Users/…/.venv/bin/python -c import sys; from importlib import import_module; …
+
+Nothing in that string contains `d4d`, `api` or `batch`. Worse, a second batch
+was then launched for the same labels while the first was still alive, so two
+processes wrote the same directories — which is the most likely reason one
+record ended up invalid and why files appeared to change under `git`.
+
+So a running sweep writes a lock naming itself. The lock is the answer to three
+questions a `pkill` pattern cannot answer: is one running, what is it doing, and
+what is its pid.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOCK_DIR = Path("data/.run_locks")
+
+
+@dataclass
+class Lock:
+    path: Path
+    pid: int
+    label_prefix: str
+    projects: list[str]
+    started: str
+
+    @property
+    def alive(self) -> bool:
+        """Is the process still running?
+
+        Signal 0 checks for existence without delivering anything. A stale lock
+        left by a killed process must not make the next sweep refuse to start —
+        that would turn a crash into a permanent block.
+
+        A **zombie** is not alive. `os.kill(pid, 0)` succeeds for a process that
+        has exited but not yet been reaped by its parent, so a sweep stopped by
+        a launcher still holding the handle would read as running and its label
+        would stay blocked. Found by a test that stopped a real child and then
+        asked whether it had stopped.
+        """
+        try:
+            os.kill(self.pid, 0)
+        except (ProcessLookupError, ValueError):
+            return False
+        except PermissionError:
+            return True                      # exists, owned by someone else
+        return not self._is_zombie()
+
+    def _is_zombie(self) -> bool:
+        try:
+            out = subprocess.run(["ps", "-p", str(self.pid), "-o", "state="],
+                                 capture_output=True, text=True, check=False)
+        except OSError:
+            return False
+        return out.stdout.strip().startswith("Z")
+
+
+def _path_for(label_prefix: str, lock_dir: Path = LOCK_DIR) -> Path:
+    safe = label_prefix.replace("/", "_")
+    return Path(lock_dir) / f"{safe}.json"
+
+
+def read(path: Path) -> Lock | None:
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if "pid" not in data:
+        return None
+    return Lock(path=Path(path), pid=int(data["pid"]),
+                label_prefix=data.get("label_prefix", "?"),
+                projects=data.get("projects", []),
+                started=data.get("started", "?"))
+
+
+def live(lock_dir: Path = LOCK_DIR) -> list[Lock]:
+    """Every lock whose process is still running.
+
+    Stale locks are reported by `stale()` rather than silently deleted here: a
+    lock left behind is evidence that a sweep died without cleaning up, and
+    quietly removing it hides that.
+    """
+    return [l for l in _all(lock_dir) if l.alive]
+
+
+def stale(lock_dir: Path = LOCK_DIR) -> list[Lock]:
+    return [l for l in _all(lock_dir) if not l.alive]
+
+
+def _all(lock_dir: Path = LOCK_DIR) -> list[Lock]:
+    d = Path(lock_dir)
+    if not d.exists():
+        return []
+    out = []
+    for p in sorted(d.glob("*.json")):
+        lock = read(p)
+        if lock:
+            out.append(lock)
+    return out
+
+
+class AlreadyRunning(RuntimeError):
+    """A live sweep already holds this label prefix."""
+
+
+def acquire(label_prefix: str, projects: list[str],
+            lock_dir: Path = LOCK_DIR) -> Path:
+    """Claim a label prefix for this process.
+
+    Refuses when a live sweep already holds it. Two processes writing the same
+    label directories is not a race to be tolerated: each writes phase
+    snapshots and a progress file under the same names, so the survivor's
+    record can be a mixture of both runs and its provenance would describe
+    neither.
+    """
+    path = _path_for(label_prefix, lock_dir)
+    existing = read(path)
+    if existing and existing.alive:
+        raise AlreadyRunning(
+            f"pid {existing.pid} has been running {label_prefix} since "
+            f"{existing.started}. Stop it with `d4d api stop "
+            f"--label-prefix {label_prefix}`, or use a different label.")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "pid": os.getpid(),
+        "label_prefix": label_prefix,
+        "projects": projects,
+        "started": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def release(path: Path) -> None:
+    """Drop the lock. Missing is fine — release must never be the thing that
+    fails at the end of an otherwise successful sweep."""
+    try:
+        Path(path).unlink()
+    except OSError:
+        pass
+
+
+def stop(lock: Lock, sig: int = signal.SIGTERM) -> bool:
+    """Signal the process a lock names. Returns whether the signal was sent."""
+    try:
+        os.kill(lock.pid, sig)
+    except (ProcessLookupError, ValueError):
+        return False
+    except PermissionError:
+        return False
+    return True

--- a/tests/test_run_lock.py
+++ b/tests/test_run_lock.py
@@ -1,0 +1,153 @@
+"""A sweep must be findable and stoppable without guessing a pattern (#513).
+
+On 2026-08-11 a `d4d api batch` was asked to stop. `pkill -f "d4d api"` matched
+nothing and `pgrep -f "d4d api"` returned 0, so it was reported stopped. It ran
+for about two more hours, because a console-script entry point runs as
+`python -c import sys; from importlib import import_module; …` and carries none
+of its own name.
+
+A second batch was then launched for the same labels while the first was alive,
+so two processes wrote the same directories for two hours.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from data_sheets_schema import run_lock
+
+
+class TestAcquireAndRelease(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+
+    def test_a_lock_names_the_process_and_what_it_is_doing(self):
+        run_lock.acquire("2026-08-11_x", ["AI_READI", "CHORUS"], self.dir)
+        [lock] = run_lock.live(self.dir)
+        self.assertEqual(lock.pid, os.getpid())
+        self.assertEqual(lock.label_prefix, "2026-08-11_x")
+        self.assertEqual(lock.projects, ["AI_READI", "CHORUS"])
+
+    def test_a_second_acquire_is_refused(self):
+        """Two batches on one label is not a race to tolerate: both write
+        phase snapshots and a progress file under the same names."""
+        run_lock.acquire("dup", ["A"], self.dir)
+        with self.assertRaises(run_lock.AlreadyRunning):
+            run_lock.acquire("dup", ["A"], self.dir)
+
+    def test_the_refusal_says_how_to_stop_it(self):
+        run_lock.acquire("dup", ["A"], self.dir)
+        with self.assertRaises(run_lock.AlreadyRunning) as ctx:
+            run_lock.acquire("dup", ["A"], self.dir)
+        self.assertIn("d4d api stop", str(ctx.exception))
+
+    def test_a_different_label_is_not_blocked(self):
+        run_lock.acquire("one", ["A"], self.dir)
+        run_lock.acquire("two", ["A"], self.dir)
+        self.assertEqual(len(run_lock.live(self.dir)), 2)
+
+    def test_release_frees_the_label(self):
+        path = run_lock.acquire("x", ["A"], self.dir)
+        run_lock.release(path)
+        run_lock.acquire("x", ["A"], self.dir)     # must not raise
+
+    def test_release_of_a_missing_lock_is_not_an_error(self):
+        """Release must never be the thing that fails at the end of an
+        otherwise successful sweep."""
+        run_lock.release(self.dir / "absent.json")
+
+    def test_no_locks_is_not_an_error(self):
+        self.assertEqual(run_lock.live(self.dir), [])
+        self.assertEqual(run_lock.stale(self.dir), [])
+
+
+class TestStaleLocks(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+
+    def _write(self, pid, label="x"):
+        (self.dir / f"{label}.json").write_text(json.dumps({
+            "pid": pid, "label_prefix": label, "projects": [],
+            "started": "t"}), encoding="utf-8")
+
+    def test_a_dead_pid_is_stale_not_live(self):
+        """A lock left by a hard kill must not block the next sweep for ever —
+        that would turn a crash into a permanent block."""
+        self._write(2 ** 22)                       # implausible pid
+        self.assertEqual(run_lock.live(self.dir), [])
+        self.assertEqual(len(run_lock.stale(self.dir)), 1)
+
+    def test_a_stale_lock_does_not_refuse_a_new_acquire(self):
+        self._write(2 ** 22, "x")
+        run_lock.acquire("x", ["A"], self.dir)     # must not raise
+
+    def test_stale_locks_are_reported_not_silently_deleted(self):
+        """A leftover lock is evidence a sweep died without cleaning up."""
+        self._write(2 ** 22)
+        run_lock.stale(self.dir)
+        self.assertTrue((self.dir / "x.json").exists())
+
+    def test_an_unreadable_lock_is_ignored_rather_than_fatal(self):
+        (self.dir / "bad.json").write_bytes(b"\xff\xfe not json")
+        self.assertEqual(run_lock.live(self.dir), [])
+
+
+class TestAgainstARealProcess(unittest.TestCase):
+    """The property that actually failed: found by lock, not by name."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"])
+        self.addCleanup(self._reap)
+        (self.dir / "real.json").write_text(json.dumps({
+            "pid": self.child.pid, "label_prefix": "real",
+            "projects": ["A"], "started": "t"}), encoding="utf-8")
+
+    def _reap(self):
+        try:
+            self.child.kill()
+            self.child.wait(timeout=5)
+        except Exception:                                    # noqa: BLE001
+            pass
+
+    def test_pgrep_by_name_does_not_find_it(self):
+        """The premise. If this ever starts finding it, the lock is still
+        correct but this test has stopped demonstrating why it exists."""
+        found = subprocess.run(["pgrep", "-f", "d4d api"],
+                               capture_output=True, text=True).stdout
+        self.assertNotIn(str(self.child.pid), found)
+
+    def test_the_lock_finds_it(self):
+        self.assertEqual([l.pid for l in run_lock.live(self.dir)],
+                         [self.child.pid])
+
+    def test_stop_actually_stops_it(self):
+        [lock] = run_lock.live(self.dir)
+        self.assertTrue(run_lock.stop(lock))
+        for _ in range(50):
+            if not lock.alive:
+                break
+            time.sleep(0.1)
+        self.assertFalse(lock.alive, "process survived SIGTERM")
+
+    def test_it_becomes_stale_once_stopped(self):
+        [lock] = run_lock.live(self.dir)
+        run_lock.stop(lock)
+        for _ in range(50):
+            if not lock.alive:
+                break
+            time.sleep(0.1)
+        self.assertEqual(run_lock.live(self.dir), [])
+        self.assertEqual(len(run_lock.stale(self.dir)), 1)


### PR DESCRIPTION
Closes #513. This is the defect that let a stopped sweep keep running for two hours.

`pkill -f "d4d api"` matched nothing and `pgrep -f "d4d api"` returned 0, so the batch was reported stopped. It was not — a console-script entry point carries none of its own name:

```
/Users/…/.venv/bin/python -c import sys; from importlib import import_module; …
```

Three signals were misread as a result: records appearing under the label directories, `runs check --strict` failing then passing, and a `git checkout` refusing on files nobody had edited. **Each was the batch writing.** `pgrep` returning 0 was treated as proof when it was only weak evidence.

Worse, a second batch was launched for the same labels while the first was alive, so **two processes wrote the same directories for two hours** — the most likely reason one record finished invalid.

## What this adds

```bash
d4d api status                          # which sweeps are running, and their pids
d4d api stop --label-prefix <prefix>    # stop one; --force for SIGKILL
```

A sweep writes a lock naming its pid, label prefix and projects, and **refuses to start while a live lock holds the same prefix**. Neither command depends on how Python spelled the command line.

## Verified against a real process, not a mock

```
child pid: 42675
pgrep -f 'd4d api' finds it: NOTHING
run_lock.live() finds it:    [42675]
```

`stop` then terminates it and `status` reports the lock as stale. A test asserts the `pgrep` blindness **explicitly**, so if that ever changes the test reports that the demonstration has lapsed rather than silently passing.

## Failure modes handled

- The lock releases even when the sweep fails or is interrupted mid-loop.
- A lock whose pid is gone reads as **stale**, not blocking — a crash must not become a permanent block.
- Stale locks are **reported, never silently deleted**: one left behind is evidence a sweep died without cleaning up.
- **A zombie is not alive.** `os.kill(pid, 0)` succeeds for a process that has exited but not been reaped, so a sweep stopped by a launcher still holding the handle would read as running and keep its label blocked. Found by the test that stopped a real child and then asked whether it had stopped.

Fifteen tests. Full suite: **1741 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)