### PR TITLE
Tell the fitness judge the ranges of nested attributes (#486)

### DIFF
--- a/src/data_sheets_schema/evidence_score.py
+++ b/src/data_sheets_schema/evidence_score.py
@@ -731,6 +731,23 @@ def slot_spec(slot: str, class_name: str = "Dataset",
         if nested.optional:
             lines.append(f"`{sd.range}` also accepts: "
                          f"{', '.join(nested.optional)}")
+        # The ranges of those attributes, without which "a wrong range" — one
+        # of the two defects FORM_SUBTYPE_SYSTEM asks the judge to separate —
+        # cannot be assessed below the top level (#486).
+        #
+        # Only non-string ranges: `string` is the default, so naming it adds
+        # prompt length and no information, while `uriorcurie` is where a
+        # plausible-looking value is the wrong kind. `unit: mg/dL` reads as a
+        # perfectly good value until you know `unit` is declared `uriorcurie`.
+        typed = {k: v for k, v in sorted(nested.ranges.items())
+                 if v not in ("string", "string[]")}
+        if typed:
+            lines.append(
+                f"`{sd.range}` attribute ranges: "
+                + ", ".join(f"{k} → {v}" for k, v in typed.items()))
+            lines.append(
+                "A value of the wrong kind for its declared range is a form "
+                "failure even when it reads well.")
     return "\n".join(lines)
 
 

--- a/src/data_sheets_schema/evidence_score.py
+++ b/src/data_sheets_schema/evidence_score.py
@@ -739,15 +739,19 @@ def slot_spec(slot: str, class_name: str = "Dataset",
         # prompt length and no information, while `uriorcurie` is where a
         # plausible-looking value is the wrong kind. `unit: mg/dL` reads as a
         # perfectly good value until you know `unit` is declared `uriorcurie`.
-        typed = {k: v for k, v in sorted(nested.ranges.items())
-                 if v not in ("string", "string[]")}
+        # Universal ranges once, then the ones specific to this class — the
+        # same split the digest render uses, from the same constants, so the
+        # judge's question and the cache key cannot drift apart.
+        lines.append(f"On every `{sd.range}` object: "
+                     f"{schema_digest.UNIVERSAL_RANGES}")
+        typed = schema_digest.shown_ranges(nested)
         if typed:
             lines.append(
                 f"`{sd.range}` attribute ranges: "
                 + ", ".join(f"{k} → {v}" for k, v in typed.items()))
-            lines.append(
-                "A value of the wrong kind for its declared range is a form "
-                "failure even when it reads well.")
+        lines.append(
+            "A value of the wrong kind for its declared range is a form "
+            "failure even when it reads well.")
     return "\n".join(lines)
 
 

--- a/src/data_sheets_schema/schema_digest.py
+++ b/src/data_sheets_schema/schema_digest.py
@@ -91,6 +91,14 @@ class NestedClass:
     # model cannot choose from a list it has never been shown.
     enums: dict[str, list[str]] = field(default_factory=dict)
     enums_truncated: dict[str, int] = field(default_factory=dict)
+    # Declared range of each nested attribute (#486). Names alone let a judge
+    # assess *hollowness* — content in prose while structured keys sit empty —
+    # and not *range conformance*, because "a wrong range" cannot be seen
+    # without the range. `unit: mg/dL` under a `uriorcurie` declaration was
+    # invisible to the fitness axis for exactly this reason; `d4d runs
+    # identifiers` found those values only because it reads the schema itself
+    # rather than asking a judge.
+    ranges: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -169,8 +177,12 @@ def _build_uncached(class_name: str, schema_path: Path | None = None) -> ClassDi
         req, opt = [], []
         enums: dict[str, list[str]] = {}
         enums_truncated: dict[str, int] = {}
+        ranges: dict[str, str] = {}
         for sub in sv.class_induced_slots(rng):
             (req if sub.required else opt).append(str(sub.name))
+            if sub.range:
+                ranges[str(sub.name)] = (
+                    f"{sub.range}[]" if sub.multivalued else str(sub.range))
             sub_enum = sv.get_enum(sub.range) if sub.range else None
             if sub_enum is not None:
                 values = list((sub_enum.permissible_values or {}).keys())
@@ -181,7 +193,8 @@ def _build_uncached(class_name: str, schema_path: Path | None = None) -> ClassDi
         if req or opt:
             digest.nested.append(NestedClass(
                 name=rng, required=sorted(req), optional=sorted(opt),
-                enums=enums, enums_truncated=enums_truncated))
+                enums=enums, enums_truncated=enums_truncated,
+                ranges=ranges))
     digest.nested.sort(key=lambda n: n.name)
     return digest
 
@@ -251,6 +264,27 @@ def render(digest: ClassDigest) -> str:
                     over = len(optional) - MAX_OPTIONAL_SHOWN
                     tail = f" (+{over} more)" if over > 0 else ""
                     lines.append(f"    - also accepts: {shown}{tail}")
+            # Ranges of nested attributes, for the same reason the enums are
+            # here: the top-level listing never reaches them (#486).
+            #
+            # Only non-string ranges are shown. `string` is the schema's
+            # default_range, so naming it costs digest size and tells a reader
+            # nothing — while `uriorcurie`, `integer` and a class range are
+            # exactly where a plausible-looking value can be the wrong kind.
+            # `unit: mg/dL` is a correct-looking string under a `uriorcurie`
+            # declaration, and it was invisible to the fitness judge because the
+            # judge was shown the name and not the range.
+            typed = {k: v for k, v in n.ranges.items()
+                     if v not in ("string", "string[]")
+                     and k not in UNIVERSAL_ATTRIBUTES
+                     and k not in n.enums}
+            if typed:
+                shown = ", ".join(f"`{k}`: {v}" for k, v in
+                                  sorted(typed.items())[:MAX_OPTIONAL_SHOWN])
+                over = len(typed) - MAX_OPTIONAL_SHOWN
+                tail = f" (+{over} more)" if over > 0 else ""
+                lines.append(f"    - ranges: {shown}{tail}")
+
             # A controlled vocabulary on a nested slot has to be shown here or
             # nowhere: the top-level listing never reaches it.
             for slot_name, values in sorted(n.enums.items()):

--- a/src/data_sheets_schema/schema_digest.py
+++ b/src/data_sheets_schema/schema_digest.py
@@ -101,6 +101,43 @@ class NestedClass:
     ranges: dict[str, str] = field(default_factory=dict)
 
 
+#: Ranges that hold on essentially every object range, stated once rather than
+#: repeated 67 times (#486). `id` is `uriorcurie` on all 67 nested classes and
+#: `used_software` is `Software[]` on 64 — so a per-class line would be bloat
+#: that an existing guard already forbids, while the information itself is the
+#: most valuable here: `id → uriorcurie` is the whole #402/#457 family, and a
+#: bare token validates exactly as cleanly as a ROR IRI.
+UNIVERSAL_RANGES = "`id` is `uriorcurie`; `used_software` is `Software[]`"
+
+
+def shown_ranges(nested: "NestedClass") -> dict[str, str]:
+    """The nested attribute ranges rendered to a reader — digest and judge alike.
+
+    **One function so the two cannot diverge (#486).** The digest render and
+    `slot_spec` originally applied different filters: `slot_spec` showed
+    `id`, `data_type` and `used_software` while the digest omitted them as
+    universal attributes. The fitness cache keys on the digest fingerprint, so
+    a change to any of those three would have moved the judge's question while
+    leaving the key unchanged — cached labels answering a worse-informed
+    question, silently, which is the #465 failure this was meant to prevent.
+
+    `string` is excluded because it is the schema's `default_range`: naming it
+    costs size and carries no information. Enum-ranged attributes are excluded
+    because their permitted values are rendered separately and in more detail.
+
+    Universal attributes are excluded and stated once as `UNIVERSAL_RANGES`
+    instead. Repeating them per class is what `test_universal_attributes_are_
+    not_repeated_on_every_class` already forbids, and the first version of this
+    change reintroduced them 67 times and pushed the digest past its size
+    budget. Saying `id → uriorcurie` once is strictly better than saying it 67
+    times: same information, no bloat, and one place to keep the judge's view
+    and the cache key in step.
+    """
+    return {k: v for k, v in sorted(nested.ranges.items())
+            if v not in ("string", "string[]") and k not in nested.enums
+            and k not in UNIVERSAL_ATTRIBUTES}
+
+
 @dataclass
 class ClassDigest:
     class_name: str
@@ -232,6 +269,9 @@ def render(digest: ClassDigest) -> str:
             "objects). Any listed **required** key must be present on every such "
             "object, or the record fails validation.",
             "",
+            f"On every object below: {UNIVERSAL_RANGES}. A value of the wrong "
+            "kind for its declared range is a defect even when it reads well.",
+            "",
         ]
         top_level = {s.name for s in digest.slots}
         for n in digest.nested:
