### PR TITLE
Core exchange completeness and pair-model correctness (#510, #499, #518, #521)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,20 @@ gen-examples:
 .PHONY: full-schema
 full-schema: $(SOURCE_SCHEMA_ALL)
 
-$(SOURCE_SCHEMA_ALL):
+# Prerequisites are the source schema and every module it imports. Without
+# them this rule had none at all, so it fired only when the merged file was
+# missing and `make full-schema` was a silent no-op on an existing one — which
+# is why `regen-all` has to `rm -f` the target first. Combined with #518 that
+# made a closed loop: `check-sync` reported the merged schema stale and told
+# you to run `make full-schema`, which did nothing, so it stayed stale (#521).
+#
+# The module list is derived, not written out, so a module added to the source
+# schema's `imports:` is a prerequisite the day it is added.
+SCHEMA_IMPORTS = $(addprefix $(SOURCE_SCHEMA_DIR),$(addsuffix .yaml,$(shell \
+	sed -n '/^imports:/,/^[a-z\#]/p' $(SOURCE_SCHEMA_PATH) | \
+	sed -n 's/^[[:space:]]*-[[:space:]]*\(D4D_[A-Za-z_]*\)[[:space:]]*$$/\1/p')))
+
+$(SOURCE_SCHEMA_ALL): $(SOURCE_SCHEMA_PATH) $(SCHEMA_IMPORTS)
 	@echo "Generating D4D-Full schema with merged imports..."
 	$(RUN) gen-linkml -o $@ -f 'yaml' $(SOURCE_SCHEMA_PATH)
 	@echo '---' | cat - $@ > $@.tmp && mv $@.tmp $@
@@ -370,7 +383,16 @@ SSSOM_STRUCTURAL = data/semantic_exchange/d4d_rocrate_structural_mapping.sssom.t
 
 gen-core-schema: $(D4D_CORE_SCHEMA_ALL) ## Generate merged core exchange schema (data_sheets_schema_core_all.yaml)
 
-$(D4D_CORE_SCHEMA_ALL): $(D4D_CORE_SCHEMA) src/data_sheets_schema/schema/D4D_Core.yaml
+# Same derivation as SCHEMA_IMPORTS, over D4D_Core's own imports. Listing only
+# D4D_Core.yaml missed every module it imports: editing D4D_Base_import.yaml
+# left the merged core schema stale with make reporting nothing to be done
+# (#521). D4D_Core and the full schema import overlapping but not identical
+# module sets, so this is derived separately rather than shared.
+CORE_SCHEMA_IMPORTS = $(addprefix $(SOURCE_SCHEMA_DIR),$(addsuffix .yaml,$(shell \
+	sed -n '/^imports:/,/^[a-z\#]/p' $(SOURCE_SCHEMA_DIR)D4D_Core.yaml | \
+	sed -n 's/^[[:space:]]*-[[:space:]]*\(D4D_[A-Za-z_]*\)[[:space:]]*$$/\1/p')))
+
+$(D4D_CORE_SCHEMA_ALL): $(D4D_CORE_SCHEMA) $(SOURCE_SCHEMA_DIR)D4D_Core.yaml $(CORE_SCHEMA_IMPORTS)
 	@echo "Generating merged core exchange schema..."
 	$(RUN) gen-linkml -o $(D4D_CORE_SCHEMA_ALL) -f yaml $(D4D_CORE_SCHEMA)
 	@echo "✓ Core schema: $(D4D_CORE_SCHEMA_ALL)"

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -305,7 +305,7 @@ validation:
       md5: 19f4a17c60311d6bbc32fd06d266a76c
   schema:
     full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/AI_READI_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -304,8 +304,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_d4d_core.yaml
       md5: 19f4a17c60311d6bbc32fd06d266a76c
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/AI_READI_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -267,7 +267,7 @@ validation:
       md5: 57d52aa67e15baf249e791cd1ce32481
   schema:
     full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/CHORUS_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -266,8 +266,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_d4d_core.yaml
       md5: 57d52aa67e15baf249e791cd1ce32481
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/CHORUS_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
@@ -131,5 +131,5 @@ validation:
       md5: 7fa94e1ccb88dcc9d7090ce6ff0b49d5
   schema:
     full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_d4d_core.yaml
       md5: 7fa94e1ccb88dcc9d7090ce6ff0b49d5
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
@@ -131,5 +131,5 @@ validation:
       md5: cc5bea839075f00de433612a313f358a
   schema:
     full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_d4d_core.yaml
       md5: cc5bea839075f00de433612a313f358a
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
@@ -131,5 +131,5 @@ validation:
       md5: 1afef4d05562622097d4e577b3bb4648
   schema:
     full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_d4d_core.yaml
       md5: 1afef4d05562622097d4e577b3bb4648
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -131,5 +131,5 @@ validation:
       md5: 94585ede7df663fb3b0a2f601f639fac
   schema:
     full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 94585ede7df663fb3b0a2f601f639fac
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_d4d_core.yaml
       md5: d5dfd18340393dfd485b22c888d33010
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
@@ -131,5 +131,5 @@ validation:
       md5: d5dfd18340393dfd485b22c888d33010
   schema:
     full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    core_sha256: de0438d7df6b4b4e64abfde16e729531bc9c4fc72328872d84bc8b7dcad4db25
   recorded_by: d4d runs validate

--- a/src/data_sheets_schema/d4d_pair_consistency.py
+++ b/src/data_sheets_schema/d4d_pair_consistency.py
@@ -31,6 +31,19 @@ CORE_CLASS = "CoreDataset"
 PHASE4_HEADER = "# Phase 4 reconciliation: completed"
 
 
+#: Annotation marking a slot as describing *the record* rather than the dataset
+#: (#499). Such a slot's correct value necessarily differs between a full and a
+#: core record — `conforms_to_class` is `Dataset` in one and `CoreDataset` in
+#: the other — so strict identity makes it unrepresentable: any honest value
+#: fails the pair check, and `--sync-core` would copy full's value into core and
+#: write a false claim about what the core record instantiates.
+#:
+#: Read from the schema rather than hardcoded here, so the category is visible
+#: where the slots are defined and a new one is covered by declaring it. A
+#: hardcoded name list is the hand-maintained-list problem #431 removed.
+PER_RECORD_ANNOTATION = "d4d:perRecord"
+
+
 @dataclass(frozen=True)
 class PairSchema:
     """Schema-derived rules for comparing a full/core pair."""
@@ -39,6 +52,7 @@ class PairSchema:
     core_view: SchemaView
     identity_slots: Tuple[str, ...]
     projected_slots: Tuple[str, ...]
+    per_record_slots: Tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -91,6 +105,36 @@ def _slot_value_signature(slot: SlotDefinition) -> Tuple[Any, ...]:
     )
 
 
