### PR TITLE
A URI without :// is still a URI (#530)

### DIFF
--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -116,6 +116,12 @@ def identifiers_cmd(label, method, output, show, strict):
     click.echo(f"   slots with range uriorcurie: {', '.join(slots)}")
     c = report["counts"]
     click.echo(f"   {c[ident.URI]:>6}  absolute IRI")
+    # Named separately, never folded into either neighbour (#530). Folded into
+    # `uri` it would claim resolvability these do not have; left among the
+    # undeclared CURIEs it inflated the unresolvable headline by 1,067 values
+    # that need no remedy at all.
+    click.echo(f"   {c[ident.URI_UNVERIFIED]:>6}  URI on a no-authority scheme "
+               "(urn:, ark:, doi:) — well-formed, resolution not established")
     click.echo(f"   {c[ident.CURIE_DECLARED]:>6}  CURIE on a declared prefix")
     click.echo(f"   {c[ident.CURIE_UNDECLARED]:>6}  CURIE on an undeclared prefix")
     click.echo(f"   {c[ident.BARE]:>6}  bare token — neither IRI nor CURIE")

--- a/src/data_sheets_schema/identifiers.py
+++ b/src/data_sheets_schema/identifiers.py
@@ -55,8 +55,20 @@ _CURIE = re.compile(r"^([A-Za-z_][A-Za-z0-9._\-]*):(\S+)$")
 #: 1,067 corpus values sit here — `urn:` 757, `ark:` 286, `doi:` 24 — and every
 #: one was counted as an undeclared CURIE, inflating the migration #457 is sized
 #: against by 28% of that bucket.
+#:
+#: **Kept deliberately short, and to registered schemes only.** Every name here
+#: exempts a value from the audit, so a name that is *not* a scheme silently
+#: excuses a real defect. `isbn`, `issn` and `uuid` were dropped for exactly
+#: this reason: they are URN *namespaces* (`urn:isbn:…`), not schemes, and a
+#: record writing `uuid:abc` would be minting a prefix, not citing one.
+#:
+#: `file` is the sharpest case and is **excluded**. It is a registered scheme,
+#: but its 22 corpus occurrences are `file:torchaudio_spectrograms_parquet` —
+#: a minted type-prefix in the same family as `org:`, `creator:` and
+#: `software:` (#531), not `file:///path`. Adding it would erase 22 genuine
+#: findings to accommodate a name collision.
 NO_AUTHORITY_SCHEMES = frozenset({
-    "urn", "doi", "ark", "mailto", "isbn", "issn", "info", "tel", "uuid",
+    "urn", "doi", "ark", "mailto", "tel", "info",
 })
 
 URI = "uri"

--- a/src/data_sheets_schema/identifiers.py
+++ b/src/data_sheets_schema/identifiers.py
@@ -47,7 +47,25 @@ _ABSOLUTE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*://")
 #: accepting it would pass a value that names no entity.
 _CURIE = re.compile(r"^([A-Za-z_][A-Za-z0-9._\-]*):(\S+)$")
 
+#: URI schemes whose syntax has no authority component, so `://` never appears
+#: and the `_ABSOLUTE` test above misses them (#530). They are URIs, not CURIEs:
+#: `urn` is a scheme, not a namespace this schema could bind to a base IRI, and
+#: declaring a prefix for it would produce an expansion that means nothing.
+#:
+#: 1,067 corpus values sit here — `urn:` 757, `ark:` 286, `doi:` 24 — and every
+#: one was counted as an undeclared CURIE, inflating the migration #457 is sized
+#: against by 28% of that bucket.
+NO_AUTHORITY_SCHEMES = frozenset({
+    "urn", "doi", "ark", "mailto", "isbn", "issn", "info", "tel", "uuid",
+})
+
 URI = "uri"
