### PR TITLE
Say whether a run's runtime read the playbooks (#545)

### DIFF
--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -167,7 +167,21 @@ def repo_relative(path: Path | str) -> str:
         return str(resolved)
 
 
-def playbook_facts(paths: tuple[Path, ...] = AGENT_PLAYBOOKS) -> dict[str, Any]:
+#: Runtimes that open the playbooks for themselves. The agentic path does,
+#: because the launch instruction's first lines tell it to; `d4d api run`
+#: renders a condition prompt and sends nothing else (#545).
+PLAYBOOK_READING_RUNTIMES = ("claude code", "codex cli")
+
+
+def runtime_reads_playbooks(runtime: str | None) -> bool | None:
+    """Does this runtime open the playbook files? None when unstated."""
+    if not runtime:
+        return None
+    return any(r in runtime.lower() for r in PLAYBOOK_READING_RUNTIMES)
+
+
+def playbook_facts(paths: tuple[Path, ...] = AGENT_PLAYBOOKS,
+                   consumed: bool | None = None) -> dict[str, Any]:
     """Hash the instruction files an agentic run follows.
 
     The launch prompt is sent to the agent; these it opens itself, because the
@@ -179,14 +193,34 @@ def playbook_facts(paths: tuple[Path, ...] = AGENT_PLAYBOOKS) -> dict[str, Any]:
     Recorded for every run, not just agentic ones: an API run does not read
     them, and a record showing they were unchanged is how you can later tell
     that it did not.
+
+    ``consumed`` says which case this run is, so a reader does not have to
+    already know that the API path skips them (#545). Without it the block is
+    three files with hashes and no statement about their role, and the obvious
+    reading — that the run followed them — is wrong for every API record. The
+    four uniform decision rules reach the API path only because the *condition
+    prompt* carries its own copy; the two added to the playbook since (#502's
+    American English, and the CURIE rule) reach it not at all.
+
+    None means the runtime was not stated, which is a third case and not the
+    same as False.
     """
-    out = []
+    out: list[dict[str, Any]] = []
     for p in paths:
         p = Path(p)
         out.append({"path": repo_relative(p), "sha256": _sha256(p),
                     "bytes": p.stat().st_size if p.exists() else None,
                     "exists": p.exists()})
