### PR TITLE
Give data standards a vocabulary that reaches core (#403)

### DIFF
--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -304,8 +304,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_d4d_core.yaml
       md5: 19f4a17c60311d6bbc32fd06d266a76c
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/AI_READI_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -266,8 +266,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_d4d_core.yaml
       md5: 57d52aa67e15baf249e791cd1ce32481
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 intermediates:
 - path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/intermediate/CHORUS_audit.json

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_d4d_core.yaml
       md5: 7fa94e1ccb88dcc9d7090ce6ff0b49d5
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_d4d_core.yaml
       md5: cc5bea839075f00de433612a313f358a
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_d4d_core.yaml
       md5: 1afef4d05562622097d4e577b3bb4648
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 94585ede7df663fb3b0a2f601f639fac
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_d4d_core.yaml
       md5: d5dfd18340393dfd485b22c888d33010
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_d4d_core.yaml
       md5: bf8d3706efaf398738fbbdbcfc098c70
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_d4d_core.yaml
       md5: 658a6794c50cda7ae4b52beb5192c366
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_d4d_core.yaml
       md5: 67384e7d32a1740264d74ee6ed79c501
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 4634f260ce16cbbeda7017e8bd5e0cea
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_d4d_core.yaml
       md5: 81cdfa0b72a0ed18c08eb8a3ae5901a8
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
@@ -130,8 +130,8 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_d4d_core.yaml
       md5: 54464b3bb28dfa874966782a218526ee
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:
   criterion: full and core both validate against the current schema, then most slots,

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_d4d_core.yaml
       md5: cbf2482273b6d8bcfa10711b43266cf5
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_d4d_core.yaml
       md5: de505046d64b4139dcd43f4b2dcbf730
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_d4d_core.yaml
       md5: a6cd0da0d9079e6726857bec5c05eca7
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_d4d_core.yaml
       md5: a25640d2448384452c46bd5bec04ca2e
   schema:
-    full_sha256: da5ad57b5db9e0b832ad2ae4c048550601b213b69f5d786b768adcbb7287cc88
-    core_sha256: 9b3fbe3bb8fdc01792ee41dd9db75cbef3c5ea40fdc1d90d5fce037951ad154f
+    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/src/data_sheets_schema/schema/D4D_Base_import.yaml
+++ b/src/data_sheets_schema/schema/D4D_Base_import.yaml
@@ -296,6 +296,7 @@ classes:
       - conforms_to
       - conforms_to_class
       - conforms_to_schema
+      - conforms_to_standard
       - created_by
       - created_on
       - doi
@@ -489,6 +490,27 @@ slots:
     annotations:
       "d4d:docExample": "Brain Imaging Data Structure (BIDS) v1.9.0"
 
+  conforms_to_standard:
+    description: >-
+      Which registered data standard `conforms_to` names, where one applies —
+      a term rather than prose, so the corpus can be queried for "what
+      standards does this follow?" (#403).
+
+      `conforms_to` records what the sources say, in their words. This records
+      which standard that is. Populate both for the same standard: one is
+      verbatim evidence, the other is the normalized term, and they answer
+      different questions.
+
+      Use `OTHER` when the sources name a standard this vocabulary lacks, and
+      keep the name in `conforms_to` so nothing is lost. Never pick a
+      near-neighbour — reporting BIDS because a dataset is neuroimaging, when
+      the sources say otherwise, is an invention.
+    slot_uri: dcterms:conformsTo
+    range: DataStandardEnum
+    multivalued: true
+    annotations:
+      "d4d:docExample": "BIDS"
+
   conforms_to_schema:
     description: >-
       The metadata schema **this record itself** is written in — normally
@@ -617,6 +639,68 @@ slots:
 
 ## SHARED ENUMS ##
 enums:
+
+  DataStandardEnum:
+    description: >-
+      Data standards and common data models a dataset's content follows.
+
+      Deliberately **not** merged into `FormatEnum` (#403). A serialization and
+      a data standard are different concepts: CSV says how bytes are laid out,
+      OMOP CDM says what the columns mean. Widening `FormatEnum` to absorb
+      DICOM would conflate them and make `format` unanswerable.
+
+      Free-text `conforms_to` records what a source *says*; this records which
+      registered standard that is, where one applies. Both may be populated for
+      the same standard — one verbatim, one normalized — which is the ordinary
+      label-plus-code pattern and is consistent with the per-slot completeness
+      decision on #501.
+
+      ⚠️ **No `meaning:` is asserted on any value.** Several of these standards
+      have no stable ontology term this repository can verify, and inventing a
+      CURIE that resolves to nothing is worse than leaving the grounding
+      absent — it is the exact failure `d4d runs identifiers` exists to find.
+      The `B2AI_STANDARD` prefix is declared and is the natural home for these
+      once the registry carries them; until it does, this is a controlled
+      vocabulary without ontology grounding, and says so.
+    permissible_values:
+      DICOM:
+        description: >-
+          Digital Imaging and Communications in Medicine — imaging data and
+          its acquisition metadata.
+      BIDS:
+        description: >-
+          Brain Imaging Data Structure — a file and directory layout with
+          accompanying metadata for neuroimaging and related recordings.
+      OMOP_CDM:
+        description: >-
+          Observational Medical Outcomes Partnership Common Data Model — a
+          relational model for observational health data.
+      WFDB:
+        description: >-
+          WaveForm DataBase — physiologic signal records and annotations.
+      OPEN_MHEALTH:
+        description: >-
+          Open mHealth — schemas for mobile health and wearable measures.
+      ESDS:
+        description: >-
+          ASCII File Format Guidelines for Earth Science Data.
+      CDS:
+        description: >-
+          Clinical Dataset Structure.
+      RO_CRATE:
+        description: >-
+          RO-Crate — a packaging convention describing a dataset and its
+          context as linked data.
+      FHIR:
+        description: >-
+          HL7 FHIR — a standard for exchanging healthcare information.
+      OTHER:
+        description: >-
+          A standard the sources name that has no value here. Use it **with**
+          `conforms_to` carrying the name as the source states it, so the fact
+          is not lost to the absence of a term. A run must never pick a
+          near-neighbour: reporting BIDS because a dataset is neuroimaging,
+          when the sources say something else, is an invention.
 
   FormatEnum:
     description: Common file format extensions for data files and documents.

--- a/src/data_sheets_schema/schema/D4D_Core.yaml
+++ b/src/data_sheets_schema/schema/D4D_Core.yaml
@@ -89,6 +89,11 @@ classes:
       # member — but the loss was created by the schema, not by the evidence,
       # and took a paragraph of reconciliation prose to explain.
       - conforms_to
+      # And the term for it (#403). Free text could reach core once
+      # `conforms_to` was added, but a string cannot be queried or mapped —
+      # the exchange layer's whole purpose. `DataStandardEnum` crosses into
+      # core where prose cannot.
+      - conforms_to_standard
 
   # ---------------------------------------------------------------------------
   # CoreDatasetCollection — tree root for core exchange datasheets

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -394,6 +394,67 @@ types:
     uri: xsd:string
     repr: str
 enums:
+  DataStandardEnum:
+    name: DataStandardEnum
+    description: 'Data standards and common data models a dataset''s content follows.
+
+      Deliberately **not** merged into `FormatEnum` (#403). A serialization and a
+      data standard are different concepts: CSV says how bytes are laid out, OMOP
+      CDM says what the columns mean. Widening `FormatEnum` to absorb DICOM would
+      conflate them and make `format` unanswerable.
+
+      Free-text `conforms_to` records what a source *says*; this records which registered
+      standard that is, where one applies. Both may be populated for the same standard
+      — one verbatim, one normalized — which is the ordinary label-plus-code pattern
+      and is consistent with the per-slot completeness decision on #501.
+
+      ⚠️ **No `meaning:` is asserted on any value.** Several of these standards have
+      no stable ontology term this repository can verify, and inventing a CURIE that
+      resolves to nothing is worse than leaving the grounding absent — it is the exact
+      failure `d4d runs identifiers` exists to find. The `B2AI_STANDARD` prefix is
+      declared and is the natural home for these once the registry carries them; until
+      it does, this is a controlled vocabulary without ontology grounding, and says
+      so.'
+    from_schema: https://w3id.org/bridge2ai/data-sheets-schema
+    permissible_values:
+      DICOM:
+        text: DICOM
+        description: Digital Imaging and Communications in Medicine — imaging data
+          and its acquisition metadata.
+      BIDS:
+        text: BIDS
+        description: Brain Imaging Data Structure — a file and directory layout with
+          accompanying metadata for neuroimaging and related recordings.
+      OMOP_CDM:
+        text: OMOP_CDM
+        description: Observational Medical Outcomes Partnership Common Data Model
+          — a relational model for observational health data.
+      WFDB:
+        text: WFDB
+        description: WaveForm DataBase — physiologic signal records and annotations.
+      OPEN_MHEALTH:
+        text: OPEN_MHEALTH
+        description: Open mHealth — schemas for mobile health and wearable measures.
+      ESDS:
+        text: ESDS
+        description: ASCII File Format Guidelines for Earth Science Data.
+      CDS:
+        text: CDS
+        description: Clinical Dataset Structure.
+      RO_CRATE:
+        text: RO_CRATE
+        description: RO-Crate — a packaging convention describing a dataset and its
+          context as linked data.
+      FHIR:
+        text: FHIR
+        description: HL7 FHIR — a standard for exchanging healthcare information.
+      OTHER:
+        text: OTHER
+        description: 'A standard the sources name that has no value here. Use it **with**
+          `conforms_to` carrying the name as the source states it, so the fact is
+          not lost to the absence of a term. A run must never pick a near-neighbour:
+          reporting BIDS because a dataset is neuroimaging, when the sources say something
+          else, is an invention.'
   FormatEnum:
     name: FormatEnum
     description: Common file format extensions for data files and documents.
@@ -1802,6 +1863,34 @@ slots:
     - Dataset
     - DataSubset
     - File
+  conforms_to_standard:
+    name: conforms_to_standard
+    annotations:
+      d4d:docExample:
+        tag: d4d:docExample
+        value: BIDS
+    description: 'Which registered data standard `conforms_to` names, where one applies
+      — a term rather than prose, so the corpus can be queried for "what standards
+      does this follow?" (#403).
+
+      `conforms_to` records what the sources say, in their words. This records which
+      standard that is. Populate both for the same standard: one is verbatim evidence,
+      the other is the normalized term, and they answer different questions.
+
+      Use `OTHER` when the sources name a standard this vocabulary lacks, and keep
+      the name in `conforms_to` so nothing is lost. Never pick a near-neighbour —
+      reporting BIDS because a dataset is neuroimaging, when the sources say otherwise,
+      is an invention.'
+    from_schema: https://w3id.org/bridge2ai/data-sheets-schema
+    slot_uri: dcterms:conformsTo
+    domain_of:
+    - Information
+    - DatasetCollection
+    - Dataset
+    - DataSubset
+    - File
+    range: DataStandardEnum
+    multivalued: true
   conforms_to_schema:
     name: conforms_to_schema
     annotations:
@@ -2171,6 +2260,36 @@ classes:
         - DataSubset
         - File
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: DatasetCollection
+        domain_of:
+        - Information
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - File
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:
@@ -4119,6 +4238,36 @@ classes:
         - DataSubset
         - File
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: Dataset
+        domain_of:
+        - Information
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - File
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:
@@ -6006,6 +6155,36 @@ classes:
         - DataSubset
         - File
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: DataSubset
+        domain_of:
+        - Information
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - File
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:
@@ -8913,6 +9092,7 @@ classes:
     - conforms_to
     - conforms_to_class
     - conforms_to_schema
+    - conforms_to_standard
     - created_by
     - created_on
     - doi
@@ -9021,6 +9201,36 @@ classes:
         - DataSubset
         - File
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: Information
+        domain_of:
+        - Information
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - File
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:
@@ -47039,6 +47249,36 @@ classes:
         - DataSubset
         - File
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: File
+        domain_of:
+        - Information
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - File
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:
@@ -48033,6 +48273,36 @@ classes:
         - DataSubset
         - File
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: FileCollection
+        domain_of:
+        - Information
+        - DatasetCollection
+        - Dataset
+        - DataSubset
+        - File
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:

--- a/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
@@ -400,6 +400,67 @@ types:
     uri: xsd:string
     repr: str
 enums:
+  DataStandardEnum:
+    name: DataStandardEnum
+    description: 'Data standards and common data models a dataset''s content follows.
+
+      Deliberately **not** merged into `FormatEnum` (#403). A serialization and a
+      data standard are different concepts: CSV says how bytes are laid out, OMOP
+      CDM says what the columns mean. Widening `FormatEnum` to absorb DICOM would
+      conflate them and make `format` unanswerable.
+
+      Free-text `conforms_to` records what a source *says*; this records which registered
+      standard that is, where one applies. Both may be populated for the same standard
+      — one verbatim, one normalized — which is the ordinary label-plus-code pattern
+      and is consistent with the per-slot completeness decision on #501.
+
+      ⚠️ **No `meaning:` is asserted on any value.** Several of these standards have
+      no stable ontology term this repository can verify, and inventing a CURIE that
+      resolves to nothing is worse than leaving the grounding absent — it is the exact
+      failure `d4d runs identifiers` exists to find. The `B2AI_STANDARD` prefix is
+      declared and is the natural home for these once the registry carries them; until
+      it does, this is a controlled vocabulary without ontology grounding, and says
+      so.'
+    from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
+    permissible_values:
+      DICOM:
+        text: DICOM
+        description: Digital Imaging and Communications in Medicine — imaging data
+          and its acquisition metadata.
+      BIDS:
+        text: BIDS
+        description: Brain Imaging Data Structure — a file and directory layout with
+          accompanying metadata for neuroimaging and related recordings.
+      OMOP_CDM:
+        text: OMOP_CDM
+        description: Observational Medical Outcomes Partnership Common Data Model
+          — a relational model for observational health data.
+      WFDB:
+        text: WFDB
+        description: WaveForm DataBase — physiologic signal records and annotations.
+      OPEN_MHEALTH:
+        text: OPEN_MHEALTH
+        description: Open mHealth — schemas for mobile health and wearable measures.
+      ESDS:
+        text: ESDS
+        description: ASCII File Format Guidelines for Earth Science Data.
+      CDS:
+        text: CDS
+        description: Clinical Dataset Structure.
+      RO_CRATE:
+        text: RO_CRATE
+        description: RO-Crate — a packaging convention describing a dataset and its
+          context as linked data.
+      FHIR:
+        text: FHIR
+        description: HL7 FHIR — a standard for exchanging healthcare information.
+      OTHER:
+        text: OTHER
+        description: 'A standard the sources name that has no value here. Use it **with**
+          `conforms_to` carrying the name as the source states it, so the fact is
+          not lost to the absence of a term. A run must never pick a near-neighbour:
+          reporting BIDS because a dataset is neuroimaging, when the sources say something
+          else, is an invention.'
   FormatEnum:
     name: FormatEnum
     description: Common file format extensions for data files and documents.
@@ -1670,6 +1731,32 @@ slots:
     - Information
     - CoreDistribution
     - CoreDatasetCollection
+  conforms_to_standard:
+    name: conforms_to_standard
+    annotations:
+      d4d:docExample:
+        tag: d4d:docExample
+        value: BIDS
+    description: 'Which registered data standard `conforms_to` names, where one applies
+      — a term rather than prose, so the corpus can be queried for "what standards
+      does this follow?" (#403).
+
+      `conforms_to` records what the sources say, in their words. This records which
+      standard that is. Populate both for the same standard: one is verbatim evidence,
+      the other is the normalized term, and they answer different questions.
+
+      Use `OTHER` when the sources name a standard this vocabulary lacks, and keep
+      the name in `conforms_to` so nothing is lost. Never pick a near-neighbour —
+      reporting BIDS because a dataset is neuroimaging, when the sources say otherwise,
+      is an invention.'
+    from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
+    slot_uri: dcterms:conformsTo
+    domain_of:
+    - Information
+    - CoreDistribution
+    - CoreDatasetCollection
+    range: DataStandardEnum
+    multivalued: true
   conforms_to_schema:
     name: conforms_to_schema
     annotations:
@@ -3949,6 +4036,7 @@ classes:
     - conforms_to
     - conforms_to_class
     - conforms_to_schema
+    - conforms_to_standard
     - created_by
     - created_on
     - doi
@@ -4046,6 +4134,34 @@ classes:
         - Information
         - CoreDatasetCollection
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: Information
+        domain_of:
+        - Information
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:
@@ -41134,6 +41250,7 @@ classes:
     - compression
     - media_type
     - conforms_to
+    - conforms_to_standard
     attributes:
       bytes:
         name: bytes
@@ -41299,6 +41416,34 @@ classes:
         - CoreDistribution
         - CoreDatasetCollection
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: CoreDistribution
+        domain_of:
+        - Information
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: DataStandardEnum
+        multivalued: true
       id:
         name: id
         annotations:
@@ -41905,6 +42050,34 @@ classes:
         - Information
         - CoreDatasetCollection
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: CoreDatasetCollection
+        domain_of:
+        - Information
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:
@@ -43523,6 +43696,34 @@ classes:
         - Information
         - CoreDatasetCollection
         range: string
+      conforms_to_standard:
+        name: conforms_to_standard
+        annotations:
+          d4d:docExample:
+            tag: d4d:docExample
+            value: BIDS
+        description: 'Which registered data standard `conforms_to` names, where one
+          applies — a term rather than prose, so the corpus can be queried for "what
+          standards does this follow?" (#403).
+
+          `conforms_to` records what the sources say, in their words. This records
+          which standard that is. Populate both for the same standard: one is verbatim
+          evidence, the other is the normalized term, and they answer different questions.
+
+          Use `OTHER` when the sources name a standard this vocabulary lacks, and
+          keep the name in `conforms_to` so nothing is lost. Never pick a near-neighbour
+          — reporting BIDS because a dataset is neuroimaging, when the sources say
+          otherwise, is an invention.'
+        from_schema: https://w3id.org/bridge2ai/data-sheets-schema/core-schema
+        slot_uri: dcterms:conformsTo
+        alias: conforms_to_standard
+        owner: CoreDataset
+        domain_of:
+        - Information
+        - CoreDistribution
+        - CoreDatasetCollection
+        range: DataStandardEnum
+        multivalued: true
       created_by:
         name: created_by
         annotations:

--- a/tests/test_d4d_pair_consistency.py
+++ b/tests/test_d4d_pair_consistency.py
@@ -47,6 +47,11 @@ class TestD4DPairConsistency(unittest.TestCase):
     #: state the same fact in either record, so a full/core pair disagreeing
     #: about who runs the access committee is a defect and not a projection.
     #:
+    #: Went 78 -> 79 when `conforms_to_standard` was added (#403). Identity is
+    #: right: which standard the *data* follows is a fact about the data and is
+    #: the same in either record — unlike `conforms_to_class`, which describes
+    #: the record and is per-record for that reason.
+    #:
     #: Went 80 -> 78 when `conforms_to_class` and `conforms_to_schema` became
     #: per-record slots (#499). They describe the record rather than the
     #: dataset, so their correct values *differ* between a pair — identity
@@ -56,7 +61,7 @@ class TestD4DPairConsistency(unittest.TestCase):
     'acquisition_methods', 'addressing_gaps', 'annotation_analyses',
     'anomalies', 'at_risk_populations', 'cleaning_strategies',
     'collection_mechanisms', 'collection_timeframes', 'compression',
-    'confidential_elements', 'conforms_to',
+    'confidential_elements', 'conforms_to', 'conforms_to_standard',
     'content_warnings', 'created_by',
     'created_on', 'creators', 'data_collectors', 'data_governance',
     'data_protection_impacts', 'description', 'discouraged_uses',

--- a/tests/test_data_standards.py
+++ b/tests/test_data_standards.py
@@ -145,3 +145,56 @@ class TestTheGroundingGapIsNamed(unittest.TestCase):
 
     def test_the_absence_is_documented_rather_than_silent(self):
         self.assertIn("No `meaning:` is asserted", self.enum.description)
+
+
+BUNDLES = ROOT / "data/preprocessed/concatenated"
+
+#: How each value is actually written in the source documents. A vocabulary
+#: value is a claim that some dataset follows this standard, so it has to be
+#: traceable to evidence like any other claim.
+IN_SOURCES = {
+    "DICOM": "DICOM",
+    "BIDS": "Brain Imaging Data Structure",
+    "OMOP_CDM": "OMOP",
+    "WFDB": "WFDB",
+    "OPEN_MHEALTH": "Open mHealth",
+    "ESDS": "Earth Science Data",
+    "CDS": "Clinical Dataset Structure",
+    "RO_CRATE": "RO-Crate",
+    "FHIR": "FHIR",
+}
+
+
+@unittest.skipUnless(BUNDLES.exists(), "bundles absent")
+class TestEveryValueIsAttested(unittest.TestCase):
+    """No value comes from model memory.
+
+    `CDS` — "Clinical Dataset Structure v0.1.1" — was the one to check: it
+    appears in a generated record, and a standard named only by a record and
+    by no source would be a hallucination about to be enshrined in the schema,
+    where it would look authoritative for ever. It appears on 19 lines of the
+    bundles, so it is real.
+
+    This guard matters more than it looks. Adding a plausible standard is easy
+    and unfalsifiable once merged: the schema is not evidence, and nothing else
+    would ever check it against a source.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = "\n".join(
+            p.read_text(encoding="utf-8", errors="replace").lower()
+            for p in sorted(BUNDLES.glob("*_preprocessed.txt")))
+
+    def test_each_value_appears_in_some_bundle(self):
+        for value, phrase in IN_SOURCES.items():
+            with self.subTest(value=value):
+                self.assertIn(phrase.lower(), self.text,
+                              f"{value} is named by no source document")
+
+    def test_every_enum_value_is_covered_by_this_check(self):
+        """So a value added later cannot skip the check by not being listed."""
+        enum = SchemaView(str(FULL)).get_enum("DataStandardEnum")
+        unchecked = set(enum.permissible_values) - set(IN_SOURCES) - {"OTHER"}
+        self.assertEqual(unchecked, set(),
+                         "a vocabulary value with no attestation entry")

--- a/tests/test_data_standards.py
+++ b/tests/test_data_standards.py
@@ -1,0 +1,147 @@
+"""Data standards are terms, not prose (#403).
+
+Every record of `2026-08-07_…-generic-v3_rep1` put a data standard into free
+text `conforms_to`, in four different shapes for one concept:
+
+    Brain Imaging Data Structure (BIDS) v1.9.0
+    Digital Imaging and Communications in Medicine (DICOM)
+    Open mHealth
+    https://www.researchobject.org/ro-crate/
+
+None resolvable to a term, so the corpus cannot be queried for "what standards
+does this follow?" — and a free string had no way into the exchange layer.
+
+Added rather than replaced. `conforms_to` still records what the sources *say*;
+`conforms_to_standard` records which standard that is.
+"""
+
+import unittest
+from pathlib import Path
+
+from linkml_runtime import SchemaView
+
+ROOT = Path(__file__).resolve().parents[1]
+FULL = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
+CORE = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml"
+
+#: The standards actually seen in the corpus, which the vocabulary must cover
+#: or the slot is unusable on the records that motivated it.
+OBSERVED = ("DICOM", "BIDS", "OMOP_CDM", "WFDB", "OPEN_MHEALTH", "ESDS",
+            "CDS", "RO_CRATE")
+
+
+class TestTheVocabularyExists(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.view = SchemaView(str(FULL))
+        cls.enum = cls.view.get_enum("DataStandardEnum")
+
+    def test_the_enum_exists(self):
+        self.assertIsNotNone(self.enum)
+
+    def test_it_covers_every_standard_the_corpus_names(self):
+        values = set(self.enum.permissible_values)
+        for standard in OBSERVED:
+            with self.subTest(standard=standard):
+                self.assertIn(standard, values)
+
+    def test_it_has_an_escape_hatch(self):
+        """Without `OTHER` a run meeting an uncovered standard either drops the
+        fact or picks a near-neighbour, and the second is an invention."""
+        self.assertIn("OTHER", self.enum.permissible_values)
+
+    def test_other_says_to_keep_the_name(self):
+        text = self.enum.permissible_values["OTHER"].description
+        self.assertIn("conforms_to", text)
+
+    def test_it_warns_against_the_near_neighbour(self):
+        text = self.enum.permissible_values["OTHER"].description
+        self.assertIn("invention", text)
+
+
+class TestItIsNotMergedIntoFormatEnum(unittest.TestCase):
+    """A serialization and a data standard are different concepts. Widening
+    `FormatEnum` to absorb DICOM would make `format` unanswerable."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.view = SchemaView(str(FULL))
+
+    def test_format_enum_does_not_carry_data_standards(self):
+        values = set(self.view.get_enum("FormatEnum").permissible_values)
+        for standard in ("DICOM", "BIDS", "OMOP_CDM", "WFDB"):
+            with self.subTest(standard=standard):
+                self.assertNotIn(standard, values)
+
+    def test_the_two_enums_do_not_overlap(self):
+        fmt = set(self.view.get_enum("FormatEnum").permissible_values)
+        std = set(self.view.get_enum("DataStandardEnum").permissible_values)
+        self.assertEqual(fmt & std, set())
+
+
+class TestItReachesTheExchangeLayer(unittest.TestCase):
+    """The projection failure #403 reported: a free string had no home in core,
+    so the most interoperability-relevant fact about a distribution was lost."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.core = SchemaView(str(CORE))
+
+    def test_core_distribution_carries_it(self):
+        slots = {s.name for s in
+                 self.core.class_induced_slots("CoreDistribution")}
+        self.assertIn("conforms_to_standard", slots)
+
+    def test_core_dataset_carries_it(self):
+        slots = {s.name for s in self.core.class_induced_slots("CoreDataset")}
+        self.assertIn("conforms_to_standard", slots)
+
+    def test_the_enum_resolves_from_the_core_schema(self):
+        """A slot whose range is unreachable would generate but not validate."""
+        self.assertIsNotNone(self.core.get_enum("DataStandardEnum"))
+
+
+class TestFreeTextSurvives(unittest.TestCase):
+    """Added, not replaced. The sources say things the vocabulary cannot, and
+    a term-only slot would drop `ASCII File Format Guidelines for Earth Science
+    Data` rather than record it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.view = SchemaView(str(FULL))
+        cls.slots = {s.name: s for s in cls.view.class_induced_slots("Dataset")}
+
+    def test_conforms_to_is_still_free_text(self):
+        self.assertEqual(self.slots["conforms_to"].range, "string")
+
+    def test_the_new_slot_is_multivalued(self):
+        """A dataset commonly follows several standards — AI_READI names five."""
+        self.assertTrue(self.slots["conforms_to_standard"].multivalued)
+
+    def test_neither_is_required(self):
+        for slot in ("conforms_to", "conforms_to_standard"):
+            with self.subTest(slot=slot):
+                self.assertFalse(self.slots[slot].required)
+
+    def test_the_description_says_to_populate_both(self):
+        text = self.slots["conforms_to_standard"].description
+        self.assertIn("Populate both", text)
+
+
+class TestTheGroundingGapIsNamed(unittest.TestCase):
+    """No `meaning:` is asserted. Several of these standards have no stable
+    ontology term this repository can verify, and inventing a CURIE that
+    resolves to nothing is the failure `d4d runs identifiers` exists to find.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.enum = SchemaView(str(FULL)).get_enum("DataStandardEnum")
+
+    def test_no_value_asserts_an_unverified_meaning(self):
+        for name, value in self.enum.permissible_values.items():
+            with self.subTest(value=name):
+                self.assertIsNone(value.meaning)
+
+    def test_the_absence_is_documented_rather_than_silent(self):
+        self.assertIn("No `meaning:` is asserted", self.enum.description)


### PR DESCRIPTION
Closes #403.

## Two of the three items were already done

Confirmed rather than redone:

- **Item 1** — `conforms_to_schema` / `conforms_to_class` now have distinct, enforced meanings via #499: they describe *the record*, so they are per-record slots exempt from strict identity. They are no longer near-synonyms of `conforms_to`.
- **Item 3** — `CoreDistribution.conforms_to` already exists.

## What remained: the vocabulary

Every record of `2026-08-07_…-generic-v3_rep1` put a data standard into free-text `conforms_to`, in four shapes for one concept — long-name-plus-parenthetical, bare name, name-with-version, raw URL. None resolvable to a term, so the corpus cannot be queried for "what standards does this follow?".

`DataStandardEnum` covers the eight the corpus names (DICOM, BIDS, OMOP_CDM, WFDB, OPEN_MHEALTH, ESDS, CDS, RO_CRATE) plus FHIR and `OTHER`. `conforms_to_standard` carries it on `Dataset`, `CoreDataset` and `CoreDistribution`.

**That closes the projection loss.** A free string had no home in core, so the most interoperability-relevant fact about a distribution was dropped. AI_READI's phase 4 handled it correctly — it left `format` unset rather than coerce a wrong enum member — but the loss was created by the schema and took a paragraph of reconciliation prose to explain.

## Not merged into FormatEnum

The issue warns against this and a test now enforces it. CSV says how bytes are laid out; OMOP CDM says what the columns *mean*. Absorbing DICOM would conflate the two and make `format` unanswerable. The two enums are asserted disjoint.

## Added, not replaced

`conforms_to` stays free text recording what the sources say. The new slot records which standard that is. **Both are populated for the same standard** — verbatim and normalized — the ordinary label-plus-code pattern, and consistent with what #501 decided about repetition.

A term-only slot would drop "ASCII File Format Guidelines for Earth Science Data" rather than record it. `OTHER` exists so an uncovered standard is kept rather than forced onto a near-neighbour: **reporting BIDS because a dataset is neuroimaging, when the sources say otherwise, is an invention**, and the enum says so where a run will read it.

## The grounding gap is named, not papered over

**No `meaning:` is asserted on any value**, and the enum's own description explains why. Several of these standards have no stable ontology term this repository can verify, and a CURIE that resolves to nothing is exactly what `d4d runs identifiers` exists to find. `B2AI_STANDARD` is declared and is the natural home once the registry carries them; until then this is a controlled vocabulary without ontology grounding, and says so.

A test asserts every value's `meaning` is `None`, so grounding cannot arrive by accident — only by decision.

## State

Identity slots **78 → 79**. Identity is right here: which standard the *data* follows is a fact about the data and is the same in either record — unlike `conforms_to_class`, which describes the record.

17 verdicts went `STALE` on the schema move; all 17 revalidate unchanged. Corpus at 156 valid, 0 stale.

**1858 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)