### PR TITLE
Bind the B2AI_* prefixes to the registry's namespaces (#535)

### DIFF
--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -304,7 +304,7 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_d4d_core.yaml
       md5: 19f4a17c60311d6bbc32fd06d266a76c
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 intermediates:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -266,7 +266,7 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_d4d_core.yaml
       md5: 57d52aa67e15baf249e791cd1ce32481
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 intermediates:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_d4d_core.yaml
       md5: 7fa94e1ccb88dcc9d7090ce6ff0b49d5
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_d4d_core.yaml
       md5: cc5bea839075f00de433612a313f358a
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_d4d_core.yaml
       md5: 1afef4d05562622097d4e577b3bb4648
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 94585ede7df663fb3b0a2f601f639fac
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_d4d_core.yaml
       md5: d5dfd18340393dfd485b22c888d33010
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_d4d_core.yaml
       md5: bf8d3706efaf398738fbbdbcfc098c70
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
@@ -130,7 +130,7 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_d4d_core.yaml
       md5: 658a6794c50cda7ae4b52beb5192c366
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
@@ -130,7 +130,7 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_d4d_core.yaml
       md5: 67384e7d32a1740264d74ee6ed79c501
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
@@ -130,7 +130,7 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_d4d_core.yaml
       md5: 4634f260ce16cbbeda7017e8bd5e0cea
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
@@ -130,7 +130,7 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_d4d_core.yaml
       md5: 81cdfa0b72a0ed18c08eb8a3ae5901a8
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
@@ -130,7 +130,7 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_d4d_core.yaml
       md5: 54464b3bb28dfa874966782a218526ee
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate
 canonical:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_d4d_core.yaml
       md5: cbf2482273b6d8bcfa10711b43266cf5
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_d4d_core.yaml
       md5: de505046d64b4139dcd43f4b2dcbf730
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_d4d_core.yaml
       md5: a6cd0da0d9079e6726857bec5c05eca7
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
@@ -130,6 +130,6 @@ validation:
       path: data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_d4d_core.yaml
       md5: a25640d2448384452c46bd5bec04ca2e
   schema:
-    full_sha256: 27992f75f8ee0c9905e9e4947d51298f7184b4bcd126cc45491e6616af127eb2
+    full_sha256: 992cbb48d6c8fbcfce68a88f6992de81851c070037baec5db07db8c594514e47
     core_sha256: 3ed2ec45e974af811362988ac084e73a4ec9e026f60b4294db1cf66676244f92
   recorded_by: d4d runs validate

--- a/src/data_sheets_schema/b2ai_registry_prefixes.yaml
+++ b/src/data_sheets_schema/b2ai_registry_prefixes.yaml
@@ -1,0 +1,35 @@
+# Prefixes the Bridge2AI standards registry declares, pinned so this repository
+# cannot drift from it silently (#535).
+#
+# Our three B2AI_* prefixes all pointed at the registry's *homepage* URL rather
+# than at the per-schema namespaces the registry actually declares. A prefix
+# bound to the wrong namespace is worse than an undeclared one: the CURIE is
+# well-formed and the prefix is declared, so `d4d runs identifiers` passes it
+# while it resolves somewhere else. Nothing downstream can tell.
+#
+# Refresh with:
+#   curl -sSL https://raw.githubusercontent.com/bridge2ai/standards-schemas/main/src/standards_schemas/schema/standards_dataset_schema.yaml
+# and update `source` below. `tests/test_registry_prefixes.py` compares the
+# schema against this file; it does not reach the network, so a refresh is a
+# deliberate act with a diff a reviewer can read.
+source:
+  repository: bridge2ai/standards-schemas
+  path: src/standards_schemas/schema/standards_dataset_schema.yaml
+  commit: 76122808d3bf1b178c8f7325b0b2705f2e208d95
+  committed: '2026-01-12T22:54:08Z'
+  retrieved: '2026-08-12'
+
+prefixes:
+  B2AI_DATA: https://w3id.org/bridge2ai/standards-dataset-schema/
+  B2AI_ORG: https://w3id.org/bridge2ai/standards-organization-schema/
+  B2AI_SUBSTRATE: https://w3id.org/bridge2ai/standards-datasubstrate-schema/
+  B2AI_TOPIC: https://w3id.org/bridge2ai/standards-datatopic-schema/
+
+# Declared by this repository and not by the registry. Recorded here so the
+# check can tell "ours, deliberately" from "drifted from theirs".
+local_only:
+  B2AI_STANDARD: >-
+    The registry models this concept as `DataStandardOrTool` and declares no
+    such prefix. #403 names B2AI_STANDARD as the eventual grounding for
+    DataStandardEnum; whether to retire it in favour of the registry's own term
+    is an open decision.

--- a/src/data_sheets_schema/schema/data_sheets_schema.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema.yaml
@@ -29,9 +29,22 @@ prefixes:
   schema: http://schema.org/
   sh: https://w3id.org/shacl/
   skos: http://www.w3.org/2004/02/skos/core#
