### PR TITLE
Hand out a copy of the cached digest, not the cache (#528)

### DIFF
--- a/src/data_sheets_schema/schema_digest.py
+++ b/src/data_sheets_schema/schema_digest.py
@@ -19,6 +19,7 @@ truncated because their tail is usually curation notes rather than instruction.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -161,11 +162,32 @@ _BUILD_CACHE: dict[tuple[str, str], "ClassDigest"] = {}
 
 
 def build(class_name: str, schema_path: Path | None = None) -> ClassDigest:
-    """Memoised on (class_name, schema_path); see _build_uncached."""
+    """Memoised on (class_name, schema_path); see _build_uncached.
+
+    Returns a **copy**. The cache used to hand out the stored object itself, so
+    any caller that mutated the result — or its `nested` entries, or their
+    `ranges`/`enums` dicts — silently changed what every later `build()` for
+    that class returned, for the life of the process (#528).
+
+    Found when a test stripped `ranges` to check the fingerprint responded, and
+    two later tests in the same file then measured an empty digest and failed.
+    Those failures read as real defects in the code under test, which is the
+    dangerous shape: the first instinct is to "fix" code that was correct.
+
+    The exposure is not confined to tests. `build` feeds the generation prompt,
+    `slot_spec` (what the fitness judge reads) and the digest fingerprint that
+    keys the fitness and sub-type caches. A mutation anywhere in a long-lived
+    process would change the prompt or the cache key for everything after it,
+    silently and with nothing recording that it happened.
+
+    A copy per call is cheap against what memoisation saves here: `SchemaView`
+    construction and `class_induced_slots` over the whole class, which is the
+    expensive part this cache exists to avoid repeating.
+    """
     key = (class_name, str(schema_path or ""))
     if key not in _BUILD_CACHE:
         _BUILD_CACHE[key] = _build_uncached(class_name, schema_path)
-    return _BUILD_CACHE[key]
+    return copy.deepcopy(_BUILD_CACHE[key])
 
 
 def _build_uncached(class_name: str, schema_path: Path | None = None) -> ClassDigest:

--- a/src/data_sheets_schema/schema_digest.py
+++ b/src/data_sheets_schema/schema_digest.py
@@ -355,8 +355,25 @@ def render(digest: ClassDigest) -> str:
     return "\n".join(lines)
 
 
+_TEXT_CACHE: dict[tuple[str, str], str] = {}
+
+
 def digest_text(class_name: str, schema_path: Path | None = None) -> str:
-    return render(build(class_name, schema_path))
+    """The rendered digest, memoised separately from `build`.
+
+    `build` returns a deep copy so a caller cannot corrupt the cache (#528),
+    which costs ~1.7 ms. `digest_text` renders and discards, so it needs no
+    copy at all — and it is on a hot path: `LLMSlotFitnessScorer._context`
+    calls it once per judgement to compute the cache key, so the copy would
+    have been paid 1,441 times in a sweep for a value that never changes.
+
+    Caching the *string* is safe where caching the object was not: strings are
+    immutable, so there is nothing for a caller to mutate.
+    """
+    key = (class_name, str(schema_path or ""))
+    if key not in _TEXT_CACHE:
+        _TEXT_CACHE[key] = render(build(class_name, schema_path))
+    return _TEXT_CACHE[key]
 
 
 def fingerprint(text: str) -> str:

--- a/tests/test_digest_isolation.py
+++ b/tests/test_digest_isolation.py
@@ -49,13 +49,48 @@ class TestMutationIsIsolated(unittest.TestCase):
 
     def test_the_rendered_digest_is_unchanged_after_a_mutation(self):
         """The property that actually matters: the generation prompt and the
-        cache key must not move because someone inspected a digest."""
+        cache key must not move because someone inspected a digest.
+
+        `_TEXT_CACHE` is cleared between the two reads on purpose. Without
+        that this passes trivially — the second call would return the string
+        memoised before the mutation, and the test would hold even if `build`
+        went back to sharing the object.
+        """
         before = schema_digest.fingerprint(schema_digest.digest_text("Dataset"))
         scratch = schema_digest.build("Dataset")
         scratch.nested.clear()
         scratch.slots.clear()
+        schema_digest._TEXT_CACHE.clear()
         after = schema_digest.fingerprint(schema_digest.digest_text("Dataset"))
         self.assertEqual(before, after)
+
+
+class TestTheTextCacheIsSafe(unittest.TestCase):
+    """Caching the rendered string is safe where caching the object was not:
+    strings are immutable, so there is nothing for a caller to mutate.
+
+    It exists because `digest_text` is on a hot path — `_context` calls it once
+    per fitness judgement to build the cache key — and renders-and-discards, so
+    it needs no copy at all.
+    """
+
+    def test_repeated_calls_are_free(self):
+        schema_digest.digest_text("Dataset")
+        start = time.perf_counter()
+        for _ in range(50):
+            schema_digest.digest_text("Dataset")
+        self.assertLess((time.perf_counter() - start) / 50, 0.001)
+
+    def test_it_agrees_with_an_uncached_render(self):
+        """The cache must not be able to serve something `render` would not."""
+        cached = schema_digest.digest_text("Dataset")
+        schema_digest._TEXT_CACHE.clear()
+        schema_digest._BUILD_CACHE.clear()
+        self.assertEqual(cached, schema_digest.digest_text("Dataset"))
+
+    def test_classes_are_cached_separately(self):
+        self.assertNotEqual(schema_digest.digest_text("Dataset"),
+                            schema_digest.digest_text("CoreDataset"))
 
 
 class TestTheCacheStillWorks(unittest.TestCase):

--- a/tests/test_digest_isolation.py
+++ b/tests/test_digest_isolation.py
@@ -1,0 +1,84 @@
+"""`build()` hands out a copy, not the cached object (#528).
+
+The cache returned the stored `ClassDigest` by reference, so any caller that
+mutated it — or its `nested` entries, or their `ranges`/`enums` dicts — silently
+changed what every later `build()` for that class returned, for the life of the
+process.
+
+Found when a test stripped `ranges` to check the fingerprint responded, and two
+later tests in the same file measured an empty digest and failed. Those failures
+read as real defects in the code under test, which is the dangerous shape: the
+first instinct is to fix code that was correct.
+
+The exposure is not confined to tests. `build` feeds the generation prompt,
+`slot_spec` (what the fitness judge reads) and the fingerprint keying the
+fitness and sub-type caches.
+"""
+
+import time
+import unittest
+
+from data_sheets_schema import schema_digest
+
+
+class TestMutationIsIsolated(unittest.TestCase):
+    def test_clearing_nested_ranges_does_not_persist(self):
+        first = schema_digest.build("Dataset")
+        self.assertTrue(any(n.ranges for n in first.nested),
+                        "no ranges to strip; this test proves nothing")
+        for nested in first.nested:
+            nested.ranges = {}
+        second = schema_digest.build("Dataset")
+        self.assertTrue(any(n.ranges for n in second.nested))
+
+    def test_mutating_a_range_dict_in_place_does_not_persist(self):
+        """The subtler half: replacing the dict is caught by a shallow copy,
+        mutating it is not. Only a deep copy isolates both."""
+        first = schema_digest.build("Dataset")
+        target = next(n for n in first.nested if n.ranges)
+        name = target.name
+        target.ranges.clear()
+        second = schema_digest.build("Dataset")
+        self.assertTrue(next(n for n in second.nested if n.name == name).ranges)
+
+    def test_dropping_slots_does_not_persist(self):
+        first = schema_digest.build("Dataset")
+        count = len(first.slots)
+        first.slots.clear()
+        self.assertEqual(len(schema_digest.build("Dataset").slots), count)
+
+    def test_the_rendered_digest_is_unchanged_after_a_mutation(self):
+        """The property that actually matters: the generation prompt and the
+        cache key must not move because someone inspected a digest."""
+        before = schema_digest.fingerprint(schema_digest.digest_text("Dataset"))
+        scratch = schema_digest.build("Dataset")
+        scratch.nested.clear()
+        scratch.slots.clear()
+        after = schema_digest.fingerprint(schema_digest.digest_text("Dataset"))
+        self.assertEqual(before, after)
+
+
+class TestTheCacheStillWorks(unittest.TestCase):
+    """A copy on every call must not turn the memo into a no-op."""
+
+    def test_a_cached_build_is_far_cheaper_than_a_cold_one(self):
+        schema_digest.build("Dataset")            # warm
+        start = time.perf_counter()
+        for _ in range(20):
+            schema_digest.build("Dataset")
+        cached = (time.perf_counter() - start) / 20
+
+        schema_digest._BUILD_CACHE.clear()
+        start = time.perf_counter()
+        schema_digest.build("Dataset")
+        cold = time.perf_counter() - start
+
+        self.assertLess(cached, cold / 20,
+                        f"copy cost {cached*1000:.1f}ms is not cheap against "
+                        f"a {cold*1000:.0f}ms cold build")
+
+    def test_equal_content_across_calls(self):
+        a = schema_digest.build("Dataset")
+        b = schema_digest.build("Dataset")
+        self.assertIsNot(a, b)
+        self.assertEqual(schema_digest.render(a), schema_digest.render(b))

--- a/tests/test_nested_ranges.py
+++ b/tests/test_nested_ranges.py
@@ -17,7 +17,6 @@ better-informed question, so cached labels from before it are not comparable and
 must not be reused. The last class here is what makes that safe.
 """
 
-import copy
 import unittest
 
 from data_sheets_schema import schema_digest
@@ -106,11 +105,11 @@ class TestCachedJudgementsCannotSurviveThis(unittest.TestCase):
         """Render the same digest with the ranges stripped and confirm the
         fingerprint differs. If it did not, the cache key would be blind to
         exactly the information the judge gained."""
-        # Deep-copied because `build` memoises and returns the *shared*
-        # object: stripping ranges in place corrupted the cached digest for
-        # every later test in the process, and the two tests below then
-        # measured an empty digest and failed for the wrong reason.
-        digest = copy.deepcopy(schema_digest.build("Dataset"))
+        # No longer deep-copied: `build` returns a copy since #528, so
+        # stripping ranges here cannot reach the cache. Left mutating in place
+        # deliberately — if that isolation ever regresses, the two tests below
+        # fail, which is how this one was found in the first place.
+        digest = schema_digest.build("Dataset")
         before = schema_digest.fingerprint(schema_digest.render(digest))
         for nested in digest.nested:
             nested.ranges = {}

--- a/tests/test_schema/test_schema_stats.py
+++ b/tests/test_schema/test_schema_stats.py
@@ -120,15 +120,48 @@ if __name__ == '__main__':
 
 
 class TestDigestBuildIsMemoised(unittest.TestCase):
-    """Rebuilding cost ~0.5s per call and was paid once per distinct slot (#181)."""
+    """Rebuilding cost ~0.5s per call and was paid once per distinct slot (#181).
 
-    def test_repeated_builds_return_the_same_object(self):
+    Asserted by cost, not by object identity. This used to be `assertIs(a, b)`,
+    which was a proxy for "it was memoised" — and stopped being a valid one when
+    #528 made `build` return a copy, precisely so that a caller mutating the
+    result could not corrupt the cache for the rest of the process.
+
+    Identity was the means; not re-reading the schema is the end.
+    """
+
+    def test_a_repeated_build_does_not_reread_the_schema(self):
+        import time
+
+        from data_sheets_schema import schema_digest
+
+        schema_digest.build("Dataset")                 # warm
+        start = time.perf_counter()
+        for _ in range(10):
+            schema_digest.build("Dataset")
+        cached = (time.perf_counter() - start) / 10
+
+        schema_digest._BUILD_CACHE.clear()
+        start = time.perf_counter()
+        schema_digest.build("Dataset")
+        cold = time.perf_counter() - start
+
+        self.assertLess(cached, cold / 10,
+                        f"cached build {cached*1000:.1f}ms against a cold "
+                        f"{cold*1000:.0f}ms — the memo is not working")
+
+    def test_repeated_builds_return_equal_content(self):
+        """What a caller actually depends on, now that the objects differ."""
         from data_sheets_schema import schema_digest
         a = schema_digest.build("Dataset")
         b = schema_digest.build("Dataset")
-        self.assertIs(a, b)
+        self.assertIsNot(a, b)
+        self.assertEqual(schema_digest.render(a), schema_digest.render(b))
 
     def test_different_classes_are_cached_separately(self):
+        """Compared by content. `assertIsNot` would now pass whatever the cache
+        did, because every call returns a distinct object."""
         from data_sheets_schema import schema_digest
-        self.assertIsNot(schema_digest.build("Dataset"),
-                         schema_digest.build("CoreDataset"))
+        self.assertNotEqual(
+            schema_digest.render(schema_digest.build("Dataset")),
+            schema_digest.render(schema_digest.build("CoreDataset")))


### PR DESCRIPTION
Closes #528.

## The defect

`build()` memoised into `_BUILD_CACHE` and returned the stored `ClassDigest` **by reference**. Any caller mutating it — or its `nested` entries, or their `ranges`/`enums` dicts — silently changed what every later `build()` for that class returned, for the life of the process.

Found when a test stripped `ranges` to check the fingerprint responded, and two later tests in the same file measured an empty digest and failed. **Those failures read as real defects in the code under test**, which is the dangerous shape — the first instinct is to fix code that was correct.

## Why it matters outside tests

`build` feeds:

- the generation prompt (the digest a run consumes),
- `slot_spec`, which is what the fitness judge reads,
- `schema_digest.fingerprint(...)`, which keys the fitness and sub-type caches.

A mutation anywhere in a long-lived process — a batch sweep, a notebook, a CLI command that builds twice — would change the prompt or the cache key for everything after it, with nothing recording that it happened.

## Deep, not shallow

Replacing a dict is caught by a shallow copy; mutating one in place is not. A test covers both, because the second is the likelier accident.

## Cost, measured

```
cached build (with copy):   1.62 ms
cold build:               638 ms
copy costs 0.25% of a cold build
```

`SchemaView` construction and `class_induced_slots` are the expensive part the memo exists to avoid, and they are untouched.

## Two existing tests changed, deliberately

`test_repeated_builds_return_the_same_object` asserted `assertIs(a, b)`. That was a **proxy** for "it was memoised" and is no longer a valid one — identity was the means, not re-reading the schema is the end. It now asserts cost directly.

`test_different_classes_are_cached_separately` used `assertIsNot`, which would now pass **whatever the cache did**, since every call returns a distinct object. It compares rendered content instead. That one is worth noting: my change would otherwise have quietly turned a real test into a tautology.

The deep-copy workaround added to the #486 test is removed, and left mutating in place on purpose — if this isolation ever regresses, those tests fail, which is how it was found.

**1879 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)