### PR TITLE
Render the registry vocabulary the slots already declared (#538)

### DIFF
--- a/src/data_sheets_schema/b2ai_registry_vocabularies.yaml
+++ b/src/data_sheets_schema/b2ai_registry_vocabularies.yaml
@@ -1,0 +1,166 @@
+# Bridge2AI registry vocabularies for `values_from` slots, pinned (#538).
+#
+# `data_topic` and `data_substrate` declare `values_from: B2AI_TOPIC` /
+# `B2AI_SUBSTRATE`. Nothing rendered that declaration, so no run has ever been
+# shown the vocabulary — and the corpus reflects it: all 23 well-formed
+# `data_substrate` IRIs name cell lines (Cellosaurus MDA-MB-468, KOLF2.1J) or
+# assay techniques (Fluorescence, Mass Spectrometry, CRISPR-Cas Systems), none
+# of which is a type of data. The 11 prose values are correct in substance and
+# had no term to be expressed as.
+#
+# Pinned rather than fetched, for the same reason as the prompt pins: a
+# refresh is an edit with a diff a reviewer reads, not a network dependency
+# that turns a registry-side change into a surprise CI failure.
+#
+# Refresh with:
+#   curl -sSL https://raw.githubusercontent.com/bridge2ai/b2ai-standards-registry/main/project/data/DataSubstrate.tsv
+#   curl -sSL https://raw.githubusercontent.com/bridge2ai/b2ai-standards-registry/main/project/data/DataTopic.tsv
+source:
+  repository: bridge2ai/b2ai-standards-registry
+  commit: d38bcf2408c960a75dfadc295b47990a3890c26f
+  committed: '2026-06-04T19:20:27Z'
+  retrieved: '2026-08-13'
+  paths:
+    - project/data/DataSubstrate.tsv
+    - project/data/DataTopic.tsv
+
+vocabularies:
+  B2AI_SUBSTRATE:
+    B2AI_SUBSTRATE:1: Array
+    B2AI_SUBSTRATE:2: Associative Array
+    B2AI_SUBSTRATE:3: BIDS
+    B2AI_SUBSTRATE:4: BigQuery
+    B2AI_SUBSTRATE:5: Column Store
+    B2AI_SUBSTRATE:6: Comma-separated values
+    B2AI_SUBSTRATE:7: Data
+    B2AI_SUBSTRATE:8: Data Frame
+    B2AI_SUBSTRATE:9: Database
+    B2AI_SUBSTRATE:10: Delimited Text
+    B2AI_SUBSTRATE:11: DICOM
+    B2AI_SUBSTRATE:12: Directed acyclic graph
+    B2AI_SUBSTRATE:13: Document Database
+    B2AI_SUBSTRATE:14: Graph
+    B2AI_SUBSTRATE:15: Graph Database
+    B2AI_SUBSTRATE:16: HDF5
+    B2AI_SUBSTRATE:17: Heap
+    B2AI_SUBSTRATE:18: Hierarchical Array
+    B2AI_SUBSTRATE:19: Image
+    B2AI_SUBSTRATE:20: JSON
+    B2AI_SUBSTRATE:21: KGX TSV
+    B2AI_SUBSTRATE:22: MongoDB
+    B2AI_SUBSTRATE:23: MySQL
+    B2AI_SUBSTRATE:24: N-Dimensional Array
+    B2AI_SUBSTRATE:25: Neo4j
+    B2AI_SUBSTRATE:26: Neural Network Model
+    B2AI_SUBSTRATE:27: NNEF
+    B2AI_SUBSTRATE:28: ONNX
+    B2AI_SUBSTRATE:29: Pandas DataFrame
+    B2AI_SUBSTRATE:30: Parquet
+    B2AI_SUBSTRATE:31: PostgreSQL
+    B2AI_SUBSTRATE:32: Property graph
+    B2AI_SUBSTRATE:33: PyTorch Tensor
+    B2AI_SUBSTRATE:34: R data.frame
+    B2AI_SUBSTRATE:35: R tibble
+    B2AI_SUBSTRATE:36: Raster Image
+    B2AI_SUBSTRATE:37: Relational Database
+    B2AI_SUBSTRATE:38: Set
+    B2AI_SUBSTRATE:39: String
+    B2AI_SUBSTRATE:40: SummarizedExperiment
+    B2AI_SUBSTRATE:41: Tab-separated values
+    B2AI_SUBSTRATE:42: Tensor
+    B2AI_SUBSTRATE:43: Text
+    B2AI_SUBSTRATE:44: Tree
+    B2AI_SUBSTRATE:45: Trie
+    B2AI_SUBSTRATE:46: Vector
+    B2AI_SUBSTRATE:47: Vector Image
+    B2AI_SUBSTRATE:48: Waveform Audio File Format
+    B2AI_SUBSTRATE:49: Waveform Data
+    B2AI_SUBSTRATE:50: xarray
+    B2AI_SUBSTRATE:51: Zarr
+    B2AI_SUBSTRATE:52: Compressed Data
+    B2AI_SUBSTRATE:53: BED
+    B2AI_SUBSTRATE:54: Vector Database
+    B2AI_SUBSTRATE:55: Pinecone
+    B2AI_SUBSTRATE:56: Immunofluorescence Image
+    B2AI_SUBSTRATE:57: Spectral Data
+    B2AI_SUBSTRATE:58: Mass Spectrometry Data
+    B2AI_SUBSTRATE:59: Size Exclusion Chromatography-Mass Spectrometry Data
+    B2AI_SUBSTRATE:60: Sequence
+    B2AI_SUBSTRATE:61: DNA Sequence Data
+    B2AI_SUBSTRATE:62: RNA Sequence Data
+    B2AI_SUBSTRATE:63: Single-cell RNA Sequence Data
+    B2AI_SUBSTRATE:64: Perturb-seq Data
+    B2AI_SUBSTRATE:65: Retinal Image
+    B2AI_SUBSTRATE:66: Fluorescence Lifetime Imaging Ophthalmoscopy data
+    B2AI_SUBSTRATE:67: Optical coherence tomography data
+    B2AI_SUBSTRATE:68: Optical coherence tomography angiography data
+    B2AI_SUBSTRATE:69: Time-series data
+    B2AI_SUBSTRATE:70: Physiological data
+    B2AI_SUBSTRATE:71: Heart rate
+    B2AI_SUBSTRATE:72: Oxygen saturation
+    B2AI_SUBSTRATE:73: Physical activity data
+    B2AI_SUBSTRATE:74: Caloric burn data
+    B2AI_SUBSTRATE:75: Respiratory rate
+    B2AI_SUBSTRATE:76: Sleep tracking data
+    B2AI_SUBSTRATE:77: Stress tracking data
+    B2AI_SUBSTRATE:78: Glucose monitoring data
+    B2AI_SUBSTRATE:79: Participant response data
+    B2AI_SUBSTRATE:80: Questionnaire response data
+    B2AI_SUBSTRATE:81: File headers
+  B2AI_TOPIC:
+    B2AI_TOPIC:1: Biology
+    B2AI_TOPIC:2: Cell
+    B2AI_TOPIC:3: Cheminformatics
+    B2AI_TOPIC:4: Clinical Observations
+    B2AI_TOPIC:5: Data
+    B2AI_TOPIC:6: Demographics
+    B2AI_TOPIC:7: Disease
+    B2AI_TOPIC:8: Drug
+    B2AI_TOPIC:9: EHR
+    B2AI_TOPIC:10: EKG
+    B2AI_TOPIC:11: Environment
+    B2AI_TOPIC:12: Gene
+    B2AI_TOPIC:13: Genome
+    B2AI_TOPIC:14: Geolocation
+    B2AI_TOPIC:15: Image
+    B2AI_TOPIC:16: Literature
+    B2AI_TOPIC:17: Metabolome
+    B2AI_TOPIC:18: mHealth
+    B2AI_TOPIC:19: Microscale Imaging
+    B2AI_TOPIC:20: Molecular Biology
+    B2AI_TOPIC:21: Networks And Pathways
+    B2AI_TOPIC:22: Neurologic Imaging
+    B2AI_TOPIC:23: Omics
+    B2AI_TOPIC:24: Ophthalmic Imaging
+    B2AI_TOPIC:25: Phenotype
+    B2AI_TOPIC:26: Protein
+    B2AI_TOPIC:27: Protein Structure Model
+    B2AI_TOPIC:28: Proteome
+    B2AI_TOPIC:29: SDoH
+    B2AI_TOPIC:30: Social Media
+    B2AI_TOPIC:31: Survey
+    B2AI_TOPIC:32: Text
+    B2AI_TOPIC:33: Transcript
+    B2AI_TOPIC:34: Transcriptome
+    B2AI_TOPIC:35: Variant
+    B2AI_TOPIC:36: Voice
+    B2AI_TOPIC:37: Waveform
+    B2AI_TOPIC:38: Glucose Monitoring
+    B2AI_TOPIC:39: Activity Monitoring
+    B2AI_TOPIC:40: Governance
+    B2AI_TOPIC:41: Neuron
+    B2AI_TOPIC:42: Cardiomyocyte
+    B2AI_TOPIC:43: Diabetes
+    B2AI_TOPIC:44: Eye Diseases
+    B2AI_TOPIC:45: Voice Disorders
+    B2AI_TOPIC:46: Respiration
+    B2AI_TOPIC:47: Respiratory Disorders
+    B2AI_TOPIC:48: Neurology
+    B2AI_TOPIC:49: Neurological Disorders
+    B2AI_TOPIC:50: Psychiatry
+    B2AI_TOPIC:51: Psychiatric Disorders
+    B2AI_TOPIC:52: Training
+    B2AI_TOPIC:53: Ontology
+    B2AI_TOPIC:54: Metadata
+    B2AI_TOPIC:55: Data Packaging
+    B2AI_TOPIC:56: Nutrition

--- a/src/data_sheets_schema/evidence_score.py
+++ b/src/data_sheets_schema/evidence_score.py
@@ -752,6 +752,14 @@ def slot_spec(slot: str, class_name: str = "Dataset",
         lines.append(
             "A value of the wrong kind for its declared range is a form "
             "failure even when it reads well.")
+        # The registry vocabulary those attributes draw from (#538). Without
+        # it a judge cannot tell that a Cellosaurus cell line in
+        # `data_substrate` is the wrong *kind* of thing — it is a resolvable
+        # IRI, so every syntactic check passes it.
+        for attribute, names in sorted(nested.values_from.items()):
+            vocabulary = schema_digest.render_values_from(names)
+            if vocabulary:
+                lines.append(f"`{attribute}` must be drawn from {vocabulary}")
     return "\n".join(lines)
 
 

--- a/src/data_sheets_schema/schema_digest.py
+++ b/src/data_sheets_schema/schema_digest.py
@@ -156,7 +156,18 @@ def render_values_from(names: list[str]) -> str | None:
             f"{k[len(prefix):] if k.startswith(prefix) else k}={v}"
             for k, v in terms.items())
         parts.append(f"{name} (use `{name}:<id>`) — {items}")
-    return "; ".join(parts) if parts else None
+    if not parts:
+        return None
+    # The fallback, carried here because a nested attribute's *description* is
+    # not rendered: a run sees this list and never the slot's own "prefer
+    # omission over a prose topic". The vocabulary is not exhaustive — CHORUS's
+    # subject is acute and critical care, and none of the 56 B2AI_TOPIC terms
+    # names it — so without this a run meeting an uncovered subject has 56
+    # near-neighbours in front of it and no instruction to decline. Picking the
+    # closest is the invention #403 added `OTHER` to prevent.
+    return ("; ".join(parts)
+            + ". If no term fits, omit the slot rather than approximate, and "
+              "never restate the subject as prose here.")
 
 
 #: Ranges that hold on essentially every object range, stated once rather than

--- a/src/data_sheets_schema/schema_digest.py
+++ b/src/data_sheets_schema/schema_digest.py
@@ -67,6 +67,10 @@ class SlotDigest:
     multivalued: bool = False
     enum_values: list[str] = field(default_factory=list)
     enum_truncated: int = 0
+    #: `values_from` targets, so the permitted vocabulary can be rendered
+    #: (#538). Collected and rendered together — collecting without rendering
+    #: is the state this issue was filed about.
+    values_from: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -100,6 +104,59 @@ class NestedClass:
     # identifiers` found those values only because it reads the schema itself
     # rather than asking a judge.
     ranges: dict[str, str] = field(default_factory=dict)
+    #: `values_from` targets per nested attribute (#538). `data_topic` and
+    #: `data_substrate` are attributes of `Instance`, not slots of `Dataset`,
+    #: so a top-level-only rendering reaches neither — the same reason #486
+    #: had to render nested ranges here rather than on the slot listing.
+    values_from: dict[str, list[str]] = field(default_factory=dict)
+
+
+#: Registry vocabularies for slots declaring `values_from` (#538), pinned in
+#: `b2ai_registry_vocabularies.yaml`.
+VOCABULARY_PIN = Path(__file__).with_name("b2ai_registry_vocabularies.yaml")
+
+_VOCABULARIES: dict[str, dict[str, str]] | None = None
+
+
+def vocabularies() -> dict[str, dict[str, str]]:
+    """The pinned registry vocabularies, keyed by `values_from` name."""
+    global _VOCABULARIES
+    if _VOCABULARIES is None:
+        import yaml as _yaml
+        doc = _yaml.safe_load(VOCABULARY_PIN.read_text(encoding="utf-8")) or {}
+        _VOCABULARIES = doc.get("vocabularies") or {}
+    return _VOCABULARIES
+
+
+def render_values_from(names: list[str]) -> str | None:
+    """The permitted terms for a slot that declares `values_from` (#538).
+
+    Rendered because nothing rendered it before. `data_topic` and
+    `data_substrate` have declared `values_from` all along and no run has ever
+    seen it, so runs improvised: every one of the 23 well-formed
+    `data_substrate` IRIs names a cell line or an assay technique, neither of
+    which is a type of data, while the 11 prose values are right in substance
+    and had no term to be written as.
+
+    The prefix is stated once and terms listed as `id=name`, which halves the
+    cost against repeating `B2AI_SUBSTRATE:` 81 times — the digest is
+    prompt-injected and defends a size budget.
+
+    A `values_from` naming no pinned vocabulary renders nothing rather than
+    guessing. Silence is the honest output when the terms are unknown.
+    """
+    known = vocabularies()
+    parts = []
+    for name in names:
+        terms = known.get(name)
+        if not terms:
+            continue
+        prefix = f"{name}:"
+        items = ", ".join(
+            f"{k[len(prefix):] if k.startswith(prefix) else k}={v}"
+            for k, v in terms.items())
+        parts.append(f"{name} (use `{name}:<id>`) — {items}")
+    return "; ".join(parts) if parts else None
 
 
 #: Ranges that hold on essentially every object range, stated once rather than
@@ -218,6 +275,7 @@ def _build_uncached(class_name: str, schema_path: Path | None = None) -> ClassDi
             multivalued=bool(slot.multivalued),
             enum_values=enum_values,
             enum_truncated=truncated,
+            values_from=[str(v) for v in (slot.values_from or [])],
         ))
     digest.slots.sort(key=lambda s: s.name)
 
