### PR TITLE
Accept cross-slot repetition, and measure it (#501)

### DIFF
--- a/notes/decision_501_cross_slot_repetition.md
+++ b/notes/decision_501_cross_slot_repetition.md
@@ -33,6 +33,30 @@ word Jaccard ≥ 0.6:
 Between 4.9% and 9.0% across five projects, so this is uniform behaviour rather
 than one project's quirk, and any rule would have moved every record.
 
+### The headline depends on the threshold, and the threshold is a judgement
+
+Same corpus, same code, varying only what counts as "the same statement":
+
+| threshold | restatements | rate |
+|---|---|---|
+| 0.5 | 191 | 12.0% |
+| **0.6** | **116** | **7.3%** |
+| 0.7 | 79 | 5.0% |
+| 0.8 | 60 | 3.8% |
+| 0.9 | 44 | 2.8% |
+| 1.0 (exact) | 34 | 2.1% |
+
+**7.3% is not a property of the corpus; it is a property of the corpus at 0.6.**
+0.6 was chosen by inspection against the Safe Harbor family, which sits at
+0.6–0.8 while unrelated sentences in the same record sit below 0.35 — so it is
+the point that separates the known case from the known non-cases, on one
+family, in one record.
+
+The decision does not rest on the exact figure: repetition is either the right
+product or it is not, and it is uniform at every threshold. But any future
+comparison must use the same threshold, which is why `d4d runs redundancy`
+prints it beside the rate.
+
 Two corrections came out of measuring rather than assuming:
 
 - **They are paraphrases, not copies.** "removed from", "stripped from",

--- a/notes/decision_501_cross_slot_repetition.md
+++ b/notes/decision_501_cross_slot_repetition.md
@@ -1,0 +1,96 @@
+# Decision: cross-slot repetition is accepted (#501)
+
+**Decided 2026-08-12. Records generated after this date repeat facts across
+slots on purpose.**
+
+## The question
+
+Camille Nebeker's review of the AI-READI and CHORUS ethics and privacy content:
+
+> Redundancy in content vs potential new content, some fields have redundant
+> content (eg multiple mentions of SAFE Harbor). … we also want to prioritize
+> new informative content vs redundant content.
+
+Confirmed. In the canonical AI_READI record the HIPAA Safe Harbor fact appears
+in five slots — `human_subject_research`, `participant_privacy`,
+`preprocessing_strategies`, `regulatory_restrictions`, `is_deidentified` —
+across eight values.
+
+## What was measured first
+
+Across the whole canonical set (the 2026-08-11 v1 arm), sentence-level, content-
+word Jaccard ≥ 0.6:
+
+| project | sentences | prose restatements | rate | structural |
+|---|---|---|---|---|
+| AI_READI | 451 | 39 | 8.6% | 3 |
+| CHORUS | 192 | 17 | 8.9% | 0 |
+| CM4AI | 324 | 19 | 5.9% | 30 |
+| VOICE | 364 | 18 | 4.9% | 9 |
+| VOICE_PEDIATRIC | 255 | 23 | 9.0% | 2 |
+| **total** | **1586** | **116** | **7.3%** | 44 |
+
+Between 4.9% and 9.0% across five projects, so this is uniform behaviour rather
+than one project's quirk, and any rule would have moved every record.
+
+Two corrections came out of measuring rather than assuming:
+
+- **They are paraphrases, not copies.** "removed from", "stripped from",
+  "excludes" — three slots, three wordings, one fact. An exact-match pass finds
+  8 restatements in AI_READI and misses the Safe Harbor family entirely. So no
+  mechanical post-pass could have implemented the alternative; it would have had
+  to be an instruction.
+- **Structural repetition is not redundancy.** A URL beside the format it
+  belongs to, or a nested `CoreDataset` under `resources` repeating its parent's
+  title. 44 pairs, almost all CM4AI Dataverse URLs. Counting them would have
+  overstated the figure by about a third.
+
+## The decision
+
+**Per-slot completeness wins. The repetition is the accepted cost.**
+
+The core record is read one slot at a time — by a consumer deciding whether to
+ingest, by a mapping into RO-Crate or DCAT, by a reviewer checking one question.
+A reader who opens `is_deidentified` alone must learn that the release is Safe
+Harbor de-identified. The alternative rule — state a fact in its most specific
+slot and cross-reference elsewhere — gives that reader a pointer instead of an
+answer, and a machine consuming one slot cannot follow a pointer at all.
+
+The document reads repetitively end to end. That is the price, and it is paid
+knowingly.
+
+## What made the alternative worse than it looks
+
+`is_deidentified` records that FAIRhub gives `deIdentType: "NoDeIdentification"`
+while the Nature Metabolism comment states Safe Harbor. **`participant_privacy`
+carries that same disagreement.** So the contradiction is itself restated — and
+it is the most valuable content in either slot.
+
+Any "state it once" rule needs an explicit exemption for preserved
+disagreements, or it deletes the best sentence in the record to save the
+third-best. That exemption is exactly the kind of clause that is easy to write
+and hard for a run to apply consistently.
+
+## What was built instead
+
+`d4d runs redundancy` measures the rate and never fails. The number exists to be
+watched, not met: at 7.3% the behaviour is as decided; a later arm at 30% would
+mean something changed that nobody chose.
+
+```bash
+d4d runs redundancy                     # each project's canonical record
+d4d runs redundancy --label <label>     # one arm
+d4d runs redundancy --threshold 0.75    # stricter notion of "same statement"
+```
+
+`tests/test_redundancy.py` holds the exit code at zero. A change that turned
+this into a gate would reverse this decision silently, which is the specific
+failure the test exists to prevent.
+
+## What this does not settle
+
+- Whether *within-slot* repetition is acceptable. Not measured here — the
+  comparison is deliberately cross-slot only.
+- Whether the five slots carrying Safe Harbor are each the right slot. That is
+  the ownership question, and it is separate from how many slots may carry it.
+- Nothing about `notes` (#385) or undeclared keys (#380), both closed.

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -1203,8 +1203,13 @@ def redundancy_cmd(method, label, project, threshold, show):
         click.echo(f"{proj:17}{s['sentences']:>10}{s['prose_restatements']:>10}"
                    f"{s['rate']:>7.1%}{s['structural_restatements']:>12}")
     rate = (total_prose / total_sentences) if total_sentences else 0.0
+    used = red.THRESHOLD if threshold is None else threshold
+    # The threshold is printed with the rate because the rate is meaningless
+    # without it: on the canonical set the same corpus reads 2.1% at exact
+    # match and 12.0% at 0.5. A figure quoted bare invites comparison against
+    # a future figure computed differently.
     click.echo(f"\n{total_prose} prose restatement(s) across {total_sentences} "
-               f"sentences — {rate:.1%}")
+               f"sentences — {rate:.1%} at threshold {used}")
     # Named separately rather than folded in: a URL beside its format, or a
     # nested sub-resource repeating its parent's title, is correct. Including
     # it would overstate the figure by about a third.

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -1141,3 +1141,88 @@ def select_cmd(method, project, config, allow_unverified, execute):
                    "what replaced it.")
     click.echo("All replicates kept — this marks one, it does not move or "
                "delete anything.")
