### PR TITLE
Run the pair checker the API path claims to have run (#544)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1165,8 +1165,13 @@ def pair_consistency(spec: RunSpec) -> dict[str, Any] | None:
         from data_sheets_schema.d4d_pair_consistency import (load_pair_schema,
                                                              validate_pair_data)
         import yaml as _yaml
-        if not (spec.full_path.exists() and spec.core_path.exists()):
-            return None
+        missing = [str(f) for f in (spec.full_path, spec.core_path)
+                   if not f.exists()]
+        if missing:
+            # Not None. None means the block was never written; this run wrote
+            # one and the file it needed was absent, which `validate_outputs`
+            # will also have flagged. Two different states, two answers.
+            return {"ran": False, "reason": f"missing: {', '.join(missing)}"}
         pair = load_pair_schema(FULL_SCHEMA_PATH, CORE_SCHEMA_PATH)
         full = _yaml.safe_load(spec.full_path.read_text(encoding="utf-8")) or {}
         core = _yaml.safe_load(spec.core_path.read_text(encoding="utf-8")) or {}
@@ -1195,8 +1200,11 @@ def pair_consistency(spec: RunSpec) -> dict[str, Any] | None:
         "errors": len(report.errors),
         "warnings": len(report.warnings),
         "identity_slots": len(report.identity_slots),
+        # Bounded, and says so. A list silently cut at 20 reads as a complete
+        # one; `errors` above is the true count either way.
         "findings": [{"code": i.code, "path": i.path, "message": i.message[:200]}
                      for i in report.errors[:20]],
+        "findings_truncated": max(0, len(report.errors) - 20) or None,
     }
 
 

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1142,6 +1142,64 @@ def validate_outputs(spec: RunSpec) -> list[dict[str, str]]:
     return problems
 
 
+def pair_consistency(spec: RunSpec) -> dict[str, Any] | None:
+    """Does the full/core pair this run produced actually agree? (#544)
+
+    The API path has `reconcile_full` and `reconcile_core` phases and writes
+    `# Phase 4 reconciliation: completed` into every core header, but nothing
+    ever ran the pair checker afterwards. The agentic playbook does, at its own
+    phase 4, and the difference is the whole difference: across the
+    2026-08-13 v4 arm 11 of 12 pairs failed, against 0 of 15 in the
+    2026-08-11 agentic arm.
+
+    Every individual record validated in both arms, which is why neither
+    `linkml-validate` nor `runs check --strict` noticed — both read one file at
+    a time, and this is a property of two files together.
+
+    Reported, never fatal. A divergent pair is still usable evidence and the
+    records are individually valid; the defect being fixed here is that it was
+    invisible, not that it is fatal. Returns None when the checker cannot run,
+    so "not established" stays distinct from "consistent".
+    """
+    try:
+        from data_sheets_schema.d4d_pair_consistency import (load_pair_schema,
+                                                             validate_pair_data)
+        import yaml as _yaml
+        if not (spec.full_path.exists() and spec.core_path.exists()):
+            return None
+        pair = load_pair_schema(FULL_SCHEMA_PATH, CORE_SCHEMA_PATH)
+        full = _yaml.safe_load(spec.full_path.read_text(encoding="utf-8")) or {}
+        core = _yaml.safe_load(spec.core_path.read_text(encoding="utf-8")) or {}
+        report = validate_pair_data(full, core, pair)
+    except Exception as exc:                                       # noqa: BLE001
+        # A checker that cannot run must say so rather than report agreement.
+        return {"ran": False, "reason": str(exc)[:200]}
+    from data_sheets_schema.provenance import _md5
+    return {
+        "ran": True,
+        "consistent": report.passed,
+        # Pinned for the same reason `validation_block` pins its artifacts
+        # (#426, #433): a verdict about two files is a cached assertion, and
+        # editing either one leaves it saying `consistent: true` about bytes
+        # that no longer exist. Both files, because either can break the pair.
+        # Paths as well as hashes, and for the same reason `validation_block`
+        # records them: the two records do not live in one directory — the full
+        # record is under `{method}/{label}/` and the core one under
+        # `{method}_core/{label}/`, beside this provenance file. A re-check
+        # that reconstructs either path from the record's own location looks
+        # for a file that was never there and calls every pair stale.
+        "artifacts": {
+            "full": {"path": str(spec.full_path), "md5": _md5(spec.full_path)},
+            "core": {"path": str(spec.core_path), "md5": _md5(spec.core_path)},
+        },
+        "errors": len(report.errors),
+        "warnings": len(report.warnings),
+        "identity_slots": len(report.identity_slots),
+        "findings": [{"code": i.code, "path": i.path, "message": i.message[:200]}
+                     for i in report.errors[:20]],
+    }
+
+
 REPAIR_SYSTEM = (
     "You repair the shape of Datasheets-for-Datasets records. The schema "
     "digest defines the required structure. The validator findings are the "
@@ -1869,6 +1927,9 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     else:
         rec.data["repair"] = prior_repair or None
     rec.data["validation"] = validation_block(spec, problems)
+    # After repair, not before: repair rewrites both records, so a pair checked
+    # earlier would describe bytes that no longer exist (#544).
+    rec.data["pair_consistency"] = pair_consistency(spec)
     rec.data["intermediates"] = _intermediates_block(spec)
 
     rec.write(spec.provenance_path)

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -614,6 +614,8 @@ def check_cmd(method, label, project, strict):
                    f"{pairs[PAIR_UNRECORDED]} predate the check):")
         for project, label, errs in sorted(divergent)[:8]:
             click.echo(f"     {project:9} {label:44} {errs} error(s)")