+#: Well-formed under its scheme, resolution not established. Separate from
+#: `URI` on purpose: `urn:cm4ai:org:ucsd` is a syntactically valid URN whose
+#: NID is not IANA-registered, and `ark:59853/…` depends on a NAAN that may not
+#: be assigned. Filing those beside a resolvable `https://ror.org/…` would
+#: overstate their standing as badly as calling them CURIEs understates it.
+URI_UNVERIFIED = "uri_unverified"
 CURIE_DECLARED = "curie_declared"
 CURIE_UNDECLARED = "curie_undeclared"
 BARE = "bare_token"
@@ -70,12 +88,21 @@ def declared_prefixes(schema_path: Path = FULL_SCHEMA) -> set[str]:
 
 
 def classify(value: str, prefixes: set[str]) -> str:
-    """Which of the four shapes an identifier value has."""
+    """Which of the five shapes an identifier value has.
+
+    Scheme detection runs before the CURIE test, because the two grammars
+    overlap: `urn:cm4ai:org:ucsd` matches `prefix:reference` perfectly well and
+    is not a CURIE. Order is what separates them, and a declared prefix that
+    collided with a scheme name would otherwise change a value's classification
+    depending on which test ran first.
+    """
     v = value.strip()
     if _ABSOLUTE.match(v):
         return URI
     m = _CURIE.match(v)
     if m:
+        if m.group(1).lower() in NO_AUTHORITY_SCHEMES:
+            return URI_UNVERIFIED
         return CURIE_DECLARED if m.group(1) in prefixes else CURIE_UNDECLARED
     return BARE
 
@@ -136,7 +163,8 @@ def audit_record(path: Path, prefixes: set[str],
                  slots: set[str] | None = None) -> dict[str, Any]:
     """Classify every identifier-ranged value in one record."""
     doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    counts = {URI: 0, CURIE_DECLARED: 0, CURIE_UNDECLARED: 0, BARE: 0}
+    counts = {URI: 0, URI_UNVERIFIED: 0, CURIE_DECLARED: 0,
+              CURIE_UNDECLARED: 0, BARE: 0}
     offenders: list[dict[str, str]] = []
     for slot_path, slot, value in walk_identifiers(doc, slots or {"id"}):
         kind = classify(value, prefixes)