+
+
+@runs.command("redundancy")
+@click.option("--method", default="claudecode_agent", show_default=True)
+@click.option("--label", default=None,
+              help="one run label; default is each project's canonical record")
+@click.option("--project", default=None)
+@click.option("--threshold", default=None, type=float,
+              help="content-word overlap above which two sentences are the "
+                   "same statement (default 0.6)")
+@click.option("--show", default=3, type=int, show_default=True,
+              help="example restatements to print per project")
+def redundancy_cmd(method, label, project, threshold, show):
+    """How often one fact is stated in more than one slot (#501).
+
+    Reported, never fatal. The repetition is **intended**: the decision on #501
+    was that a reader who opens one slot must get an answer there rather than a
+    pointer elsewhere, so per-slot completeness wins and the document reads
+    repetitively as the price.
+
+    This exists so the rate can be watched. It sat at 7.4% of sentences across
+    the canonical set when that was decided; a later arm at 30% would mean
+    something changed that nobody chose.
+    """
+    from pathlib import Path as _Path
+
+    from data_sheets_schema import redundancy as red
+    from data_sheets_schema.constants import PROJECTS
+    from data_sheets_schema.runs import CONCAT_DIR, canonical_runs
+
+    kwargs = {} if threshold is None else {"threshold": threshold}
+    if label:
+        targets = {p: label for p in ([project] if project else PROJECTS)}
+    else:
+        targets = {p: info["label"] for p, info in canonical_runs().items()
+                   if not project or p == project}
+        if not targets:
+            raise click.ClickException(
+                "no canonical records; pass --label, or run "
+                "`d4d runs select --execute`")
+
+    total_sentences = total_prose = total_structural = 0
+    rows = []
+    for proj, lab in sorted(targets.items()):
+        path = _Path(CONCAT_DIR) / method / lab / f"{proj}_d4d.yaml"
+        if not path.exists():
+            continue
+        summary = red.summarize(red.load(path), **kwargs)
+        rows.append((proj, lab, summary))
+        total_sentences += summary["sentences"]
+        total_prose += summary["prose_restatements"]
+        total_structural += summary["structural_restatements"]
+
+    if not rows:
+        raise click.ClickException("no records found for that selection")
+
+    click.echo(f"{'project':17}{'sentences':>10}{'restated':>10}{'rate':>8}"
+               f"{'structural':>12}")
+    for proj, _lab, s in rows:
+        click.echo(f"{proj:17}{s['sentences']:>10}{s['prose_restatements']:>10}"
+                   f"{s['rate']:>7.1%}{s['structural_restatements']:>12}")
+    rate = (total_prose / total_sentences) if total_sentences else 0.0
+    click.echo(f"\n{total_prose} prose restatement(s) across {total_sentences} "
+               f"sentences — {rate:.1%}")
+    # Named separately rather than folded in: a URL beside its format, or a
+    # nested sub-resource repeating its parent's title, is correct. Including
+    # it would overstate the figure by about a third.
+    click.echo(f"{total_structural} further pair(s) are structural (a URL or a "
+               "nested resource) and are not redundancy.")
+
+    for proj, _lab, s in rows:
+        if not s["restatements"]:
+            continue
+        click.echo(f"\n{proj} — {len(s['slots_involved'])} slots involved:")
+        for r in sorted(s["restatements"],
+                        key=lambda x: -x.similarity)[:show]:
+            click.echo(f"   {r.similarity:.2f}  {r.slot_a} | {r.slot_b}")
+            click.echo(f"          {r.text_a[:96]}")
+            click.echo(f"          {r.text_b[:96]}")
+        if len(s["restatements"]) > show:
+            click.echo(f"   … {len(s['restatements']) - show} more "
+                       "(raise --show)")
+
+    click.echo("\nThis is reported, not failed: per-slot completeness is the "
+               "decision on #501, and the repetition is its accepted cost.")