@@ -237,11 +295,14 @@ def _build_uncached(class_name: str, schema_path: Path | None = None) -> ClassDi
         enums: dict[str, list[str]] = {}
         enums_truncated: dict[str, int] = {}
         ranges: dict[str, str] = {}
+        values_from: dict[str, list[str]] = {}
         for sub in sv.class_induced_slots(rng):
             (req if sub.required else opt).append(str(sub.name))
             if sub.range:
                 ranges[str(sub.name)] = (
                     f"{sub.range}[]" if sub.multivalued else str(sub.range))
+            if sub.values_from:
+                values_from[str(sub.name)] = [str(v) for v in sub.values_from]
             sub_enum = sv.get_enum(sub.range) if sub.range else None
             if sub_enum is not None:
                 values = list((sub_enum.permissible_values or {}).keys())
@@ -253,7 +314,7 @@ def _build_uncached(class_name: str, schema_path: Path | None = None) -> ClassDi
             digest.nested.append(NestedClass(
                 name=rng, required=sorted(req), optional=sorted(opt),
                 enums=enums, enums_truncated=enums_truncated,
-                ranges=ranges))
+                ranges=ranges, values_from=values_from))
     digest.nested.sort(key=lambda n: n.name)
     return digest
 
@@ -281,6 +342,9 @@ def render(digest: ClassDigest) -> str:
             shown = ", ".join(f"`{v}`" for v in s.enum_values)
             tail = f" (+{s.enum_truncated} more)" if s.enum_truncated else ""
             lines.append(f"Permitted: {shown}{tail}")
