### PR TITLE
State the core header block instead of implying it (#515)

### DIFF
--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -75,7 +75,15 @@ HEADER_FIELDS = ("Generation Method", "Agent runtime", "Provider", "Model",
                  # `Prompt` was absent, so `parse_header` silently discarded
                  # the one field a historical prompt could be recovered from
                  # (#399). 15 records carry it and read as carrying nothing.
-                 "Prompt", "Prompt components")
+                 "Prompt", "Prompt components",
+                 # The core record's link to the full record it was projected
+                 # from (#515). Present in substance in every core record and
+                 # discarded by `parse_header` in all of them, because the key
+                 # was never listed — the same silent drop `Prompt` suffered
+                 # until #399. It was also spelled four ways across one arm,
+                 # which is what "use exactly, except add two lines" produces
+                 # when fifteen runs each resolve the contradiction alone.
+                 "Sources", "Phase 4 reconciliation")
 
 
 def _md5(path: Path) -> str | None:

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -53,37 +53,69 @@ files:
       \ is left to the manifest scope declaration rather than restated here (#422)."
     sha256: b7db067c2852b57287cb68bd1fd4f3bfc229496cc2a4bd33065bb9558a35b215
   src/download/prompts/d4d_generic_arm_prompt.md:
-    bytes: 5754
-    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
-    pinned_on: '2026-08-10'
-    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
-      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
-      retroactively.'
-    sha256: 0fbc626bc3a51d74a8ba3d8e2813752f3bc5ce9366ee5f19c99089afdfd9e8dc
+    bytes: 6737
+    pinned_at_commit: 7141fdc63e43f5049bf98289a142c85bd63107ed
+    pinned_on: '2026-08-13'
+    reason: '#515: the core header block is stated in full instead of implied by ''the core
+      file uses phase 2 and the core schema path''. That one line contradicted the playbook''s
+      requirement for ''# Sources:'' and ''# Phase 4 reconciliation: completed'', and fifteen
+      runs of the 2026-08-11 arm resolved it four different ways.'
+    sha256: f5873222343632a97e0d9200e283924751cddfc70e1c879bbeb9f6416cf95d86
+    superseded:
+    - pinned_on: '2026-08-10'
+      reason: 'initial pin (#432): the file as it stood when the registry was created. All
+        77 recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+        retroactively.'
+      retired_on: '2026-08-13'
+      sha256: 0fbc626bc3a51d74a8ba3d8e2813752f3bc5ce9366ee5f19c99089afdfd9e8dc
   src/download/prompts/d4d_generic_arm_prompt_v2.md:
-    bytes: 9110
-    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
-    pinned_on: '2026-08-10'
-    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
-      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
-      retroactively.'
-    sha256: 4780613475ef2a629f98b69a934228b58eccd5fe93915fcd259a62cff6583de6
+    bytes: 10099
+    pinned_at_commit: 7141fdc63e43f5049bf98289a142c85bd63107ed
+    pinned_on: '2026-08-13'
+    reason: '#515: the core header block is stated in full instead of implied by ''the core
+      file uses phase 2 and the core schema path''. That one line contradicted the playbook''s
+      requirement for ''# Sources:'' and ''# Phase 4 reconciliation: completed'', and fifteen
+      runs of the 2026-08-11 arm resolved it four different ways.'
+    sha256: 7bb7a2b854e11ad49361eccbd6b84f00ff0eb0808f16b67a148bbb49be76bf67
+    superseded:
+    - pinned_on: '2026-08-10'
+      reason: 'initial pin (#432): the file as it stood when the registry was created. All
+        77 recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+        retroactively.'
+      retired_on: '2026-08-13'
+      sha256: 4780613475ef2a629f98b69a934228b58eccd5fe93915fcd259a62cff6583de6
   src/download/prompts/d4d_generic_arm_prompt_v3.md:
-    bytes: 7204
-    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
-    pinned_on: '2026-08-10'
-    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
-      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
-      retroactively.'
-    sha256: 2126da06d0834c2501c55fe9838720fe3ee33ab38c4775f2af329bc4759da45a
+    bytes: 8193
+    pinned_at_commit: 7141fdc63e43f5049bf98289a142c85bd63107ed
+    pinned_on: '2026-08-13'
+    reason: '#515: the core header block is stated in full instead of implied by ''the core
+      file uses phase 2 and the core schema path''. That one line contradicted the playbook''s
+      requirement for ''# Sources:'' and ''# Phase 4 reconciliation: completed'', and fifteen
+      runs of the 2026-08-11 arm resolved it four different ways.'
+    sha256: 71c808bca3529140b4b82802ca8cf5c68ee972ec664a2b4e06137cd5df06a714
+    superseded:
+    - pinned_on: '2026-08-10'
+      reason: 'initial pin (#432): the file as it stood when the registry was created. All
+        77 recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+        retroactively.'
+      retired_on: '2026-08-13'
+      sha256: 2126da06d0834c2501c55fe9838720fe3ee33ab38c4775f2af329bc4759da45a
   src/download/prompts/d4d_generic_arm_prompt_v4.md:
-    bytes: 7670
-    pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866
-    pinned_on: '2026-08-10'
-    reason: 'initial pin (#432): the file as it stood when the registry was created. All 77
-      recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
-      retroactively.'
-    sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
+    bytes: 8659
+    pinned_at_commit: 7141fdc63e43f5049bf98289a142c85bd63107ed
+    pinned_on: '2026-08-13'
+    reason: '#515: the core header block is stated in full instead of implied by ''the core
+      file uses phase 2 and the core schema path''. That one line contradicted the playbook''s
+      requirement for ''# Sources:'' and ''# Phase 4 reconciliation: completed'', and fifteen
+      runs of the 2026-08-11 arm resolved it four different ways.'
+    sha256: 3845b66c33ba25e585741496755a8e0c9bbec172f6a26a1b90e6fe4fcb0a0cb9
+    superseded:
+    - pinned_on: '2026-08-10'
+      reason: 'initial pin (#432): the file as it stood when the registry was created. All
+        77 recorded prompt hashes in the corpus match these bytes, so pinning here fails nothing
+        retroactively.'
+      retired_on: '2026-08-13'
+      sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/d4d_generic_arm_prompt.md
+++ b/src/download/prompts/d4d_generic_arm_prompt.md
@@ -93,7 +93,29 @@ HEADER BLOCK — use exactly:
     # Temperature: 0.0
     # Generated: 2026-07-28
 
-The core file uses "phase 2" and the core schema path in the corresponding lines.
+CORE HEADER BLOCK — use exactly (it is not the full-record block with two
+words changed; four lines differ and two have no counterpart above):
+
+    # D4D Core Datasheet for {PROJECT} Dataset
+    # Generation Method: schema-grounded agentic, phase 2
+    # Agent runtime: {RUNTIME}
+    # Provider: {PROVIDER}
+    # Model: {MODEL}
+    # Mode: four-phase project agent, generic prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt.md (identical for all projects)
+    # Arm: {ARM}
+    # Source bundle: {BUNDLE}
+    # Sources: {BUNDLE} + data/d4d_concatenated/{METHOD}/{LABEL}/{PROJECT}_d4d.yaml
+    {MANIFEST_LINE}
+    # Schema: src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+    # Prior D4D factual reuse: prohibited
+    # Temperature: 0.0
+    # Generated: {DATE}
+    # Phase 4 reconciliation: completed
+
+`# Sources:` is required, not decorative: it is what ties a core record to the
+full record it was projected from, and the provenance guard checks for it. Write
+`# Phase 4 reconciliation: completed` only once phase 4 has actually run.
 
 AFTER Phase 4, write a LIVE provenance record:
 

--- a/src/download/prompts/d4d_generic_arm_prompt_v2.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v2.md
@@ -145,7 +145,29 @@ HEADER BLOCK — use exactly:
     # Temperature: 0.0
     # Generated: {DATE}
 
-The core file uses "phase 2" and the core schema path in the corresponding lines.
+CORE HEADER BLOCK — use exactly (it is not the full-record block with two
+words changed; four lines differ and two have no counterpart above):
+
+    # D4D Core Datasheet for {PROJECT} Dataset
+    # Generation Method: schema-grounded agentic, phase 2
+    # Agent runtime: {RUNTIME}
+    # Provider: {PROVIDER}
+    # Model: {MODEL}
+    # Mode: four-phase project agent, generic-v2 prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v2.md (identical for all projects)
+    # Arm: {ARM}
+    # Source bundle: {BUNDLE}
+    # Sources: {BUNDLE} + data/d4d_concatenated/{METHOD}/{LABEL}/{PROJECT}_d4d.yaml
+    {MANIFEST_LINE}
+    # Schema: src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+    # Prior D4D factual reuse: prohibited
+    # Temperature: 0.0
+    # Generated: {DATE}
+    # Phase 4 reconciliation: completed
+
+`# Sources:` is required, not decorative: it is what ties a core record to the
+full record it was projected from, and the provenance guard checks for it. Write
+`# Phase 4 reconciliation: completed` only once phase 4 has actually run.
 
 AFTER Phase 4, write a LIVE provenance record:
 

--- a/src/download/prompts/d4d_generic_arm_prompt_v3.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v3.md
@@ -97,7 +97,29 @@ HEADER BLOCK — use exactly:
     # Temperature: 0.0
     # Generated: {DATE}
 
-The core file uses "phase 2" and the core schema path in the corresponding lines.
+CORE HEADER BLOCK — use exactly (it is not the full-record block with two
+words changed; four lines differ and two have no counterpart above):
+
+    # D4D Core Datasheet for {PROJECT} Dataset
+    # Generation Method: schema-grounded agentic, phase 2
+    # Agent runtime: {RUNTIME}
+    # Provider: {PROVIDER}
+    # Model: {MODEL}
+    # Mode: four-phase project agent, generic-v3 prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v3.md (identical for all projects)
+    # Arm: {ARM}
+    # Source bundle: {BUNDLE}
+    # Sources: {BUNDLE} + data/d4d_concatenated/{METHOD}/{LABEL}/{PROJECT}_d4d.yaml
+    {MANIFEST_LINE}
+    # Schema: src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+    # Prior D4D factual reuse: prohibited
+    # Temperature: 0.0
+    # Generated: {DATE}
+    # Phase 4 reconciliation: completed
+
+`# Sources:` is required, not decorative: it is what ties a core record to the
+full record it was projected from, and the provenance guard checks for it. Write
+`# Phase 4 reconciliation: completed` only once phase 4 has actually run.
 
 AFTER Phase 4, write a LIVE provenance record:
 

--- a/src/download/prompts/d4d_generic_arm_prompt_v4.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v4.md
@@ -98,7 +98,29 @@ HEADER BLOCK — use exactly:
     # Temperature: 0.0
     # Generated: {DATE}
 
-The core file uses "phase 2" and the core schema path in the corresponding lines.
+CORE HEADER BLOCK — use exactly (it is not the full-record block with two
+words changed; four lines differ and two have no counterpart above):
+
+    # D4D Core Datasheet for {PROJECT} Dataset
+    # Generation Method: schema-grounded agentic, phase 2
+    # Agent runtime: {RUNTIME}
+    # Provider: {PROVIDER}
+    # Model: {MODEL}
+    # Mode: four-phase project agent, generic-v4 prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v4.md (identical for all projects)
+    # Arm: {ARM}
+    # Source bundle: {BUNDLE}
+    # Sources: {BUNDLE} + data/d4d_concatenated/{METHOD}/{LABEL}/{PROJECT}_d4d.yaml
+    {MANIFEST_LINE}
+    # Schema: src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+    # Prior D4D factual reuse: prohibited
+    # Temperature: 0.0
+    # Generated: {DATE}
+    # Phase 4 reconciliation: completed
+
+`# Sources:` is required, not decorative: it is what ties a core record to the
+full record it was projected from, and the provenance guard checks for it. Write
+`# Phase 4 reconciliation: completed` only once phase 4 has actually run.
 
 AFTER Phase 4, write a LIVE provenance record:
 

--- a/tests/test_agentic_provenance_completeness.py
+++ b/tests/test_agentic_provenance_completeness.py
@@ -97,14 +97,26 @@ class TestTheCanaryRecordIsComplete(unittest.TestCase):
         from data_sheets_schema.runs import verify_request
 
         status, why = verify_request("claudecode_agent", CANARY, "CHORUS")
-        self.assertEqual(status, "match", why)
+        # `unverifiable` is accepted only for the one reason that is not a
+        # defect: #515 rotated the prompt pins on 2026-08-13, so a record made
+        # before that cannot be re-rendered from today's file. The gate says so
+        # explicitly and keeps the recorded hash standing. `mismatch` is still
+        # a failure — that is the instruction-substitution this gate exists for.
+        self.assertNotEqual(status, "mismatch", why)
+        if status != "match":
+            self.assertIn("prompt file has changed since this run", why or "")
 
     def test_the_prompt_is_at_its_canonical_pin(self):
         from data_sheets_schema.runs import canonical_prompt_status
 
         status, why = canonical_prompt_status(
             "claudecode_agent", CANARY, "CHORUS")
-        self.assertEqual(status, "canonical", why)
+        # `superseded` since #515 rotated the pins. Ordinary evolution, and the
+        # distinction that matters is preserved: `uncanonical` would mean the
+        # text was never a published version of its condition, which is the
+        # `cp`-to-another-path bypass (#436). Being pinned once and since
+        # rotated is a different and honest state.
+        self.assertIn(status, ("canonical", "superseded"), why)
 
     def test_the_record_is_live_and_validated(self):
         self.assertEqual(self.data.get("record_mode"), "live")
@@ -179,6 +191,8 @@ class TestTheSweepPassesItsOwnGate(unittest.TestCase):
             if not record.exists():
                 continue
             status, why = verify_request("claudecode_agent", label, project)
-            if status != "match":
+            # See above: a pin rotation makes an older record unverifiable
+            # rather than wrong. Only `mismatch` is a defect here.
+            if status == "mismatch":
                 bad.append(f"{project}: {status} — {why}")
         self.assertEqual(bad, [])

--- a/tests/test_american_english_rule.py
+++ b/tests/test_american_english_rule.py
@@ -65,8 +65,16 @@ class TestItDidNotRedefineACondition(unittest.TestCase):
         self.assertEqual(result.returncode, 0,
                          (result.stdout + result.stderr)[-600:])
 
-    def test_the_canonical_arm_is_still_canonical(self):
-        """The property that would have been lost by editing v1."""
+    def test_the_canonical_arm_is_not_uncanonical(self):
+        """The property that would have been lost by editing v1 *for this rule*.
+
+        The arm reads `superseded` since #515 deliberately rotated the pins
+        ahead of a re-baselining. That is the state this test was written to
+        avoid reaching *accidentally* — and reaching it by decision, with the
+        rotation recorded and the previous hash retained, is a different thing.
+        `uncanonical` remains the failure: it would mean the text was never a
+        published version of its condition.
+        """
         from data_sheets_schema.runs import (canonical_prompt_status,
                                              canonical_runs)
         runs = canonical_runs()
@@ -76,4 +84,4 @@ class TestItDidNotRedefineACondition(unittest.TestCase):
             with self.subTest(project=project):
                 status, why = canonical_prompt_status(
                     "claudecode_agent", info["label"], project)
-                self.assertEqual(status, "canonical", why)
+                self.assertIn(status, ("canonical", "superseded"), why)

--- a/tests/test_schema_straddle.py
+++ b/tests/test_schema_straddle.py
@@ -198,12 +198,20 @@ class TestAgainstTheRealArm(unittest.TestCase):
             for project in PROJECTS:
                 label = f"{ARM}_rep{rep}"
                 with self.subTest(rep=rep, project=project):
-                    self.assertEqual(
+                    # `match`/`canonical` were true when this arm was written
+                    # and are properties of a *fresh* record, not of a record.
+                    # #515 rotated the prompt pins on 2026-08-13, so these now
+                    # read `unverifiable`/`superseded` — the file moved under
+                    # them. The failures worth catching are `mismatch` (the
+                    # instruction sent was not the one the spec produces) and
+                    # `uncanonical` (the text was never published).
+                    self.assertNotEqual(
                         verify_request("claudecode_agent", label, project)[0],
-                        "match")
-                    self.assertEqual(
+                        "mismatch")
+                    self.assertNotIn(
                         canonical_prompt_status(
-                            "claudecode_agent", label, project)[0], "canonical")
+                            "claudecode_agent", label, project)[0],
+                        ("uncanonical", "missing"))
                     # Not asserted `current`: the AI_READI bundle changed on
                     # 2026-08-12 when it absorbed the release-3.0.0 RO-Crate
                     # and the v2.0 licence (#539), so those records correctly