--- a/src/data_sheets_schema/redundancy.py
+++ b/src/data_sheets_schema/redundancy.py
@@ -1,0 +1,170 @@
+"""How often one fact is stated in more than one slot (#501).
+
+From Camille Nebeker's review: *"some fields have redundant content (eg multiple
+mentions of SAFE Harbor) … we also want to prioritize new informative content vs
+redundant content."*
+
+**The decision was to accept the repetition.** The core record is read one slot
+at a time — by a consumer deciding whether to ingest, by a mapping into RO-Crate
+or DCAT, by a reviewer checking one question. A reader who opens
+`is_deidentified` alone must learn that the release is Safe Harbor
+de-identified; a cross-reference to another slot leaves them with a pointer
+instead of an answer. Per-slot completeness wins, and the document reads
+repetitively end to end as the price.
+
+So this module measures and never enforces. The number exists to be watched: at
+the time of the decision 7.4% of sentences in the canonical set participated in
+a cross-slot restatement, and a later arm at 30% would mean something changed
+that nobody chose.
+
+## Why the measure works on meaning rather than strings
+
+The restatements are **paraphrases**, not copies. The same Safe Harbor fact
+appears as "removed from", "stripped from" and "excludes" in three slots of one
+record. An exact-match pass over those records reports 8 restatements and misses
+Safe Harbor entirely — which is how the first measurement of this understated
+it. Comparison is therefore Jaccard overlap on content words.
+
+## Two things deliberately not counted as redundancy
+
+- **Structural repetition.** A URL in both `resources` and
+  `distribution_formats`, or a nested `CoreDataset` under `resources` repeating
+  its parent's title. Counted and reported separately: collapsing it would be
+  wrong, and folding it into the headline would overstate the problem by a
+  third.
+- **Preserved disagreements.** `is_deidentified` and `participant_privacy` both
+  record that FAIRhub says `deIdentType: "NoDeIdentification"` while the Nature
+  Metabolism comment says Safe Harbor. That contradiction is the most valuable
+  content in either slot. It is still counted — suppressing it from the count
+  would hide a real restatement — but any future rule acting on these numbers
+  must exempt it, or it will delete the best sentence to save the third-best.
+"""
+
+from __future__ import annotations
+
+import itertools
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+#: Function words excluded before overlap is computed. Short and deliberately
+#: not a full stopword list: the aim is to stop "the/of/and" dominating the
+#: intersection, not to do linguistics.
+STOPWORDS = frozenset("""
+a an and any all are as at be been by can for from in is it its may no not of
+on or such that the their there this to was were which with
+""".split())
+
+#: Slots whose repetition is structural rather than redundant — a sub-resource
+#: legitimately restates its parent, and a download URL legitimately appears
+#: beside the format it belongs to.
+NESTING_SLOTS = frozenset({"resources", "file_collections"})
+
+#: Below this, two sentences are different statements that happen to share
+#: vocabulary. Chosen by inspection against the Safe Harbor family, which sits
+#: at 0.6-0.8 while unrelated sentences in the same record sit below 0.35.
+THRESHOLD = 0.6
+
+#: Shorter than this and a "sentence" is a fragment, label or bare identifier,
+#: where vocabulary overlap says nothing about restatement.
+MIN_CHARS = 60
+
+#: Fewer content words than this and Jaccard is unstable — two 5-word sentences
+#: sharing 3 words score 0.43 without restating anything.
+MIN_CONTENT_WORDS = 8
+
+
+@dataclass(frozen=True)
+class Restatement:
+    """One fact found in two slots."""
+
+    slot_a: str
+    slot_b: str
+    text_a: str
+    text_b: str
+    similarity: float
+    structural: bool
+
+
+def _walk(node: Any, slot: str | None = None) -> Iterator[tuple[str, str]]:
+    """Yield (outermost slot, string). The outermost key is kept so a finding
+    is attributed to the slot a reader would go looking in."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from _walk(value, slot or key)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _walk(value, slot)
+    elif isinstance(node, str):
+        yield (slot or "?", node)
+
+
+def sentences(text: str) -> list[str]:
+    collapsed = re.sub(r"\s+", " ", text).strip()
+    return [s.strip() for s in re.split(r"(?<=[.;])\s+", collapsed)
+            if len(s.strip()) >= MIN_CHARS]
+
+
+def _content_words(sentence: str) -> set[str]:
+    return {w for w in re.findall(r"[a-z0-9]+", sentence.lower())
+            if w not in STOPWORDS and len(w) > 2}
+
+
+def _is_bare_url(sentence: str) -> bool:
+    return sentence.strip().lower().startswith(("http://", "https://", "doi:"))
+
+
+def restatements(record: dict, threshold: float = THRESHOLD
+                 ) -> list[Restatement]:
+    """Every pair of sentences in different slots that state the same thing."""
+    items = []
+    for slot, text in _walk(record):
+        for sentence in sentences(text):
+            words = _content_words(sentence)
+            if len(words) >= MIN_CONTENT_WORDS:
+                items.append((slot, sentence, words))
+
+    found = []
+    for (slot_a, text_a, words_a), (slot_b, text_b, words_b) in \
+            itertools.combinations(items, 2):
+        if slot_a == slot_b:
+            continue
+        overlap = len(words_a & words_b) / len(words_a | words_b)
+        if overlap < threshold:
+            continue
+        found.append(Restatement(
+            slot_a=slot_a, slot_b=slot_b, text_a=text_a, text_b=text_b,
+            similarity=overlap,
+            structural=(_is_bare_url(text_a) or _is_bare_url(text_b)
+                        or bool({slot_a, slot_b} & NESTING_SLOTS)),
+        ))
+    return found
+
+
+def summarize(record: dict, threshold: float = THRESHOLD) -> dict:
+    """Counts for one record, with the sentence total as the denominator.
+
+    The rate is per sentence rather than per slot on purpose: a record with more
+    slots populated is not thereby more repetitive, and a per-slot rate would
+    fall simply by generating more content.
+    """
+    total = sum(1 for _slot, text in _walk(record)
+                for s in sentences(text)
+                if len(_content_words(s)) >= MIN_CONTENT_WORDS)
+    found = restatements(record, threshold)
+    prose = [r for r in found if not r.structural]
+    return {
+        "sentences": total,
+        "prose_restatements": len(prose),
+        "structural_restatements": len(found) - len(prose),
+        "rate": (len(prose) / total) if total else 0.0,
+        "slots_involved": sorted({s for r in prose
+                                  for s in (r.slot_a, r.slot_b)}),
+        "restatements": prose,
+    }
+
+
+def load(path: Path) -> dict:
+    import yaml
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -140,3 +140,36 @@ class TestItIsReportedNotEnforced(unittest.TestCase):
         if result.returncode != 0:
             self.skipTest("command unavailable here")
         self.assertIn("reported, not failed", result.stdout)
+
+
+class TestTheRateIsReportedWithItsThreshold(unittest.TestCase):
+    """Found reviewing this change. The headline swings 2.1% (exact match) to
+    12.0% (0.6 -> 0.5) on the same corpus, so a rate quoted without its
+    threshold is unfalsifiable and invites comparison against a future figure
+    computed differently."""
+
+    def test_the_threshold_changes_the_count(self):
+        """The premise. If these ever agreed, the measure would have stopped
+        depending on the parameter and this guard would be vacuous."""
+        record = {"is_deidentified": LONG, "preprocessing_strategies": PARA}
+        loose = red.summarize(record, threshold=0.5)["prose_restatements"]
+        strict = red.summarize(record, threshold=1.0)["prose_restatements"]
+        self.assertGreater(loose, strict)
+
+    def test_the_command_prints_the_threshold(self):
+        result = subprocess.run(
+            ["poetry", "run", "d4d", "runs", "redundancy"],
+            capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            self.skipTest("command unavailable here")
+        self.assertIn(f"threshold {red.THRESHOLD}", result.stdout)
+
+    def test_an_overridden_threshold_is_the_one_reported(self):
+        """Printing the default while having used an override would be worse
+        than printing nothing."""
+        result = subprocess.run(
+            ["poetry", "run", "d4d", "runs", "redundancy", "--threshold", "0.9"],
+            capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            self.skipTest("command unavailable here")
+        self.assertIn("threshold 0.9", result.stdout)

--- a/tests/test_redundancy.py
+++ b/tests/test_redundancy.py
@@ -1,0 +1,142 @@
+"""Cross-slot restatement is measured, not enforced (#501).
+
+The decision on #501 was to **accept** the repetition: a reader who opens one
+slot must find an answer there, not a pointer to another slot. So these tests
+hold that the measurement is honest and that nothing acts on it — a later change
+that turned this into a gate would silently reverse a decision.
+"""
+
+import subprocess
+import unittest
+from pathlib import Path
+
+from data_sheets_schema import redundancy as red
+
+CORE = Path("data/d4d_concatenated/claudecode_agent")
+LONG = ("The public release is stripped of protected health information as "
+        "defined by the HIPAA Privacy Rule Safe Harbor method.")
+PARA = ("The public release excludes protected health information as defined "
+        "by the HIPAA Privacy Rule Safe Harbor method.")
+OTHER = ("Participants were recruited at three clinical sites between March "
+         "2021 and November 2023 under a common protocol.")
+
+
+class TestItFindsParaphraseNotOnlyCopies(unittest.TestCase):
+    """The property an exact-match pass lacks. Measured on the real records,
+    exact matching found 8 restatements in AI_READI and missed the Safe Harbor
+    family entirely, because every one of its five placements is reworded."""
+
+    def test_a_paraphrase_across_slots_is_found(self):
+        found = red.restatements({"is_deidentified": LONG,
+                                  "preprocessing_strategies": PARA})
+        self.assertEqual(len(found), 1)
+        self.assertGreater(found[0].similarity, red.THRESHOLD)
+
+    def test_an_exact_copy_is_found_too(self):
+        found = red.restatements({"is_deidentified": LONG,
+                                  "participant_privacy": LONG})
+        self.assertEqual(len(found), 1)
+
+    def test_unrelated_sentences_are_not(self):
+        self.assertEqual(
+            red.restatements({"is_deidentified": LONG, "creators": OTHER}), [])
+
+    def test_repetition_within_one_slot_is_not_cross_slot(self):
+        """A slot restating itself is a different defect and not this one."""
+        self.assertEqual(
+            red.restatements({"is_deidentified": [LONG, PARA]}), [])
+
+
+class TestWhatIsDeliberatelyNotCounted(unittest.TestCase):
+    def test_a_bare_url_is_structural(self):
+        found = red.restatements({
+            "distribution_formats": "https://dataverse.lib.virginia.edu/x?persistentId=doi:10.18130/V3/B35XWX",
+            "download_url": "https://dataverse.lib.virginia.edu/x?persistentId=doi:10.18130/V3/B35XWX"})
+        self.assertTrue(all(r.structural for r in found))
+
+    def test_a_nested_resource_repeating_its_parent_is_structural(self):
+        found = red.restatements({"title": LONG, "resources": LONG})
+        self.assertTrue(all(r.structural for r in found))
+
+    def test_structural_pairs_are_excluded_from_the_headline_rate(self):
+        """Folding them in would overstate the figure by about a third —
+        CM4AI's 30 structural pairs are almost all Dataverse URLs."""
+        summary = red.summarize({"title": LONG, "resources": LONG})
+        self.assertEqual(summary["prose_restatements"], 0)
+        self.assertEqual(summary["structural_restatements"], 1)
+
+    def test_short_fragments_are_ignored(self):
+        """Below the content-word floor, overlap says nothing: two five-word
+        sentences sharing three words score 0.43 without restating anything."""
+        self.assertEqual(red.restatements({"a": "Yes, it is.",
+                                           "b": "Yes, it is."}), [])
+
+
+class TestTheRateIsPerSentence(unittest.TestCase):
+    def test_the_denominator_is_sentences_not_slots(self):
+        """A per-slot rate would fall simply by generating more content, which
+        would reward padding."""
+        summary = red.summarize({"is_deidentified": LONG,
+                                 "preprocessing_strategies": PARA,
+                                 "creators": OTHER})
+        self.assertEqual(summary["sentences"], 3)
+        self.assertAlmostEqual(summary["rate"], 1 / 3)
+
+    def test_an_empty_record_has_no_rate_rather_than_a_crash(self):
+        self.assertEqual(red.summarize({})["rate"], 0.0)
+
+
+@unittest.skipUnless(CORE.exists(), "corpus absent")
+class TestAgainstTheCanonicalSet(unittest.TestCase):
+    def test_the_rate_is_in_the_range_the_decision_was_made_on(self):
+        """A floor and a ceiling, not a pinned figure. The decision to accept
+        repetition was made at 7.4%; if a later arm reads 30% something changed
+        that nobody chose, and if it reads 0% the measure has broken.
+        """
+        from data_sheets_schema.runs import canonical_runs
+
+        total = restated = 0
+        for project, info in canonical_runs().items():
+            path = CORE / info["label"] / f"{project}_d4d.yaml"
+            if not path.exists():
+                continue
+            summary = red.summarize(red.load(path))
+            total += summary["sentences"]
+            restated += summary["prose_restatements"]
+        if not total:
+            self.skipTest("no canonical records on disk")
+        rate = restated / total
+        self.assertGreater(rate, 0.01, "measure appears to have stopped firing")
+        self.assertLess(rate, 0.25, "restatement well above the decided level")
+
+    def test_the_safe_harbor_family_is_detected(self):
+        """The case the issue was filed about. If this stops firing, the
+        measure has regressed to string matching."""
+        from data_sheets_schema.runs import canonical_runs
+
+        info = canonical_runs().get("AI_READI")
+        path = CORE / info["label"] / "AI_READI_d4d.yaml" if info else None
+        if not path or not path.exists():
+            self.skipTest("AI_READI canonical record absent")
+        found = red.restatements(red.load(path))
+        self.assertTrue(found, "no restatement found in the worst-case record")
+
+
+class TestItIsReportedNotEnforced(unittest.TestCase):
+    def test_the_command_exits_zero(self):
+        """The decision was to accept the repetition. A non-zero exit would
+        make it a gate and reverse that silently."""
+        result = subprocess.run(
+            ["poetry", "run", "d4d", "runs", "redundancy"],
+            capture_output=True, text=True, check=False)
+        if "no canonical records" in (result.stdout + result.stderr):
+            self.skipTest("no canonical records on disk")
+        self.assertEqual(result.returncode, 0)
+
+    def test_the_output_says_it_is_not_a_failure(self):
+        result = subprocess.run(
+            ["poetry", "run", "d4d", "runs", "redundancy"],
+            capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            self.skipTest("command unavailable here")
+        self.assertIn("reported, not failed", result.stdout)


### PR DESCRIPTION
Closes #501.

## The question was a decision, not a bug

Camille Nebeker's review found the same Safe Harbor fact in five slots of AI-READI. #501 framed the tension honestly: a reviewer reading only `is_deidentified` should learn the release is Safe Harbor de-identified, but the document then reads repetitively end to end. Those are different products and the rule has to say which it optimises for.

## Measured before deciding

Across the whole canonical set (the 2026-08-11 v1 arm), sentence-level, content-word Jaccard ≥ 0.6:

| project | sentences | prose restatements | rate | structural |
|---|---|---|---|---|
| AI_READI | 451 | 39 | 8.6% | 3 |
| CHORUS | 192 | 17 | 8.9% | 0 |
| CM4AI | 324 | 19 | 5.9% | 30 |
| VOICE | 364 | 18 | 4.9% | 9 |
| VOICE_PEDIATRIC | 255 | 23 | 9.0% | 2 |
| **total** | **1586** | **116** | **7.3%** | 44 |

Between 4.9% and 9.0% on all five projects — uniform behaviour, so whichever way the rule went it would have moved every record.

## The decision: per-slot completeness wins

The core record is read one slot at a time — by a consumer deciding whether to ingest, by a mapping into RO-Crate or DCAT, by a reviewer checking one question. A reader who opens `is_deidentified` alone must find an answer there. Cross-referencing gives them a pointer instead, and a machine consuming one slot cannot follow a pointer at all.

The repetition is the price, paid knowingly. **No prompt change**, so no condition is re-baselined and no pin rotates.

## Two things measuring changed

**They are paraphrases, not copies.** "removed from", "stripped from", "excludes" — three slots, three wordings, one fact. An exact-match pass over the same records reports 8 restatements in AI_READI and misses the Safe Harbor family entirely. The alternative rule could therefore never have been a mechanical de-duplication pass; it would have had to be an instruction applied by every future run.

**Structural repetition is not redundancy.** A URL beside the format it belongs to, a nested `CoreDataset` under `resources` repeating its parent's title. 44 pairs, almost all CM4AI Dataverse URLs. Counted and reported separately — folding them into the headline would have overstated it by about a third.

## The alternative was worse than #501 flagged

The issue warned that a naive dedup would delete `is_deidentified`, which preserves that FAIRhub gives `deIdentType: "NoDeIdentification"` while the Nature Metabolism comment states Safe Harbor. Measuring shows **`participant_privacy` carries that same disagreement**. The contradiction is itself restated across two slots — and it is the most valuable content in either.

Any "state it once" rule needs an explicit exemption for preserved disagreements, or it deletes the best sentence in the record to save the third-best.

## What is built

`d4d runs redundancy` — reported, never fatal. The number exists to be watched, not met: at 7.3% the behaviour is as decided; a later arm at 30% would mean something changed that nobody chose.

`tests/test_redundancy.py` holds the exit code at zero. Turning this into a gate would reverse the decision silently, which is what that test prevents.

`notes/decision_501_cross_slot_repetition.md` records the decision, the numbers it was made on, and what it does not settle — so this is not re-filed in three months as an unnoticed defect.

**1795 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)