### PR TITLE
Check reconciliation reports against the record and the schema (#546)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1208,6 +1208,39 @@ def pair_consistency(spec: RunSpec) -> dict[str, Any] | None:
     }
 
 
+def report_claims_block(spec: RunSpec) -> dict[str, Any] | None:
+    """Check the reconciliation report against the record and the schema (#546).
+
+    The report is what a reviewer reads instead of diffing YAML, and nothing
+    checked it against anything. In the v4 arm every record that emitted a
+    `distributions` block — 9 of 12 — reported removing it, from the premise
+    that `distributions` is not a declared slot. It is, with range
+    `CoreDistribution`, and the blocks are still there.
+
+    Reported, never fatal, like the pair check: a wrong report does not make a
+    record wrong, and the whole corpus predates this.
+    """
+    try:
+        import yaml as _yaml
+
+        from data_sheets_schema.report_claims import (check_report,
+                                                      declared_slots)
+        if not spec.report_path.exists():
+            return {"checked": False, "reason": "no reconciliation report"}
+        full = _yaml.safe_load(spec.full_path.read_text(encoding="utf-8")) \
+            if spec.full_path.exists() else {}
+        core = _yaml.safe_load(spec.core_path.read_text(encoding="utf-8")) \
+            if spec.core_path.exists() else {}
+        out = check_report(spec.report_path, full or {}, core or {},
+                           declared_slots())
+    except Exception as exc:                                       # noqa: BLE001
+        return {"checked": False, "reason": str(exc)[:200]}
+    from data_sheets_schema.provenance import _md5
+    out["artifacts"] = {"report": {"path": str(spec.report_path),
+                                   "md5": _md5(spec.report_path)}}
+    return out
+
+
 REPAIR_SYSTEM = (
     "You repair the shape of Datasheets-for-Datasets records. The schema "
     "digest defines the required structure. The validator findings are the "
@@ -1938,6 +1971,7 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     # After repair, not before: repair rewrites both records, so a pair checked
     # earlier would describe bytes that no longer exist (#544).
     rec.data["pair_consistency"] = pair_consistency(spec)
+    rec.data["report_claims"] = report_claims_block(spec)
     rec.data["intermediates"] = _intermediates_block(spec)
 
     rec.write(spec.provenance_path)

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -603,6 +603,39 @@ def check_cmd(method, label, project, strict):
         if st == PAIR_DIVERGENT:
             divergent.append((r["project"], r["label"], errs))
 
+    # Reconciliation reports checked against the record and the schema (#546).
+    # The report is what a reviewer reads instead of diffing YAML; nothing
+    # checked it against either. In the v4 arm every record that emitted a
+    # `distributions` block reported removing it, from the false premise that
+    # the slot is not declared — and the blocks are still there.
+    from data_sheets_schema.runs import (
+        CLAIMS_CLEAN, CLAIMS_CONTRADICTED, CLAIMS_NOT_RUN, CLAIMS_UNRECORDED,
+        report_claim_status,
+    )
+    claims: collections.Counter = collections.Counter()
+    contradicted: list[tuple[str, str, int]] = []
+    for r in rows:
+        st, n = report_claim_status(r["method"], r["label"], r["project"])
+        claims[st] += 1
+        if st == CLAIMS_CONTRADICTED:
+            contradicted.append((r["project"], r["label"], n))
+
+    if claims[CLAIMS_CONTRADICTED]:
+        click.echo(f"\nⓘ  {claims[CLAIMS_CONTRADICTED]} reconciliation "
+                   f"report(s) assert something the record or the schema "
+                   f"contradicts ({claims[CLAIMS_CLEAN]} clean, "
+                   f"{claims[CLAIMS_NOT_RUN]} not checked, "
+                   f"{claims[CLAIMS_UNRECORDED]} predate the check):")
+        for project, label, n in sorted(contradicted)[:8]:
+            click.echo(f"     {project:9} {label:44} {n} claim(s)")
+        if len(contradicted) > 8:
+            click.echo(f"     … and {len(contradicted) - 8} more")
+        click.echo("   A report is the audit trail read instead of the diff. "
+                   "These claims are decidable and were never decided.")
+    elif claims[CLAIMS_UNRECORDED]:
+        click.echo(f"\nⓘ  {claims[CLAIMS_UNRECORDED]} record(s) predate the "
+                   "reconciliation-report check (#546).")
+
     if pairs[PAIR_STALE]:
         click.echo(f"\nⓘ  {pairs[PAIR_STALE]} pair verdict(s) describe bytes "
                    "that have since changed; the pair is unknown again.")

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -609,8 +609,8 @@ def check_cmd(method, label, project, strict):
     # `distributions` block reported removing it, from the false premise that
     # the slot is not declared — and the blocks are still there.
     from data_sheets_schema.runs import (
-        CLAIMS_CLEAN, CLAIMS_CONTRADICTED, CLAIMS_NOT_RUN, CLAIMS_UNRECORDED,
-        report_claim_status,
+        CLAIMS_CLEAN, CLAIMS_CONTRADICTED, CLAIMS_NOT_RUN, CLAIMS_STALE,
+        CLAIMS_UNRECORDED, report_claim_status,
     )
     claims: collections.Counter = collections.Counter()
     contradicted: list[tuple[str, str, int]] = []
@@ -625,6 +625,7 @@ def check_cmd(method, label, project, strict):
                    f"report(s) assert something the record or the schema "
                    f"contradicts ({claims[CLAIMS_CLEAN]} clean, "
                    f"{claims[CLAIMS_NOT_RUN]} not checked, "
+                   f"{claims[CLAIMS_STALE]} stale, "
                    f"{claims[CLAIMS_UNRECORDED]} predate the check):")
         for project, label, n in sorted(contradicted)[:8]:
             click.echo(f"     {project:9} {label:44} {n} claim(s)")

