### PR TITLE
The American-English rule, and playbook drift detection (#502, #525)

### DIFF
--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -216,9 +216,27 @@ to every project. Enforce them whether or not a prompt file was used to launch:
 - There is no target slot count, no expected density, and no expected
   relationship to any other arm or project. Apply your own judgment about what
   the evidence supports.
+- **Write generated prose in American English** — `program`, `organization`,
+  `analyze`, `license`, `center`, `labeling`, `enrollment`. This is house style
+  for the text *you* compose, and it applies to identifiers you mint as well as
+  to descriptions.
 
-The last rule is the load-bearing one: it is what makes a slot count an
-observation rather than a target.
+  Three carve-outs, and they are not optional:
+
+  - **Quoted source text keeps its original spelling.** Changing a quotation to
+    match house style corrupts evidence, which is the one thing the provenance
+    guard exists to prevent. The bundles contain `licence` 13 times and
+    `programme` 6.
+  - **Proper nouns keep their spelling** — "Wellcome Trust Sanger Centre",
+    "Medical Research Council Programme Grant". A name is not prose.
+  - **Identifiers copied from a source keep the source's spelling.** An id you
+    take from a crate or a DOI is a token, not a sentence. Only ids *you* mint
+    follow house style.
+
+The rule about there being no target slot count is the load-bearing one: it is
+what makes a slot count an observation rather than a target. Named rather than
+referred to by position, so inserting a rule cannot silently point this sentence
+at a different one.
 
 ### Recording the condition
 

--- a/notes/decision_502_american_english.md
+++ b/notes/decision_502_american_english.md
@@ -1,0 +1,81 @@
+# Decision: generated prose is American English (#502)
+
+**Decided 2026-08-12.** From Camille Nebeker's review: *"Standardize on American
+English in the D4D generated docs ie no 'programme'."*
+
+## The rule
+
+Generated prose uses American English — `program`, `organization`, `analyze`,
+`license`, `center`, `labeling`, `enrollment` — and so do identifiers the run
+mints. Three carve-outs:
+
+1. **Quoted source text keeps its original spelling.** Americanising a quote
+   corrupts evidence, which is the one thing the provenance guard exists to
+   prevent.
+2. **Proper nouns keep their spelling.** "Wellcome Trust Sanger Centre" is a
+   name, not prose.
+3. **Identifiers copied from a source keep the source's spelling.** An id taken
+   from a crate or a DOI is a token. Only minted ids follow house style.
+
+## Where it lives, and why not in the condition prompts
+
+**In the playbook** (`.claude/commands/d4d-full-core.md`, uniform decision
+rules), not in `d4d_generic_arm_prompt*.md`.
+
+Editing a condition prompt rotates its pin, and v1's pin is what the fifteen
+records of the 2026-08-11 canonical arm hashed. Rotating it would move all
+fifteen from `canonical` to `superseded` — reported, not failed, but a real
+degradation of the baseline #516 was generated to establish. Verified after the
+change: `prompts check --strict` exits 0, `runs check --strict` exits 0, and all
+five projects still read `canonical`.
+
+House style is also orthogonal to what the conditions differ on. v1 against v3
+is about structured-slot population and defect counts; spelling does not enter
+it, so the rule does not belong in the axis being compared.
+
+## The gap this leaves, named rather than hidden
+
+**The API path does not read the playbook.** `d4d api run` renders a condition
+prompt and nothing else, so API-generated records are unaffected by this rule.
+
+That is deliberate for now and it is a real limitation:
+
+- Production datasheets come from the agentic path (`claudecode_agent`), which
+  this covers.
+- The API path is the experimental arm for §6, and adding a style rule to it
+  while that comparison is pending is the change #517 exists to warn about — a
+  prompt edit mid-comparison makes the arms non-comparable.
+
+When the §6 arms are complete, the rule should move into the condition prompts
+as part of whatever version rotation follows, so both paths carry it.
+
+## Measured at the time of the decision
+
+Across the canonical set (`d4d evaluate spelling`):
+
+```
+1345 occurrences in generated prose
+  43 in text quoted from a bundle (left alone)
+   8 inside an `id`
+```
+
+All 8 identifiers are minted, not copied — `d4d:VOICE-purpose-programme`,
+`chorus:related-bridge2ai-programme`, `#instance-programme-aggregate` — so every
+one violates the rule as stated. One is mixed: a real DOI with a minted
+fragment, where the offending span is the part the run composed.
+
+The 43 quoted occurrences are the reason this is not a find-and-replace. The
+bundles contain `licence` 13 times and `programme` 6, and one line shows both at
+once — the record's own prose says *programme* while the text it quotes says
+*Program*.
+
+## What this does not settle
+
+- **Existing records are not rewritten.** The 1345 occurrences stand. Editing
+  them would make a record state prose no run produced, the same objection as
+  #520. New runs comply; old records are evidence of what was generated.
+- `d4d evaluate spelling` cannot tell a minted id from a copied one, and the
+  rule turns on that distinction. It has not yet mattered — all 8 are minted —
+  but a real identifier containing `licence` would be a false positive.
+- Nothing here is enforced at generation time. The checker reports; no gate
+  fails a run for saying `programme`.

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -548,6 +548,34 @@ def check_cmd(method, label, project, strict):
         click.echo("   Each record correctly names the schema it saw. Slot "
                    "counts across the split are not like-for-like.")
 
+    # Playbook drift (#525). The same question as bundle drift, asked of the
+    # declared *instructions* rather than the declared input — the playbook is
+    # where the uniform decision rules live, so editing one changes the method
+    # for every run that follows and left every earlier record attesting to
+    # bytes that no longer exist. Reported, never fatal: playbooks are meant to
+    # evolve, and a gate would make every improvement a corpus-wide failure.
+    from data_sheets_schema.runs import (
+        PLAYBOOK_ABSENT, PLAYBOOK_CURRENT, PLAYBOOK_DRIFTED,
+        PLAYBOOK_UNRECORDED, playbook_drift,
+    )
+    books: collections.Counter = collections.Counter()
+    book_detail: collections.Counter = collections.Counter()
+    for r in rows:
+        st, why = playbook_drift(r["method"], r["label"], r["project"])
+        books[st] += 1
+        if st in (PLAYBOOK_DRIFTED, PLAYBOOK_ABSENT) and why:
+            book_detail[why] += 1
+
+    moved = books[PLAYBOOK_DRIFTED] + books[PLAYBOOK_ABSENT]
+    if moved:
+        click.echo(f"\nⓘ  {moved} record(s) read a playbook whose bytes have "
+                   f"since changed ({books[PLAYBOOK_CURRENT]} still match, "
+                   f"{books[PLAYBOOK_UNRECORDED]} record no playbook hash):")
+        for why, n in book_detail.most_common(6):
+            click.echo(f"     {why[:66]:66} {n}")
+        click.echo("   The decision rules live in these files, so a record "
+                   "that names them cannot be re-derived from them.")
+
     stale = drift[BUNDLE_DRIFTED] + drift[BUNDLE_ABSENT]
     if stale:
         click.echo(f"\nⓘ  {stale} record(s) name an input bundle whose bytes "

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1172,6 +1172,71 @@ def bundle_drift_detail(method: str, label: str, project: str,
                             f"record pinned {recorded[:8]}"), declared
 
 
+PLAYBOOK_CURRENT, PLAYBOOK_DRIFTED = "current", "drifted"
+PLAYBOOK_ABSENT, PLAYBOOK_UNRECORDED = "absent", "unrecorded"
+
+
+def playbook_drift(method: str, label: str, project: str,
+                   concat_dir: Path = CONCAT_DIR
+                   ) -> tuple[str, str | None]:
+    """Do the playbooks this run read still hash to what it recorded? (#525)
+
+    `bundle_drift` asks this of a record's declared *input*. This asks it of the
+    declared *instructions*, which nothing asked before — every agentic record
+    hashes its playbooks and no command ever compared them to the files again.
+
+    That matters because the playbook is where the uniform decision rules live:
+    prefer omission over inference, represent disagreement rather than selecting
+    one source, one referent per `Dataset`. A playbook edit is a change to the
+    method exactly as a prompt edit is, and prompt edits are guarded three ways
+    while playbook edits were guarded by none.
+
+    Reported, never fatal, for the same reason as bundle drift: a drifted record
+    is still valid evidence of what was generated, it simply can no longer be
+    re-derived from the files it names. Playbooks are also *expected* to evolve
+    — a gate would turn every improvement to the method into a corpus-wide
+    failure, which is why this is not prompt-style pinning.
+    """
+    import hashlib
+
+    from data_sheets_schema.provenance import record_path_for
+    path = record_path_for(project, method, label, concat_dir)
+    if not path.exists():
+        return PLAYBOOK_UNRECORDED, "no provenance record"
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    block = data.get("playbooks") or {}
+    files = block.get("files") if isinstance(block, dict) else None
+    if not files:
+        return PLAYBOOK_UNRECORDED, "no playbook hashes recorded"
+
+    algorithm = (block.get("hash_algorithm") or "sha256").lower()
+    drifted, missing = [], []
+    for entry in files:
+        if not isinstance(entry, dict):
+            continue
+        declared, recorded = entry.get("path"), entry.get(algorithm)
+        if not declared or not recorded:
+            continue
+        playbook = Path(declared)
+        if not playbook.exists():
+            # Distinguished from drift: a renamed or deleted playbook is a
+            # different diagnosis from an edited one, and #431 was filed
+            # because a rename silently became `exists: false` in the record.
+            missing.append(declared)
+            continue
+        digest = (hashlib.sha256 if algorithm == "sha256" else hashlib.md5)(
+            playbook.read_bytes()).hexdigest()
+        if digest != recorded:
+            drifted.append(f"{Path(declared).name} "
+                           f"({recorded[:8]} -> {digest[:8]})")
+
+    if missing:
+        return PLAYBOOK_ABSENT, f"no longer present: {', '.join(missing)}"
+    if drifted:
+        return PLAYBOOK_DRIFTED, "; ".join(drifted)
+    return PLAYBOOK_CURRENT, None
+
+
 def canonical_prompt_status(method: str, label: str, project: str,
                             concat_dir: Path = CONCAT_DIR
                             ) -> tuple[str, str | None]:

--- a/src/data_sheets_schema/spelling.py
+++ b/src/data_sheets_schema/spelling.py
@@ -169,6 +169,20 @@ def in_identifiers(record: dict) -> list[Occurrence]:
     Structural rather than stylistic: an id is a token other records and
     mappings may key on, so it cannot be fixed by a later copy-edit. The
     2026-08-11 arm carries `aireadi:external-training-programme`.
+
+    ⚠️ **Does not distinguish a minted id from one copied out of a source**,
+    and the rule adopted for #502 turns on exactly that: an id *you* mint
+    follows house style, an id taken from a crate or a DOI keeps the source's
+    spelling. All 8 hits in the canonical set are minted — descriptive
+    fragments like `#instance-programme-aggregate` — so the distinction has not
+    yet mattered, but a real identifier containing `licence` would be a false
+    positive here.
+
+    One case is already mixed: `https://doi.org/10.60775/fairhub.3
+    #limitation-enrolment-incomplete` is a real DOI with a minted fragment. The
+    whole id is flagged, and the finding is still correct because the offending
+    span is the minted part. Distinguishing them properly needs the id's
+    provenance, which the record does not carry.
     """
     out: list[Occurrence] = []
     for slot, text in _walk_leaf(record, None):

--- a/tests/test_american_english_rule.py
+++ b/tests/test_american_english_rule.py
@@ -1,0 +1,79 @@
+"""The American-English rule is stated where it does not redefine a condition (#502).
+
+From Camille Nebeker's review. The rule itself is uncontroversial; *where* it is
+written is the decision, because editing a condition prompt rotates its pin and
+v1's pin is what the fifteen records of the 2026-08-11 canonical arm hashed.
+Rotating it would move all fifteen from `canonical` to `superseded`.
+
+So the rule lives in the playbook, and these tests hold both halves: that it is
+stated there, and that stating it disturbed no pin.
+"""
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAYBOOK = ROOT / ".claude/commands/d4d-full-core.md"
+PROMPTS = ROOT / "src/download/prompts"
+
+
+class TestTheRuleIsStated(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = PLAYBOOK.read_text(encoding="utf-8")
+
+    def test_the_playbook_states_american_english(self):
+        self.assertIn("American English", self.text)
+
+    def test_it_sits_among_the_uniform_decision_rules(self):
+        """Not in a section a run might skip. The uniform rules are the ones
+        the playbook says to enforce whether or not a prompt file was used."""
+        start = self.text.index("Uniform decision rules")
+        end = self.text.index("### Recording the condition")
+        self.assertIn("American English", self.text[start:end])
+
+    def test_the_three_carve_outs_are_present(self):
+        """Without them the rule instructs a run to corrupt evidence — the
+        bundles contain `licence` 13 times and `programme` 6."""
+        section = self.text[self.text.index("American English"):]
+        for phrase in ("Quoted source text", "Proper nouns",
+                       "Identifiers copied from a source"):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, section)
+
+    def test_the_load_bearing_rule_is_named_not_positional(self):
+        """It used to read "the last rule", which a later insertion would
+        silently repoint at something else."""
+        self.assertNotIn("The last rule is the load-bearing", self.text)
+        self.assertIn("no target slot count is the load-bearing", self.text)
+
+
+class TestItDidNotRedefineACondition(unittest.TestCase):
+    """The reason it is in the playbook rather than the prompts."""
+
+    def test_no_condition_prompt_carries_the_rule(self):
+        for path in sorted(PROMPTS.glob("d4d_*_arm_prompt*.md")):
+            with self.subTest(prompt=path.name):
+                self.assertNotIn("American English",
+                                 path.read_text(encoding="utf-8"))
+
+    def test_every_pinned_prompt_is_still_at_its_pin(self):
+        import subprocess
+        result = subprocess.run(
+            ["poetry", "run", "d4d", "api", "prompts", "check", "--strict"],
+            capture_output=True, text=True, check=False, cwd=ROOT)
+        self.assertEqual(result.returncode, 0,
+                         (result.stdout + result.stderr)[-600:])
+
+    def test_the_canonical_arm_is_still_canonical(self):
+        """The property that would have been lost by editing v1."""
+        from data_sheets_schema.runs import (canonical_prompt_status,
+                                             canonical_runs)
+        runs = canonical_runs()
+        if not runs:
+            self.skipTest("no canonical records on disk")
+        for project, info in runs.items():
+            with self.subTest(project=project):
+                status, why = canonical_prompt_status(
+                    "claudecode_agent", info["label"], project)
+                self.assertEqual(status, "canonical", why)

--- a/tests/test_playbook_drift.py
+++ b/tests/test_playbook_drift.py
@@ -1,0 +1,134 @@
+"""A playbook edit is visible in the records that read the old one (#525).
+
+Every agentic record hashes the playbooks it read, and until this nothing ever
+compared those hashes to the files again. `runs check` reported bundle drift,
+render-gate status, prompt pins, verdict schema pins and schema straddle — and
+said nothing about the files the decision rules actually live in.
+
+Found by editing one. #524 adds the American-English rule to
+`.claude/commands/d4d-full-core.md`; the 15 records of the canonical arm hash
+the previous bytes, and `runs check --strict` still exited 0 with nothing said.
+"""
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.runs import (PLAYBOOK_ABSENT, PLAYBOOK_CURRENT,
+                                     PLAYBOOK_DRIFTED, PLAYBOOK_UNRECORDED,
+                                     playbook_drift)
+
+
+class TestOnFixtures(unittest.TestCase):
+    """Synthetic records, so these keep working where the corpus does not."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.book = self.dir / "playbook.md"
+        self.book.write_text("prefer omission over inference\n",
+                             encoding="utf-8")
+
+    def _record(self, entries, label="s_rep1", project="P"):
+        path = self.dir / "m_core" / label / f"{project}_provenance.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(
+            {"playbooks": {"hash_algorithm": "sha256", "files": entries}}),
+            encoding="utf-8")
+        return ("m", label, project)
+
+    def _digest(self):
+        return hashlib.sha256(self.book.read_bytes()).hexdigest()
+
+    def test_an_unedited_playbook_is_current(self):
+        args = self._record([{"path": str(self.book),
+                              "sha256": self._digest()}])
+        self.assertEqual(playbook_drift(*args, self.dir)[0], PLAYBOOK_CURRENT)
+
+    def test_an_edited_playbook_is_drifted(self):
+        args = self._record([{"path": str(self.book),
+                              "sha256": self._digest()}])
+        self.book.write_text("prefer inference over omission\n",
+                             encoding="utf-8")
+        status, why = playbook_drift(*args, self.dir)
+        self.assertEqual(status, PLAYBOOK_DRIFTED)
+        self.assertIn("playbook.md", why)
+
+    def test_the_reason_names_both_hashes(self):
+        """So a reader can tell which edit, not merely that there was one."""
+        old = self._digest()
+        args = self._record([{"path": str(self.book), "sha256": old}])
+        self.book.write_text("changed\n", encoding="utf-8")
+        _status, why = playbook_drift(*args, self.dir)
+        self.assertIn(old[:8], why)
+        self.assertIn(self._digest()[:8], why)
+
+    def test_a_deleted_playbook_is_absent_not_drifted(self):
+        """A rename is a different diagnosis from an edit — #431 exists
+        because a renamed playbook silently became `exists: false`."""
+        args = self._record([{"path": str(self.book),
+                              "sha256": self._digest()}])
+        self.book.unlink()
+        self.assertEqual(playbook_drift(*args, self.dir)[0], PLAYBOOK_ABSENT)
+
+    def test_a_record_with_no_playbook_block_is_unrecorded(self):
+        path = self.dir / "m_core" / "s_rep1" / "P_provenance.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump({"run": {}}), encoding="utf-8")
+        self.assertEqual(
+            playbook_drift("m", "s_rep1", "P", self.dir)[0],
+            PLAYBOOK_UNRECORDED)
+
+    def test_a_missing_record_is_unrecorded_rather_than_a_crash(self):
+        self.assertEqual(
+            playbook_drift("m", "absent", "P", self.dir)[0],
+            PLAYBOOK_UNRECORDED)
+
+    def test_one_drifted_file_among_several_is_reported(self):
+        """A run reads three playbooks; editing any one changes the method."""
+        other = self.dir / "second.md"
+        other.write_text("one referent per Dataset\n", encoding="utf-8")
+        args = self._record([
+            {"path": str(self.book), "sha256": self._digest()},
+            {"path": str(other),
+             "sha256": hashlib.sha256(other.read_bytes()).hexdigest()}])
+        other.write_text("two referents\n", encoding="utf-8")
+        status, why = playbook_drift(*args, self.dir)
+        self.assertEqual(status, PLAYBOOK_DRIFTED)
+        self.assertIn("second.md", why)
+        self.assertNotIn("playbook.md", why)
+
+    def test_an_entry_without_a_hash_is_skipped_not_fatal(self):
+        args = self._record([{"path": str(self.book)}])
+        self.assertEqual(playbook_drift(*args, self.dir)[0], PLAYBOOK_CURRENT)
+
+
+class TestAgainstTheCorpus(unittest.TestCase):
+    def test_it_is_reported_and_never_fatal(self):
+        """Playbooks are meant to evolve. A gate would turn every improvement
+        to the method into a corpus-wide failure, which is why this is drift
+        detection and not prompt-style pinning."""
+        import subprocess
+
+        result = subprocess.run(
+            ["poetry", "run", "d4d", "runs", "check", "--strict"],
+            capture_output=True, text=True, check=False)
+        if "read a playbook" not in result.stdout:
+            self.skipTest("no drifted playbooks in corpus")
+        self.assertEqual(result.returncode, 0)
+
+    def test_the_real_records_carry_playbook_hashes_to_check(self):
+        """If this ever finds none, the guard above is vacuous."""
+        from data_sheets_schema.runs import canonical_runs
+        runs = canonical_runs()
+        if not runs:
+            self.skipTest("no canonical records")
+        statuses = {playbook_drift("claudecode_agent", i["label"], p)[0]
+                    for p, i in runs.items()}
+        self.assertTrue(statuses - {PLAYBOOK_UNRECORDED},
+                        "no canonical record records a playbook hash")


### PR DESCRIPTION
Closes #502.

## The rule was easy; the placement was the decision

Camille Nebeker: *"Standardize on American English in the D4D generated docs ie no 'programme'."*

Generated prose — and identifiers the run **mints** — use American English. Three carve-outs, none optional:

- **Quoted source text keeps its original spelling.** Americanising a quotation corrupts evidence, which is exactly what the provenance guard exists to prevent.
- **Proper nouns keep theirs.** "Wellcome Trust Sanger Centre" is a name, not prose.
- **Identifiers copied from a source keep theirs.** An id from a crate or a DOI is a token.

## Why the playbook and not the condition prompts

Editing `d4d_generic_arm_prompt.md` rotates v1's pin — and that pin is what the fifteen records of the 2026-08-11 canonical arm hashed. Rotating it moves all fifteen from `canonical` to `superseded`. Reported rather than failed, but a real degradation of the baseline #516 was generated to establish.

Verified after the change:

```
d4d api prompts check --strict   exit 0
d4d runs check --strict          exit 0
canonical_prompt_status          canonical x5
```

House style is also orthogonal to what the conditions differ on. v1 against v3 measures structured-slot population and defect counts; spelling does not enter it, so the rule does not belong in the axis being compared.

## Measured

```
1345 occurrences in generated prose
  43 in text quoted from a bundle (left alone)
   8 inside an `id`
```

All 8 identifiers are **minted**, not copied — `d4d:VOICE-purpose-programme`, `chorus:related-bridge2ai-programme`, `#instance-programme-aggregate` — so every one violates the rule as stated.

The 43 quoted occurrences are why this cannot be a find-and-replace. The bundles contain `licence` 13 times and `programme` 6, and one line carries both at once: the record's own prose says *programme* while the text it quotes says *Program*.

## Two gaps, named rather than hidden

**The API path does not read the playbook**, so API-generated records are unaffected. Deliberate while §6 is pending — a prompt edit mid-comparison is the change #517 exists to warn about. The rule should move into the condition prompts at the next version rotation, once the arms are complete.

**`d4d evaluate spelling` cannot tell a minted id from a copied one**, and the rule turns on that distinction. It has not mattered because all 8 are minted, but a real identifier containing `licence` would be a false positive. One case is already mixed — a real DOI with a minted fragment — where the finding is still correct because the offending span is the part the run composed.

## Not done

**Existing records are not rewritten.** The 1345 occurrences stand. Editing them would make a record state prose no run produced — the same objection as #520. New runs comply; old records are evidence of what was generated.

Also replaces "the last rule is the load-bearing one" with the rule named explicitly, since inserting a rule silently repointed that sentence at a different one.

**1805 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)