-  B2AI_TOPIC: https://w3id.org/bridge2ai/b2ai-standards-registry/
+  # Taken from the registry's own schemas, not from the registry's homepage
+  # URL (#535). All three previously pointed at
+  # `https://w3id.org/bridge2ai/b2ai-standards-registry/`, so `B2AI_TOPIC:x`
+  # here and `B2AI_TOPIC:x` in the registry were different IRIs — a CURIE that
+  # resolves to the wrong thing, which the identifier audit passes because the
+  # prefix *is* declared. See `src/data_sheets_schema/b2ai_registry_prefixes.yaml`
+  # for the pin and how to refresh it.
+  B2AI_DATA: https://w3id.org/bridge2ai/standards-dataset-schema/
+  B2AI_ORG: https://w3id.org/bridge2ai/standards-organization-schema/
+  B2AI_SUBSTRATE: https://w3id.org/bridge2ai/standards-datasubstrate-schema/
+  B2AI_TOPIC: https://w3id.org/bridge2ai/standards-datatopic-schema/
+  # Local to this repository: the registry models the concept as
+  # `DataStandardOrTool` and declares no `B2AI_STANDARD`. Kept rather than
+  # retired because #403 names it as the eventual grounding for
+  # `DataStandardEnum`, and retiring it is a separate decision.
   B2AI_STANDARD: https://w3id.org/bridge2ai/b2ai-standards-registry/
-  B2AI_SUBSTRATE: https://w3id.org/bridge2ai/b2ai-standards-registry/
 default_prefix: data_sheets_schema
 default_range: string
 

--- a/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+++ b/src/data_sheets_schema/schema/data_sheets_schema_all.yaml
@@ -53,14 +53,20 @@ prefixes:
   skos:
     prefix_prefix: skos
     prefix_reference: http://www.w3.org/2004/02/skos/core#
-  B2AI_TOPIC:
-    prefix_prefix: B2AI_TOPIC
-    prefix_reference: https://w3id.org/bridge2ai/b2ai-standards-registry/
-  B2AI_STANDARD:
-    prefix_prefix: B2AI_STANDARD
-    prefix_reference: https://w3id.org/bridge2ai/b2ai-standards-registry/
+  B2AI_DATA:
+    prefix_prefix: B2AI_DATA
+    prefix_reference: https://w3id.org/bridge2ai/standards-dataset-schema/
+  B2AI_ORG:
+    prefix_prefix: B2AI_ORG
+    prefix_reference: https://w3id.org/bridge2ai/standards-organization-schema/
   B2AI_SUBSTRATE:
     prefix_prefix: B2AI_SUBSTRATE
+    prefix_reference: https://w3id.org/bridge2ai/standards-datasubstrate-schema/
+  B2AI_TOPIC:
+    prefix_prefix: B2AI_TOPIC
+    prefix_reference: https://w3id.org/bridge2ai/standards-datatopic-schema/
+  B2AI_STANDARD:
+    prefix_prefix: B2AI_STANDARD
     prefix_reference: https://w3id.org/bridge2ai/b2ai-standards-registry/
   xsd:
     prefix_prefix: xsd