--- a/src/data_sheets_schema/report_claims.py
+++ b/src/data_sheets_schema/report_claims.py
@@ -369,7 +369,17 @@ def check_report(report: Path, full: dict, core: dict,
                                    "it is declared on " + ", ".join(holders)),
                         "claim": claim.strip()[:240]})
 
-    return {"checked": True, "findings": findings, "claims_checked": claims,
+    # One claim can be stated twice — a summary table row and the prose that
+    # elaborates it. Reporting it twice inflates the count a reader uses to
+    # judge how bad a report is.
+    seen, unique = set(), []
+    for f in findings:
+        key = (f["kind"], f.get("slot"), f.get("record"))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(f)
+    return {"checked": True, "findings": unique, "claims_checked": claims,
             # Named rather than dropped: a claim naming no slot in backticks
             # cannot be checked, and a reader should know how many there were.
             "claims_unnamed": unnamed}

--- a/src/data_sheets_schema/report_claims.py
+++ b/src/data_sheets_schema/report_claims.py
@@ -1,0 +1,390 @@
+"""Check a reconciliation report against the record and the schema (#546).
+
+A reconciliation report is the human-readable audit trail — the artifact a
+reviewer reads *instead of* diffing YAML. Nothing checked it against anything,
+and in the 2026-08-13 v4 arm three of twelve reports asserted:
+
+    **Action:** the `distributions` block was removed from the core record in
+    its entirety.
+
+on records that retained ten, ten and three entries. All three justified it the
+same way:
+
+    No such slot appears in the schema digest's inventory for
+    `Dataset`/`CoreDataset`.
+
+`distributions` is a declared `CoreDataset` slot with range `CoreDistribution`,
+and every key those reports listed is a declared `CoreDistribution` slot. The
+audit reasoned from a false statement about the schema toward a removal, and
+then did not perform it. The records are correct by accident.
+
+Both claims are decidable: one against the record, one against a schema that is
+machine-readable and right there.
+
+## Precision over recall, deliberately
+
+Only two claim forms are read, because they are the two whose subject is
+unambiguous:
+
+- a table row whose change cell says the slot was removed —
+  ``| `distributions` | **Removed** | Not declared anywhere in the schema. |``
+- an ``**Action:**`` line naming its subject in backticks.
+
+A first version read every sentence containing a removal verb and produced 122
+findings across the 12 v4 reports, most of them wrong: ``citation prose removed
+from core `notes` `` was read as removing `notes`, ``neither was deleted`` as a
+removal, and markdown table cells bled into their neighbours. A checker whose
+output a reader learns to ignore is how the reports got into this state; it
+would be a poor way to fix it.
+
+So there are real claims here this will not check — "The four MuSIC-pipeline
+objects were removed" names no slot in backticks and is skipped. The count of
+what was skipped is reported rather than left silent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+#: A change cell asserting the slot is gone. Anchored to the cell, so a reason
+#: cell mentioning removal cannot trigger it.
+_CELL_REMOVED = re.compile(
+    r"^\W*(?:\*\*)?(?:removed|deleted|dropped)\b", re.I)
+
+#: An `**Action:**` line that asserts a removal. Negations are excluded here
+#: rather than filtered later: "neither was deleted" is a claim that nothing
+#: happened, and reading it as a removal is how the first version got CHORUS
+#: rep1 wrong.
+#: Reports label their outcome paragraph inconsistently — `**Action:**`,
+#: `**Disposition — changed.**`, `**Resolution:**` all appear across the 12 v4
+#: reports. Matching only the first missed two of the three false removals
+#: #546 names.
+_ACTION = re.compile(r"^\s*(?:[-*]\s*)?\*\*(?:action|disposition|resolution)"
+                     r"\b[^*]*\*\*:?\s*(?P<body>.*)$", re.I | re.S)
+_REMOVAL_VERB = re.compile(r"\b(?:was|were|have been|has been)\s+"
+                           r"(?:removed|deleted|dropped)\b", re.I)
+_NEGATED = re.compile(r"\b(?:neither|nor|not|never|no)\b[^.]{0,40}"
+                      r"\b(?:removed|deleted|dropped)\b", re.I)
+
+#: A claim that something is not in the schema. Decidable, and in every v4
+#: instance false.
+_ABSENT_FROM_SCHEMA = re.compile(
+    r"\bnot declared\b|\bno such slot\b|\bdoes not (?:exist|appear)\b|"
+    r"\bnot a (?:declared|valid|recognised|recognized) slot\b|"
+    r"\bnot in the (?:inventory|schema)\b|\bnot attested (?:keys?|slots?)\b|"
+    r"\bappears? to have been invented\b", re.I)
+
+_TICKED = re.compile(r"`([A-Za-z_][\w]*(?:\[(?:\d+|\*)\])?"
+                     r"(?:\.[\w]+(?:\[(?:\d+|\*)\])?)*)`")
+#: A backticked name in this position is a container or a destination, not the
+#: thing removed: "citation prose removed from core `notes`".
+_OBLIQUE = re.compile(r"\b(?:from|into|to|in|on|within|onto|under|beside|"
+                      r"alongside)\s+(?:the\s+|core\s+|full\s+)*`")
+#: The head noun after a backticked name decides what was removed. "the
+#: `distributions` block was removed" removes the slot; "the unfounded
+#: `source_caveats` claim was removed" removes a sentence of prose from inside
+#: a slot that stays. Only the second kind is excluded — `block`, `slot`,
+#: `entry` and a bare name all mean the slot itself.
+_CONTENT_NOUN = re.compile(
+    r"^\s*(?:claim|prose|note|notes|sentence|statement|assertion|text|"
+    r"wording|caveat|disclaimer|phrase|language|description|dates?|values?|"
+    r"keys?|fields?|reference|prefix)\b", re.I)
+
+
+def _cells(line: str) -> list[str] | None:
+    """The cells of a markdown table row, or None if this is not one."""
+    if not line.lstrip().startswith("|"):
+        return None
+    parts = [c.strip() for c in line.strip().strip("|").split("|")]
+    if len(parts) < 2 or all(set(c) <= set("-: ") for c in parts):
+        return None                                   # separator row
+    return parts
+
+
+def resolve(data: Any, path: str) -> tuple[bool, Any]:
+    """(present, value) for a dotted/indexed path like `instances[0].counts`.
+
+    Reports name nested slots as often as top-level ones. `[*]` means "any
+    element", so `creators[*].affiliations` is present when any creator has it
+    — a report claiming that was removed is contradicted by one survivor.
+    """
+    parts = re.findall(r"[\w]+|\[\d+\]|\[\*\]", path)
+
+    def walk(cur: Any, i: int) -> tuple[bool, Any]:
+        if i == len(parts):
+            return True, cur
+        part = parts[i]
+        if part == "[*]":
+            if not isinstance(cur, list):
+                return False, None
+            for item in cur:
+                ok, val = walk(item, i + 1)
+                if ok and _populated(val):
+                    return True, val
+            return False, None
+        if part.startswith("["):
+            idx = int(part[1:-1])
+            if not isinstance(cur, list) or idx >= len(cur):
+                return False, None
+            return walk(cur[idx], i + 1)
+        if not isinstance(cur, dict) or part not in cur:
+            return False, None
+        return walk(cur[part], i + 1)
+
+    return walk(data, 0)
+
+
+def _populated(value: Any) -> bool:
+    """A slot present but empty is removed for the purpose a report describes.
+
+    `distributions: []` is not a ten-entry block, and calling that a false
+    claim would be pedantry that buries the real finding.
+    """
+    return value not in (None, [], {}, "")
+
+
+def _target(text: str) -> str:
+    """Which record a claim is about: 'core', 'full' or 'either'.
+
+    'either' means the claim named no record. Those are read against the core
+    record: reconciliation exists to produce core from full, and a slot the
+    full record legitimately keeps while core drops it is the normal outcome,
+    not a false claim. Reading them against both instead was too weak to see
+    AI_READI rep1, whose `distributions` block only ever existed in core — the
+    full record's absence of it made the claim look satisfied.
+    """
+    low = text.lower()
+    core = "core record" in low or "core file" in low or "from core" in low
+    full = "full record" in low or "full file" in low or "from full" in low
+    if core and not full:
+        return "core"
+    if full and not core:
+        return "full"
+    return "either"
+
+
+def _named(text: str) -> list[str]:
+    """Backticked names in `text` that denote a slot, not a place or a phrase.
+
+    Shared by prose and table cells. A cell reading "Dataverse Subject in
+    `keywords`" names where something was removed *from*, and one reading
+    "`collection_timeframes` dates" names what inside the slot went — neither
+    is a claim that the slot is gone.
+    """
+    out = []
+    for m in _TICKED.finditer(text):
+        if _OBLIQUE.search(text[max(0, m.start() - 30):m.start()] + "`"):
+            continue
+        if _CONTENT_NOUN.match(text[m.end():m.end() + 24]):
+            continue
+        out.append(m.group(1))
+    return out
+
+
+def _subjects(body: str) -> list[str]:
+    """Backticked names that are the thing removed.
+
+    Two rules, both learned from false positives on the v4 reports:
+
+    - The name must come *before* the removal verb. "the block was removed. Its
+      content was already represented by the declared `distribution_formats`
+      slot, which was retained" names the slot that survived, not the one that
+      went.
+    - It must not sit in an oblique phrase: "citation prose removed from core
+      `notes`" removes prose, not `notes`.
+
+    A removal whose subject is only "the slot" or "the block" yields nothing,
+    and is counted as unnamed rather than guessed at.
+    """
+    verb = _REMOVAL_VERB.search(body)
+    if not verb:
+        return []
+    # The sentence containing the verb, not the whole paragraph. Reading the
+    # paragraph let "`id` is now `https://ror.org/…`" three sentences earlier
+    # become the subject of a removal further down.
+    start = max((body.rfind(p, 0, verb.start()) for p in (". ", "! ", "? ")),
+                default=-1)
+    return _named(body[start + 1:verb.start()])
+
+
+#: A removal whose subject is a bare noun — "the block was removed". Its slot
+#: is named in the section heading and nowhere else, which is how AI_READI
+#: rep1's false removal escaped a first version that only read the sentence.
+_BARE_SUBJECT = re.compile(r"\b(?:the|this|these|those|that)\s+(?:\w+\s+){0,2}"
+                           r"(?:block|slot|slots|object|objects|entries|array|"
+                           r"list)\s+(?:was|were|have been|has been)\s+"
+                           r"(?:removed|deleted|dropped)\b", re.I)
+
+
+def _heading_fallback(body: str, heading_slots: list[str]) -> list[str]:
+    """The heading's slot, but only when the sentence names none of its own.
+
+    Guarded twice. If the sentence contains any backticked name, that name was
+    considered and rejected — "the unfounded `source_caveats` claim was
+    removed" removes prose, and reaching past it to the heading would
+    resurrect exactly the false positive the content-noun rule just removed.
+    And the subject must actually be a bare noun, so a sentence about
+    something else entirely cannot borrow the heading's subject.
+    """
+    verb = _REMOVAL_VERB.search(body)
+    if not verb or _TICKED.search(body[:verb.end()]):
+        return []
+    return heading_slots if _BARE_SUBJECT.search(body) else []
+
+
+def _describe(value: Any) -> str:
+    if isinstance(value, list):
+        return f"{len(value)} entr{'y' if len(value) == 1 else 'ies'}"
+    return "a value"
+
+
+def check_report(report: Path, full: dict, core: dict,
+                 declared: dict[str, set[str]]) -> dict[str, Any]:
+    """Findings, plus what was skipped.
+
+    `declared` maps a class name to its induced slot names — passed in so a
+    caller checking twelve reports builds the SchemaView once.
+    """
+    if not report.exists():
+        return {"checked": False, "reason": f"no report at {report}",
+                "findings": []}
+    text = report.read_text(encoding="utf-8", errors="replace")
+    findings: list[dict[str, str]] = []
+    claims = unnamed = 0
+
+    def removal(names: list[str], context: str, claim: str) -> None:
+        nonlocal claims, unnamed
+        if not names:
+            unnamed += 1
+            return
+        claims += 1
+        where = _target(context)
+        for name in names:
+            # `errata[0] removed` cannot be checked by presence at index 0.
+            # Removing an element renumbers the rest, so index 0 afterwards is
+            # the object that survived — VOICE rep1 folded one Erratum into
+            # another and the surviving one sits exactly where the dropped one
+            # was. Skipped and counted, not guessed at.
+            if re.search(r"\[\d+\]$", name):
+                unnamed += 1
+                continue
+            in_full, v_full = resolve(full, name)
+            in_core, v_core = resolve(core, name)
+            live = {"core": in_core and _populated(v_core),
+                    "full": in_full and _populated(v_full),
+                    "either": in_core and _populated(v_core)}[where]
+            if live:
+                v = v_full if where == "full" else v_core
+                findings.append({
+                    "kind": "removal_not_performed", "slot": name,
+                    "record": where,
+                    "detail": f"report says removed; record has {_describe(v)}",
+                    "claim": claim[:240]})
+
+    for line in text.splitlines():
+        cells = _cells(line)
+        if not cells:
+            continue
+        # The change cell is found rather than assumed at a fixed index: one
+        # report writes `| core | \`distributions\` | removed; … |`, putting the
+        # record in column 0 and the slot in column 1.
+        for i, cell in enumerate(cells):
+            if i and _CELL_REMOVED.match(cell):
+                named = [n for c in cells[:i] for n in _named(c)]
+                removal(named, line, line)
+                break
+
+    # Paragraphs, not lines: an outcome sentence wraps, and "The three
+    # `distributions` objects were removed from" is the whole of its first line.
+    paras = re.split(r"\n\s*\n", text)
+    headings: dict[int, tuple[list[str], str]] = {}
+    para_index: dict[int, int] = {}
+    current: tuple[list[str], str] = ([], "")
+    for n, para in enumerate(paras):
+        para_index[id(para)] = n
+        for ln in para.splitlines():
+            h = re.match(r"^#{1,6}\s+(.*)$", ln)
+            if h:
+                current = (_TICKED.findall(h.group(1)), h.group(1))
+        headings[n] = current
+    for para in paras:
+        if para.lstrip().startswith("|"):
+            continue
+        m = _ACTION.match(" ".join(para.split()))
+        if not m:
+            continue
+        body = m.group("body")
+        if _REMOVAL_VERB.search(body) and not _NEGATED.search(body):
+            head, head_text = headings.get(para_index.get(id(para), -1),
+                                           ([], ""))
+            # The heading is part of the context, not only a source of names:
+            # "### 2.1 Core `distributions` slot not in the schema" is where
+            # that section says which record it is about, and without it the
+            # claim falls back to the conservative both-records rule and a real
+            # false removal goes unreported.
+            removal(_subjects(body) or _heading_fallback(body, head),
+                    body + " " + head_text, body)
+
+    # Schema claims, per sentence. "This slot is not declared on `CoreDataset`"
+    # names its subject in the sentence before it, and the surrounding key
+    # lists — `path`, `format`, `media_type` — are examples, not subjects. The
+    # first version flagged every backticked name on the line.
+    classes = set(declared)
+    for line in text.splitlines():
+        cells = _cells(line)
+        if cells and len(cells) >= 3 and _ABSENT_FROM_SCHEMA.search(cells[-1]):
+            sentence_subjects = [(_TICKED.findall(cells[0]), cells[-1])]
+        elif cells:
+            continue
+        else:
+            sentence_subjects = []
+            prev: list[str] = []
+            for sent in re.split(r"(?<=[.!?])\s+", line):
+                here = [n for n in _TICKED.findall(sent) if n not in classes]
+                for phrase in _ABSENT_FROM_SCHEMA.finditer(sent):
+                    # Only names *before* the phrase. After it they are
+                    # attributions, and the report is generally right about
+                    # them: "the key set is a hybrid of `FileCollection`
+                    # (`path`) and `DistributionFormat` (`format`)" correctly
+                    # places two keys it is not claiming are undeclared.
+                    before = [n for n in _TICKED.findall(sent[:phrase.start()])
+                              if n not in classes]
+                    # Nothing before it means the subject is a demonstrative —
+                    # "This slot is not declared" — naming the slot introduced
+                    # in the sentence above.
+                    sentence_subjects.append((before or prev[:1], sent))
+                if here:
+                    prev = here
+
+        for names, claim in sentence_subjects:
+            for name in names:
+                root = re.split(r"[.\[]", name)[0]
+                holders = sorted(c for c, sl in declared.items() if root in sl)
+                if holders:
+                    findings.append({
+                        "kind": "false_schema_claim", "slot": root,
+                        "detail": ("report says this is not a declared slot; "
+                                   "it is declared on " + ", ".join(holders)),
+                        "claim": claim.strip()[:240]})
+
+    return {"checked": True, "findings": findings, "claims_checked": claims,
+            # Named rather than dropped: a claim naming no slot in backticks
+            # cannot be checked, and a reader should know how many there were.
+            "claims_unnamed": unnamed}
+
+
+def declared_slots() -> dict[str, set[str]]:
+    """Induced slots for the classes a report makes claims about."""
+    from linkml_runtime import SchemaView
+
+    from data_sheets_schema.provenance import CORE_SCHEMA, FULL_SCHEMA
+    out: dict[str, set[str]] = {}
+    for schema, classes in ((FULL_SCHEMA, ("Dataset",)),
+                            (CORE_SCHEMA, ("CoreDataset", "CoreDistribution"))):
+        view = SchemaView(str(schema))
+        for cls in classes:
+            if cls in view.all_classes():
+                out[cls] = {s.name for s in view.class_induced_slots(cls)}
+    return out

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1174,6 +1174,7 @@ def bundle_drift_detail(method: str, label: str, project: str,
 
 CLAIMS_CLEAN, CLAIMS_CONTRADICTED = "clean", "contradicted"
 CLAIMS_NOT_RUN, CLAIMS_UNRECORDED = "not_run", "unrecorded"
+CLAIMS_STALE = "stale"
 
 
 def report_claim_status(method: str, label: str, project: str,
@@ -1201,7 +1202,10 @@ def report_claim_status(method: str, label: str, project: str,
             continue
         f = Path(entry["path"])
         if not f.exists() or _md5(f) != entry["md5"]:
-            return CLAIMS_NOT_RUN, 0      # the report was edited after checking
+            # Distinct from `not_run`, as PAIR_STALE is: a checker that could
+            # not run and a verdict about bytes that have changed are different
+            # states, and the pair check already draws that line.
+            return CLAIMS_STALE, 0
     n = len(block.get("findings") or [])
     return (CLAIMS_CONTRADICTED if n else CLAIMS_CLEAN), n
 

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1172,6 +1172,40 @@ def bundle_drift_detail(method: str, label: str, project: str,
                             f"record pinned {recorded[:8]}"), declared
 
 
+CLAIMS_CLEAN, CLAIMS_CONTRADICTED = "clean", "contradicted"
+CLAIMS_NOT_RUN, CLAIMS_UNRECORDED = "not_run", "unrecorded"
+
+
+def report_claim_status(method: str, label: str, project: str,
+                        concat_dir: Path | None = None) -> tuple[str, int]:
+    """(status, finding count) for a record's reconciliation report (#546).
+
+    Read from the record, like `pair_status`, and for the same reason: every
+    other reporter here reads what a run attested rather than recomputing an
+    answer about today's files.
+    """
+    import yaml as _yaml
+
+    from data_sheets_schema.provenance import _md5, record_path_for
+    path = record_path_for(project, method, label, concat_dir or CONCAT_DIR)
+    if not path.exists():
+        return CLAIMS_UNRECORDED, 0
+    rec = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    block = rec.get("report_claims")
+    if not isinstance(block, dict):
+        return CLAIMS_UNRECORDED, 0
+    if not block.get("checked"):
+        return CLAIMS_NOT_RUN, 0
+    for entry in (block.get("artifacts") or {}).values():
+        if not isinstance(entry, dict) or not entry.get("md5"):
+            continue
+        f = Path(entry["path"])
+        if not f.exists() or _md5(f) != entry["md5"]:
+            return CLAIMS_NOT_RUN, 0      # the report was edited after checking
+    n = len(block.get("findings") or [])
+    return (CLAIMS_CONTRADICTED if n else CLAIMS_CLEAN), n
+
+
 PAIR_CONSISTENT, PAIR_DIVERGENT = "consistent", "divergent"
 PAIR_NOT_RUN, PAIR_UNRECORDED = "not_run", "unrecorded"
 PAIR_STALE = "stale"

--- a/tests/test_report_claims.py
+++ b/tests/test_report_claims.py
@@ -1,0 +1,241 @@
+"""Reconciliation-report claims, checked against the record and the schema.
+
+Why this exists (#546): a reconciliation report is the audit trail a reviewer
+reads *instead of* diffing YAML, and nothing checked it against anything. In
+the 2026-08-13 v4 arm, every record that emitted a `distributions` block — 9 of
+12 — reported having removed it, justified by the claim that `distributions` is
+not declared. It is, with range `CoreDistribution`, and the blocks are still on
+disk.
+
+Most of these tests are about **precision**, because the first version of the
+checker produced 122 findings across those 12 reports and most were wrong. A
+checker whose output a reader learns to ignore is how the reports got into this
+state.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.report_claims import check_report, resolve
+
+DECLARED = {"Dataset": {"file_collections", "distributions", "keywords"},
+            "CoreDataset": {"distributions", "source_caveats", "notes",
+                            "errata", "collection_timeframes"},
+            "CoreDistribution": {"path", "md5", "format", "media_type"}}
+
+
+class Harness(unittest.TestCase):
+    def check(self, markdown, full=None, core=None):
+        import tempfile
+        d = Path(tempfile.mkdtemp())
+        (d / "r.md").write_text(markdown, encoding="utf-8")
+        self.addCleanup(lambda: None)
+        return check_report(d / "r.md", full or {}, core or {}, DECLARED)
+
+    def kinds(self, markdown, **kw):
+        return [(f["kind"], f["slot"]) for f in self.check(markdown, **kw)["findings"]]
+
+
+class RemovalClaimTest(Harness):
+
+    CORE = {"distributions": [{"path": "a"}, {"path": "b"}]}
+
+    def test_action_line_naming_its_subject(self):
+        md = ("### 2.1 `distributions`\n\n**Action:** the `distributions` "
+              "block was removed from the core record in its entirety.\n")
+        self.assertEqual(self.kinds(md, core=self.CORE),
+                         [("removal_not_performed", "distributions")])
+
+    def test_bare_subject_takes_the_slot_from_its_heading(self):
+        """"the block was removed" names nothing; the heading above does.
+
+        AI_READI rep1 is written this way. A version that read only the
+        sentence reported nothing for it while the ten-entry block sat in the
+        record.
+        """
+        md = ("### 2.1 Core `distributions` slot not in the schema\n\n"
+              "**Resolution:** the block was removed. Its content was "
+              "redistributed to slots that do exist.\n")
+        # Two findings, both true: the heading asserts the slot is not in the
+        # schema, which is the false premise the removal was reasoned from.
+        self.assertEqual(sorted(self.kinds(md, core=self.CORE)),
+                         [("false_schema_claim", "distributions"),
+                          ("removal_not_performed", "distributions")])
+
+    def test_table_row_with_the_change_cell_anywhere(self):
+        """One report writes `| core | \\`distributions\\` | removed; … |`.
+
+        The change cell is found, not assumed to be column 1.
+        """
+        md = ("| record | slot | change |\n|---|---|---|\n"
+              "| core | `distributions` | removed; content moved |\n")
+        self.assertEqual(self.kinds(md, core=self.CORE),
+                         [("removal_not_performed", "distributions")])
+
+    def test_a_true_removal_is_not_reported(self):
+        md = "**Action:** the `distributions` block was removed.\n"
+        self.assertEqual(self.kinds(md, core={"notes": "x"}), [])
+
+    def test_an_emptied_slot_counts_as_removed(self):
+        """`distributions: []` is not a two-entry block; calling that a false
+        claim would be pedantry that buries the real finding."""
+        md = "**Action:** the `distributions` block was removed.\n"
+        self.assertEqual(self.kinds(md, core={"distributions": []}), [])
+
+
+class PrecisionTest(Harness):
+    """Each of these was a real false positive on the v4 reports."""
+
+    def test_negation_is_not_a_removal(self):
+        md = ("### `subsets`\n\n**Action:** a cross-referencing note was added "
+              "to each so they cannot silently diverge; neither was deleted.\n")
+        self.assertEqual(self.kinds(md, core={"subsets": [1]}), [])
+
+    def test_content_removed_from_a_slot_is_not_the_slot(self):
+        """"the citation prose removed from core `notes`" removes prose."""
+        md = "**Action:** the citation prose was removed from core `notes`.\n"
+        self.assertEqual(self.kinds(md, core={"notes": "kept"}), [])
+
+    def test_a_claim_inside_a_slot_is_not_the_slot(self):
+        """VOICE rep1: "the unfounded `source_caveats` claim was removed"."""
+        md = ("**Action:** the structured amounts are recorded, and the "
+              "unfounded `source_caveats` claim was removed.\n")
+        self.assertEqual(self.kinds(md, core={"source_caveats": "kept"}), [])
+
+    def test_a_slot_named_after_the_verb_is_not_the_subject(self):
+        """VOICE rep1: the named slot is the one that survived."""
+        md = ("### `file_collections`\n\n**Action:** the block was removed. "
+              "Its content was already represented by the declared "
+              "`distributions` slot, which was retained and left unchanged.\n")
+        self.assertEqual(self.kinds(md, core={"distributions": [1]}), [])
+
+    def test_a_slot_named_three_sentences_earlier_is_not_the_subject(self):
+        """AI_READI rep1: reading the whole paragraph made `id` a subject."""
+        md = ("**Action:** `id` is now `https://ror.org/01yc7t268`. That is "
+              "the registered identifier. The minted URN was removed.\n")
+        self.assertEqual(self.kinds(md, core={"id": "x"}), [])
+
+    def test_a_field_of_a_slot_is_not_the_slot(self):
+        """CM4AI rep2: "`collection_timeframes` dates | **Removed**"."""
+        md = ("| n | sev | slot | change |\n|---|---|---|---|\n"
+              "| 22 | low | `collection_timeframes` dates | **Removed** |\n")
+        self.assertEqual(self.kinds(md, core={"collection_timeframes": [1]}), [])
+
+    def test_removed_from_a_slot_in_a_table_cell(self):
+        """CM4AI rep2: "Dataverse Subject in `keywords` | **Removed**"."""
+        md = ("| n | slot | change |\n|---|---|---|\n"
+              "| 23 | Dataverse Subject in `keywords` | **Removed** |\n")
+        self.assertEqual(self.kinds(md, core={"keywords": [1, 2]}), [])
+
+    def test_an_indexed_element_is_not_checked_by_index(self):
+        """VOICE rep1 folded one `Erratum` into another.
+
+        Removing an element renumbers the rest, so `errata[0]` afterwards is
+        the object that survived. Skipped and counted, not guessed at.
+        """
+        md = ("#### (d) `errata[0]` removed\n\n**Action:** the object was "
+              "dropped. Its remark was folded into the surviving object.\n")
+        out = self.check(md, core={"errata": [{"erratum_details": "kept"}]})
+        self.assertEqual(out["findings"], [])
+        self.assertEqual(out["claims_unnamed"], 1,
+                         "skipped claims are counted, not silently dropped")
+
+    def test_unnamed_claims_are_counted(self):
+        md = "**Action:** the four MuSIC-pipeline objects were removed.\n"
+        out = self.check(md)
+        self.assertEqual(out["findings"], [])
+        self.assertEqual(out["claims_unnamed"], 1)
+
+
+class SchemaClaimTest(Harness):
+
+    def test_a_slot_said_not_to_exist_but_declared(self):
+        md = ("**Finding:** the core record carried a `distributions` block. "
+              "No such slot exists in the `CoreDataset` inventory.\n")
+        self.assertEqual(self.kinds(md),
+                         [("false_schema_claim", "distributions")])
+
+    def test_the_subject_is_the_slot_not_the_attribution(self):
+        """VOICE rep1 correctly attributes `path` to `FileCollection`.
+
+        Flagging the names that follow the phrase made the checker contradict
+        a sentence that was right.
+        """
+        md = ("The core record carried a `distributions` block. This slot is "
+              "not declared on `CoreDataset`, and the key set is a hybrid of "
+              "`FileCollection` (`path`) and `DistributionFormat` "
+              "(`format`, `media_type`).\n")
+        self.assertEqual(self.kinds(md),
+                         [("false_schema_claim", "distributions")])
+
+    def test_keys_said_not_to_be_attested(self):
+        """CM4AI rep3 names `md5` and `path`; both are `CoreDistribution`."""
+        md = ("No such slot appears in the inventory for `Dataset`, and `md5` "
+              "and `path` are not attested keys on any listed range class.\n")
+        self.assertEqual(sorted(self.kinds(md)),
+                         [("false_schema_claim", "md5"),
+                          ("false_schema_claim", "path")])
+
+    def test_a_true_absence_claim_is_not_reported(self):
+        md = "**Finding:** `invented_slot` is not declared on `CoreDataset`.\n"
+        self.assertEqual(self.kinds(md), [])
+
+
+class ResolveTest(unittest.TestCase):
+
+    def test_dotted_and_indexed(self):
+        d = {"instances": [{"counts": 3}]}
+        self.assertEqual(resolve(d, "instances[0].counts"), (True, 3))
+        self.assertEqual(resolve(d, "instances[1].counts")[0], False)
+        self.assertEqual(resolve(d, "instances[0].missing")[0], False)
+
+    def test_star_means_any_element(self):
+        """`creators[*].affiliations` survives if any creator has one."""
+        d = {"creators": [{"name": "a"}, {"name": "b", "affiliations": ["x"]}]}
+        self.assertEqual(resolve(d, "creators[*].affiliations"), (True, ["x"]))
+        self.assertEqual(resolve(d, "creators[*].orcid")[0], False)
+
+
+class CorpusTest(unittest.TestCase):
+    """The finding itself, pinned against the records it came from."""
+
+    BASE = Path("data/d4d_concatenated")
+    LABELS = [f"2026-08-13_claude-opus-5-api-generic-v4_rep{r}"
+              for r in (1, 2, 3)]
+
+    def test_every_record_with_a_distributions_block_claims_it_removed(self):
+        from data_sheets_schema.report_claims import declared_slots
+        declared = declared_slots()
+        retained, claimed = [], []
+        for label in self.LABELS:
+            core_dir = self.BASE / "claudecode_agent_core" / label
+            full_dir = self.BASE / "claudecode_agent" / label
+            if not core_dir.exists():
+                self.skipTest("v4 arm not present in this checkout")
+            for proj in ("AI_READI", "CHORUS", "CM4AI", "VOICE"):
+                core_p = core_dir / f"{proj}_d4d_core.yaml"
+                report = core_dir / f"{proj}_reconciliation.md"
+                if not (core_p.exists() and report.exists()):
+                    continue
+                core = yaml.safe_load(core_p.read_text(encoding="utf-8")) or {}
+                if not core.get("distributions"):
+                    continue
+                retained.append(f"{proj}_{label[-4:]}")
+                full_p = full_dir / f"{proj}_d4d.yaml"
+                full = yaml.safe_load(full_p.read_text(encoding="utf-8")) \
+                    if full_p.exists() else {}
+                out = check_report(report, full or {}, core, declared)
+                if any(f["kind"] == "removal_not_performed"
+                       and f["slot"].startswith("distributions")
+                       for f in out["findings"]):
+                    claimed.append(f"{proj}_{label[-4:]}")
+        self.assertEqual(len(retained), 9,
+                         "9 of the 12 v4 records emitted a distributions block")
+        self.assertEqual(sorted(claimed), sorted(retained),
+                         "every one of them reports having removed it")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_claims.py
+++ b/tests/test_report_claims.py
@@ -29,10 +29,11 @@ DECLARED = {"Dataset": {"file_collections", "distributions", "keywords"},
 class Harness(unittest.TestCase):
     def check(self, markdown, full=None, core=None):
         import tempfile
-        d = Path(tempfile.mkdtemp())
-        (d / "r.md").write_text(markdown, encoding="utf-8")
-        self.addCleanup(lambda: None)
-        return check_report(d / "r.md", full or {}, core or {}, DECLARED)
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / "r.md"
+        path.write_text(markdown, encoding="utf-8")
+        return check_report(path, full or {}, core or {}, DECLARED)
 
     def kinds(self, markdown, **kw):
         return [(f["kind"], f["slot"]) for f in self.check(markdown, **kw)["findings"]]


### PR DESCRIPTION
Closes #546.

## The count is larger than the issue's

#546 found three reports asserting a `distributions` removal that did not
happen. Measuring across all 12 v4 records rather than by hand:

**9 of the 12 emitted a `distributions` block. All 9 report having removed it.**

The other six were missed by the manual scan because they phrase it
differently — "the block was removed", "The slot was deleted", or a table cell
reading `| core | \`distributions\` | removed; content moved |`. CHORUS is the
only project whose three records never emitted the block, and its three reports
make no such claim.

Every one of the 9 reasons from the same false premise: that `distributions` is
not a declared slot. It is declared on `CoreDataset` with range
`CoreDistribution`, and `path`, `md5`, `format` and `media_type` — which three
reports call unattested keys — are declared on `CoreDistribution`.

So this is uniform behaviour of the audit phase, not three stray records.

## Precision was the whole difficulty

A first version read every sentence containing a removal verb: **122 findings,
most of them wrong.** Each rule below deleted a class of false positive found
by hand-reading the output against the reports.

| rule | the false positive it removes |
|---|---|
| subject must precede the verb, same sentence | ``the block was removed. Its content was already represented by the declared `distribution_formats` slot, which was retained`` named the survivor |
| oblique phrases name a place | ``prose removed from core `notes` `` removes prose |
| content nouns name content | ``the unfounded `source_caveats` claim was removed`` |
| negation | ``neither was deleted`` |
| no indexed paths | removing an element renumbers the rest — VOICE rep1 folded one `Erratum` into another, and `errata[0]` afterwards is the survivor |

Final: **20 findings across the arm, 27 removal claims checked, 11 skipped.**
The skipped count is reported rather than dropped — "the four MuSIC-pipeline
objects were removed" names no slot, and guessing at it is how an audit becomes
something readers ignore.

## Shape

Same as the pair check in #549: computed by the runner, pinned to the report's
md5 so it goes stale if the report is edited, reported by `d4d runs check`, and
never fatal. A wrong report does not make a record wrong.

21 tests, each precision test named for the real report line it came from, plus
one corpus test pinning the 9-of-9 result.

Suite: 1959 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)