+        vocabulary = render_values_from(s.values_from)
+        if vocabulary:
+            lines.append(f"Draw from: {vocabulary}")
         lines.append("")
 
     if digest.nested:
@@ -351,6 +415,12 @@ def render(digest: ClassDigest) -> str:
                 extra = n.enums_truncated.get(slot_name, 0)
                 tail = f" (+{extra} more)" if extra else ""
                 lines.append(f"    - `{slot_name}` accepts only: {shown}{tail}")
+            # The registry vocabulary a nested attribute draws from (#538).
+            # Here or nowhere, exactly as for the enums above.
+            for slot_name, names in sorted(n.values_from.items()):
+                vocabulary = render_values_from(names)
+                if vocabulary:
+                    lines.append(f"    - `{slot_name}` draws from {vocabulary}")
         lines.append("")
     return "\n".join(lines)
 

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -51,10 +51,41 @@ class TestSchemaDigest(unittest.TestCase):
             schema_digest.build("NoSuchClass")
 
     def test_digest_carries_no_dataset_facts(self):
-        """It states structure. Content would breach the provenance boundary."""
+        """It states structure. Content would breach the provenance boundary.
+
+        `b2ai` was narrowed to `b2ai-voice` on 2026-08-13. The bare token was a
+        proxy for dataset-specific leakage and now also matches
+        `B2AI_SUBSTRATE` / `B2AI_TOPIC`, the registry *vocabulary* names that
+        #538 renders. A controlled vocabulary is structure — it says what kinds
+        of value a slot admits, never what any dataset contains — so matching
+        it here would fail the test for doing the right thing.
+
+        The dataset-specific forms are still forbidden, and the companion test
+        below asserts the vocabulary names *are* present, so this exemption
+        cannot widen silently into one that lets a real fact through.
+        """
         text = schema_digest.digest_text("Dataset").lower()
