### PR TITLE
Give retention incentives their own slots (#504)

### DIFF
--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -304,8 +304,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_d4d_core.yaml
       md5: 19f4a17c60311d6bbc32fd06d266a76c
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/AI_READI_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -304,8 +304,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_d4d_core.yaml
       md5: 19f4a17c60311d6bbc32fd06d266a76c
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/AI_READI_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -266,8 +266,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_d4d_core.yaml
       md5: 57d52aa67e15baf249e791cd1ce32481
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/CHORUS_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -266,8 +266,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_d4d_core.yaml
       md5: 57d52aa67e15baf249e791cd1ce32481
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/CHORUS_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_d4d_core.yaml
       md5: 7fa94e1ccb88dcc9d7090ce6ff0b49d5
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_d4d_core.yaml
       md5: 7fa94e1ccb88dcc9d7090ce6ff0b49d5
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_d4d_core.yaml
       md5: cc5bea839075f00de433612a313f358a
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_d4d_core.yaml
       md5: cc5bea839075f00de433612a313f358a
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_d4d_core.yaml
       md5: 1afef4d05562622097d4e577b3bb4648
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_d4d_core.yaml
       md5: 1afef4d05562622097d4e577b3bb4648
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 94585ede7df663fb3b0a2f601f639fac
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 94585ede7df663fb3b0a2f601f639fac
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_d4d_core.yaml
       md5: d5dfd18340393dfd485b22c888d33010
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_d4d_core.yaml
       md5: d5dfd18340393dfd485b22c888d33010
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_d4d_core.yaml
       md5: bf8d3706efaf398738fbbdbcfc098c70
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_d4d_core.yaml
       md5: bf8d3706efaf398738fbbdbcfc098c70
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_d4d_core.yaml
       md5: 658a6794c50cda7ae4b52beb5192c366
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_d4d_core.yaml
       md5: 658a6794c50cda7ae4b52beb5192c366
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_d4d_core.yaml
       md5: 67384e7d32a1740264d74ee6ed79c501
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_d4d_core.yaml
       md5: 67384e7d32a1740264d74ee6ed79c501
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 4634f260ce16cbbeda7017e8bd5e0cea
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 4634f260ce16cbbeda7017e8bd5e0cea
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_d4d_core.yaml
       md5: 81cdfa0b72a0ed18c08eb8a3ae5901a8
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_d4d_core.yaml
       md5: 81cdfa0b72a0ed18c08eb8a3ae5901a8
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_d4d_core.yaml
       md5: 54464b3bb28dfa874966782a218526ee
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_d4d_core.yaml
       md5: 54464b3bb28dfa874966782a218526ee
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_d4d_core.yaml
       md5: cbf2482273b6d8bcfa10711b43266cf5
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_d4d_core.yaml
       md5: cbf2482273b6d8bcfa10711b43266cf5
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_d4d_core.yaml
       md5: de505046d64b4139dcd43f4b2dcbf730
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_d4d_core.yaml
       md5: de505046d64b4139dcd43f4b2dcbf730
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_d4d_core.yaml
       md5: a6cd0da0d9079e6726857bec5c05eca7
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_d4d_core.yaml
       md5: a6cd0da0d9079e6726857bec5c05eca7
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_d4d_core.yaml
       md5: a25640d2448384452c46bd5bec04ca2e
   schema:
-    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
-    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
+    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
+    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_d4d_core.yaml
       md5: a25640d2448384452c46bd5bec04ca2e
   schema:
-    full_sha256: 060d9f542f817e291a5557e758715687b985a584df8d2fc74d2bfc99f857f9de
-    core_sha256: 4b725d5da4694a66326acf3f488c8c8c0042b2c5d5d81019ac5525f54bf511c0
+    full_sha256: f223e4bf11641452c706a28dd6dce3423d6c24d1f6e749a58bfa0726b0e7dc87
+    core_sha256: 3a660827ea17d6a8972899aeeb3843b0051ec5b0c0ef12456f1c0735c13ff43d
   recorded_by: d4d runs validate

--- a/src/data_sheets_schema/schema/D4D_Human.yaml
+++ b/src/data_sheets_schema/schema/D4D_Human.yaml
@@ -215,6 +215,16 @@ classes:
           the structure. An escalating payment schedule is not by itself
           evidence that retention was its purpose; report the schedule under
           the compensation slots and leave this absent.
+
+          ⚠️ **"Retention" here means keeping participants enrolled, never
+          keeping data.** How long the data is kept belongs in
+          `retention_limit`, which is a different slot about a different
+          subject. The word is treacherous in this corpus: across all five
+          project bundles nearly every occurrence of "retention" is about data
+          or specimen retention — "limits on the retention of the data",
+          "bioSpecRetention", "records retention requirements" — and none so
+          far describes an incentive structure. An empty slot is the correct
+          outcome for those sources.
         slot_uri: d4d:retentionIncentiveStructure
         range: string
         annotations:

--- a/src/data_sheets_schema/schema/D4D_Human.yaml
+++ b/src/data_sheets_schema/schema/D4D_Human.yaml
@@ -157,7 +157,23 @@ classes:
 
   HumanSubjectCompensation:
     description: >
-      Information about compensation or incentives provided to human research participants.
+      What participants received, and — where the sources describe one — how
+      that was structured to keep them enrolled.
+
+      Two different claims live here and must not be conflated (#504).
+      **Compensation** is payment for time and burden: what was provided, of
+      what type, of what value. **Retention incentives** are structure designed
+      to prevent attrition — escalating amounts, completion bonuses, payments
+      tied to later visits. The ethical reading of the two differs, which is
+      why an Ethics and Privacy review asked for the distinction: "$40 then
+      $80" reported as compensation says something different from the same
+      figures reported as a retention design.
+
+      Record the incentive slots only where a source describes the structure or
+      its purpose. Most sources describe payments and say nothing about
+      retention intent, and an escalating schedule is not by itself evidence
+      that retention was the goal. Inferring one from the other is the failure
+      the evidence boundary exists to prevent.
     is_a: DatasetProperty
     attributes:
       compensation_provided:
@@ -185,6 +201,37 @@ classes:
           What was the rationale for the compensation structure?
           How was the amount determined to be appropriate?
         slot_uri: d4d:compensationRationale
+        range: string
+
+      retention_incentives:
+        description: >
+          Where the sources describe it, how the incentive structure was
+          designed to keep participants enrolled across the study — escalating
+          amounts, completion bonuses, payments tied to later visits or to
+          returning after a gap.
+
+          Distinct from `compensation_type` and `compensation_amount`, which
+          record what was provided. State this only where a source describes
+          the structure. An escalating payment schedule is not by itself
+          evidence that retention was its purpose; report the schedule under
+          the compensation slots and leave this absent.
+        slot_uri: d4d:retentionIncentiveStructure
+        range: string
+        annotations:
+          "d4d:docExample": "Payment rises across the four annual visits, with a completion bonus at year four, described in the protocol as designed to reduce loss to follow-up."
+
+      retention_incentive_rationale:
+        description: >
+          The stated reason for structuring incentives to support retention,
+          where a source gives one — an attrition rate the design responds to,
+          an IRB condition, or a documented equity concern about who can afford
+          to stay enrolled.
+
+          Separate from `retention_incentives` (the structure) for the same
+          reason `compensation_rationale` is separate from
+          `compensation_amount`: what was done and why it was done are
+          different claims, and sources frequently give one without the other.
+        slot_uri: d4d:retentionIncentiveRationale
         range: string
 
 

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -42577,6 +42577,14 @@ classes:
           was its purpose; report the schedule under the compensation slots and leave
           this absent.
 
+          ⚠️ **"Retention" here means keeping participants enrolled, never keeping
+          data.** How long the data is kept belongs in `retention_limit`, which is
+          a different slot about a different subject. The word is treacherous in this
+          corpus: across all five project bundles nearly every occurrence of "retention"
+          is about data or specimen retention — "limits on the retention of the data",
+          "bioSpecRetention", "records retention requirements" — and none so far describes
+          an incentive structure. An empty slot is the correct outcome for those sources.
+
           '
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/human
         slot_uri: d4d:retentionIncentiveStructure

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -42480,8 +42480,22 @@ classes:
         inlined_as_list: true
   HumanSubjectCompensation:
     name: HumanSubjectCompensation
-    description: 'Information about compensation or incentives provided to human research
-      participants.
+    description: 'What participants received, and — where the sources describe one
+      — how that was structured to keep them enrolled.
+
+      Two different claims live here and must not be conflated (#504). **Compensation**
+      is payment for time and burden: what was provided, of what type, of what value.
+      **Retention incentives** are structure designed to prevent attrition — escalating
+      amounts, completion bonuses, payments tied to later visits. The ethical reading
+      of the two differs, which is why an Ethics and Privacy review asked for the
+      distinction: "$40 then $80" reported as compensation says something different
+      from the same figures reported as a retention design.
+
+      Record the incentive slots only where a source describes the structure or its
+      purpose. Most sources describe payments and say nothing about retention intent,
+      and an escalating schedule is not by itself evidence that retention was the
+      goal. Inferring one from the other is the failure the evidence boundary exists
+      to prevent.
 
       '
     from_schema: https://w3id.org/bridge2ai/data-sheets-schema
@@ -42540,6 +42554,53 @@ classes:
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/human
         slot_uri: d4d:compensationRationale
         alias: compensation_rationale
+        owner: HumanSubjectCompensation
+        domain_of:
+        - HumanSubjectCompensation
+        range: string
+      retention_incentives:
+        name: retention_incentives
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: Payment rises across the four annual visits, with a completion
+              bonus at year four, described in the protocol as designed to reduce
+              loss to follow-up.
+        description: 'Where the sources describe it, how the incentive structure was
+          designed to keep participants enrolled across the study — escalating amounts,
+          completion bonuses, payments tied to later visits or to returning after
+          a gap.
+
+          Distinct from `compensation_type` and `compensation_amount`, which record
+          what was provided. State this only where a source describes the structure.
+          An escalating payment schedule is not by itself evidence that retention
+          was its purpose; report the schedule under the compensation slots and leave
+          this absent.
+
+          '
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/human
+        slot_uri: d4d:retentionIncentiveStructure
+        alias: retention_incentives
+        owner: HumanSubjectCompensation
+        domain_of:
+        - HumanSubjectCompensation
+        range: string
+      retention_incentive_rationale:
+        name: retention_incentive_rationale
+        description: 'The stated reason for structuring incentives to support retention,
+          where a source gives one — an attrition rate the design responds to, an
+          IRB condition, or a documented equity concern about who can afford to stay
+          enrolled.
+
+          Separate from `retention_incentives` (the structure) for the same reason
+          `compensation_rationale` is separate from `compensation_amount`: what was
+          done and why it was done are different claims, and sources frequently give
+          one without the other.
+
+          '
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/human
+        slot_uri: d4d:retentionIncentiveRationale
+        alias: retention_incentive_rationale
         owner: HumanSubjectCompensation
         domain_of:
         - HumanSubjectCompensation

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -36985,6 +36985,14 @@ classes:
           was its purpose; report the schedule under the compensation slots and leave
           this absent.
 
+          ⚠️ **"Retention" here means keeping participants enrolled, never keeping
+          data.** How long the data is kept belongs in `retention_limit`, which is
+          a different slot about a different subject. The word is treacherous in this
+          corpus: across all five project bundles nearly every occurrence of "retention"
+          is about data or specimen retention — "limits on the retention of the data",
+          "bioSpecRetention", "records retention requirements" — and none so far describes
+          an incentive structure. An empty slot is the correct outcome for those sources.
+
           '
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/human
         slot_uri: d4d:retentionIncentiveStructure

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -36888,8 +36888,22 @@ classes:
         inlined_as_list: true
   HumanSubjectCompensation:
     name: HumanSubjectCompensation
-    description: 'Information about compensation or incentives provided to human research
-      participants.
+    description: 'What participants received, and — where the sources describe one
+      — how that was structured to keep them enrolled.
+
+      Two different claims live here and must not be conflated (#504). **Compensation**
+      is payment for time and burden: what was provided, of what type, of what value.
+      **Retention incentives** are structure designed to prevent attrition — escalating
+      amounts, completion bonuses, payments tied to later visits. The ethical reading
+      of the two differs, which is why an Ethics and Privacy review asked for the
+      distinction: "$40 then $80" reported as compensation says something different
+      from the same figures reported as a retention design.
+
+      Record the incentive slots only where a source describes the structure or its
+      purpose. Most sources describe payments and say nothing about retention intent,
+      and an escalating schedule is not by itself evidence that retention was the
+      goal. Inferring one from the other is the failure the evidence boundary exists
+      to prevent.
 
       '
     from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
@@ -36948,6 +36962,53 @@ classes:
         from_schema: https://w3id.org/bridge2ai/data-sheets-schema/human
         slot_uri: d4d:compensationRationale
         alias: compensation_rationale
+        owner: HumanSubjectCompensation
+        domain_of:
+        - HumanSubjectCompensation
+        range: string
+      retention_incentives:
+        name: retention_incentives
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: Payment rises across the four annual visits, with a completion
+              bonus at year four, described in the protocol as designed to reduce
+              loss to follow-up.
+        description: 'Where the sources describe it, how the incentive structure was
+          designed to keep participants enrolled across the study — escalating amounts,
+          completion bonuses, payments tied to later visits or to returning after
+          a gap.
+
+          Distinct from `compensation_type` and `compensation_amount`, which record
+          what was provided. State this only where a source describes the structure.
+          An escalating payment schedule is not by itself evidence that retention
+          was its purpose; report the schedule under the compensation slots and leave
+          this absent.
+
+          '
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/human
+        slot_uri: d4d:retentionIncentiveStructure
+        alias: retention_incentives
+        owner: HumanSubjectCompensation
+        domain_of:
+        - HumanSubjectCompensation
+        range: string
+      retention_incentive_rationale:
+        name: retention_incentive_rationale
+        description: 'The stated reason for structuring incentives to support retention,
+          where a source gives one — an attrition rate the design responds to, an
+          IRB condition, or a documented equity concern about who can afford to stay
+          enrolled.
+
+          Separate from `retention_incentives` (the structure) for the same reason
+          `compensation_rationale` is separate from `compensation_amount`: what was
+          done and why it was done are different claims, and sources frequently give
+          one without the other.
+
+          '
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/human
+        slot_uri: d4d:retentionIncentiveRationale
+        alias: retention_incentive_rationale
         owner: HumanSubjectCompensation
         domain_of:
         - HumanSubjectCompensation

--- a/tests/test_retention_incentives.py
+++ b/tests/test_retention_incentives.py
@@ -110,3 +110,44 @@ class TestTheChangeIsAdditive(unittest.TestCase):
                 self.assertFalse(getattr(slots[slot], "deprecated", None),
                                  "compensation is still the right slot when "
                                  "the source reports only a payment")
+
+
+class TestItDoesNotCollideWithDataRetention(unittest.TestCase):
+    """`retention_limit` already exists and means how long the *data* is kept.
+
+    Found reviewing this change. Across all five project bundles nearly every
+    occurrence of "retention" is about data or specimen retention — "limits on
+    the retention of the data", "bioSpecRetention", "records retention
+    requirements". A run meeting `retention_incentives` with those sources in
+    context has an obvious wrong place to put them, and #403 recorded what
+    happens next: when two slots are near-synonyms and neither is constrained,
+    records pick one at random.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.view = SchemaView(str(FULL))
+        cls.slots = {s.name: s for s in
+                     cls.view.class_induced_slots("HumanSubjectCompensation")}
+
+    def test_both_slots_still_exist_separately(self):
+        dataset = {s.name for s in self.view.class_induced_slots("Dataset")}
+        self.assertIn("retention_limit", dataset)
+        self.assertIn("retention_incentives", self.slots)
+
+    def test_the_description_disambiguates_them_by_name(self):
+        """By name, not by implication — a reader resolving an ambiguity needs
+        to be told which other slot to use, not merely that this is not it."""
+        text = self.slots["retention_incentives"].description
+        self.assertIn("retention_limit", text)
+
+    def test_it_says_which_sense_of_retention_is_meant(self):
+        text = self.slots["retention_incentives"].description.lower()
+        self.assertIn("participants enrolled", text)
+        self.assertIn("never", text)
+
+    def test_it_says_an_empty_slot_is_correct(self):
+        """Otherwise a reviewer reads five empty slots as a generation failure
+        and someone 'fixes' it by filling them from data-retention text."""
+        text = self.slots["retention_incentives"].description
+        self.assertIn("empty slot is the correct outcome", text)

--- a/tests/test_retention_incentives.py
+++ b/tests/test_retention_incentives.py
@@ -1,0 +1,112 @@
+"""Compensation and retention incentives are separate claims (#504).
+
+From Camille Nebeker's review: *"For compensation, the goal should be to
+represent as incentives to prevent dropout of participants. Deemphasize
+compensation itself and replace with incentives."*
+
+**Widened rather than renamed.** Renaming `compensation_*` would move the schema
+digest and orphan the values already in the corpus, and — worse — it would make
+a record report a payment as a retention design when the source says only that a
+payment was made. The evidence usually says "compensation"; re-framing it is the
+`target` failure the fitness axis names.
+
+So the two live side by side, and these tests hold that they stay distinguishable.
+"""
+
+import unittest
+from pathlib import Path
+
+from linkml_runtime import SchemaView
+
+ROOT = Path(__file__).resolve().parents[1]
+FULL = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
+
+COMPENSATION = ("compensation_provided", "compensation_type",
+                "compensation_amount", "compensation_rationale")
+RETENTION = ("retention_incentives", "retention_incentive_rationale")
+
+
+class TestBothVocabulariesExist(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.view = SchemaView(str(FULL))
+        cls.slots = {s.name: s for s in
+                     cls.view.class_induced_slots("HumanSubjectCompensation")}
+
+    def test_the_compensation_slots_survive(self):
+        """The whole point of widening rather than renaming. If these ever
+        disappear, existing values are orphaned and every record that reports a
+        payment has nowhere honest to put it."""
+        for slot in COMPENSATION:
+            with self.subTest(slot=slot):
+                self.assertIn(slot, self.slots)
+
+    def test_the_retention_slots_exist(self):
+        for slot in RETENTION:
+            with self.subTest(slot=slot):
+                self.assertIn(slot, self.slots)
+
+    def test_structure_and_rationale_are_separate(self):
+        """What was done and why it was done are different claims, and sources
+        frequently give one without the other — the same reason
+        `compensation_rationale` is separate from `compensation_amount`."""
+        self.assertIn("retention_incentives", self.slots)
+        self.assertIn("retention_incentive_rationale", self.slots)
+
+    def test_the_retention_slots_have_their_own_uris(self):
+        """Reusing a compensation URI would erase the distinction downstream,
+        where a consumer sees the URI and not the slot name."""
+        uris = {self.slots[s].slot_uri for s in RETENTION}
+        comp = {self.slots[s].slot_uri for s in COMPENSATION}
+        self.assertEqual(uris & comp, set())
+        self.assertEqual(len(uris), len(RETENTION))
+
+    def test_nothing_is_required(self):
+        """A source that reports only a payment must produce a valid record.
+        Requiring a retention slot would force a run to invent intent."""
+        for slot in RETENTION:
+            with self.subTest(slot=slot):
+                self.assertFalse(self.slots[slot].required)
+
+
+class TestTheDescriptionsForbidInference(unittest.TestCase):
+    """The instruction half. Without it the schema invites exactly the error
+    the review would create: reading an escalating payment schedule as evidence
+    of retention design."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.view = SchemaView(str(FULL))
+        cls.slots = {s.name: s for s in
+                     cls.view.class_induced_slots("HumanSubjectCompensation")}
+
+    def test_the_class_says_the_two_must_not_be_conflated(self):
+        text = self.view.get_class("HumanSubjectCompensation").description
+        self.assertIn("must not be conflated", text)
+
+    def test_the_class_names_both_concepts(self):
+        text = self.view.get_class("HumanSubjectCompensation").description.lower()
+        self.assertIn("compensation", text)
+        self.assertIn("retention", text)
+
+    def test_retention_incentives_says_not_to_infer_from_a_schedule(self):
+        text = self.slots["retention_incentives"].description
+        self.assertIn("not by itself evidence", text)
+
+    def test_it_says_where_to_put_the_schedule_instead(self):
+        """A rule that says only "do not" leaves the run with nowhere to put a
+        true fact, which is how content gets dropped."""
+        text = self.slots["retention_incentives"].description
+        self.assertIn("compensation slots", text)
+
+
+class TestTheChangeIsAdditive(unittest.TestCase):
+    def test_no_compensation_slot_was_renamed_or_deprecated(self):
+        view = SchemaView(str(FULL))
+        slots = {s.name: s for s in
+                 view.class_induced_slots("HumanSubjectCompensation")}
+        for slot in COMPENSATION:
+            with self.subTest(slot=slot):
+                self.assertFalse(getattr(slots[slot], "deprecated", None),
+                                 "compensation is still the right slot when "
+                                 "the source reports only a payment")


### PR DESCRIPTION
Closes #504.

## The ask

Camille Nebeker: *"For compensation, the goal should be to represent as incentives to prevent dropout of participants. Deemphasize compensation itself and replace with incentives."*

## Widened, not renamed

This is what #504 itself recommends, and what the evidence requires.

Renaming `compensation_*` would move the schema digest and orphan values already in the corpus. Worse, it would make a record report a payment as a retention design when the source says only that a payment was made — the `target` failure the fitness axis names. **The sources overwhelmingly describe compensation**, and a record must represent what a source states.

So two new slots sit beside the four existing ones:

| slot | claim |
|---|---|
| `compensation_type` / `_amount` | what participants received |
| `compensation_rationale` | why that amount was appropriate |
| **`retention_incentives`** | how the structure was designed to keep them enrolled |
| **`retention_incentive_rationale`** | the stated reason for that design |

Each new slot has its own `slot_uri`, so the distinction survives into consumers that see a URI and not a slot name.

## Why this is substantive, not terminological

The ethical reading differs, which is why an Ethics and Privacy reviewer raised it. **"$40 then $80" reported as compensation says something different from the same figures reported as a retention design** — the second is a claim about study design and about who can afford to stay enrolled.

Structure and rationale are separate slots for the same reason `compensation_rationale` is separate from `compensation_amount`: what was done and why it was done are different claims, and sources routinely give one without the other.

## The load-bearing instruction

The descriptions state plainly that **an escalating payment schedule is not by itself evidence that retention was its purpose** — report the schedule under the compensation slots and leave the retention slots absent.

That second half matters. A rule that only said "do not infer" would leave a run with a true fact and nowhere to put it, which is how content gets dropped rather than corrected. A test holds both halves.

Nothing is required, so a source reporting only a payment still produces a valid record.

## Blast radius

17 verdicts pinned the schema and went `STALE` — the digest working as designed. All 17 revalidate unchanged, since adding optional slots is additive.

```
before: {'valid': 139, 'invalid': 19, 'stale': 17}
after:  {'valid': 156, 'invalid': 19}
```

The pair model is unaffected: `human_subject_research` remains a strict-identity slot and the identity count holds at 78.

**1808 passed, 4 skipped.** The 19 pre-existing lint problems in `D4D_Human.yaml` are unchanged and none mention these slots — verified against `main`.

## Timing

Between arms, deliberately. The API sweep is stopped and #517 established that a schema move during an arm is what must not happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)