+def _is_per_record(slot: SlotDefinition) -> bool:
+    """Is this slot annotated as describing the record rather than the dataset?
+
+    Subscript access, not `.get`: LinkML surfaces `annotations` as a
+    `jsonasobj2.JsonObj`, which has no `.get`. The first version of this called
+    it inside `except AttributeError: return False`, so every slot silently
+    read as unmarked and the annotation did nothing — a check that cannot fail
+    is worse than no check, because the schema then claims a guarantee that is
+    not enforced. The except clause here is narrow and re-raises nothing else.
+
+    Tolerant about the value's form, because it may arrive as an `Annotation`
+    object, a plain string or a bool depending on how the schema was loaded.
+    Anything falsy or the literal string `false` is not a marking — present and
+    set to false must not silently mean the same as present and set to true.
+    """
+    annotations = getattr(slot, "annotations", None)
+    if annotations is None:
+        return False
+    try:
+        entry = annotations[PER_RECORD_ANNOTATION]
+    except (KeyError, TypeError):
+        return False
+    if entry is None:
+        return False
+    value = getattr(entry, "value", entry)
+    if isinstance(value, str):
+        return value.strip().lower() not in ("", "false", "no", "0")
+    return bool(value)
+
+
 def load_pair_schema(
     full_schema: Path = DEFAULT_FULL_SCHEMA,
     core_schema: Path = DEFAULT_CORE_SCHEMA,
@@ -108,8 +152,16 @@ def load_pair_schema(
 
     identity_slots = []
     projected_slots = []
+    per_record_slots = []
     for name in sorted(full_slots.keys() & core_slots.keys()):
-        if _slot_value_signature(full_slots[name]) == _slot_value_signature(
+        # Checked before the signature comparison, because a per-record slot
+        # has an *identical* signature — that is precisely why it fell into
+        # strict identity and became unrepresentable. Signature equality is
+        # the right test for whether two slots hold the same shape, and the
+        # wrong test for whether they hold the same fact.
+        if _is_per_record(full_slots[name]) or _is_per_record(core_slots[name]):
+            per_record_slots.append(name)
+        elif _slot_value_signature(full_slots[name]) == _slot_value_signature(
             core_slots[name]
         ):
             identity_slots.append(name)
@@ -121,6 +173,7 @@ def load_pair_schema(
         core_view=core_view,
         identity_slots=tuple(identity_slots),
         projected_slots=tuple(projected_slots),
+        per_record_slots=tuple(per_record_slots),
     )
 
 

--- a/src/data_sheets_schema/d4d_pair_consistency.py
+++ b/src/data_sheets_schema/d4d_pair_consistency.py
@@ -70,6 +70,7 @@ class PairConsistencyReport:
 
     identity_slots: Tuple[str, ...]
     projected_slots: Tuple[str, ...]
+    per_record_slots: Tuple[str, ...] = ()
     errors: List[ConsistencyIssue] = field(default_factory=list)
     warnings: List[ConsistencyIssue] = field(default_factory=list)
 
@@ -83,6 +84,10 @@ class PairConsistencyReport:
             "identity_slot_count": len(self.identity_slots),
             "identity_slots": list(self.identity_slots),
             "projected_slots": list(self.projected_slots),
+            # Named, not merely excluded (#499). An exemption nobody is told
+            # about reads as a slot that was checked and agreed, which is the
+            # opposite of what happened.
+            "per_record_slots": list(self.per_record_slots),
             "errors": [asdict(issue) for issue in self.errors],
             "warnings": [asdict(issue) for issue in self.warnings],
         }
@@ -563,6 +568,7 @@ def validate_pair_data(
     report = PairConsistencyReport(
         identity_slots=pair_schema.identity_slots,
         projected_slots=pair_schema.projected_slots,
+        per_record_slots=pair_schema.per_record_slots,
     )
     _append_identity_errors(
         report,
@@ -751,7 +757,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         status = "PASS" if report.passed else "FAIL"
         print(
             f"{status}: {len(report.identity_slots)} schema-identical slots; "
-            f"projected slots={list(report.projected_slots)}"
+            f"projected slots={list(report.projected_slots)}; "
+            f"per-record slots (exempt, must differ)="
+            f"{list(report.per_record_slots)}"
         )
         for issue in report.errors:
             print(f"ERROR [{issue.code}] {issue.path}: {issue.message}")

--- a/src/data_sheets_schema/schema/D4D_Base_import.yaml
+++ b/src/data_sheets_schema/schema/D4D_Base_import.yaml
@@ -500,6 +500,10 @@ slots:
       - dcterms:conformsTo
     annotations:
       "d4d:docExample": "https://w3id.org/bridge2ai/data-sheets-schema"
+      # Describes the record, so a full/core pair must state it *differently*
+      # and strict identity made it unrepresentable — any honest value failed
+      # the pair check and `--sync-core` copied full's value into core (#499).
+      "d4d:perRecord": true
 
   conforms_to_class:
     description: >-
@@ -511,6 +515,9 @@ slots:
       - dcterms:conformsTo
     annotations:
       "d4d:docExample": "Dataset"
+      # `Dataset` in a full record and `CoreDataset` in a core one — the
+      # clearest case of a slot whose correct values differ by record (#499).
+      "d4d:perRecord": true
 
   license:
     description: The legal license under which the resource is made available (e.g., "MIT", "CC-BY-4.0").

--- a/src/data_sheets_schema/schema/D4D_Core.yaml
+++ b/src/data_sheets_schema/schema/D4D_Core.yaml
@@ -652,6 +652,23 @@ classes:
         broad_mappings:
           - schema:conditionsOfAccess
 
+      data_governance:
+        description: >-
+          Who decides who may use this dataset, and how. The access committee,
+          its membership and contacts, the review process, and who remains
+          accountable for the data over time.
+
+          Distinct from `license_and_use_terms` (the terms) and
+          `regulatory_restrictions` (the regulations): this is the people and
+          the process that apply them. Core carried the other two and not this
+          one, so the exchange layer could say what a licence permits and which
+          regulations apply but not who to ask for access (#510).
+        range: DataGovernance
+        inlined: true
+        slot_uri: d4d:dataGovernance
+        broad_mappings:
+          - schema:conditionsOfAccess
+
       # -----------------------------------------------------------------------
       # Group 3 — simple flags and scalar fields on Dataset
       # -----------------------------------------------------------------------
@@ -697,6 +714,27 @@ classes:
         slot_uri: schema:relatedLink
         broad_mappings:
           - schema:relatedLink
+
+      related_datasets:
+        description: >-
+          Datasets related to this one, each with a typed relationship
+          (supplements, derives from, is version of, and kin). Use
+          DatasetRelationship to state the relationship type rather than
+          implying it from placement.
+
+          This is the slot `source_manifest.yaml` names in `express_as` for a
+          related-but-distinct dataset, so a core record could not express its
+          own declared scope relation: VOICE_PEDIATRIC could be in scope by
+          `id` while a core-only reader had no way to see the distinct adult
+          dataset (#510). Citing a related dataset here is what keeps it out of
+          `resources` and `distribution_formats`, where it would be absorbed
+          into this dataset's own distribution (#441).
+        range: DatasetRelationship
+        multivalued: true
+        inlined_as_list: true
+        slot_uri: schema:isRelatedTo
+        broad_mappings:
+          - schema:isRelatedTo
 
       resources:
         description: >-

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -1808,6 +1808,9 @@ slots:
       d4d:docExample:
         tag: d4d:docExample
         value: https://w3id.org/bridge2ai/data-sheets-schema
+      d4d:perRecord:
+        tag: d4d:perRecord
+        value: true
     description: The metadata schema **this record itself** is written in — normally
       `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
       not about the data it describes; a standard the *data* follows belongs in `conforms_to`.
@@ -1827,6 +1830,9 @@ slots:
       d4d:docExample:
         tag: d4d:docExample
         value: Dataset
+      d4d:perRecord:
+        tag: d4d:perRecord
+        value: true
     description: The class within `conforms_to_schema` that this record instantiates
       — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
       a statement about the record rather than the data.
@@ -2120,6 +2126,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -2142,6 +2151,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in
@@ -4062,6 +4074,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -4084,6 +4099,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in
@@ -5943,6 +5961,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -5965,6 +5986,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in
@@ -8952,6 +8976,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -8974,6 +9001,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in
@@ -46895,6 +46925,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -46917,6 +46950,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in
@@ -47883,6 +47919,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -47905,6 +47944,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -1949,6 +1949,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -2037,6 +2038,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -2124,6 +2126,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -2209,6 +2212,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -2296,6 +2300,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -2516,6 +2521,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -2597,6 +2603,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -2678,6 +2685,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -2763,6 +2771,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -2848,6 +2857,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -2922,6 +2932,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -3065,6 +3076,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3152,6 +3164,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3239,6 +3252,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3324,6 +3338,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3411,6 +3426,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3558,6 +3574,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3646,6 +3663,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3733,6 +3751,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3818,6 +3837,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -3905,6 +3925,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -4362,6 +4383,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -4450,6 +4472,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -4537,6 +4560,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -4622,6 +4646,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -4709,6 +4734,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -4877,6 +4903,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -4958,6 +4985,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -5039,6 +5067,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -5124,6 +5153,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -5209,6 +5239,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -5283,6 +5314,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -5395,6 +5427,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -5476,6 +5509,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -5557,6 +5591,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -5642,6 +5677,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -5727,6 +5763,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -5801,6 +5838,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -5916,6 +5954,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -5997,6 +6036,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -6078,6 +6118,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -6163,6 +6204,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -6248,6 +6290,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -6322,6 +6365,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -6463,6 +6507,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -6544,6 +6589,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -6625,6 +6671,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -6710,6 +6757,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -6795,6 +6843,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -6869,6 +6918,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -6992,6 +7042,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -7073,6 +7124,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -7154,6 +7206,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -7239,6 +7292,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -7324,6 +7378,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -7398,6 +7453,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -7892,6 +7948,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -7973,6 +8030,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -8054,6 +8112,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -8139,6 +8198,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -8224,6 +8284,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -8298,6 +8359,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -8500,6 +8562,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -8581,6 +8644,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -8662,6 +8726,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -8747,6 +8812,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -8832,6 +8898,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -8906,6 +8973,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -9041,6 +9109,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -9122,6 +9191,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -9203,6 +9273,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -9288,6 +9359,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -9373,6 +9445,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -9447,6 +9520,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -9563,6 +9637,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -9644,6 +9719,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -9725,6 +9801,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -9810,6 +9887,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -9895,6 +9973,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -9969,6 +10048,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -10085,6 +10165,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -10166,6 +10247,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -10247,6 +10329,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -10332,6 +10415,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -10417,6 +10501,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -10491,6 +10576,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -10606,6 +10692,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -10687,6 +10774,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -10768,6 +10856,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -10853,6 +10942,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -10938,6 +11028,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -11012,6 +11103,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -11177,6 +11269,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -11258,6 +11351,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -11339,6 +11433,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -11424,6 +11519,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -11509,6 +11605,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -11583,6 +11680,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -11744,6 +11842,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -11825,6 +11924,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -11906,6 +12006,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -11991,6 +12092,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -12076,6 +12178,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -12150,6 +12253,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -12313,6 +12417,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -12394,6 +12499,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -12475,6 +12581,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -12560,6 +12667,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -12645,6 +12753,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -12719,6 +12828,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -12844,6 +12954,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -12925,6 +13036,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -13006,6 +13118,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -13091,6 +13204,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -13176,6 +13290,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -13250,6 +13365,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -13374,6 +13490,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -13455,6 +13572,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -13536,6 +13654,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -13621,6 +13740,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -13706,6 +13826,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -13780,6 +13901,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -13918,6 +14040,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -13999,6 +14122,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -14080,6 +14204,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -14165,6 +14290,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -14250,6 +14376,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -14324,6 +14451,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -14468,6 +14596,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -14549,6 +14678,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -14630,6 +14760,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -14715,6 +14846,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -14800,6 +14932,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -14874,6 +15007,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -14999,6 +15133,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -15080,6 +15215,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -15161,6 +15297,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -15246,6 +15383,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -15331,6 +15469,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -15405,6 +15544,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -15574,6 +15714,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -15655,6 +15796,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -15740,6 +15882,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -15825,6 +15968,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -15899,6 +16043,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -16057,6 +16202,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -16138,6 +16284,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -16219,6 +16366,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -16304,6 +16452,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -16389,6 +16538,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -16463,6 +16613,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -16581,6 +16732,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -16662,6 +16814,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -16743,6 +16896,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -16828,6 +16982,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -16913,6 +17068,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -16987,6 +17143,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -17117,6 +17274,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -17198,6 +17356,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -17279,6 +17438,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -17364,6 +17524,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -17449,6 +17610,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -17523,6 +17685,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -17668,6 +17831,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -17749,6 +17913,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -17830,6 +17995,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -17915,6 +18081,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -18000,6 +18167,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -18074,6 +18242,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -18199,6 +18368,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -18280,6 +18450,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -18361,6 +18532,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -18446,6 +18618,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -18531,6 +18704,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -18605,6 +18779,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -18755,6 +18930,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -18836,6 +19012,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -18917,6 +19094,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -19002,6 +19180,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -19087,6 +19266,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -19161,6 +19341,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -19331,6 +19512,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -19412,6 +19594,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -19493,6 +19676,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -19578,6 +19762,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -19663,6 +19848,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -19737,6 +19923,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -19854,6 +20041,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -19935,6 +20123,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -20016,6 +20205,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -20101,6 +20291,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -20186,6 +20377,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -20260,6 +20452,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -20377,6 +20570,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -20458,6 +20652,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -20539,6 +20734,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -20624,6 +20820,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -20709,6 +20906,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -20783,6 +20981,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -20975,6 +21174,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -21056,6 +21256,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -21137,6 +21338,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -21222,6 +21424,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -21307,6 +21510,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -21381,6 +21585,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -21505,6 +21710,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -21586,6 +21792,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -21667,6 +21874,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -21752,6 +21960,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -21837,6 +22046,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -21911,6 +22121,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -22075,6 +22286,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -22156,6 +22368,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -22237,6 +22450,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -22322,6 +22536,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -22407,6 +22622,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -22481,6 +22697,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -22648,6 +22865,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -22729,6 +22947,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -22810,6 +23029,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -22895,6 +23115,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -22980,6 +23201,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -23054,6 +23276,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -23209,6 +23432,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -23290,6 +23514,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -23371,6 +23596,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -23456,6 +23682,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -23541,6 +23768,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -23615,6 +23843,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -23728,6 +23957,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -23809,6 +24039,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -23890,6 +24121,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -23975,6 +24207,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -24060,6 +24293,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -24134,6 +24368,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -24256,6 +24491,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -24337,6 +24573,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -24418,6 +24655,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -24503,6 +24741,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -24588,6 +24827,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -24662,6 +24902,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -24775,6 +25016,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -24856,6 +25098,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -24937,6 +25180,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -25022,6 +25266,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -25107,6 +25352,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -25181,6 +25427,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -25302,6 +25549,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -25383,6 +25631,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -25464,6 +25713,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -25549,6 +25799,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -25634,6 +25885,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -25708,6 +25960,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -25822,6 +26075,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -25903,6 +26157,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -25984,6 +26239,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -26069,6 +26325,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -26154,6 +26411,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -26228,6 +26486,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -26373,6 +26632,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -26454,6 +26714,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -26535,6 +26796,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -26620,6 +26882,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -26705,6 +26968,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -26779,6 +27043,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -26892,6 +27157,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -26973,6 +27239,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -27054,6 +27321,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -27139,6 +27407,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -27224,6 +27493,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -27298,6 +27568,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -27409,6 +27680,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -27490,6 +27762,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -27571,6 +27844,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -27656,6 +27930,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -27741,6 +28016,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -27815,6 +28091,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -27975,6 +28252,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -28056,6 +28334,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -28137,6 +28416,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -28222,6 +28502,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -28307,6 +28588,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -28381,6 +28663,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -28496,6 +28779,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -28577,6 +28861,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -28658,6 +28943,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -28743,6 +29029,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -28828,6 +29115,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -28902,6 +29190,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -29029,6 +29318,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -29110,6 +29400,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -29191,6 +29482,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -29276,6 +29568,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -29361,6 +29654,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -29435,6 +29729,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -29564,6 +29859,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -29645,6 +29941,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -29726,6 +30023,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -29811,6 +30109,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -29896,6 +30195,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -29970,6 +30270,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -30103,6 +30404,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -30184,6 +30486,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -30265,6 +30568,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -30350,6 +30654,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -30435,6 +30740,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -30509,6 +30815,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -30640,6 +30947,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -30721,6 +31029,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -30802,6 +31111,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -30887,6 +31197,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -30972,6 +31283,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -31046,6 +31358,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -31189,6 +31502,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -31270,6 +31584,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -31351,6 +31666,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -31436,6 +31752,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -31521,6 +31838,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -31595,6 +31913,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -31726,6 +32045,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -31807,6 +32127,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -31888,6 +32209,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -31973,6 +32295,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -32058,6 +32381,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -32132,6 +32456,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -32279,6 +32604,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -32360,6 +32686,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -32441,6 +32768,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -32526,6 +32854,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -32611,6 +32940,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -32685,6 +33015,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -32803,6 +33134,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -32884,6 +33216,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -32965,6 +33298,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -33050,6 +33384,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -33135,6 +33470,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -33209,6 +33545,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -33327,6 +33664,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -33408,6 +33746,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -33489,6 +33828,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -33574,6 +33914,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -33659,6 +34000,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -33733,6 +34075,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -33850,6 +34193,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -33931,6 +34275,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -34012,6 +34357,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -34097,6 +34443,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -34182,6 +34529,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -34256,6 +34604,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -34374,6 +34723,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -34455,6 +34805,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -34536,6 +34887,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -34621,6 +34973,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -34706,6 +35059,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -34780,6 +35134,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -34951,6 +35306,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -35032,6 +35388,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -35113,6 +35470,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -35198,6 +35556,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -35283,6 +35642,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -35357,6 +35717,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -35526,6 +35887,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -35607,6 +35969,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -35688,6 +36051,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -35773,6 +36137,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -35858,6 +36223,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -35932,6 +36298,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -36090,6 +36457,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -36171,6 +36539,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -36252,6 +36621,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -36337,6 +36707,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -36422,6 +36793,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -36496,6 +36868,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -36650,6 +37023,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -36731,6 +37105,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -36812,6 +37187,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -36897,6 +37273,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -36982,6 +37359,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -37056,6 +37434,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -37211,6 +37590,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -37292,6 +37672,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -37373,6 +37754,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -37458,6 +37840,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -37543,6 +37926,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -37617,6 +38001,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -37769,6 +38154,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -37850,6 +38236,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -37931,6 +38318,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -38016,6 +38404,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -38101,6 +38490,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -38175,6 +38565,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -38294,6 +38685,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -38375,6 +38767,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -38456,6 +38849,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -38541,6 +38935,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -38626,6 +39021,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -38700,6 +39096,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -38778,9 +39175,10 @@ classes:
         range: ConfidentialityLevelEnum
       governance_committee_contact:
         name: governance_committee_contact
-        description: Contact person for data governance committee. This person can
-          answer questions about data governance policies, access procedures, and
-          oversight mechanisms.
+        description: DEPRECATED — use `DataGovernance.committee_contact` (#503). Kept
+          so the records that already populate it stay valid; a governance contact
+          is not an export-control fact and should not have to be nested inside one
+          to be stated.
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
         broad_mappings:
         - schema:contactPoint
@@ -38873,6 +39271,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -38954,6 +39353,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -39035,6 +39435,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -39120,6 +39521,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -39205,6 +39607,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -39279,11 +39682,637 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
         inlined: true
         inlined_as_list: true
+  DataGovernance:
+    name: DataGovernance
+    description: 'Who decides who may use this dataset, and how? Covers the body responsible
+      for access decisions — commonly a Data Access Committee — its membership and
+      contacts, the process it follows, and who remains accountable for the data over
+      time.
+
+      Distinct from `LicenseAndUseTerms`, which states the terms, and from `ExportControlRegulatoryRestrictions`,
+      which states the regulations. This class is about the people and the process
+      that apply them.
+
+      '
+    from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
+    is_a: DatasetProperty
+    attributes:
+      committee_name:
+        name: committee_name
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: Bridge2AI-Voice Data Access Committee (DACO)
+        description: Name of the body responsible for access decisions, as the source
+          states it (e.g. "AI-READI Data Access Committee", "DACO").
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
+        slot_uri: d4d:governanceCommitteeName
+        alias: committee_name
+        owner: DataGovernance
+        domain_of:
+        - DataGovernance
+        range: string
+      committee_members:
+        name: committee_members
+        description: Members of the governance or data access committee. One entry
+          per person; do not collapse several members into one. Record only members
+          the sources name — committee membership is frequently undisclosed, and an
+          absent list is a correct answer.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
+        slot_uri: d4d:governanceCommitteeMember
+        alias: committee_members
+        owner: DataGovernance
+        domain_of:
+        - DataGovernance
+        range: Person
+        multivalued: true
+        inlined_as_list: true
+      committee_contact:
+        name: committee_contact
+        description: Contact point for the governance committee — the person or address
+          that answers questions about access policy, procedure and oversight. Replaces
+          `ExportControlRegulatoryRestrictions.governance_committee_contact`.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
+        broad_mappings:
+        - schema:contactPoint
+        slot_uri: d4d:governanceContactPoint
+        alias: committee_contact
+        owner: DataGovernance
+        domain_of:
+        - DataGovernance
+        range: Person
+      access_review_process:
+        name: access_review_process
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: Requests are submitted through the portal with a research plan
+              and institutional signature, and reviewed at the committee's monthly
+              meeting.
+        description: 'How an access request is reviewed and decided: who submits,
+          what is required of them, who reviews, and on what criteria.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
+        slot_uri: d4d:accessReviewProcess
+        alias: access_review_process
+        owner: DataGovernance
+        domain_of:
+        - DataGovernance
+        range: string
+      access_decision_timeframe:
+        name: access_decision_timeframe
+        description: Stated turnaround for an access decision, as the source gives
+          it. Free text rather than a duration, because sources state this as prose
+          ("within 30 days", "at the next quarterly meeting").
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
+        slot_uri: d4d:accessDecisionTimeframe
+        alias: access_decision_timeframe
+        owner: DataGovernance
+        domain_of:
+        - DataGovernance
+        range: string
+      appeal_process:
+        name: appeal_process
+        description: What recourse an applicant has if access is refused or revoked.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
+        slot_uri: d4d:appealProcess
+        alias: appeal_process
+        owner: DataGovernance
+        domain_of:
+        - DataGovernance
+        range: string
+      stewardship_roles:
+        name: stewardship_roles
+        description: Named stewardship or custodianship roles for the data, distinct
+          from its creators — who holds continuing responsibility for it, and for
+          what.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
+        slot_uri: d4d:stewardshipRole
+        alias: stewardship_roles
+        owner: DataGovernance
+        domain_of:
+        - DataGovernance
+        range: string
+        multivalued: true
+      accountable_organization:
+        name: accountable_organization
+        description: The organization accountable for the dataset over time, including
+          after the funding period ends. Frequently different from the organization
+          that created it.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/data-governance
+        slot_uri: d4d:accountableOrganization
+        alias: accountable_organization
+        owner: DataGovernance
+        domain_of:
+        - DataGovernance
+        range: Organization
+        inlined: true
+      id:
+        name: id
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: https://example.org/dataset/property-001
+        description: An optional identifier for this property.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:identifier
+        alias: id
+        owner: DataGovernance
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - DataGovernance
+        - VariableMetadata
+        range: uriorcurie
+      name:
+        name: name
+        description: A human-readable name for this property.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:name
+        alias: name
+        owner: DataGovernance
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - DataGovernance
+        - VariableMetadata
+        range: string
+      description:
+        name: description
+        description: A human-readable description for this property.
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:description
+        alias: description
+        owner: DataGovernance
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - DatasetRelationship
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - DataGovernance
+        - VariableMetadata
+        range: string
+      notes:
+        name: notes
+        description: 'Residual content only, after every fitting slot is used (#385):
+          structured slots first, description as the default home for narrative, notes
+          last — solely for content description cannot hold. Never a restatement of
+          a sibling slot''s value, and never a substitute for inventing keys the schema
+          does not declare (#380).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: schema:comment
+        alias: notes
+        owner: DataGovernance
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - DataGovernance
+        - VariableMetadata
+        range: string
+      source_caveats:
+        name: source_caveats
+        description: 'Commentary on the evidence behind this object''s values — source
+          conflicts, what a value was transcribed from, questions the source material
+          leaves unanswered (#385). A trust annotation about the sibling slots, not
+          dataset content: content belongs in the structured slots, description or
+          notes.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: dcterms:provenance
+        alias: source_caveats
+        owner: DataGovernance
+        domain_of:
+        - NamedThing
+        - Organization
+        - DatasetProperty
+        - Grant
+        - Software
+        - Person
+        - Information
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Grantor
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - DataGovernance
+        - VariableMetadata
+        range: string
+      used_software:
+        name: used_software
+        description: What software was used as part of this dataset property?
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/base
+        slot_uri: d4d:usedSoftware
+        alias: used_software
+        owner: DataGovernance
+        domain_of:
+        - DatasetProperty
+        - Purpose
+        - Task
+        - AddressingGap
+        - Creator
+        - FundingMechanism
+        - Instance
+        - SamplingStrategy
+        - MissingInfo
+        - Relationships
+        - Splits
+        - DataAnomaly
+        - DatasetBias
+        - DatasetLimitation
+        - ExternalResource
+        - Confidentiality
+        - ContentWarning
+        - Subpopulation
+        - Deidentification
+        - SensitiveElement
+        - DatasetRelationship
+        - InstanceAcquisition
+        - CollectionMechanism
+        - DataCollector
+        - CollectionTimeframe
+        - DirectCollection
+        - MissingDataDocumentation
+        - RawDataSource
+        - PreprocessingStrategy
+        - CleaningStrategy
+        - LabelingStrategy
+        - RawData
+        - ImputationProtocol
+        - AnnotationAnalysis
+        - MachineAnnotationTools
+        - ExistingUse
+        - UseRepository
+        - OtherTask
+        - FutureUseImpact
+        - DiscouragedUse
+        - IntendedUse
+        - ProhibitedUse
+        - ThirdPartySharing
+        - DistributionFormat
+        - DistributionDate
+        - Maintainer
+        - Erratum
+        - UpdatePlan
+        - RetentionLimits
+        - VersionAccess
+        - ExtensionMechanism
+        - EthicalReview
+        - DataProtectionImpact
+        - CollectionNotification
+        - CollectionConsent
+        - ConsentRevocation
+        - HumanSubjectResearch
+        - InformedConsent
+        - ParticipantPrivacy
+        - HumanSubjectCompensation
+        - AtRiskPopulations
+        - LicenseAndUseTerms
+        - IPRestrictions
+        - ExportControlRegulatoryRestrictions
+        - DataGovernance
+        - VariableMetadata
+        range: Software
+        multivalued: true
+        inlined: true
+        inlined_as_list: true
+    class_uri: d4d:DataGovernance
   VariableMetadata:
     name: VariableMetadata
     description: Metadata describing an individual variable, field, or column in a
@@ -39583,6 +40612,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -39664,6 +40694,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -39745,6 +40776,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -39830,6 +40862,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -39915,6 +40948,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -39989,6 +41023,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -40266,6 +41301,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: uriorcurie
       name:
@@ -40347,6 +41383,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       description:
@@ -40428,6 +41465,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       notes:
@@ -40513,6 +41551,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       source_caveats:
@@ -40598,6 +41637,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: string
       used_software:
@@ -40672,6 +41712,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         range: Software
         multivalued: true
@@ -41126,6 +42167,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -41214,6 +42256,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -41301,6 +42344,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -41386,6 +42430,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -41473,6 +42518,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -42196,6 +43242,27 @@ classes:
         - CoreDataset
         range: ExportControlRegulatoryRestrictions
         inlined: true
+      data_governance:
+        name: data_governance
+        description: 'Who decides who may use this dataset, and how. The access committee,
+          its membership and contacts, the review process, and who remains accountable
+          for the data over time.
+
+          Distinct from `license_and_use_terms` (the terms) and `regulatory_restrictions`
+          (the regulations): this is the people and the process that apply them. Core
+          carried the other two and not this one, so the exchange layer could say
+          what a licence permits and which regulations apply but not who to ask for
+          access (#510).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core
+        broad_mappings:
+        - schema:conditionsOfAccess
+        slot_uri: d4d:dataGovernance
+        alias: data_governance
+        owner: CoreDataset
+        domain_of:
+        - CoreDataset
+        range: DataGovernance
+        inlined: true
       is_deidentified:
         name: is_deidentified
         description: De-identification status and procedures applied to the dataset.
@@ -42249,6 +43316,29 @@ classes:
         - ExternalResource
         - CoreDataset
         range: ExternalResource
+        multivalued: true
+        inlined_as_list: true
+      related_datasets:
+        name: related_datasets
+        description: 'Datasets related to this one, each with a typed relationship
+          (supplements, derives from, is version of, and kin). Use DatasetRelationship
+          to state the relationship type rather than implying it from placement.
+
+          This is the slot `source_manifest.yaml` names in `express_as` for a related-but-distinct
+          dataset, so a core record could not express its own declared scope relation:
+          VOICE_PEDIATRIC could be in scope by `id` while a core-only reader had no
+          way to see the distinct adult dataset (#510). Citing a related dataset here
+          is what keeps it out of `resources` and `distribution_formats`, where it
+          would be absorbed into this dataset''s own distribution (#441).'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core
+        broad_mappings:
+        - schema:isRelatedTo
+        slot_uri: schema:isRelatedTo
+        alias: related_datasets
+        owner: CoreDataset
+        domain_of:
+        - CoreDataset
+        range: DatasetRelationship
         multivalued: true
         inlined_as_list: true
       resources:
@@ -42689,6 +43779,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -42777,6 +43868,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -42864,6 +43956,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -42949,6 +44042,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection
@@ -43036,6 +44130,7 @@ classes:
         - LicenseAndUseTerms
         - IPRestrictions
         - ExportControlRegulatoryRestrictions
+        - DataGovernance
         - VariableMetadata
         - CoreDistribution
         - CoreDatasetCollection

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -1676,6 +1676,9 @@ slots:
       d4d:docExample:
         tag: d4d:docExample
         value: https://w3id.org/bridge2ai/data-sheets-schema
+      d4d:perRecord:
+        tag: d4d:perRecord
+        value: true
     description: The metadata schema **this record itself** is written in — normally
       `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
       not about the data it describes; a standard the *data* follows belongs in `conforms_to`.
@@ -1692,6 +1695,9 @@ slots:
       d4d:docExample:
         tag: d4d:docExample
         value: Dataset
+      d4d:perRecord:
+        tag: d4d:perRecord
+        value: true
     description: The class within `conforms_to_schema` that this record instantiates
       — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
       a statement about the record rather than the data.
@@ -4001,6 +4007,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -4020,6 +4029,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in
@@ -41785,6 +41797,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -41804,6 +41819,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in
@@ -43397,6 +43415,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: Dataset
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The class within `conforms_to_schema` that this record instantiates
           — `Dataset` for a full datasheet, `CoreDataset` for a core one. Like `conforms_to_schema`,
           a statement about the record rather than the data.
@@ -43416,6 +43437,9 @@ classes:
           d4d:docExample:
             tag: d4d:docExample
             value: https://w3id.org/bridge2ai/data-sheets-schema
+          d4d:perRecord:
+            tag: d4d:perRecord
+            value: true
         description: The metadata schema **this record itself** is written in — normally
           `https://w3id.org/bridge2ai/data-sheets-schema`. A statement about the datasheet,
           not about the data it describes; a standard the *data* follows belongs in

--- a/tests/test_core_exchange_completeness.py
+++ b/tests/test_core_exchange_completeness.py
@@ -1,0 +1,130 @@
+"""What must reach the exchange layer, and why (#510).
+
+`CoreDataset` carried two of the three Data Governance classes and not the
+third, and had no `related_datasets` at all. Neither omission was decided; both
+were the residue of adding slots one at a time, each time keeping the blast
+radius small. The asymmetry accumulated because nobody was asked the general
+question.
+
+**The position these tests encode: the core record is for deciding whether to
+ingest a dataset, not only for describing one already ingested.** The evidence
+is what core already carried before this change — `license_and_use_terms` (may
+I use it), `regulatory_restrictions` (what law applies), `conforms_to` on
+`CoreDistribution` (#403, can I read it). Every one is an ingest-decision fact.
+Access governance is the same kind of fact and arguably the most decisive: a
+consumer who cannot find out who grants access cannot obtain the data at all.
+
+The tests are written against that position rather than against the slot list,
+so if the position is ever reversed the failure says which claim was abandoned.
+"""
+
+import unittest
+from pathlib import Path
+
+from linkml_runtime import SchemaView
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml"
+FULL = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
+
+#: The Data Governance module's three top-level classes as they attach to a
+#: dataset. Named, not counted — a count would pass if one were swapped out.
+GOVERNANCE = {
+    "license_and_use_terms": "what the licence permits",
+    "regulatory_restrictions": "which regulations apply",
+    "data_governance": "who decides access, and how",
+}
+
+
+class TestGovernanceReachesCore(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.core = {s.name for s in
+                    SchemaView(str(CORE)).class_induced_slots("CoreDataset")}
+        cls.full = {s.name for s in
+                    SchemaView(str(FULL)).class_induced_slots("Dataset")}
+
+    def test_all_three_governance_slots_are_in_core(self):
+        for slot, what in GOVERNANCE.items():
+            with self.subTest(slot=slot):
+                self.assertIn(slot, self.core,
+                              f"core cannot say {what}")
+
+    def test_an_ingest_decision_cannot_be_made_without_them(self):
+        """Stated as the whole set rather than three separate facts.
+
+        Two of three is the state this issue was filed about, and it is worse
+        than none: a reader who finds licence terms and regulations present
+        reasonably infers governance was considered and found absent, rather
+        than never expressible.
+        """
+        self.assertEqual(set(GOVERNANCE) & self.core, set(GOVERNANCE))
+
+    def test_related_datasets_can_express_a_scope_relation(self):
+        """`source_manifest.yaml` names `related_datasets` in `express_as` for
+        a related-but-distinct dataset. Without it in core, a core record could
+        not state its own declared scope relation — VOICE_PEDIATRIC is in scope
+        by `id` while a core-only reader cannot see the distinct adult dataset.
+        """
+        self.assertIn("related_datasets", self.core)
+
+    def test_core_stays_a_subset_of_full(self):
+        """The direction that must not reverse. Core is a projection of the
+        full record; a slot in core and not in full would be unprojectable and
+        could only be authored by hand.
+
+        Two exceptions are declared, not discovered: `CoreDistribution` and
+        `FormatDialect` group full-schema slots that live on other classes.
+        """
+        core_only = self.core - self.full - {"distributions", "dialect"}
+        self.assertEqual(core_only, set())
+
+
+class TestTheRelationIsIdentityNotProjection(unittest.TestCase):
+    """A fact that appears in both records must appear identically.
+
+    `resources` is the one projected slot — its range differs between the two
+    schemas, so full and core legitimately state it differently. Governance and
+    relations are not like that: they are the same fact, and a pair disagreeing
+    about who runs the access committee is a defect rather than a projection.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from data_sheets_schema.d4d_pair_consistency import load_pair_schema
+        cls.pair = load_pair_schema(FULL, CORE)
+
+    def test_governance_and_relations_are_identity_slots(self):
+        for slot in (*GOVERNANCE, "related_datasets"):
+            with self.subTest(slot=slot):
+                self.assertIn(slot, self.pair.identity_slots)
+
+    def test_resources_is_still_the_only_projected_slot(self):
+        """If a second projected slot ever appears, it is a decision someone
+        made about what core is for, and it should not arrive silently."""
+        self.assertEqual(("resources",), self.pair.projected_slots)
+
+
+class TestTheRangesResolve(unittest.TestCase):
+    """A slot whose range is not reachable from the core schema would generate
+    but not validate — the failure would surface on the first record that used
+    it, not here."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sv = SchemaView(str(CORE))
+
+    def test_data_governance_resolves_to_a_class_with_a_committee(self):
+        cls = self.sv.get_class("DataGovernance")
+        self.assertIsNotNone(cls, "DataGovernance unreachable from core")
+        attrs = {s.name for s in self.sv.class_induced_slots("DataGovernance")}
+        for expected in ("committee_name", "committee_contact",
+                        "access_review_process", "accountable_organization"):
+            with self.subTest(attr=expected):
+                self.assertIn(expected, attrs)
+
+    def test_related_datasets_resolves_to_a_typed_relationship(self):
+        """Untyped relations are the failure this range prevents: a bare list
+        of ids says two datasets are connected and never how."""
+        cls = self.sv.get_class("DatasetRelationship")
+        self.assertIsNotNone(cls, "DatasetRelationship unreachable from core")

--- a/tests/test_d4d_pair_consistency.py
+++ b/tests/test_d4d_pair_consistency.py
@@ -46,12 +46,18 @@ class TestD4DPairConsistency(unittest.TestCase):
     #: `CoreDataset` (#510). Identity is the right relation for both: they
     #: state the same fact in either record, so a full/core pair disagreeing
     #: about who runs the access committee is a defect and not a projection.
+    #:
+    #: Went 80 -> 78 when `conforms_to_class` and `conforms_to_schema` became
+    #: per-record slots (#499). They describe the record rather than the
+    #: dataset, so their correct values *differ* between a pair — identity
+    #: made them unrepresentable. `conforms_to` stays here: a standard the
+    #: data follows is a fact about the data and is the same in both.
     EXPECTED_IDENTITY_SLOTS = (
     'acquisition_methods', 'addressing_gaps', 'annotation_analyses',
     'anomalies', 'at_risk_populations', 'cleaning_strategies',
     'collection_mechanisms', 'collection_timeframes', 'compression',
-    'confidential_elements', 'conforms_to', 'conforms_to_class',
-    'conforms_to_schema', 'content_warnings', 'created_by',
+    'confidential_elements', 'conforms_to',
+    'content_warnings', 'created_by',
     'created_on', 'creators', 'data_collectors', 'data_governance',
     'data_protection_impacts', 'description', 'discouraged_uses',
     'distribution_dates', 'distribution_formats', 'doi',

--- a/tests/test_d4d_pair_consistency.py
+++ b/tests/test_d4d_pair_consistency.py
@@ -41,13 +41,18 @@ class TestD4DPairConsistency(unittest.TestCase):
     #: Went 76 -> 78 when `notes` and `source_caveats` were added to the base
     #: class in f192c34f (#385). Both are genuinely shared and genuinely
     #: identical, so the count was stale rather than the schema wrong.
+    #:
+    #: Went 78 -> 80 when `data_governance` and `related_datasets` reached
+    #: `CoreDataset` (#510). Identity is the right relation for both: they
+    #: state the same fact in either record, so a full/core pair disagreeing
+    #: about who runs the access committee is a defect and not a projection.
     EXPECTED_IDENTITY_SLOTS = (
     'acquisition_methods', 'addressing_gaps', 'annotation_analyses',
     'anomalies', 'at_risk_populations', 'cleaning_strategies',
     'collection_mechanisms', 'collection_timeframes', 'compression',
     'confidential_elements', 'conforms_to', 'conforms_to_class',
     'conforms_to_schema', 'content_warnings', 'created_by',
-    'created_on', 'creators', 'data_collectors',
+    'created_on', 'creators', 'data_collectors', 'data_governance',
     'data_protection_impacts', 'description', 'discouraged_uses',
     'distribution_dates', 'distribution_formats', 'doi',
     'download_url', 'errata', 'ethical_reviews', 'existing_uses',
@@ -62,7 +67,8 @@ class TestD4DPairConsistency(unittest.TestCase):
     'missing_data_documentation', 'modified_by', 'name', 'notes',
     'other_tasks', 'page', 'preprocessing_strategies',
     'prohibited_uses', 'publisher', 'purposes', 'raw_data_sources',
-    'raw_sources', 'regulatory_restrictions', 'retention_limit',
+    'raw_sources', 'regulatory_restrictions', 'related_datasets',
+    'retention_limit',
     'sampling_strategies', 'sensitive_elements', 'source_caveats',
     'status', 'subpopulations', 'tasks', 'title', 'updates',
     'use_repository', 'version', 'version_access',

--- a/tests/test_per_record_slots.py
+++ b/tests/test_per_record_slots.py
@@ -1,0 +1,145 @@
+"""A slot that describes the record is exempt from strict identity (#499).
+
+`conforms_to_schema` and `conforms_to_class` describe the record they sit in,
+so their correct values necessarily differ between a full/core pair — `Dataset`
+in one and `CoreDataset` in the other. Both were strict-identity slots, which
+made them unrepresentable: any honest population failed the pair check, and
+`--sync-core` copied full's value into core and wrote a false claim about what
+the core record instantiates.
+
+The AI_READI run of the 2026-08-11 sweep hit this in phase 4 and resolved it by
+omitting the slot from both records — the only state that neither fails the gate
+nor asserts something false.
+
+`conforms_to` is *correctly* strict-identity: a standard the dataset's content
+follows is a fact about the dataset and is the same in both records. The tests
+below hold that distinction from both sides, because an exemption that leaked
+to `conforms_to` would silently stop checking a real fact.
+"""
+
+import unittest
+from pathlib import Path
+
+from linkml_runtime.linkml_model.meta import SlotDefinition
+
+from data_sheets_schema.d4d_pair_consistency import (
+    PER_RECORD_ANNOTATION,
+    _is_per_record,
+    load_pair_schema,
+    synchronize_core_data,
+    validate_pair_data,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+FULL = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
+CORE = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml"
+
+PER_RECORD = ("conforms_to_class", "conforms_to_schema")
+
+
+def _pair(**core_over):
+    full = {"id": "https://e.org/d", "name": "x",
+            "conforms_to_class": "Dataset",
+            "conforms_to_schema": "https://w3id.org/bridge2ai/data-sheets-schema",
+            "conforms_to": "BIDS v1.9.0"}
+    core = {**full, "conforms_to_class": "CoreDataset",
+            "conforms_to_schema":
+                "https://w3id.org/bridge2ai/data-sheets-schema/core-schema"}
+    core.update(core_over)
+    return full, core
+
+
+class TestTheAnnotationIsActuallyRead(unittest.TestCase):
+    """The bug that made the first version of this do nothing.
+
+    `slot.annotations` is a `jsonasobj2.JsonObj`, which has no `.get`. The
+    accessor called it inside `except AttributeError: return False`, so every
+    slot read as unmarked, `per_record_slots` was empty, and the schema
+    annotation was decorative. A check that cannot fail is worse than no check.
+    """
+
+    def test_a_marked_slot_reads_as_marked(self):
+        slot = SlotDefinition("s", annotations={PER_RECORD_ANNOTATION: True})
+        self.assertTrue(_is_per_record(slot))
+
+    def test_an_unmarked_slot_does_not(self):
+        self.assertFalse(_is_per_record(SlotDefinition("s")))
+
+    def test_a_slot_with_other_annotations_does_not(self):
+        slot = SlotDefinition("s", annotations={"d4d:docExample": "Dataset"})
+        self.assertFalse(_is_per_record(slot))
+
+    def test_explicit_false_is_not_a_marking(self):
+        """Present-and-false must not mean the same as present-and-true."""
+        for value in (False, "false", "no", ""):
+            with self.subTest(value=value):
+                slot = SlotDefinition(
+                    "s", annotations={PER_RECORD_ANNOTATION: value})
+                self.assertFalse(_is_per_record(slot))
+
+    def test_it_reads_the_real_schema_not_only_fixtures(self):
+        """The property the fixtures cannot establish: that the annotation as
+        actually written in D4D_Base_import.yaml survives the merge and is
+        found on the induced slot."""
+        pair = load_pair_schema(FULL, CORE)
+        self.assertEqual(sorted(pair.per_record_slots), sorted(PER_RECORD))
+
+
+class TestTheExemptionApplies(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.pair = load_pair_schema(FULL, CORE)
+
+    def test_an_honest_pair_now_passes(self):
+        """`Dataset` in full and `CoreDataset` in core — both correct, and
+        before this the only passing state was to omit them from both."""
+        full, core = _pair()
+        report = validate_pair_data(full, core, self.pair)
+        self.assertEqual(report.errors, [])
+
+    def test_per_record_slots_are_not_identity_slots(self):
+        for slot in PER_RECORD:
+            with self.subTest(slot=slot):
+                self.assertNotIn(slot, self.pair.identity_slots)
+
+    def test_sync_core_no_longer_overwrites_the_core_value(self):
+        """The damaging half. `--sync-core` copying `Dataset` into a core
+        record makes it claim to instantiate a class it does not."""
+        full, core = _pair()
+        synced = synchronize_core_data(full, dict(core), self.pair)
+        out = synced[0] if isinstance(synced, tuple) else synced
+        self.assertEqual(out.get("conforms_to_class"), "CoreDataset")
+        self.assertIn("core-schema", out.get("conforms_to_schema", ""))
+
+
+class TestTheExemptionDoesNotLeak(unittest.TestCase):
+    """An over-broad exemption would stop checking a real fact, which is the
+    more dangerous direction: it fails silently and forever."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pair = load_pair_schema(FULL, CORE)
+
+    def test_conforms_to_is_still_strict_identity(self):
+        self.assertIn("conforms_to", self.pair.identity_slots)
+        self.assertNotIn("conforms_to", self.pair.per_record_slots)
+
+    def test_a_disagreement_about_conforms_to_is_still_an_error(self):
+        full, core = _pair(conforms_to="OMOP CDM v5.4")
+        report = validate_pair_data(full, core, self.pair)
+        self.assertTrue(
+            any(i.path.endswith("conforms_to") for i in report.errors),
+            "a dataset standard differing between the pair must still fail")
+
+    def test_only_the_two_declared_slots_are_exempt(self):
+        """If a third ever appears it is a decision someone made about what
+        describes the record, and it should not arrive silently."""
+        self.assertEqual(sorted(self.pair.per_record_slots), sorted(PER_RECORD))
+
+    def test_the_three_categories_do_not_overlap(self):
+        buckets = (set(self.pair.identity_slots),
+                   set(self.pair.projected_slots),
+                   set(self.pair.per_record_slots))
+        for i, a in enumerate(buckets):
+            for b in buckets[i + 1:]:
+                self.assertEqual(a & b, set())

--- a/tests/test_per_record_slots.py
+++ b/tests/test_per_record_slots.py
@@ -143,3 +143,27 @@ class TestTheExemptionDoesNotLeak(unittest.TestCase):
         for i, a in enumerate(buckets):
             for b in buckets[i + 1:]:
                 self.assertEqual(a & b, set())
+
+
+class TestTheExemptionIsVisible(unittest.TestCase):
+    """An exemption nobody is told about reads as a slot that was checked and
+    agreed — the opposite of what happened. Found reviewing this change: the
+    report named identity and projected slots and silently dropped the third
+    category, so a passing pair looked fully verified."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pair = load_pair_schema(FULL, CORE)
+
+    def test_the_report_names_the_exempt_slots(self):
+        full, core = _pair()
+        data = validate_pair_data(full, core, self.pair).to_dict()
+        self.assertEqual(sorted(data["per_record_slots"]), sorted(PER_RECORD))
+
+    def test_a_passing_pair_still_names_them(self):
+        """The case that matters. On failure someone reads the output anyway;
+        on success this is the only thing that says two slots went unchecked."""
+        full, core = _pair()
+        report = validate_pair_data(full, core, self.pair)
+        self.assertTrue(report.passed)
+        self.assertEqual(sorted(report.per_record_slots), sorted(PER_RECORD))

--- a/utils/check-schema-sync.sh
+++ b/utils/check-schema-sync.sh
@@ -54,17 +54,31 @@ SOURCE_TIME=$(stat -f %m "$SOURCE_SCHEMA" 2>/dev/null || stat -c %Y "$SOURCE_SCH
 MERGED_TIME=$(stat -f %m "$MERGED_SCHEMA" 2>/dev/null || stat -c %Y "$MERGED_SCHEMA" 2>/dev/null || echo 0)
 PYTHON_TIME=$(stat -f %m "$PYTHON_MODEL" 2>/dev/null || stat -c %Y "$PYTHON_MODEL" 2>/dev/null || echo 0)
 
-# Check if module files are newer than source schema
+# Check if module files are newer than source schema.
+#
+# The module list comes from the source schema's own `imports:` block, not from
+# a glob over D4D_*.yaml. The glob was over-broad: `D4D_Core.yaml` matches it
+# and is *not* imported by data_sheets_schema.yaml — it belongs to the core
+# exchange schema. So editing a core-only module reported the full merged
+# schema out of date, and regenerating to satisfy that produced ~2200 lines of
+# OWL re-serialization and two changed timestamps, with no semantic change
+# (#518). A churn commit is not a harmless one: it hides the real diff.
+#
+# Deriving the list means it cannot drift from what is actually imported. A new
+# module added to `imports:` is covered the day it is added.
 MODULES_DIR="src/data_sheets_schema/schema"
 NEWEST_MODULE_TIME=0
 if [[ -d "$MODULES_DIR" ]]; then
-    while IFS= read -r -d '' module_file; do
+    while IFS= read -r module_name; do
+        module_file="$MODULES_DIR/${module_name}.yaml"
+        [[ -f "$module_file" ]] || continue
         MODULE_TIME=$(stat -f %m "$module_file" 2>/dev/null || stat -c %Y "$module_file" 2>/dev/null || echo 0)
         if [[ $MODULE_TIME -gt $NEWEST_MODULE_TIME ]]; then
             NEWEST_MODULE_TIME=$MODULE_TIME
             NEWEST_MODULE="$module_file"
         fi
-    done < <(find "$MODULES_DIR" -name "D4D_*.yaml" -print0)
+    done < <(sed -n '/^imports:/,/^[a-z#]/p' "$SOURCE_SCHEMA" \
+             | sed -n 's/^[[:space:]]*-[[:space:]]*\(D4D_[A-Za-z_]*\)[[:space:]]*$/\1/p')
 fi
 
 # Use the newest timestamp between source and modules


### PR DESCRIPTION
Closes #510. Also closes #518, found while landing it.

## The decision

#510 asked a question rather than reporting a bug: **what is `CoreDataset` for?** Access governance matters enormously if core is for deciding whether to ingest a dataset, and not at all if it is for describing one already ingested.

This PR takes the first position, on the evidence of what core already carried:

| slot | the question it answers |
|---|---|
| `license_and_use_terms` | may I use it |
| `regulatory_restrictions` | what law applies |
| `conforms_to` on `CoreDistribution` (#403) | can I read it |

All ingest-decision facts. Access governance is the same kind and arguably the most decisive — a consumer who cannot find out who grants access cannot obtain the data at all.

**Two of three was worse than none.** A reader who finds licence terms and regulations present reasonably infers that governance was considered and found absent, rather than never expressible.

## What changed

`CoreDataset` gains `data_governance` (range `DataGovernance`) and `related_datasets` (range `DatasetRelationship`). Both ranges were already reachable — `D4D_Core` imports `D4D_Data_Governance` and `D4D_Composition` — so this is two slots, not a module.

`related_datasets` was the same gap found independently by the VOICE_PEDIATRIC agent in the 2026-08-11 sweep: it is the slot `source_manifest.yaml` names in `express_as`, so a core record could not state its own declared scope relation. Core was in scope by `id` while a core-only reader had no way to see the distinct adult dataset. Citing a related dataset there is also what keeps it out of `resources` and `distribution_formats`, where it would be absorbed into this dataset's own distribution (#441).

Both are **identity** slots, not projected: they state the same fact in either record. `resources` remains the only projected slot, and a test now pins that so a second one cannot arrive silently.

## Blast radius, measured

7 verdicts pin the core schema and went `STALE` on the hash change — the digest working exactly as #426 designed. All 7 revalidate unchanged, since widening a schema with optional slots is additive:

```
before: {'valid': 139, 'invalid': 19, 'stale': 7}
after:  {'valid': 146, 'invalid': 19}
```

Full suite: **1749 passed, 4 skipped**.

## Timing

Deliberate. The API sweep is stopped, and #517 established that a schema moving *during* an arm is the thing that must not happen — it turned part of a replicate-variance measurement into a schema effect. Between arms is the window for schema changes, and this is between arms.

Consequence to note: when #516 merges, its 10 rep2/rep3 records will go `STALE` against this schema until revalidated, for the same additive reason and with the same fix (`d4d runs validate --recheck`).

## #518, found doing this

`utils/check-schema-sync.sh` globbed `D4D_*.yaml` for the newest module. `D4D_Core.yaml` matches and is **not** imported by `data_sheets_schema.yaml`, so a core-only edit reported the full merged schema out of date. Obeying that instruction regenerated `project/owl/data_sheets_schema.owl.ttl` with 2226 changed lines of pure re-serialization ordering plus two timestamp-only diffs — a commit with no semantic content that would have buried this 5-file change under 2200 lines of noise.

The module list now derives from the source schema's own `imports:` block, so it cannot drift from what is actually imported. Verified both ways: touching `D4D_Ethics.yaml` still fails and names it; touching `D4D_Core.yaml` no longer does.

Not fixed: `check-sync` remains mtime-based throughout, so it flags touched-but-unchanged files and would miss a content change preserving mtime. Content hashing is the stronger check and is out of scope here — this fixes the wrong-input problem, not the weak-comparison one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)