-        for leak in ("chorus", "cm4ai", "ai-readi", "physionet", "b2ai"):
-            self.assertNotIn(leak, text)
+        for leak in ("chorus", "cm4ai", "ai-readi", "physionet", "b2ai-voice",
+                     "aireadi", "fairhub"):
+            with self.subTest(leak=leak):
+                self.assertNotIn(leak, text)
+
+    def test_the_registry_vocabulary_names_are_structure_not_facts(self):
+        """The exemption above, stated positively so it is visible.
+
+        `B2AI_SUBSTRATE:11 = DICOM` names a kind of data any dataset might
+        hold. It is the same category of statement as an enum's permitted
+        values, which the digest has always carried.
+        """
+        text = schema_digest.digest_text("Dataset")
+        self.assertIn("B2AI_SUBSTRATE", text)
+        self.assertIn("B2AI_TOPIC", text)
+        # And no dataset is named alongside them.
+        for line in text.splitlines():
+            if "B2AI_" in line:
+                with self.subTest(line=line[:60]):
+                    self.assertNotIn("AI-READI", line)
+                    self.assertNotIn("CHORUS", line)
 
     def test_fingerprint_is_stable_and_content_sensitive(self):
         a = schema_digest.digest_text("Dataset")

--- a/tests/test_schema/test_schema_digest_optional.py
+++ b/tests/test_schema/test_schema_digest_optional.py
@@ -233,10 +233,22 @@ class TestTheDigestStaysCompact(unittest.TestCase):
 
     def test_the_listing_did_not_double_the_digest(self):
         """It grew ~20%. A regression that enumerated the mirroring classes in
-        full would roughly double it, and this is the cheapest way to notice."""
+        full would roughly double it, and this is the cheapest way to notice.
+
+        Ceiling raised 40k -> 44k on 2026-08-13, deliberately. #538 renders the
+        B2AI_SUBSTRATE (81 terms) and B2AI_TOPIC (56) vocabularies that
+        `data_topic` and `data_substrate` have always declared and no run had
+        ever been shown — 2,550 characters, 6.8%. The guard exists to catch a
+        regression that *doubles* the digest, which this is not, and the cost
+        buys the thing whose absence let 23 of 34 `data_substrate` values name
+        cell lines and assay techniques instead of data types.
+
+        The prefix is stated once and terms listed `id=name`, which halves what
+        repeating `B2AI_SUBSTRATE:` 81 times would have cost.
+        """
         for target in TARGETS:
             with self.subTest(target=target):
-                self.assertLess(len(schema_digest.digest_text(target)), 40_000)
+                self.assertLess(len(schema_digest.digest_text(target)), 44_000)
 
 
 class TestTheTruncationSafeguard(unittest.TestCase):

--- a/tests/test_values_from.py
+++ b/tests/test_values_from.py
@@ -126,3 +126,59 @@ class TestTheCacheKeyMoves(unittest.TestCase):
             nested.values_from = {}
         after = schema_digest.fingerprint(schema_digest.render(digest))
         self.assertNotEqual(before, after)
+
+
+class TestTheFallbackIsRendered(unittest.TestCase):
+    """The vocabulary is not exhaustive, and the slot's own guidance does not
+    reach the run.
+
+    Found reviewing this change. A nested attribute's *description* is not
+    rendered, so `data_topic`'s "Where no term is found, prefer omission over a
+    prose topic" is invisible — a run sees 56 terms and no instruction to
+    decline. CHORUS is the live case: its subject is acute and critical care,
+    and none of the 56 `B2AI_TOPIC` terms names it. Without the fallback the
+    run has 56 near-neighbours in front of it, and picking the closest is the
+    invention `OTHER` was added to prevent in #403.
+    """
+
+    def test_the_rendering_says_to_omit_rather_than_approximate(self):
+        out = schema_digest.render_values_from(["B2AI_TOPIC"])
+        self.assertIn("omit the slot rather than approximate", out)
+
+    def test_it_also_forbids_falling_back_to_prose(self):
+        """The other failure mode, and the one the corpus actually shows: 11
+        prose values in a slot ranged `uriorcurie`."""
+        out = schema_digest.render_values_from(["B2AI_TOPIC"])
+        self.assertIn("never restate the subject as prose", out)
+
+    def test_it_reaches_both_the_run_and_the_judge(self):
+        self.assertIn("omit the slot rather than approximate",
+                      schema_digest.digest_text("Dataset"))
+        self.assertIn("omit the slot rather than approximate",
+                      slot_spec("instances"))
+
+    def test_nothing_is_rendered_when_no_vocabulary_is_known(self):
+        """The fallback must not appear on its own — a bare instruction to
+        omit, with no list, would be worse than silence."""
+        self.assertIsNone(schema_digest.render_values_from(["NOT_A_REGISTRY"]))
+
+
+class TestTheVocabularyCoverageIsKnown(unittest.TestCase):
+    """What the vocabulary can and cannot express, pinned so a future registry
+    refresh shows up as a diff here rather than as a silent change in what runs
+    can say."""
+
+    def test_every_substrate_concept_the_corpus_needs_exists(self):
+        terms = set(schema_digest.vocabularies()["B2AI_SUBSTRATE"].values())
+        for concept in ("DICOM", "Comma-separated values", "Waveform Data",
+                        "JSON", "Text", "Image", "Parquet", "Data Frame"):
+            with self.subTest(concept=concept):
+                self.assertIn(concept, terms)
+
+    def test_chorus_topic_is_a_known_gap(self):
+        """Not a defect to fix here — a fact the fallback exists for. If a
+        `Critical Care` term is ever added upstream, this test fails and the
+        gap is closed rather than forgotten."""
+        terms = set(schema_digest.vocabularies()["B2AI_TOPIC"].values())
+        self.assertNotIn("Critical Care", terms)
+        self.assertNotIn("Radiology", terms)

--- a/tests/test_values_from.py
+++ b/tests/test_values_from.py
@@ -1,0 +1,128 @@
+"""The registry vocabulary reaches the run and the judge (#538).
+
+`data_topic` and `data_substrate` have declared `values_from: B2AI_TOPIC` /
+`B2AI_SUBSTRATE` all along. Nothing rendered it, so no run was ever shown the
+terms — and the corpus records the consequence:
+
+    data_substrate, 23 well-formed IRIs, every one wrong
+      cellosaurus.org/CVCL_0419  x11   MDA-MB-468, a breast cancer cell line
+      cellosaurus.org/CVCL_B5P3  x9    KOLF2.1J, an iPSC line
+      meshb…D005453 / D013058 / D064113  Fluorescence, Mass Spectrometry, CRISPR
+
+None is a type of data. The 11 prose values were right in substance and had no
+term to be written as — `B2AI_SUBSTRATE` has DICOM, Comma-separated values,
+Waveform Data, JSON, Image, Text and Parquet, and always did.
+
+So the declaration was correct and invisible. This renders it.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema import schema_digest
+from data_sheets_schema.evidence_score import slot_spec
+
+ROOT = Path(__file__).resolve().parents[1]
+PIN = ROOT / "src/data_sheets_schema/b2ai_registry_vocabularies.yaml"
+
+
+class TestTheVocabularyIsPinned(unittest.TestCase):
+    def test_both_vocabularies_are_present(self):
+        vocab = schema_digest.vocabularies()
+        self.assertGreater(len(vocab["B2AI_SUBSTRATE"]), 70)
+        self.assertGreater(len(vocab["B2AI_TOPIC"]), 50)
+
+    def test_it_covers_what_the_prose_values_describe(self):
+        """The test that decides whether option 3 was possible at all. If the
+        registry could not express DICOM or waveform data, rendering it would
+        have forced runs to pick a near-neighbour."""
+        terms = set(schema_digest.vocabularies()["B2AI_SUBSTRATE"].values())
+        for needed in ("DICOM", "Comma-separated values", "Waveform Data",
+                       "JSON", "Image", "Text"):
+            with self.subTest(term=needed):
+                self.assertIn(needed, terms)
+
+    def test_it_covers_each_project_topic(self):
+        terms = set(schema_digest.vocabularies()["B2AI_TOPIC"].values())
+        for needed in ("Diabetes", "Voice", "Clinical Observations", "Cell"):
+            with self.subTest(term=needed):
+                self.assertIn(needed, terms)
+
+    def test_the_pin_is_traceable(self):
+        source = (yaml.safe_load(PIN.read_text(encoding="utf-8")) or {})["source"]
+        self.assertRegex(str(source["commit"]), r"^[0-9a-f]{40}$")
+        self.assertTrue(source.get("repository"))
+
+
+class TestItReachesTheGenerationPrompt(unittest.TestCase):
+    """`data_topic` and `data_substrate` are attributes of `Instance`, not
+    slots of `Dataset`, so a top-level-only rendering would reach neither —
+    the same trap #486 hit with nested ranges."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = schema_digest.digest_text("Dataset")
+
+    def test_the_digest_names_the_vocabulary(self):
+        self.assertIn("draws from", self.text)
+
+    def test_both_slots_are_covered(self):
+        for slot in ("data_topic", "data_substrate"):
+            with self.subTest(slot=slot):
+                self.assertTrue(
+                    any(slot in line and "draws from" in line
+                        for line in self.text.splitlines()))
+
+    def test_specific_terms_are_visible(self):
+        """A vocabulary named but not listed is no more usable than none."""
+        for term in ("DICOM", "Waveform Data", "Diabetes"):
+            with self.subTest(term=term):
+                self.assertIn(term, self.text)
+
+    def test_the_digest_stays_within_budget(self):
+        self.assertLess(len(self.text), 44_000)
+
+
+class TestItReachesTheJudge(unittest.TestCase):
+    def test_slot_spec_names_the_vocabulary(self):
+        spec = slot_spec("instances")
+        self.assertIn("must be drawn from", spec)
+        self.assertIn("data_substrate", spec)
+
+    def test_the_judge_sees_the_terms(self):
+        """Without them a judge cannot tell that a Cellosaurus cell line is
+        the wrong *kind* of thing — it is a resolvable IRI, so every syntactic
+        check passes it."""
+        self.assertIn("DICOM", slot_spec("instances"))
+
+
+class TestUnknownVocabulariesRenderNothing(unittest.TestCase):
+    """Silence is the honest output when the terms are unknown — guessing
+    would put a vocabulary in front of a run that nobody pinned."""
+
+    def test_an_unpinned_name_renders_none(self):
+        self.assertIsNone(schema_digest.render_values_from(["NOT_A_REGISTRY"]))
+
+    def test_an_empty_list_renders_none(self):
+        self.assertIsNone(schema_digest.render_values_from([]))
+
+    def test_a_known_name_still_renders_alongside_an_unknown_one(self):
+        out = schema_digest.render_values_from(["NOPE", "B2AI_TOPIC"])
+        self.assertIn("Diabetes", out)
+
+
+class TestTheCacheKeyMoves(unittest.TestCase):
+    """The judge's question changed, so cached fitness labels must not be
+    reused — the #465 failure this repository keeps having to avoid."""
+
+    def test_stripping_the_vocabulary_changes_the_fingerprint(self):
+        import copy
+
+        digest = copy.deepcopy(schema_digest.build("Dataset"))
+        before = schema_digest.fingerprint(schema_digest.render(digest))
+        for nested in digest.nested:
+            nested.values_from = {}
+        after = schema_digest.fingerprint(schema_digest.render(digest))
+        self.assertNotEqual(before, after)


### PR DESCRIPTION
Closes #538. Implements option 3 — **the reverse of what I first recommended on the issue**, after resolving every term in both slots.

## What the corpus showed

All **23** well-formed `data_substrate` IRIs are the wrong *kind* of thing:

| value | × | is |
|---|---|---|
| `cellosaurus.org/CVCL_0419` | 11 | MDA-MB-468, a breast cancer cell line |
| `cellosaurus.org/CVCL_B5P3` | 9 | KOLF2.1J, an iPSC line |
| `meshb…D005453` | 1 | Fluorescence |
| `meshb…D013058` | 1 | Mass Spectrometry |
| `meshb…D064113` | 1 | CRISPR-Cas Systems |

The slot means *"type of data"*. A cell line is biological material; fluorescence and mass spectrometry are assay techniques.

Meanwhile the **11 prose values** — tabular survey data, DICOM imaging, waveform signals — are correct in substance and had no term available to be written as.

**`B2AI_SUBSTRATE` has DICOM, Comma-separated values, Waveform Data, JSON, Image, Text and Parquet — and always did.** `B2AI_TOPIC` has Diabetes, Voice, Voice Disorders, Clinical Observations and Cell. The declaration was right; it was invisible.

## Why option 3 and not the two I first preferred

- **Widening** `values_from` to MeSH/EDAM/OBO would have *blessed the cell lines*.
- **Removing** it would have discarded a correct declaration because it had never been enforced.

## What changed

Rendered in the digest **and** in `slot_spec`, from one function, so the run and the fitness judge see the same list.

Both go through the **nested** class — `data_topic` and `data_substrate` are attributes of `Instance`, not slots of `Dataset`, so a top-level rendering reaches neither. Same trap #486 hit with nested ranges.

Pinned in `b2ai_registry_vocabularies.yaml` with the commit it came from, for the reason the prompt pins exist. A `values_from` naming no pinned vocabulary renders **nothing** rather than guessing.

## Cost, and the guard I raised

```
digest       37,680 → 40,230   (+2,550, 6.8%)
fingerprint  5c26b444 → bfa6db52
```

The prefix is stated once and terms listed `id=name`, halving what repeating `B2AI_SUBSTRATE:` 81 times would cost.

The size guard is raised **40k → 44k deliberately**. It exists to catch a regression that *doubles* the digest; this is 6.8% and buys the thing whose absence produced 23 wrong values.

**The fingerprint move is intended** — the judge's question changed, so cached fitness labels must not be reused (#465). A test strips the vocabulary and asserts the fingerprint responds.

## A guard I had to narrow, carefully

`test_digest_carries_no_dataset_facts` forbade the bare token `b2ai`, which now matches the *vocabulary namespace*. Narrowed to the dataset-specific forms — and **widened** to also catch `aireadi` and `fairhub`, which it had been missing.

A companion test asserts the vocabulary names **are** present and that no dataset is ever named on the same line, so the exemption cannot quietly become one that lets a real fact through. A controlled vocabulary is structure: it says what kinds of value a slot admits, never what a dataset contains.

## Not done

Existing records are not rewritten (#520). The 23 mis-typed values stand as evidence of what was generated without the vocabulary.

**1913 passed, 4 skipped.** `runs check --strict` 0, `prompts check --strict` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)