### PR TITLE
Scope the presence check to the schema a pair was written against (#520)

### DIFF
--- a/src/data_sheets_schema/d4d_pair_consistency.py
+++ b/src/data_sheets_schema/d4d_pair_consistency.py
@@ -244,23 +244,44 @@ def _append_identity_errors(
     core_data: Mapping[str, Any],
     slots: Iterable[str],
     path: str = "$",
+    schema_moved: bool = False,
 ) -> None:
+    """Compare the slots a full/core pair must state identically.
+
+    `schema_moved` says the pair was generated against a schema that is no
+    longer the current one. Presence is then a **warning** rather than an
+    error (#520): a slot added after the pair was written is absent from core
+    because it could not have been present, which is a fact about the schema's
+    history and not a defect in the record.
+
+    Content disagreement stays an error either way. Two records asserting
+    different values for one slot were wrong when they were written and are
+    wrong now — no schema change excuses that.
+
+    Scoped by the recorded schema digest rather than by a date, so it rests on
+    what the run actually consumed rather than on a cutoff someone maintains.
+    Adding `related_datasets` to core made 70 historical pairs report this,
+    all correctly and none actionably; back-filling them would have made a
+    2026-07-28 record assert content no run of that date produced.
+    """
     for slot in slots:
         full_present = slot in full_data
         core_present = slot in core_data
         slot_path = f"{path}.{slot}"
         if full_present != core_present:
             present_in = "full" if full_present else "core"
-            report.errors.append(
-                ConsistencyIssue(
-                    code="shared-slot-presence",
-                    path=slot_path,
-                    message=(
-                        "schema-identical slot is present only in "
-                        f"{present_in}; it must be present in both or neither"
-                    ),
-                )
+            issue = ConsistencyIssue(
+                code="shared-slot-presence",
+                path=slot_path,
+                message=(
+                    "schema-identical slot is present only in "
+                    f"{present_in}; it must be present in both or neither"
+                    + (" — but this pair predates the current schema, so the "
+                       "slot may not have existed when it was written"
+                       if schema_moved else "")
+                ),
             )
+            (report.warnings if schema_moved else report.errors).append(issue)
             continue
         if not full_present:
             continue
@@ -562,6 +583,7 @@ def validate_pair_data(
     full_data: Mapping[str, Any],
     core_data: Mapping[str, Any],
     pair_schema: PairSchema,
+    schema_moved: bool = False,
 ) -> PairConsistencyReport:
     """Validate strict shared content and schema-related projections."""
 
@@ -575,6 +597,7 @@ def validate_pair_data(
         full_data,
         core_data,
         pair_schema.identity_slots,
+        schema_moved=schema_moved,
     )
 
     if "resources" in pair_schema.projected_slots:
@@ -677,6 +700,34 @@ def synchronize_core_data(
     return synchronized
 
 
+def pair_predates_current_schema(core_path: Path) -> bool:
+    """Was this pair generated against a schema that has since moved? (#520)
+
+    Read from the core record's own provenance — the `schema.digest_md5` the
+    run recorded — rather than from a date or a hand-maintained list of when
+    each slot arrived. A run states which schema it saw; that is the evidence,
+    and it is the same field #517's straddle check reads.
+
+    Absent provenance returns False, which is the strict reading: a pair that
+    cannot show it predates the schema is held to the current one. Silence is
+    not a licence.
+    """
+    from data_sheets_schema import schema_digest
+
+    provenance = core_path.parent / f"{core_path.name.split('_d4d')[0]}_provenance.yaml"
+    if not provenance.exists():
+        return False
+    try:
+        data = yaml.safe_load(provenance.read_text(encoding="utf-8")) or {}
+    except Exception:                                          # noqa: BLE001
+        return False
+    recorded = (data.get("schema") or {}).get("digest_md5")
+    if not recorded:
+        return False
+    live = schema_digest.fingerprint(schema_digest.digest_text(FULL_CLASS))
+    return recorded != live
+
+
 def _load_yaml_mapping(path: Path) -> Dict[str, Any]:
     loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(loaded, dict):
@@ -750,7 +801,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         core_data = synchronize_core_data(full_data, core_data, pair_schema)
         _write_synchronized_core(args.core, core_data)
 
-    report = validate_pair_data(full_data, core_data, pair_schema)
+    report = validate_pair_data(
+        full_data, core_data, pair_schema,
+        schema_moved=pair_predates_current_schema(args.core))
     if args.as_json:
         print(json.dumps(report.to_dict(), indent=2))
     else:

--- a/tests/test_presence_scoping.py
+++ b/tests/test_presence_scoping.py
@@ -1,0 +1,133 @@
+"""Presence is scoped to the schema a pair was generated against (#520).
+
+Adding `related_datasets` to `CoreDataset` (#510) made 70 historical pairs
+report `shared-slot-presence`. Every one of those findings is *true* — the core
+record does lack a fact its full record states — and none is actionable: the
+slot did not exist when the pair was written.
+
+The obvious fix was rejected. Running `--sync-core` over them would make a
+2026-07-28 core record assert content no run of that date produced, break
+`validation.artifacts.*.md5`, and orphan its reconciliation report — the same
+principle as `pre_registry` (#399) and the `canonical_superseded_by` tombstone
+(#516): historical evidence is annotated, never rewritten to satisfy a rule
+that postdates it.
+
+So the finding is demoted to a warning for pairs that predate the current
+schema, and kept fatal for pairs that do not.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.d4d_pair_consistency import (load_pair_schema,
+                                                     pair_predates_current_schema,
+                                                     validate_pair_data)
+
+ROOT = Path(__file__).resolve().parents[1]
+FULL = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_all.yaml"
+CORE = ROOT / "src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml"
+
+RELATION = [{"target_dataset": "https://e.org/other",
+             "relationship_type": "supplements"}]
+
+
+class TestPresenceIsScoped(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.pair = load_pair_schema(FULL, CORE)
+        cls.full = {"id": "https://e.org/d", "name": "x",
+                    "related_datasets": RELATION}
+        cls.core = {"id": "https://e.org/d", "name": "x"}
+
+    def test_a_current_pair_still_fails(self):
+        """The check must keep working for records being written now."""
+        report = validate_pair_data(self.full, self.core, self.pair,
+                                    schema_moved=False)
+        self.assertEqual(len(report.errors), 1)
+        self.assertEqual(report.errors[0].code, "shared-slot-presence")
+
+    def test_a_pair_predating_the_schema_warns_instead(self):
+        report = validate_pair_data(self.full, self.core, self.pair,
+                                    schema_moved=True)
+        self.assertEqual(report.errors, [])
+        self.assertEqual(len(report.warnings), 1)
+        self.assertTrue(report.passed)
+
+    def test_the_warning_says_why_it_is_not_fatal(self):
+        """A demoted finding that does not explain itself reads as a bug in
+        the checker rather than a fact about the schema's history."""
+        report = validate_pair_data(self.full, self.core, self.pair,
+                                    schema_moved=True)
+        self.assertIn("predates the current schema",
+                      report.warnings[0].message)
+
+    def test_content_disagreement_stays_fatal_regardless(self):
+        """The exemption must not leak into the check that matters most. Two
+        records asserting different values for one slot were wrong when they
+        were written; no schema change excuses that."""
+        core = {"id": "https://e.org/d", "name": "DIFFERENT",
+                "related_datasets": RELATION}
+        report = validate_pair_data(self.full, core, self.pair,
+                                    schema_moved=True)
+        self.assertTrue(any(i.code == "shared-slot-content"
+                            for i in report.errors))
+
+
+class TestTheScopeComesFromEvidence(unittest.TestCase):
+    """Read from the record's own recorded schema digest, not from a date or a
+    hand-maintained list of when each slot arrived — the hand-maintained-list
+    problem #431 removed elsewhere and #518/#521 removed from the build."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+
+    def _pair(self, digest):
+        core = self.dir / "P_d4d_core.yaml"
+        core.write_text("id: x\n", encoding="utf-8")
+        if digest is not None:
+            (self.dir / "P_provenance.yaml").write_text(
+                yaml.safe_dump({"schema": {"digest_md5": digest}}),
+                encoding="utf-8")
+        return core
+
+    def test_a_stale_digest_counts_as_predating(self):
+        self.assertTrue(pair_predates_current_schema(
+            self._pair("0" * 32)))
+
+    def test_the_current_digest_does_not(self):
+        from data_sheets_schema import schema_digest
+        live = schema_digest.fingerprint(schema_digest.digest_text("Dataset"))
+        self.assertFalse(pair_predates_current_schema(self._pair(live)))
+
+    def test_absent_provenance_is_held_to_the_current_schema(self):
+        """The strict reading. A pair that cannot show it predates the schema
+        does not get the exemption — silence is not a licence."""
+        self.assertFalse(pair_predates_current_schema(self._pair(None)))
+
+    def test_an_unreadable_record_is_not_fatal(self):
+        core = self.dir / "P_d4d_core.yaml"
+        core.write_text("id: x\n", encoding="utf-8")
+        (self.dir / "P_provenance.yaml").write_bytes(b"\xff\xfe not yaml")
+        self.assertFalse(pair_predates_current_schema(core))
+
+
+class TestAgainstTheCorpus(unittest.TestCase):
+    def test_the_canonical_arm_predates_the_current_schema(self):
+        """True since #510, #504 and #403 each moved it. Those records are
+        correct and unchanged; the schema moved under them."""
+        from data_sheets_schema.runs import canonical_runs
+
+        runs = canonical_runs()
+        if not runs:
+            self.skipTest("no canonical records")
+        project, info = next(iter(sorted(runs.items())))
+        core = (ROOT / "data/d4d_concatenated/claudecode_agent_core"
+                / info["label"] / f"{project}_d4d_core.yaml")
+        if not core.exists():
+            self.skipTest("core record absent")
+        self.assertTrue(pair_predates_current_schema(core))


### PR DESCRIPTION
Closes #520. Implements the option you chose: leave the records, scope the check.

## The situation

Adding `related_datasets` to `CoreDataset` (#510) made **70 historical pairs** report `shared-slot-presence`. Every finding is *true* — the core record does lack a fact its full record states — and none is actionable, because the slot did not exist when the pair was written.

## Back-filling stays rejected

`--sync-core` over those 70 would make a 2026-07-28 core record assert content **no run of that date produced**, break `validation.artifacts.*.md5` on every pair touched, and orphan each `*_reconciliation.md`. Same principle as `pre_registry` (#399) and the `canonical_superseded_by` tombstone (#516): historical evidence is annotated, never rewritten to satisfy a rule that postdates it.

## What changed

Presence is a **warning** for a pair generated against a schema that has since moved, and stays **fatal** otherwise — so the check keeps working for records being written now, which is the whole point of having it.

**Content disagreement stays fatal either way.** Two records asserting different values for one slot were wrong when they were written, and no schema change excuses that. A test holds this, because it is the direction where a leaky exemption would do real damage.

## Scoped by evidence, not by a date

`pair_predates_current_schema` reads the core record's own `schema.digest_md5` — what the run recorded seeing — rather than a date or a hand-maintained list of when each slot arrived. That list is the pattern #431, #518 and #521 each removed, and it is the same field #517's straddle check already reads.

**Absent provenance returns False**, the strict reading: a pair that cannot show it predates the schema is held to the current one. Silence is not a licence.

The warning text says why it is not fatal — a demoted finding that does not explain itself reads as a bug in the checker rather than a fact about the schema's history.

## Note

The 2026-08-11 canonical arm now reads as predating the current schema, because #510, #504 and #403 each moved it. Those records are correct and unchanged; the schema moved under them. That is the intended semantics, and a test pins it.

**1891 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)