-    return {"hash_algorithm": PROMPT_HASH, "files": out}
+    block: dict[str, Any] = {"hash_algorithm": PROMPT_HASH, "files": out}
+    if consumed is not None:
+        block["consumed"] = consumed
+        block["consumed_basis"] = (
+            "the runtime opens these files itself, as the launch instruction "
+            "directs" if consumed else
+            "this runtime renders a condition prompt and sends nothing else, "
+            "so these were not read; they are hashed so an unchanged hash "
+            "shows that (#545)")
+    return block
 
 
 def prompt_facts(prompt_paths: list[Path] | None,
@@ -927,7 +961,9 @@ def build_record(project: str, method: str, label: str, *, mode: str,
     # docstring forbids, in the same shape as hashing a since-refreshed bundle
     # and attributing it to an April run. Raised reviewing #420.
     if mode == "live":
-        playbooks = playbook_facts()
+        runtime = (prompt_request_spec or {}).get("runtime")
+        playbooks = playbook_facts(
+            consumed=runtime_reads_playbooks(runtime))
     else:
         playbooks = None
         unrecoverable.append({

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -1,0 +1,123 @@
+"""A record says whether its runtime read the playbooks (#545).
+
+The four uniform decision rules reach the API path only because each condition
+*prompt* carries its own copy of them. The two added to the playbook since —
+American English (#502) and the CURIE rule — reach it not at all, which is how
+the v4 arm came to carry 135 British spellings.
+
+Playbooks are hashed for every run deliberately: an unchanged hash on an API
+record is how you can tell it did not read them. But that inference requires
+already knowing the API path skips them, and the obvious reading of "three
+files with hashes" is that the run followed them. So the record now says which
+case it is.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from data_sheets_schema.provenance import (AGENT_PLAYBOOKS, playbook_facts,
+                                           runtime_reads_playbooks)
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAYBOOK = ROOT / ".claude/commands/d4d-full-core.md"
+PROMPTS = ROOT / "src/download/prompts"
+
+
+class TestRuntimeClassification(unittest.TestCase):
+    def test_the_agentic_runtime_reads_them(self):
+        self.assertTrue(runtime_reads_playbooks("Claude Code"))
+
+    def test_the_api_runtime_does_not(self):
+        self.assertFalse(runtime_reads_playbooks("Claude API (direct)"))
+
+    def test_an_unstated_runtime_is_neither(self):
+        """None is a third case. Recording False for a run that never said
+        what it was would assert something nobody established."""
+        self.assertIsNone(runtime_reads_playbooks(None))
+        self.assertIsNone(runtime_reads_playbooks(""))
+
+
+class TestTheRecordSaysWhich(unittest.TestCase):
+    def test_a_consuming_run_records_it(self):
+        block = playbook_facts(consumed=True)
+        self.assertIs(block["consumed"], True)
+        self.assertIn("opens these files itself", block["consumed_basis"])
+
+    def test_a_non_consuming_run_records_it_and_why_they_are_hashed(self):
+        """Otherwise the block reads as an unexplained inconsistency: files
+        hashed but not read, with nothing saying that is deliberate."""
+        block = playbook_facts(consumed=False)
+        self.assertIs(block["consumed"], False)
+        self.assertIn("not read", block["consumed_basis"])
+
+    def test_an_unstated_runtime_omits_the_claim(self):
+        """Silence rather than a guess — the field is absent, not False."""
+        self.assertNotIn("consumed", playbook_facts())
+
+    def test_the_files_are_hashed_either_way(self):
+        """The hashes are the evidence; `consumed` only interprets them."""
+        for flag in (True, False, None):
+            with self.subTest(consumed=flag):
+                block = playbook_facts(consumed=flag)
+                self.assertEqual(len(block["files"]), len(AGENT_PLAYBOOKS))
+
+
+class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
+    """The duplication that caused this.
+
+    The four original rules are maintained byte-identically in the playbook and
+    in every condition prompt. That is the pattern #518 and #521 kept finding in
+    the build — one list of content, several hand-kept copies — and it diverged
+    the moment two rules were added to one copy only.
+
+    This does not forbid divergence; a rule may legitimately be
+    playbook-scope. It requires that any rule present in the playbook and
+    absent from the prompts is one somebody chose, by listing it here.
+    """
+
+    #: Rules the playbook carries that the condition prompts deliberately do
+    #: not, each with the reason. Emptying this list is the goal, and v5 is
+    #: where the two below are expected to move into the prompt (#547).
+    PLAYBOOK_ONLY = {
+        "American English": "#502 — added to the playbook to avoid rotating "
+                            "pins mid-arm; reaches the agentic path only",
+        "CURIE": "same, added this session; reaches the agentic path only",
+    }
+
+    def _rule_bullets(self, text, start, end):
+        block = text[text.index(start):text.index(end)]
+        return [b.strip() for b in re.findall(r"^- (.+?)(?=\n- |\n\n)",
+                                              block, re.S | re.M)]
+
+    def test_every_playbook_only_rule_is_declared_here(self):
+        """A rule that reaches one path and not the other is a decision. If a
+        third appears without being listed, this fails and someone has to say
+        whether that was intended."""
+        playbook = PLAYBOOK.read_text(encoding="utf-8")
+        rules = self._rule_bullets(playbook, "### Uniform decision rules",
+                                   "### Recording the condition")
+        v4 = (PROMPTS / "d4d_generic_arm_prompt_v4.md").read_text(
+            encoding="utf-8")
+        undeclared = []
+        for rule in rules:
+            head = rule.split(".")[0][:60]
+            key = next((k for k in self.PLAYBOOK_ONLY if k in rule), None)
+            if key:
+                continue
+            # a shared rule: some distinctive phrase of it must appear in v4
+            probe = re.sub(r"[*`]", "", rule).split(".")[0][:40]
+            if probe and probe not in re.sub(r"[*`]", "", v4):
+                undeclared.append(head)
+        self.assertEqual(undeclared, [],
+                         "playbook rules absent from the v4 prompt and not "
+                         "declared as playbook-only")
+
+    def test_the_declared_ones_really_are_absent_from_the_prompts(self):
+        """If a listed rule reaches the prompts after all, the entry is stale
+        and should be removed rather than left asserting a gap that closed."""
+        v4 = (PROMPTS / "d4d_generic_arm_prompt_v4.md").read_text(
+            encoding="utf-8")
+        for key in self.PLAYBOOK_ONLY:
+            with self.subTest(rule=key):
+                self.assertNotIn(key, v4)


### PR DESCRIPTION
Closes #545, and corrects its framing.

## The measurement changed the diagnosis

I filed #545 saying the API path receives none of the playbook's uniform decision rules. **Four of the six are in the condition prompt**, byte-identical to the playbook's copy, and reach both paths that way:

```
prefer omission          in v4 prompt: True
sources that disagree    in v4 prompt: True
one referent             in v4 prompt: True
no target slot count     in v4 prompt: True
American English         in v4 prompt: False   <- playbook only
CURIE                    in v4 prompt: False   <- playbook only
```

So the real defect is narrower and more familiar: **one list of content maintained by hand in five files** — the playbook and all four condition prompts — which diverged the moment two rules were added to one of them. That is the #518/#521 pattern a third time.

## What changed

Hashing playbooks on every run is deliberate and was already documented: an unchanged hash on an API record is how you can later tell it did not read them. But that inference requires already knowing the API path skips them, and the obvious reading of "three files with hashes" is that the run followed them.

The record now says which case it is — `consumed: true|false` with a `consumed_basis` explaining why the files are hashed either way. **`None` when the runtime is unstated**, because that is a third case and not the same as False.

## The durable half

`TestTheRuleSetsDoNotSilentlyDiverge` compares the playbook's rule bullets against the v4 prompt. It does **not** forbid a playbook-only rule — one may legitimately be playbook-scope — but requires each to be *declared* with its reason:

```python
PLAYBOOK_ONLY = {
    "American English": "#502 — added to the playbook to avoid rotating pins mid-arm",
    "CURIE": "same, added this session; reaches the agentic path only",
}
```

A third rule appearing undeclared fails the test and forces the question at the moment it is introduced, rather than 135 spellings later. A declared entry that turns out to *be* in the prompts also fails, so the list cannot rot.

## Not done here

Moving the two rules into the prompt. That rotates pins and re-baselines every condition, which is v5's job (Tier 3) — and doing it now would supersede the v4 arm for no benefit.

**1928 passed, 4 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)