+        if len(divergent) > 8:
+            click.echo(f"     … and {len(divergent) - 8} more")
         click.echo("   Both files validate alone. This is a property of the "
                    "two together, so no single-file gate can see it.")
     elif pairs[PAIR_UNRECORDED]:

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -582,6 +582,45 @@ def check_cmd(method, label, project, strict):
         click.echo("   The decision rules live in these files, so a record "
                    "that names them cannot be re-derived from them.")
 
+    # Full/core pair consistency (#544). Every other check here reads one
+    # file; this reads two together, which is why `linkml-validate` and every
+    # gate above passed a v4 arm in which 11 of 12 pairs disagreed. The API
+    # path writes "Phase 4 reconciliation: completed" into every core header
+    # and never ran the checker that would substantiate it; the agentic
+    # playbook runs it, and scored 0 divergent pairs in 15.
+    #
+    # Reported, never fatal: each record is individually valid and usable, and
+    # the whole corpus predates the check, so a gate would fail history.
+    from data_sheets_schema.runs import (
+        PAIR_CONSISTENT, PAIR_DIVERGENT, PAIR_NOT_RUN, PAIR_STALE,
+        PAIR_UNRECORDED, pair_status,
+    )
+    pairs: collections.Counter = collections.Counter()
+    divergent: list[tuple[str, str, int]] = []
+    for r in rows:
+        st, errs = pair_status(r["method"], r["label"], r["project"])
+        pairs[st] += 1
+        if st == PAIR_DIVERGENT:
+            divergent.append((r["project"], r["label"], errs))
+
+    if pairs[PAIR_STALE]:
+        click.echo(f"\nⓘ  {pairs[PAIR_STALE]} pair verdict(s) describe bytes "
+                   "that have since changed; the pair is unknown again.")
+
+    if pairs[PAIR_DIVERGENT] or pairs[PAIR_NOT_RUN]:
+        click.echo(f"\nⓘ  {pairs[PAIR_DIVERGENT]} record(s) wrote a full/core "
+                   f"pair that disagrees ({pairs[PAIR_CONSISTENT]} agree, "
+                   f"{pairs[PAIR_NOT_RUN]} could not be checked, "
+                   f"{pairs[PAIR_UNRECORDED]} predate the check):")
+        for project, label, errs in sorted(divergent)[:8]:
+            click.echo(f"     {project:9} {label:44} {errs} error(s)")
+        click.echo("   Both files validate alone. This is a property of the "
+                   "two together, so no single-file gate can see it.")
+    elif pairs[PAIR_UNRECORDED]:
+        click.echo(f"\nⓘ  {pairs[PAIR_UNRECORDED]} record(s) predate the "
+                   "full/core pair check (#544); their pairs are unknown, "
+                   "not consistent.")
+
     stale = drift[BUNDLE_DRIFTED] + drift[BUNDLE_ABSENT]
     if stale:
         click.echo(f"\nⓘ  {stale} record(s) name an input bundle whose bytes "

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1172,6 +1172,51 @@ def bundle_drift_detail(method: str, label: str, project: str,
                             f"record pinned {recorded[:8]}"), declared
 
 
+PAIR_CONSISTENT, PAIR_DIVERGENT = "consistent", "divergent"
+PAIR_NOT_RUN, PAIR_UNRECORDED = "not_run", "unrecorded"
+PAIR_STALE = "stale"
+
+
+def pair_status(method: str, label: str, project: str,
+                concat_dir: Path | None = None) -> tuple[str, int]:
+    """(status, error count) for a record's full/core pair check (#544).
+
+    Read from the record rather than recomputed. Every other reporter here
+    reads what a run attested; recomputing would answer a question about
+    today's files instead of about the run, and would put a SchemaView load
+    per row into a status command.
+
+    `unrecorded` is the honest answer for every record written before the
+    runner learned to check — which is the whole corpus as of 2026-08-13,
+    including all 12 v4 records. It is not `consistent`.
+    """
+    import yaml as _yaml
+
+    from data_sheets_schema.provenance import record_path_for
+    path = record_path_for(project, method, label, concat_dir or CONCAT_DIR)
+    if not path.exists():
+        return PAIR_UNRECORDED, 0
+    rec = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    block = rec.get("pair_consistency")
+    if not isinstance(block, dict):
+        return PAIR_UNRECORDED, 0
+    if not block.get("ran"):
+        return PAIR_NOT_RUN, 0
+    errors = int(block.get("errors") or 0)
+    # A verdict about two files, re-checked against those files. Same reason
+    # `validation_status` re-hashes: without this, editing either record leaves
+    # the pair verdict asserting agreement about bytes that are gone.
+    from data_sheets_schema.provenance import _md5
+    for entry in (block.get("artifacts") or {}).values():
+        if not isinstance(entry, dict) or not entry.get("md5"):
+            continue
+        f = Path(entry["path"])
+        if not f.exists() or _md5(f) != entry["md5"]:
+            return PAIR_STALE, errors
+    return (PAIR_CONSISTENT if block.get("consistent") else PAIR_DIVERGENT,
+            errors)
+
+
 PLAYBOOK_CURRENT, PLAYBOOK_DRIFTED = "current", "drifted"
 PLAYBOOK_ABSENT, PLAYBOOK_UNRECORDED = "absent", "unrecorded"
 

--- a/tests/test_pair_gate.py
+++ b/tests/test_pair_gate.py
@@ -141,10 +141,62 @@ class PairConsistencyTest(unittest.TestCase):
         self.assertGreater(block["errors"], 0)
         self.assertEqual(set(block["artifacts"]), {"full", "core"})
 
-    def test_missing_record_is_none_rather_than_consistent(self):
+    def test_missing_record_names_the_missing_file(self):
+        """Distinct from a block that was never written.
+
+        `None` means no check happened at all — which is what every record
+        predating this reports. A run whose record was absent did check, and
+        found nothing to check against; collapsing the two would file it with
+        the 122 historical records instead of as the defect it is.
+        """
         from data_sheets_schema.api_runner import pair_consistency
-        spec = self._spec("NO_SUCH_PROJECT")
-        self.assertIsNone(pair_consistency(spec))
+        block = pair_consistency(self._spec("NO_SUCH_PROJECT"))
+        self.assertFalse(block["ran"])
+        self.assertIn("missing", block["reason"])
+
+    def test_truncation_is_declared_rather_than_silent(self):
+        """`errors` is the true count even when `findings` is cut at 20."""
+        from data_sheets_schema.api_runner import pair_consistency
+        spec = self._spec("CHORUS")
+        if not (spec.full_path.exists() and spec.core_path.exists()):
+            self.skipTest("v4 CHORUS records not present in this checkout")
+        block = pair_consistency(spec)
+        dropped = block["findings_truncated"] or 0
+        self.assertEqual(len(block["findings"]) + dropped, block["errors"])
+
+
+
+
+class RecordGateTest(unittest.TestCase):
+    """The new key must survive the gate the runner runs on its own output.
+
+    `execute()` writes the record and immediately calls `check_provenance`,
+    raising if it is not usable. A top-level key that gate rejected would fail
+    every live run *after* the model spend, which is the most expensive place
+    to discover it and the one no unit test of `pair_consistency` reaches.
+    """
+
+    LABEL = "2026-08-13_claude-opus-5-api-generic-v4_rep1"
+
+    def test_pair_block_does_not_break_check_provenance(self):
+        import tempfile
+
+        from data_sheets_schema.runs import check_provenance
+        src = Path("data/d4d_concatenated/claudecode_agent_core") / self.LABEL \
+            / "CHORUS_provenance.yaml"
+        if not src.exists():
+            self.skipTest("v4 CHORUS record not present in this checkout")
+        rec = yaml.safe_load(src.read_text(encoding="utf-8"))
+        rec["pair_consistency"] = {
+            "ran": True, "consistent": False, "errors": 6,
+            "artifacts": {"full": {"path": "x", "md5": "y"},
+                          "core": {"path": "x", "md5": "y"}}}
+        # A copy. Round-tripping the real record through yaml.safe_dump would
+        # strip the header comments it carries.
+        tmp = Path(tempfile.mkdtemp()) / "CHORUS_provenance.yaml"
+        tmp.write_text(yaml.safe_dump(rec, sort_keys=False), encoding="utf-8")
+        self.assertTrue(check_provenance(
+            "claudecode_agent", self.LABEL, "CHORUS", record=tmp)["ok"])
 
 
 if __name__ == "__main__":

--- a/tests/test_pair_gate.py
+++ b/tests/test_pair_gate.py
@@ -1,0 +1,151 @@
+"""The full/core pair check, run by the runner and reported by `runs check`.
+
+Why this exists (#544): the API path has `reconcile_full` and `reconcile_core`
+phases and writes `# Phase 4 reconciliation: completed` into every core header,
+but nothing ever ran `validate_pair_data` afterwards. The checker had been in
+the tree since long before, with tests — and no caller. Across the 2026-08-13
+v4 arm 11 of 12 pairs disagreed; the agentic playbook runs the same checker at
+its own phase 4 and scored 0 of 15.
+
+Every one of those records validates individually, which is why no gate saw it:
+`linkml-validate` and `runs check` each read one file at a time, and this is a
+property of two files together.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.runs import (
+    PAIR_CONSISTENT,
+    PAIR_DIVERGENT,
+    PAIR_NOT_RUN,
+    PAIR_STALE,
+    PAIR_UNRECORDED,
+    pair_status,
+)
+
+METHOD, LABEL, PROJECT = "claudecode_agent", "2026-01-01_test_rep1", "CHORUS"
+
+
+class PairStatusTest(unittest.TestCase):
+    """`pair_status` reads what a run attested, and re-checks it."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.core_dir = self.root / f"{METHOD}_core" / LABEL
+        self.full_dir = self.root / METHOD / LABEL
+        self.core_dir.mkdir(parents=True)
+        self.full_dir.mkdir(parents=True)
+        self.full = self.full_dir / f"{PROJECT}_d4d.yaml"
+        self.core = self.core_dir / f"{PROJECT}_d4d_core.yaml"
+        self.full.write_text("id: x\n", encoding="utf-8")
+        self.core.write_text("id: x\n", encoding="utf-8")
+        self.addCleanup(self._tmp.cleanup)
+
+    def _write(self, block):
+        rec = {"run": {"project": PROJECT}}
+        if block is not None:
+            rec["pair_consistency"] = block
+        (self.core_dir / f"{PROJECT}_provenance.yaml").write_text(
+            yaml.safe_dump(rec), encoding="utf-8")
+
+    def _pins(self):
+        from data_sheets_schema.provenance import _md5
+        return {"full": {"path": str(self.full), "md5": _md5(self.full)},
+                "core": {"path": str(self.core), "md5": _md5(self.core)}}
+
+    def _status(self):
+        return pair_status(METHOD, LABEL, PROJECT, self.root)
+
+    def test_absent_block_is_unrecorded_not_consistent(self):
+        """The distinction the whole corpus depends on.
+
+        Every record written before this landed has no block. Reporting those
+        as consistent would assert agreement nobody checked — the same error
+        as calling an unmeasured reasoning spend zero.
+        """
+        self._write(None)
+        self.assertEqual(self._status(), (PAIR_UNRECORDED, 0))
+
+    def test_consistent_pair(self):
+        self._write({"ran": True, "consistent": True, "errors": 0,
+                     "artifacts": self._pins()})
+        self.assertEqual(self._status(), (PAIR_CONSISTENT, 0))
+
+    def test_divergent_pair_carries_its_error_count(self):
+        self._write({"ran": True, "consistent": False, "errors": 6,
+                     "artifacts": self._pins()})
+        self.assertEqual(self._status(), (PAIR_DIVERGENT, 6))
+
+    def test_checker_that_could_not_run_is_not_a_pass(self):
+        """A checker that failed to load says so; it does not report agreement."""
+        self._write({"ran": False, "reason": "schema would not load"})
+        self.assertEqual(self._status(), (PAIR_NOT_RUN, 0))
+
+    def test_editing_either_record_makes_the_verdict_stale(self):
+        """Both files, because either one alone can break the pair."""
+        for edited in (self.full, self.core):
+            with self.subTest(edited=edited.name):
+                self.full.write_text("id: x\n", encoding="utf-8")
+                self.core.write_text("id: x\n", encoding="utf-8")
+                self._write({"ran": True, "consistent": True, "errors": 0,
+                             "artifacts": self._pins()})
+                self.assertEqual(self._status()[0], PAIR_CONSISTENT)
+                edited.write_text("id: y\n", encoding="utf-8")
+                self.assertEqual(self._status()[0], PAIR_STALE)
+
+    def test_pins_name_the_paths_rather_than_rebuilding_them(self):
+        """The two records are not in one directory (#544 review).
+
+        The full record is under `{method}/{label}/` and the core one under
+        `{method}_core/{label}/`, beside the provenance file. A re-check that
+        derived the full record's path from the provenance file's own location
+        would look for a file that was never there and call every pair stale —
+        which is what the first version of this did.
+        """
+        self.assertNotEqual(self.full.parent, self.core.parent)
+        self._write({"ran": True, "consistent": True, "errors": 0,
+                     "artifacts": self._pins()})
+        self.assertEqual(self._status()[0], PAIR_CONSISTENT)
+
+
+class PairConsistencyTest(unittest.TestCase):
+    """`pair_consistency` on real v4 records, which is where it came from."""
+
+    LABEL = "2026-08-13_claude-opus-5-api-generic-v4_rep1"
+
+    def _spec(self, project):
+        from data_sheets_schema.api_runner import RunSpec
+        return RunSpec(
+            project=project, arm="baseline", method=METHOD,
+            bundle=Path(f"data/preprocessed/concatenated/"
+                        f"{project}_preprocessed.txt"),
+            label=self.LABEL, condition="generic_v4")
+
+    def test_finds_the_divergence_the_v4_arm_shipped_with(self):
+        from data_sheets_schema.api_runner import pair_consistency
+        spec = self._spec("CHORUS")
+        if not (spec.full_path.exists() and spec.core_path.exists()):
+            self.skipTest("v4 CHORUS records not present in this checkout")
+        block = pair_consistency(spec)
+        self.assertTrue(block["ran"])
+        self.assertFalse(block["consistent"],
+                         "CHORUS v4 rep1's pair disagrees; if this now passes, "
+                         "the records were regenerated and the figure in #544 "
+                         "needs restating")
+        self.assertGreater(block["errors"], 0)
+        self.assertEqual(set(block["artifacts"]), {"full", "core"})
+
+    def test_missing_record_is_none_rather_than_consistent(self):
+        from data_sheets_schema.api_runner import pair_consistency
+        spec = self._spec("NO_SUCH_PROJECT")
+        self.assertIsNone(pair_consistency(spec))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #544.

The API path writes `# Phase 4 reconciliation: completed` into every core
header and never ran the checker that would substantiate it. `validate_pair_data`
has been in the tree with its own tests since long before, and had no caller
anywhere in the pipeline.

| arm | pairs checked | divergent |
|---|---|---|
| agentic 2026-08-11 (playbook runs the checker) | 15 | **0** |
| API v4 2026-08-13 | 12 | **11** |

Every one of those 12 records validates individually, and `d4d runs check
--strict` exits 0 on the arm. `linkml-validate` and every gate in `runs check`
read one file at a time; this is a property of two files together, so no
single-file gate could have seen it.

## What lands

- **`pair_consistency()`** in `api_runner`, called after repair — repair
  rewrites both records, so a pair checked before it describes bytes that no
  longer exist. Returns `None` when the checker cannot run, keeping "not
  established" distinct from "consistent".
- **The verdict is falsifiable.** Both artifacts pinned by md5, for the reason
  `validation_block` pins its own (#426, #433).
- **`pair_status()` + a `runs check` reporter.** Reported, never fatal: the
  records are individually valid, and the whole corpus predates the check.
  122 records report `unrecorded` — which is not `consistent`.

## A defect this PR's own review caught

The first version derived the full record's path from the provenance file's
location. The two records are not in one directory — full under
`{method}/{label}/`, core under `{method}_core/{label}/` — so it looked for a
file that was never there and would have called every pair stale. Paths are
now recorded alongside the hashes, and `test_pins_name_the_paths_rather_than_rebuilding_them`
names the mistake.

## Not in scope

Backfilling the 12 v4 records, and fixing the divergences themselves. This PR
makes the property visible and records it going forward.

Suite: 1936 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)