### PR DESCRIPTION
Closes #515.

## The contradiction

The prompts gave a full-record header under **"use exactly"**, then one line:

> The core file uses "phase 2" and the core schema path in the corresponding lines.

But the playbook requires two *further* lines on core files — `# Sources:` naming the same-run full record, and `# Phase 4 reconciliation: completed`. Both instructions are authoritative in their own terms, so every run had to resolve the conflict alone.

**Fifteen did, four ways.** Measured across the 2026-08-11 arm, the line naming the projected-from full record appears as:

| spelling | records |
|---|---|
| `# Sources:` | 8 |
| `# Full D4D input:` | 5 |
| `# Full record input:` | 1 |
| wrapped onto a continuation line, no key | 1 |

One record also opened `# D4D Datasheet` rather than `# D4D Core Datasheet`.

## The fix

The core block is now written out in full — the four lines that differ from the full-record block, and the two that have no counterpart there — and it says *why* `# Sources:` is required rather than leaving it to be inferred.

`HEADER_FIELDS` gains `Sources` and `Phase 4 reconciliation`. Every core record carries the link in substance and `parse_header` discarded it in **all** of them, because the key was never listed — the same silent drop `Prompt` suffered until #399.

## All four conditions, and why

v4 has no records. v1 and v3 are being re-baselined for the comparison, which is the cheapest moment to absorb a pin rotation. **v2 has 16 records** that become `superseded` — but the analysis plan's open mechanism question needs a v2 arm, so leaving the defect there would only make it recur.

## What the rotation does to the corpus

Two commits, deliberately: the edit, then the declaration that it is now canonical. Each pin keeps its predecessor as `superseded`, so runs made under the old text still verify.

- **The canonical arm reads `superseded`.** Pinned once and since rotated is ordinary evolution; `uncanonical` — never published at all — is the failure, and remains one.
- **18 runs read `unverifiable`** on the render gate, which recognises the file changed and says *the recorded hash still stands, it just cannot be re-derived here*. It does **not** report `mismatch`, the instruction-substitution the gate exists to catch.
- `runs check --strict` and `prompts check --strict` both stay **0**.

## Five tests updated, not weakened

They asserted `canonical`/`match` on the arm. Those were true when written and are properties of a **fresh** record rather than of a record — the same lesson #497's digest test already carries. They now assert the durable property: never `mismatch`, never `uncanonical`. Accepting anything would have thrown the checks away; this preserves exactly the distinction that matters.

**1919 passed, 4 skipped.**

## Consequence for the sweep

Today's CHORUS canary was generated under the **pre-rotation** text, so it must be re-run before any fan-out. Fixing and fanning out in the same step is what the canary rule forbids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)