### PR TITLE
Revalidate the v1 arm's rep2 and rep3 after the schema move (#510)

### DIFF
--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_d4d_core.yaml
       md5: bf8d3706efaf398738fbbdbcfc098c70
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_d4d_core.yaml
       md5: 658a6794c50cda7ae4b52beb5192c366
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_d4d_core.yaml
       md5: 67384e7d32a1740264d74ee6ed79c501
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 4634f260ce16cbbeda7017e8bd5e0cea
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_d4d_core.yaml
       md5: 81cdfa0b72a0ed18c08eb8a3ae5901a8
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_d4d_core.yaml
       md5: 54464b3bb28dfa874966782a218526ee
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_d4d_core.yaml
       md5: cbf2482273b6d8bcfa10711b43266cf5
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_d4d_core.yaml
       md5: de505046d64b4139dcd43f4b2dcbf730
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_d4d_core.yaml
       md5: a6cd0da0d9079e6726857bec5c05eca7
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_d4d_core.yaml
       md5: a25640d2448384452c46bd5bec04ca2e
   schema:
-    full_sha256: a392c073f2de00293702c7d31e6e1899f550d9b4bed2f01126630c25989da94b
-    core_sha256: 985460b61d58cf747fd67016bc0656fa204250fdd02ca69a8d638e45a22fcc6b
+    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
+    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
   recorded_by: d4d runs validate


### PR DESCRIPTION
Housekeeping following the merges of #519 and #516, in that order.

#519 widened `CoreDataset` and moved the core schema hash. The 10 records #516 merged pinned the previous hash, so their verdicts went `STALE` — the digest working as designed (#426), not a defect in either change. This was predicted on both PRs before merging.

```
before: {'valid': 146, 'invalid': 19, 'stale': 10}
after:  {'valid': 156, 'invalid': 19}
```

All 10 revalidate unchanged: widening a schema with optional slots is additive, so nothing in any record had to move.

## What is unaffected, and why that matters

**The canonical set.** Selection reads the verdict, and every candidate was valid before and after. All five projects keep the replicate #516 chose. `d4d runs check --strict` exits 0.

**The #517 straddle report.** Still names the same series and the same split:

```
claudecode_agent/2026-08-11_claude-opus-5-claudecode-generic
  488bd732  rep1
  659aae67  rep2, rep3
```

That is the point of reading the generation digest rather than the validation pin. What a run *saw* is not altered by revalidating it later, so the arm is still not a like-for-like replicate set and revalidation cannot launder it into one. A check reading `validation.schema` would now report the arm as homogeneous, which would be false.

## Scope

Provenance verdicts only — 10 files, no record content, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)