--- a/tests/test_registry_prefixes.py
+++ b/tests/test_registry_prefixes.py
@@ -1,0 +1,106 @@
+"""Our B2AI_* prefixes match the registry's (#535).
+
+All three previously pointed at the registry's *homepage* URL,
+`https://w3id.org/bridge2ai/b2ai-standards-registry/`, while the registry
+declares per-schema namespaces. So `B2AI_TOPIC:x` in one of our records and
+`B2AI_TOPIC:x` in the registry were **different IRIs**.
+
+That is worse than an undeclared prefix. `d4d runs identifiers` reports an
+undeclared prefix as unresolvable, which is honest; a prefix bound to the wrong
+namespace resolves — somewhere else — and the audit passes it, because the CURIE
+is well-formed and the prefix *is* declared. It is #402's finding one level up:
+the audit checked that a prefix was declared, never that it was declared
+correctly, because there was nothing to check it against.
+
+There is now. The registry's declarations are pinned in
+`b2ai_registry_prefixes.yaml` with the commit they were taken at, and this
+compares the schema against that pin. Deliberately offline: a refresh is an
+edit to the pin, with a diff a reviewer reads, rather than a silent network
+dependency that turns a registry change into a surprise CI failure.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "src/data_sheets_schema/schema/data_sheets_schema.yaml"
+PIN = ROOT / "src/data_sheets_schema/b2ai_registry_prefixes.yaml"
+
+
+def _schema_prefixes():
+    doc = yaml.safe_load(SCHEMA.read_text(encoding="utf-8")) or {}
+    return doc.get("prefixes") or {}
+
+
+def _pin():
+    return yaml.safe_load(PIN.read_text(encoding="utf-8")) or {}
+
+
+class TestOursMatchTheRegistry(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ours = _schema_prefixes()
+        cls.pin = _pin()
+
+    def test_every_registry_prefix_is_declared_here(self):
+        for name in self.pin["prefixes"]:
+            with self.subTest(prefix=name):
+                self.assertIn(name, self.ours,
+                              f"{name} is declared by the registry and not here")
+
+    def test_each_expands_to_the_registry_namespace(self):
+        """The bug itself. A prefix that expands differently makes two systems
+        disagree about what one CURIE names, undetectably."""
+        for name, namespace in self.pin["prefixes"].items():
+            with self.subTest(prefix=name):
+                self.assertEqual(self.ours.get(name), namespace)
+
+    def test_no_b2ai_prefix_points_at_the_registry_homepage(self):
+        """The specific mistake: binding a prefix to the site rather than to
+        the namespace. `B2AI_STANDARD` is exempt and declared local."""
+        homepage = "https://w3id.org/bridge2ai/b2ai-standards-registry/"
+        local = set(self.pin.get("local_only") or {})
+        for name, value in self.ours.items():
+            if not name.startswith("B2AI_") or name in local:
+                continue
+            with self.subTest(prefix=name):
+                self.assertNotEqual(value, homepage)
+
+
+class TestLocalPrefixesAreDeclaredAsSuch(unittest.TestCase):
+    """A prefix we invent is fine; a prefix we invent *silently* is how this
+    started. `local_only` is the difference between "ours, deliberately" and
+    "drifted from theirs"."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ours = _schema_prefixes()
+        cls.pin = _pin()
+
+    def test_every_b2ai_prefix_is_either_registry_or_declared_local(self):
+        known = set(self.pin["prefixes"]) | set(self.pin.get("local_only") or {})
+        ours = {n for n in self.ours if n.startswith("B2AI_")}
+        self.assertEqual(ours - known, set(),
+                         "a B2AI_ prefix that is neither the registry's nor "
+                         "recorded as local")
+
+    def test_local_entries_say_why(self):
+        for name, why in (self.pin.get("local_only") or {}).items():
+            with self.subTest(prefix=name):
+                self.assertGreater(len(str(why)), 40,
+                                   f"{name} is local with no reason given")
+
+
+class TestThePinIsTraceable(unittest.TestCase):
+    """A pin without provenance is a hardcoded list with extra steps."""
+
+    def test_it_names_the_source_and_the_commit(self):
+        source = _pin().get("source") or {}
+        for field in ("repository", "path", "commit"):
+            with self.subTest(field=field):
+                self.assertTrue(source.get(field))
+
+    def test_the_commit_looks_like_a_sha(self):
+        self.assertRegex(str((_pin()["source"])["commit"]), r"^[0-9a-f]{40}$")


### PR DESCRIPTION
Closes #535. Found researching #531.

## The defect

All three `B2AI_*` prefixes pointed at the registry's **homepage** URL while the registry declares per-schema namespaces:

| prefix | was | now |
|---|---|---|
| `B2AI_SUBSTRATE` | `…/b2ai-standards-registry/` | `…/standards-datasubstrate-schema/` |
| `B2AI_TOPIC` | `…/b2ai-standards-registry/` | `…/standards-datatopic-schema/` |
| `B2AI_DATA` | *not declared* | `…/standards-dataset-schema/` |
| `B2AI_ORG` | *not declared* | `…/standards-organization-schema/` |
| `B2AI_STANDARD` | `…/b2ai-standards-registry/` | unchanged — **local, and now recorded as such** |

So `B2AI_TOPIC:x` in one of our records and `B2AI_TOPIC:x` in the registry were **different IRIs**.

## Why this is worse than an undeclared prefix

`d4d runs identifiers` reports an undeclared prefix as unresolvable, which is honest. **A prefix bound to the wrong namespace resolves — somewhere else — and the audit passes it**, because the CURIE is well-formed and the prefix *is* declared. Nothing downstream can tell.

It is #402's finding one level up: the audit checked that a prefix was declared, never that it was declared *correctly*, because there was nothing to check it against.

## The durable half is the check

`b2ai_registry_prefixes.yaml` pins the registry's declarations with the commit they were taken at (`76122808`, 2026-01-12), and a test compares the schema against it.

**Deliberately offline.** A refresh is an edit to the pin with a diff a reviewer reads, not a network dependency that turns a registry-side change into a surprise CI failure. Same reasoning as the canonical prompt pins.

A second test requires every `B2AI_` prefix to be either the registry's or recorded in `local_only` **with a reason**: a prefix we invent is fine, a prefix we invent *silently* is how this started.

## Bearing on #531

`B2AI_DATA` is the registry's own `default_prefix` for datasets, and the four Grand Challenge datasets already have identifiers there (`B2AI_DATA:1`–`4`). Declaring it is the precondition for adopting them; this PR does not adopt them, since that needs the release-version question settled first.

`B2AI_ORG` is also what #378 needs for organization identifiers.

## Blast radius

Declared prefixes **33 → 35**. **No value's classification changes** — nothing yet uses `B2AI_DATA` or `B2AI_ORG`, and the two corrected prefixes bind values that were already counted as declared. The fix is to the schema and affects every future value rather than any existing one.

17 verdicts went `STALE` on the schema move; all 17 revalidate unchanged. Corpus at 156 valid, 0 stale.

**1898 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)