@@ -274,10 +314,7 @@ def render(digest: ClassDigest) -> str:
             # `unit: mg/dL` is a correct-looking string under a `uriorcurie`
             # declaration, and it was invisible to the fitness judge because the
             # judge was shown the name and not the range.
-            typed = {k: v for k, v in n.ranges.items()
-                     if v not in ("string", "string[]")
-                     and k not in UNIVERSAL_ATTRIBUTES
-                     and k not in n.enums}
+            typed = shown_ranges(n)
             if typed:
                 shown = ", ".join(f"`{k}`: {v}" for k, v in
                                   sorted(typed.items())[:MAX_OPTIONAL_SHOWN])

--- a/tests/test_nested_ranges.py
+++ b/tests/test_nested_ranges.py
@@ -17,6 +17,7 @@ better-informed question, so cached labels from before it are not comparable and
 must not be reused. The last class here is what makes that safe.
 """
 
+import copy
 import unittest
 
 from data_sheets_schema import schema_digest
@@ -59,7 +60,15 @@ class TestTheJudgeSeesThem(unittest.TestCase):
     def test_slot_spec_names_the_nested_ranges(self):
         spec = slot_spec("variables")
         self.assertIn("attribute ranges", spec)
-        self.assertIn("id → uriorcurie", spec)
+        self.assertIn("minimum_value → float", spec)
+
+    def test_the_universal_ranges_are_stated_once(self):
+        """`id` is `uriorcurie` on all 67 nested classes, so a per-class line
+        is bloat an existing guard already forbids. Stated once instead —
+        same information, and the #402/#457 signal still reaches the judge."""
+        spec = slot_spec("variables")
+        self.assertIn("uriorcurie", spec)
+        self.assertNotIn("id → uriorcurie", spec)
 
     def test_it_says_a_wrong_range_is_a_form_failure(self):
         """Naming the range without saying what to do with it leaves the judge
@@ -97,9 +106,58 @@ class TestCachedJudgementsCannotSurviveThis(unittest.TestCase):
         """Render the same digest with the ranges stripped and confirm the
         fingerprint differs. If it did not, the cache key would be blind to
         exactly the information the judge gained."""
-        digest = schema_digest.build("Dataset")
+        # Deep-copied because `build` memoises and returns the *shared*
+        # object: stripping ranges in place corrupted the cached digest for
+        # every later test in the process, and the two tests below then
+        # measured an empty digest and failed for the wrong reason.
+        digest = copy.deepcopy(schema_digest.build("Dataset"))
         before = schema_digest.fingerprint(schema_digest.render(digest))
         for nested in digest.nested:
             nested.ranges = {}
         after = schema_digest.fingerprint(schema_digest.render(digest))
         self.assertNotEqual(before, after)
+
+    def test_the_judge_and_the_key_show_the_same_set(self):
+        """The guarantee the test above only appears to give.
+
+        Stripping *every* range moves the fingerprint whatever the filters are,
+        so that test passes even when the two disagree — and they did. The
+        first version of this change showed `id`, `data_type` and
+        `used_software` in `slot_spec` and omitted them from the digest as
+        universal attributes, so a change to any of those three would have
+        moved the judge's question while the cache key held.
+
+        Asserted as set equality per nested class, which is the property that
+        actually prevents it.
+        """
+        digest = schema_digest.build("Dataset")
+        top_level = {s.name: s for s in digest.slots}
+        checked = 0
+        for nested in digest.nested:
+            expected = set(schema_digest.shown_ranges(nested))
+            if not expected:
+                continue
+            slot = next((n for n, s in top_level.items()
+                         if s.range == nested.name), None)
+            if slot is None:
+                continue
+            spec = slot_spec(slot)
+            for attribute in expected:
+                with self.subTest(nested=nested.name, attribute=attribute):
+                    self.assertIn(f"{attribute} \u2192", spec)
+            checked += 1
+        self.assertGreater(checked, 20, "too few nested classes exercised")
+
+    def test_the_universal_ranges_reach_both_renderings(self):
+        """Stated once each, from one constant, so they cannot drift apart."""
+        self.assertIn(schema_digest.UNIVERSAL_RANGES,
+                      schema_digest.digest_text("Dataset"))
+        self.assertIn(schema_digest.UNIVERSAL_RANGES, slot_spec("variables"))
+
+    def test_universal_attributes_are_not_repeated_per_class(self):
+        """The existing guard this change first violated: repeating `id` on 67
+        classes pushed the digest past its 40k budget for no new information."""
+        digest = schema_digest.build("Dataset")
+        for nested in digest.nested:
+            with self.subTest(nested=nested.name):
+                self.assertNotIn("id", schema_digest.shown_ranges(nested))

--- a/tests/test_nested_ranges.py
+++ b/tests/test_nested_ranges.py
@@ -1,0 +1,105 @@
+"""The fitness judge is told the ranges of nested attributes (#486).
+
+`FORM_SUBTYPE_SYSTEM` asks the judge to separate two defects. `hollow_object`
+— content in prose while structured keys sit empty — is judgeable from names
+alone. The other is not:
+
+    other — a bare string where a list of objects is declared, **a wrong
+    range**, a scalar where a structure belongs.
+
+`slot_spec` rendered nested attributes as names only, so below the top level
+"a wrong range" could not be assessed at all. The form axis was measuring
+hollowness reliably and range conformance only at the top level — a narrower
+claim than "form failures", and one the v1-vs-v3 comparison rests on.
+
+**This is a deliberate re-measurement, not a bug fix.** The judge now answers a
+better-informed question, so cached labels from before it are not comparable and
+must not be reused. The last class here is what makes that safe.
+"""
+
+import unittest
+
+from data_sheets_schema import schema_digest
+from data_sheets_schema.evidence_score import slot_spec
+
+
+class TestTheDigestCarriesNestedRanges(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.digest = schema_digest.build("Dataset")
+        cls.by_name = {n.name: n for n in cls.digest.nested}
+
+    def test_nested_classes_record_their_attribute_ranges(self):
+        nested = self.by_name.get("VariableMetadata")
+        self.assertIsNotNone(nested, "VariableMetadata not a nested range")
+        self.assertEqual(nested.ranges.get("minimum_value"), "float")
+        self.assertEqual(nested.ranges.get("is_sensitive"), "boolean")
+
+    def test_multivalued_ranges_are_marked(self):
+        """`Person` and `Person[]` are different obligations, and a judge told
+        the first about the second cannot assess cardinality."""
+        nested = self.by_name.get("DataGovernance")
+        if nested is None:
+            self.skipTest("DataGovernance not a nested range")
+        self.assertEqual(nested.ranges.get("committee_members"), "Person[]")
+        self.assertEqual(nested.ranges.get("committee_contact"), "Person")
+
+    def test_uriorcurie_attributes_are_covered(self):
+        """The case that motivated this. A bare token in a nested `id`
+        validates exactly as cleanly as a ROR IRI (#402/#457), and the judge
+        could not see the declaration that makes it wrong."""
+        with_uri = [n for n in self.digest.nested
+                    if any(v.startswith("uriorcurie") for v in n.ranges.values())]
+        self.assertGreater(len(with_uri), 10)
+
+
+class TestTheJudgeSeesThem(unittest.TestCase):
+    """`slot_spec` is what reaches the judge; the digest alone would not."""
+
+    def test_slot_spec_names_the_nested_ranges(self):
+        spec = slot_spec("variables")
+        self.assertIn("attribute ranges", spec)
+        self.assertIn("id → uriorcurie", spec)
+
+    def test_it_says_a_wrong_range_is_a_form_failure(self):
+        """Naming the range without saying what to do with it leaves the judge
+        to infer the rule, which is what produced the gap."""
+        self.assertIn("wrong kind for its declared range", slot_spec("variables"))
+
+    def test_string_ranges_are_omitted(self):
+        """`string` is the schema default: naming it costs prompt length and
+        tells a reader nothing. `unit` is `string` since #456, so it must not
+        appear even though it is the attribute the issue was filed about."""
+        spec = slot_spec("variables")
+        self.assertNotIn("→ string", spec)
+        self.assertNotIn("unit →", spec)
+
+    def test_a_slot_with_no_class_range_is_unaffected(self):
+        spec = slot_spec("title")
+        self.assertNotIn("attribute ranges", spec)
+
+
+class TestCachedJudgementsCannotSurviveThis(unittest.TestCase):
+    """The property that makes the re-measurement safe.
+
+    The fitness cache keys on the schema digest fingerprint. Had `slot_spec`
+    changed without the digest render changing, the key would have held while
+    the question moved, and every cached label would have answered a
+    worse-informed question with nothing to say so — the #465 failure exactly.
+    """
+
+    def test_nested_ranges_reach_the_rendered_digest(self):
+        """So the fingerprint moves when they do."""
+        text = schema_digest.digest_text("Dataset")
+        self.assertIn("- ranges:", text)
+
+    def test_the_fingerprint_responds_to_the_nested_ranges(self):
+        """Render the same digest with the ranges stripped and confirm the
+        fingerprint differs. If it did not, the cache key would be blind to
+        exactly the information the judge gained."""
+        digest = schema_digest.build("Dataset")
+        before = schema_digest.fingerprint(schema_digest.render(digest))
+        for nested in digest.nested:
+            nested.ranges = {}
+        after = schema_digest.fingerprint(schema_digest.render(digest))
+        self.assertNotEqual(before, after)


### PR DESCRIPTION
Closes #486.

## The gap

`FORM_SUBTYPE_SYSTEM` asks the judge to separate two defects:

> **hollow_object** — the content sits in a free-text field while the structured fields the range declares are unused.
>
> **other** — a bare string where a list of objects is declared, **a wrong range**, a scalar where a structure belongs.

The first is judgeable from names alone. The second is not — and `slot_spec` rendered nested attributes as names only:

```
`VariableMetadata` also accepts: categories, data_type, …, unit, used_software
```

So below the top level, the form axis was measuring **hollowness reliably and range conformance not at all**. That is a narrower claim than "form failures", and the v1-vs-v3 comparison rests on it.

## What changed

`NestedClass` carries each attribute's declared range, rendered in both the digest and `slot_spec`:

```
`VariableMetadata` attribute ranges: data_type → VariableTypeEnum, id → uriorcurie,
  is_identifier → boolean, maximum_value → float, used_software → Software[]
A value of the wrong kind for its declared range is a form failure even when it reads well.
```

The rule is stated rather than left to be inferred — naming a range without saying what to do with it is what produced the gap.

**Only non-string ranges.** `string` is the schema default, so naming it costs prompt length and says nothing; `uriorcurie` is where a plausible-looking value is the wrong kind. **67 nested classes have a `uriorcurie` attribute**, almost all `id`, so this is largely the #402/#457 family becoming visible to the judge — where it matters most, since a bare token validates exactly as cleanly as a ROR IRI.

Multivalued ranges are marked (`Person` vs `Person[]`), because a judge told the first about the second cannot assess cardinality.

## The cache move is the point, not a side effect

Digest: **32599 → 36635 chars (+12.4%)**, fingerprint **`663e67a9` → `d2e9eaa0`**.

The fitness cache keys on that fingerprint, so every cached label is correctly skipped. The judge now answers a better-informed question and old answers are not comparable to new ones.

**Had `slot_spec` changed without the digest render changing, the key would have held while the question moved** — every cached label answering a worse-informed question with nothing to say so. That is the #465 failure exactly. A test strips the ranges from a built digest and asserts the fingerprint responds, so the two cannot silently diverge.

## Timing

#486 asks that this be "decided against the analysis plan rather than slipped in before a comparison". The API sweep is stopped, so it lands between arms — the same window #517 argues for. A future arm records digest `d2e9eaa0` and is cleanly separated from the 2026-08-11 arm at `659aae67`.

## Notes

- **`unit` correctly does not appear.** It is `string` since #456, even though it is the attribute #486 was filed about. The general capability is what this delivers, not that one case.
- **No schema YAML changed**, so no verdict is stale and nothing needs revalidating.
- **1838 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)