@@ -164,7 +192,8 @@ def summarize(records: list[dict[str, Any]], prefixes_declared: int,
     record list beside corpus-wide totals states two scopes in one breath and
     reads as one.
     """
-    totals = {URI: 0, CURIE_DECLARED: 0, CURIE_UNDECLARED: 0, BARE: 0}
+    totals = {URI: 0, URI_UNVERIFIED: 0, CURIE_DECLARED: 0,
+              CURIE_UNDECLARED: 0, BARE: 0}
     for rec in records:
         for kind, n in rec["counts"].items():
             totals[kind] += n

--- a/tests/test_uri_schemes.py
+++ b/tests/test_uri_schemes.py
@@ -1,0 +1,93 @@
+"""A URI without `://` is still a URI (#530).
+
+The classifier tested for `://` and called everything else a CURIE. Schemes
+with no authority component — `urn:`, `ark:`, `doi:` — have no `//`, so 1,067
+corpus values were filed as "CURIE on an undeclared prefix" and counted toward
+the unresolvable headline #457 sizes its migration against.
+
+They are not CURIEs. `urn` is a scheme, not a namespace the schema could bind
+to a base IRI, so "declare the prefix" — the cheap remedy #457's step 2 looks
+for — does not apply and would produce a meaningless expansion.
+
+Nor are they resolvable. `urn:cm4ai:org:ucsd` is a well-formed URN on an
+unregistered NID. Hence a third category rather than a move into `uri`.
+"""
+
+import unittest
+
+from data_sheets_schema.identifiers import (BARE, CURIE_DECLARED,
+                                            CURIE_UNDECLARED,
+                                            NO_AUTHORITY_SCHEMES, URI,
+                                            URI_UNVERIFIED, classify)
+
+PREFIXES = {"d4d", "schema", "ror"}
+
+
+class TestSchemesAreNotCuries(unittest.TestCase):
+    def test_the_three_the_corpus_actually_uses(self):
+        for value in ("urn:cm4ai:org:ucsd",
+                      "ark:59853/b2ai-voice-dataset-feature-ppgs",
+                      "doi:10.18130/V3/HIGT4C"):
+            with self.subTest(value=value):
+                self.assertEqual(classify(value, PREFIXES), URI_UNVERIFIED)
+
+    def test_every_declared_scheme_classifies(self):
+        for scheme in NO_AUTHORITY_SCHEMES:
+            with self.subTest(scheme=scheme):
+                self.assertEqual(classify(f"{scheme}:something", PREFIXES),
+                                 URI_UNVERIFIED)
+
+    def test_the_scheme_test_runs_before_the_curie_test(self):
+        """The grammars overlap — `urn:cm4ai:org:ucsd` matches
+        `prefix:reference` perfectly well. Order is the only thing separating
+        them, so a scheme that were also a declared prefix must still read as a
+        URI rather than flipping on which test ran first."""
+        self.assertEqual(classify("doi:10.1/x", PREFIXES | {"doi"}),
+                         URI_UNVERIFIED)
+
+    def test_case_is_not_significant_in_a_scheme(self):
+        """RFC 3986 says schemes are case-insensitive."""
+        self.assertEqual(classify("URN:x:y", PREFIXES), URI_UNVERIFIED)
+
+
+class TestItIsNeitherNeighbour(unittest.TestCase):
+    """Folding it either way would misstate these values."""
+
+    def test_it_is_not_reported_as_a_resolvable_uri(self):
+        """`urn:cm4ai:org:ucsd` alongside `https://ror.org/…` would claim a
+        standing it does not have: the NID is not registered."""
+        self.assertNotEqual(classify("urn:cm4ai:org:ucsd", PREFIXES), URI)
+
+    def test_it_is_not_counted_unresolvable(self):
+        from data_sheets_schema.identifiers import UNRESOLVABLE
+        self.assertNotIn(URI_UNVERIFIED, UNRESOLVABLE)
+
+    def test_the_genuine_failures_still_fail(self):
+        """The exemption must not leak. A bare token and an undeclared prefix
+        are still the two things this audit exists to find."""
+        self.assertEqual(classify("funder_nih", PREFIXES), BARE)
+        self.assertEqual(classify("aireadi:public-dataset", PREFIXES),
+                         CURIE_UNDECLARED)
+        self.assertEqual(classify("d4d:x", PREFIXES), CURIE_DECLARED)
+
+    def test_a_real_url_is_still_a_uri(self):
+        self.assertEqual(classify("https://ror.org/01an7q238", PREFIXES), URI)
+
+
+class TestAgainstTheCorpus(unittest.TestCase):
+    def test_the_reclassification_moves_the_headline(self):
+        """1,067 values move out of unresolvable — 28% of the undeclared-CURIE
+        bucket — which is why #457 must be re-sized before a pattern is chosen
+        rather than after."""
+        from pathlib import Path
+
+        from data_sheets_schema import identifiers as ident
+        from data_sheets_schema.runs import CONCAT_DIR
+
+        if not Path(CONCAT_DIR).exists():
+            self.skipTest("corpus absent")
+        report = ident.audit(root=CONCAT_DIR)
+        counts = report["counts"]
+        self.assertGreater(counts[URI_UNVERIFIED], 500)
+        # Every one of them would previously have been called unresolvable.
+        self.assertLess(report["unresolvable_share"], 0.30)

--- a/tests/test_uri_schemes.py
+++ b/tests/test_uri_schemes.py
@@ -91,3 +91,35 @@ class TestAgainstTheCorpus(unittest.TestCase):
         self.assertGreater(counts[URI_UNVERIFIED], 500)
         # Every one of them would previously have been called unresolvable.
         self.assertLess(report["unresolvable_share"], 0.30)
+
+
+class TestTheSchemeListIsNarrow(unittest.TestCase):
+    """Every name in `NO_AUTHORITY_SCHEMES` exempts values from the audit, so
+    a name that is not really a scheme silently excuses a real defect. This is
+    the direction that fails quietly, and the only one worth guarding hard."""
+
+    def test_file_is_not_exempted(self):
+        """The sharpest case. `file` *is* a registered scheme, but its 22
+        corpus occurrences are `file:torchaudio_spectrograms_parquet` — a
+        minted type-prefix in the same family as `org:` and `creator:` (#531),
+        not `file:///path`. Exempting it would erase 22 genuine findings to
+        accommodate a name collision."""
+        self.assertNotIn("file", NO_AUTHORITY_SCHEMES)
+        self.assertEqual(
+            classify("file:torchaudio_spectrograms_parquet", PREFIXES),
+            CURIE_UNDECLARED)
+
+    def test_urn_namespaces_are_not_listed_as_schemes(self):
+        """`isbn`, `issn` and `uuid` are URN namespaces — `urn:isbn:…` — not
+        schemes. A record writing `uuid:abc` is minting a prefix, not citing
+        one, and must still be reported."""
+        for name in ("isbn", "issn", "uuid"):
+            with self.subTest(name=name):
+                self.assertNotIn(name, NO_AUTHORITY_SCHEMES)
+                self.assertEqual(classify(f"{name}:abc", PREFIXES),
+                                 CURIE_UNDECLARED)
+
+    def test_the_list_stays_small(self):
+        """A growing exemption list is how an audit stops auditing. Anything
+        added should be a registered scheme with corpus evidence behind it."""
+        self.assertLessEqual(len(NO_AUTHORITY_SCHEMES), 8)


### PR DESCRIPTION
Closes #530. Unblocks #457's sizing.

## The defect

`classify` tested for `://` and called everything else a CURIE. Schemes with no authority component have no `//`:

| prefix | count | example |
|---|---|---|
| `urn` | 757 | `urn:cm4ai:org:ucsd` |
| `ark` | 286 | `ark:59853/b2ai-voice-dataset-feature-ppgs` |
| `doi` | 24 | `doi:10.18130/V3/HIGT4C` |
| | **1,067** | |

All were reported as "CURIE on an undeclared prefix" and counted unresolvable.

**They are not CURIEs.** `urn` is a scheme, not a namespace this schema could bind to a base IRI — so "declare the prefix", the cheap remedy #457's step 2 goes looking for, does not apply to any of them, and declaring one would produce a meaningless expansion.

## Why a third category rather than moving them to `uri`

**Nor are they resolvable.** `urn:cm4ai:org:ucsd` is a well-formed URN whose NID is not IANA-registered; `ark:59853/…` depends on a NAAN that may not be assigned. Filing them beside a resolvable `https://ror.org/…` would overstate their standing as badly as calling them CURIEs understates it.

`URI_UNVERIFIED` says what is true: **well-formed under its scheme, resolution not established.**

## Order matters, and is pinned

The grammars overlap — `urn:cm4ai:org:ucsd` matches `prefix:reference` perfectly well. Scheme detection runs first, and a test asserts that a scheme which is *also* a declared prefix still reads as a URI, so classification cannot flip on which test ran.

## Effect

```
before   9923 uri                          8317 unresolvable (30%) / 171 records
after    9923 uri + 1067 unverified        7250 unresolvable (26%) / 144 records
```

That is the number #457 should be re-sized against, and it matches the estimate already posted there.

The exemption does not leak: `funder_nih` is still `bare_token`, `aireadi:public-dataset` is still `curie_undeclared`, and `URI_UNVERIFIED` is deliberately absent from `UNRESOLVABLE`.

**1869 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)