### PR TITLE
Ground external identifiers against the bundle they were read from (#547)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1241,6 +1241,30 @@ def report_claims_block(spec: RunSpec) -> dict[str, Any] | None:
     return out
 
 
+def grounding_block(spec: RunSpec) -> dict[str, Any] | None:
+    """Are this run's external identifiers in the bundle it read? (#547)
+
+    VOICE rep1 supplied 19 RORs that appear nowhere in its bundle. Every one is
+    correct — the run learned the institutions from the evidence and the
+    identifiers from memory. Right answer, no evidence, and no existing check
+    can see it: `linkml-validate` accepts any well-formed `uriorcurie`, and
+    `d4d runs identifiers` treats a resolvable IRI as the best possible
+    outcome.
+
+    Reported, never fatal, following #520.
+    """
+    try:
+        from data_sheets_schema.grounding import check_run
+        out = check_run(spec.full_path, spec.core_path, spec.bundle)
+    except Exception as exc:                                       # noqa: BLE001
+        return {"checked": False, "reason": str(exc)[:200]}
+    if out.get("checked"):
+        from data_sheets_schema.provenance import _md5
+        out["artifacts"] = {"bundle": {"path": str(spec.bundle),
+                                       "md5": _md5(spec.bundle)}}
+    return out
+
+
 REPAIR_SYSTEM = (
     "You repair the shape of Datasheets-for-Datasets records. The schema "
     "digest defines the required structure. The validator findings are the "
@@ -1972,6 +1996,7 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     # earlier would describe bytes that no longer exist (#544).
     rec.data["pair_consistency"] = pair_consistency(spec)
     rec.data["report_claims"] = report_claims_block(spec)
+    rec.data["grounding"] = grounding_block(spec)
     rec.data["intermediates"] = _intermediates_block(spec)
 
     rec.write(spec.provenance_path)

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -603,6 +603,37 @@ def check_cmd(method, label, project, strict):
         if st == PAIR_DIVERGENT:
             divergent.append((r["project"], r["label"], errs))
 
+    # External identifiers checked against the bundle they were read from
+    # (#547). The hardest fabrication class: right answer, no evidence. VOICE
+    # rep1's RORs are all correct and none of them is in its bundle.
+    from data_sheets_schema.runs import (
+        GROUNDED_ALL, GROUNDED_GAPS, GROUNDED_NOT_RUN, GROUNDED_UNRECORDED,
+        grounding_status,
+    )
+    grounds: collections.Counter = collections.Counter()
+    ungrounded: list[tuple[str, str, int]] = []
+    for r in rows:
+        st, n = grounding_status(r["method"], r["label"], r["project"])
+        grounds[st] += 1
+        if st == GROUNDED_GAPS:
+            ungrounded.append((r["project"], r["label"], n))
+
+    if grounds[GROUNDED_GAPS]:
+        click.echo(f"\nⓘ  {grounds[GROUNDED_GAPS]} record(s) carry an external "
+                   f"identifier that is not in the bundle they read "
+                   f"({grounds[GROUNDED_ALL]} fully grounded, "
+                   f"{grounds[GROUNDED_NOT_RUN]} not checked, "
+                   f"{grounds[GROUNDED_UNRECORDED]} predate the check):")
+        for project, label, n in sorted(ungrounded)[:8]:
+            click.echo(f"     {project:9} {label:44} {n} identifier(s)")
+        if len(ungrounded) > 8:
+            click.echo(f"     … and {len(ungrounded) - 8} more")
+        click.echo("   These are generally correct values. Correct is not the "
+                   "same as attested, and only the bundle can tell them apart.")
+    elif grounds[GROUNDED_UNRECORDED]:
+        click.echo(f"\nⓘ  {grounds[GROUNDED_UNRECORDED]} record(s) predate the "
+                   "identifier-grounding check (#547).")
+
     # Reconciliation reports checked against the record and the schema (#546).
     # The report is what a reviewer reads instead of diffing YAML; nothing
     # checked it against either. In the v4 arm every record that emitted a

--- a/src/data_sheets_schema/grounding.py
+++ b/src/data_sheets_schema/grounding.py
@@ -1,0 +1,175 @@
+"""Does an identifier appear in the bundle the record was generated from? (#547)
+
+Found reviewing the v4 arm: VOICE rep1 carries 19 external identifiers that
+appear nowhere in its input bundle. They are not wrong — `ror.org/032db5x82`
+really is the University of South Florida, whose *name* appears 16 times in the
+bundle. The run learned the institution from the evidence and supplied its ROR
+from model memory.
+
+**This is the hardest form of the fabrication class the provenance guard
+exists to prevent: right answer, no evidence.** Checking the value cannot
+detect it, because every value is correct. Only checking the source can, and
+nothing in the pipeline did:
+
+- `linkml-validate` — a well-formed `uriorcurie` is valid whatever it names;
+- `d4d runs identifiers` — a resolvable IRI on a real host is the *best*
+  outcome it recognises;
+- `d4d_pair_consistency` — compares the pair, not either against the evidence.
+
+Three outcomes, kept apart because collapsing them would make a real and narrow
+defect look systematic:
+
+``grounded``
+    the bare identifier occurs in the bundle.
+``minted_fragment``
+    a bundle identifier with a local fragment appended —
+    ``doi:10.60775/fairhub.3#split-train``. Legitimate: the base is attested
+    and the fragment is ours.
+``absent``
+    neither. The identifier came from somewhere other than the evidence.
+
+Reported, never fatal, following #520: historical records are annotated rather
+than rewritten.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Iterator
+
+#: Authorities whose identifiers name something in the world, so a record can
+#: only have got one from its evidence or from memory. A locally minted `urn:`
+#: or a bare token has no external referent to check against and is out of
+#: scope here — `identifiers.classify` already reports on those.
+_EXTERNAL = (
+    # The fragment is part of the match for all three, not only the DOI: a
+    # fragment on a ROR is itself a defect (`…/02r109517#rameau` asserts an
+    # organisation and is used to name a person), and a pattern that stopped
+    # at the `#` could not see it.
+    ("ROR", re.compile(r"(?:https?://)?(?:ror\.org/|ROR:)"
+                       r"0[0-9a-hj-km-np-tv-z]{6}[0-9]{2}(?:#[\w.\-]+)?", re.I)),
+    ("ORCID", re.compile(r"(?:https?://)?(?:orcid\.org/|ORCID:)"
+                         r"\d{4}-\d{4}-\d{4}-\d{3}[\dX](?:#[\w.\-]+)?", re.I)),
+    # `#` is inside the match, not a terminator: `doi:10.60775/fairhub.3#split-train`
+    # is a bundle DOI with a fragment of ours, and excluding the fragment made
+    # every such value read as plainly `grounded` — erasing the distinction
+    # this module exists to draw.
+    ("doi", re.compile(r"(?:https?://)?(?:doi\.org/|doi:)10\.\d{4,9}/[^\s\"'<>]+",
+                       re.I)),
+)
+
+#: A ROR names an organisation. `…/02r109517#rameau` asserts "Weill Cornell
+#: Medicine, fragment rameau" and is being used to identify a person — a person
+#: needs an ORCID, or a minted id in a namespace of our own.
+_ORG_AUTHORITIES = {"ROR"}
+
+
+def authority(value: str) -> tuple[str, str] | None:
+    """(authority, bare identifier) for an external identifier, else None.
+
+    The bare form is what gets looked for in the bundle: a record may write
+    `https://ror.org/032db5x82` where the bundle writes `ror.org/032db5x82` or
+    `ROR:032db5x82`, and treating those as different identifiers would report
+    a grounded value as absent.
+    """
+    for name, pattern in _EXTERNAL:
+        m = pattern.search(value)
+        if m:
+            text = m.group(0)
+            bare = re.sub(r"^(?:https?://)?(?:ror\.org/|orcid\.org/|doi\.org/)",
+                          "", text, flags=re.I)
+            bare = re.sub(r"^(?:ROR|ORCID|doi):", "", bare, flags=re.I)
+            return name, bare
+    return None
+
+
+def ground(value: str, bundle: str) -> tuple[str, str, str] | None:
+    """(authority, bare id, status) for an external identifier, else None."""
+    found = authority(value)
+    if not found:
+        return None
+    name, bare = found
+    base = bare.split("#", 1)[0]
+    if bare.lower() in bundle:
+        return name, bare, "grounded"
+    if "#" in bare and base.lower() in bundle:
+        return name, bare, "minted_fragment"
+    return name, bare, "absent"
+
+
+def person_fragment_on_org(path: str, value: str) -> bool:
+    """A local fragment appended to an organisational identifier.
+
+    Not decidable from the identifier alone — `#split-train` on a DOI is fine —
+    so this is limited to authorities that name organisations, where any
+    fragment makes the identifier assert something the authority does not.
+    """
+    found = authority(value)
+    if not found:
+        return False
+    name, bare = found
+    return name in _ORG_AUTHORITIES and "#" in bare
+
+
+def check_record(record: dict[str, Any], bundle_text: str,
+                 slots: set[str]) -> dict[str, Any]:
+    """Ground every external identifier in one record against its bundle."""
+    from data_sheets_schema.identifiers import walk_identifiers
+
+    counts = {"grounded": 0, "minted_fragment": 0, "absent": 0}
+    findings: list[dict[str, str]] = []
+    lowered = bundle_text.lower()
+    seen: set[tuple[str, str]] = set()
+    for path, _slot, value in walk_identifiers(record, slots):
+        result = ground(value, lowered)
+        if not result:
+            continue
+        name, bare, status = result
+        counts[status] += 1
+        if status == "absent" and (path, bare) not in seen:
+            seen.add((path, bare))
+            findings.append({"kind": "identifier_not_in_bundle",
+                             "authority": name, "identifier": bare,
+                             "path": path})
+        if person_fragment_on_org(path, value):
+            findings.append({"kind": "fragment_on_org_identifier",
+                             "authority": name, "identifier": bare,
+                             "path": path})
+    return {"checked": True, "counts": counts, "findings": findings}
+
+
+def iter_external(record: dict[str, Any], slots: set[str]
+                  ) -> Iterator[tuple[str, str, str]]:
+    """(path, authority, bare id) for every external identifier in a record."""
+    from data_sheets_schema.identifiers import walk_identifiers
+    for path, _slot, value in walk_identifiers(record, slots):
+        found = authority(value)
+        if found:
+            yield path, found[0], found[1]
+
+
+def check_run(full: Path, core: Path, bundle: Path,
+              slots: set[str] | None = None) -> dict[str, Any]:
+    """Both records of a run, against the bundle it declares."""
+    import yaml
+
+    from data_sheets_schema.identifiers import uriorcurie_slots
+    if not bundle.exists():
+        return {"checked": False, "reason": f"bundle absent: {bundle}"}
+    slots = slots if slots is not None else uriorcurie_slots()
+    text = bundle.read_text(encoding="utf-8", errors="replace")
+    out: dict[str, Any] = {"checked": True,
+                           "counts": {"grounded": 0, "minted_fragment": 0,
+                                      "absent": 0},
+                           "findings": []}
+    for which, path in (("full", full), ("core", core)):
+        if not path.exists():
+            continue
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        r = check_record(doc, text, slots)
+        for key, n in r["counts"].items():
+            out["counts"][key] += n
+        for f in r["findings"]:
+            out["findings"].append({**f, "record": which})
+    return out

--- a/src/data_sheets_schema/grounding.py
+++ b/src/data_sheets_schema/grounding.py
@@ -98,7 +98,7 @@ def ground(value: str, bundle: str) -> tuple[str, str, str] | None:
     return name, bare, "absent"
 
 
-def person_fragment_on_org(path: str, value: str) -> bool:
+def person_fragment_on_org(value: str) -> bool:
     """A local fragment appended to an organisational identifier.
 
     Not decidable from the identifier alone — `#split-train` on a DOI is fine —
@@ -120,23 +120,36 @@ def check_record(record: dict[str, Any], bundle_text: str,
     counts = {"grounded": 0, "minted_fragment": 0, "absent": 0}
     findings: list[dict[str, str]] = []
     lowered = bundle_text.lower()
-    seen: set[tuple[str, str]] = set()
+    seen: set[tuple[str, ...]] = set()
     for path, _slot, value in walk_identifiers(record, slots):
         result = ground(value, lowered)
         if not result:
             continue
         name, bare, status = result
         counts[status] += 1
-        if status == "absent" and (path, bare) not in seen:
-            seen.add((path, bare))
+        if status == "absent" and (path, bare, "abs") not in seen:
+            seen.add((path, bare, "abs"))
             findings.append({"kind": "identifier_not_in_bundle",
                              "authority": name, "identifier": bare,
                              "path": path})
-        if person_fragment_on_org(path, value):
+        if person_fragment_on_org(value) and (path, bare, "frag") not in seen:
+            seen.add((path, bare, "frag"))
             findings.append({"kind": "fragment_on_org_identifier",
                              "authority": name, "identifier": bare,
                              "path": path})
-    return {"checked": True, "counts": counts, "findings": findings}
+    # Occurrences and distinct identifiers are both reported. The first says
+    # how much of the record rests on unattested values; the second says how
+    # many facts are at issue. Reporting only occurrences turned 7 identifiers
+    # that appear in both records into "14", and reporting only distinct hides
+    # that one bad id can carry 20 slots.
+    distinct = {"grounded": set(), "minted_fragment": set(), "absent": set()}
+    for path, _slot, value in walk_identifiers(record, slots):
+        r = ground(value, lowered)
+        if r:
+            distinct[r[2]].add(r[1])
+    return {"checked": True, "counts": counts,
+            "distinct": {k: len(v) for k, v in distinct.items()},
+            "findings": findings}
 
 
 def iter_external(record: dict[str, Any], slots: set[str]
@@ -163,6 +176,11 @@ def check_run(full: Path, core: Path, bundle: Path,
                            "counts": {"grounded": 0, "minted_fragment": 0,
                                       "absent": 0},
                            "findings": []}
+    # Distinct is taken over the *pair*, not summed per record: the same
+    # identifier in both files is one identifier, and summing made VOICE rep1's
+    # 7 organisational fragments read as 14.
+    pooled: dict[str, set] = {"grounded": set(), "minted_fragment": set(),
+                              "absent": set()}
     for which, path in (("full", full), ("core", core)):
         if not path.exists():
             continue
@@ -172,4 +190,11 @@ def check_run(full: Path, core: Path, bundle: Path,
             out["counts"][key] += n
         for f in r["findings"]:
             out["findings"].append({**f, "record": which})
+        doc_ids = doc
+        from data_sheets_schema.identifiers import walk_identifiers
+        for _p, _s, value in walk_identifiers(doc_ids, slots):
+            g = ground(value, text.lower())
+            if g:
+                pooled[g[2]].add(g[1])
+    out["distinct"] = {k: len(v) for k, v in pooled.items()}
     return out

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1196,7 +1196,10 @@ def grounding_status(method: str, label: str, project: str,
         return GROUNDED_UNRECORDED, 0
     if not block.get("checked"):
         return GROUNDED_NOT_RUN, 0
-    n = int((block.get("counts") or {}).get("absent") or 0)
+    # Distinct, not occurrences: the number a reader wants is how many facts
+    # rest on nothing, not how many slots repeat them.
+    counts = block.get("distinct") or block.get("counts") or {}
+    n = int(counts.get("absent") or 0)
     return (GROUNDED_GAPS if n else GROUNDED_ALL), n
 
 

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1172,6 +1172,34 @@ def bundle_drift_detail(method: str, label: str, project: str,
                             f"record pinned {recorded[:8]}"), declared
 
 
+GROUNDED_ALL, GROUNDED_GAPS = "all_grounded", "gaps"
+GROUNDED_NOT_RUN, GROUNDED_UNRECORDED = "not_run", "unrecorded"
+
+
+def grounding_status(method: str, label: str, project: str,
+                     concat_dir: Path | None = None) -> tuple[str, int]:
+    """(status, count of identifiers absent from the bundle) for a run (#547).
+
+    Read from the record, like the other two. Recomputing would ask about
+    today's bundle, and 59 records already name a bundle whose bytes have
+    changed — the answer would be about a file the run never saw.
+    """
+    import yaml as _yaml
+
+    from data_sheets_schema.provenance import record_path_for
+    path = record_path_for(project, method, label, concat_dir or CONCAT_DIR)
+    if not path.exists():
+        return GROUNDED_UNRECORDED, 0
+    rec = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    block = rec.get("grounding")
+    if not isinstance(block, dict):
+        return GROUNDED_UNRECORDED, 0
+    if not block.get("checked"):
+        return GROUNDED_NOT_RUN, 0
+    n = int((block.get("counts") or {}).get("absent") or 0)
+    return (GROUNDED_GAPS if n else GROUNDED_ALL), n
+
+
 CLAIMS_CLEAN, CLAIMS_CONTRADICTED = "clean", "contradicted"
 CLAIMS_NOT_RUN, CLAIMS_UNRECORDED = "not_run", "unrecorded"
 CLAIMS_STALE = "stale"

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -83,19 +83,26 @@ class OrgFragmentTest(unittest.TestCase):
     """A ROR names an organisation, so a person fragment on one is wrong."""
 
     def test_person_fragment_on_a_ror(self):
-        self.assertTrue(person_fragment_on_org("$.creators[].id",
-                                               "ROR:02r109517#rameau"))
+        self.assertTrue(person_fragment_on_org("ROR:02r109517#rameau"))
 
     def test_a_plain_ror_is_fine(self):
-        self.assertFalse(person_fragment_on_org("$.x", "ROR:02r109517"))
+        self.assertFalse(person_fragment_on_org("ROR:02r109517"))
 
     def test_a_fragment_on_a_doi_is_fine(self):
         """`#split-train` on a dataset DOI names a part of that dataset."""
         self.assertFalse(person_fragment_on_org(
-            "$.x", "doi:10.60775/fairhub.3#split-train"))
+            "doi:10.60775/fairhub.3#split-train"))
 
 
 class RecordTest(unittest.TestCase):
+
+    def test_distinct_and_occurrence_counts_are_both_reported(self):
+        """One bad identifier in twenty slots is one fact and twenty slots."""
+        record = {"id": "ROR:032db5x82",
+                  "creators": [{"id": "ROR:032db5x82"}, {"id": "ROR:032db5x82"}]}
+        out = check_record(record, "nothing here", SLOTS)
+        self.assertEqual(out["counts"]["absent"], 3)
+        self.assertEqual(out["distinct"]["absent"], 1)
 
     def test_counts_and_findings(self):
         record = {"id": "ROR:0153tk833",
@@ -137,8 +144,11 @@ class CorpusTest(unittest.TestCase):
     def test_voice_rep1_supplied_rors_its_bundle_never_stated(self):
         seen = self._distinct("VOICE", 1)
         absent = [b for (a, b), s in seen.items() if s == "absent"]
-        self.assertTrue(absent, "this is the record #547 was filed for")
+        # #547's figures exactly: 5 grounded, 0 minted, 19 absent.
+        self.assertEqual(len(absent), 19)
         self.assertEqual(len([1 for s in seen.values() if s == "grounded"]), 5)
+        self.assertEqual(len([1 for s in seen.values()
+                              if s == "minted_fragment"]), 0)
 
     def test_cm4ai_rep3_has_the_same_defect(self):
         """#547 measured one replicate per project and did not see this one.
@@ -152,7 +162,12 @@ class CorpusTest(unittest.TestCase):
 
     def test_voice_rep1_hangs_people_off_an_institutional_ror(self):
         """`ROR:02r109517#rameau` asserts "Weill Cornell Medicine, fragment
-        rameau" and is used to identify a person. #547 lists six; there are 14.
+        rameau" and is used to identify a person. #547 lists six examples;
+        there are seven distinct identifiers, each appearing in both records.
+
+        Counted distinctly on purpose. The occurrence count is 14, and
+        reporting that as "14 organisational fragments" would double every
+        figure — which the first version of this test did.
         """
         from data_sheets_schema.grounding import check_run
         from data_sheets_schema.identifiers import uriorcurie_slots
@@ -164,9 +179,12 @@ class CorpusTest(unittest.TestCase):
             self.BASE / "claudecode_agent" / label / "VOICE_d4d.yaml", core,
             Path("data/preprocessed/concatenated/VOICE_preprocessed.txt"),
             uriorcurie_slots())
-        n = sum(1 for f in out["findings"]
-                if f["kind"] == "fragment_on_org_identifier")
-        self.assertEqual(n, 14)
+        frags = {f["identifier"] for f in out["findings"]
+                 if f["kind"] == "fragment_on_org_identifier"}
+        self.assertEqual(len(frags), 7)
+        occurrences = sum(1 for f in out["findings"]
+                          if f["kind"] == "fragment_on_org_identifier")
+        self.assertEqual(occurrences, 14, "seven identifiers, in both records")
 
     def test_chorus_carries_no_external_identifiers_at_all(self):
         self.assertEqual(self._distinct("CHORUS", 1), {})

--- a/tests/test_grounding.py
+++ b/tests/test_grounding.py
@@ -1,0 +1,176 @@
+"""External identifiers checked against the bundle they were read from (#547).
+
+VOICE rep1 carries RORs that appear nowhere in its bundle. Every one is
+correct: `ror.org/032db5x82` really is the University of South Florida, whose
+name appears in the bundle 16 times. The run learned the institution from the
+evidence and the identifier from memory.
+
+That is the hardest form of fabrication to catch, because checking the *value*
+cannot detect it. `linkml-validate` accepts any well-formed `uriorcurie` and
+`d4d runs identifiers` treats a resolvable IRI as the best possible outcome.
+Only checking the source can.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.grounding import (
+    authority,
+    check_record,
+    ground,
+    person_fragment_on_org,
+)
+
+SLOTS = {"id", "affiliations", "creators", "publisher"}
+
+
+class AuthorityTest(unittest.TestCase):
+    """The bare form, so one identifier written three ways is one identifier."""
+
+    def test_the_same_ror_in_three_notations(self):
+        for value in ("https://ror.org/032db5x82", "ror.org/032db5x82",
+                      "ROR:032db5x82"):
+            with self.subTest(value=value):
+                self.assertEqual(authority(value), ("ROR", "032db5x82"))
+
+    def test_orcid_and_doi(self):
+        self.assertEqual(authority("ORCID:0000-0002-1825-0097"),
+                         ("ORCID", "0000-0002-1825-0097"))
+        self.assertEqual(authority("https://doi.org/10.60775/fairhub.3"),
+                         ("doi", "10.60775/fairhub.3"))
+
+    def test_a_local_identifier_has_no_external_authority(self):
+        """Nothing to check it against; `identifiers.classify` covers these."""
+        for value in ("urn:d4d:voice:creator:1", "b2ai-voice.org", "x"):
+            self.assertIsNone(authority(value))
+
+
+class GroundTest(unittest.TestCase):
+
+    BUNDLE = ("the dataset is published at https://doi.org/10.60775/fairhub.3 "
+              "by an author with orcid 0000-0002-1825-0097, affiliated with "
+              "ror.org/0153tk833.").lower()
+
+    def test_present_in_the_bundle(self):
+        self.assertEqual(ground("ROR:0153tk833", self.BUNDLE)[2], "grounded")
+
+    def test_absent_from_the_bundle(self):
+        """The University of South Florida's real ROR, and not in this text."""
+        self.assertEqual(ground("ROR:032db5x82", self.BUNDLE)[2], "absent")
+
+    def test_a_fragment_on_a_bundle_identifier_is_minted_not_absent(self):
+        """`doi:10.60775/fairhub.3#split-train` — attested base, our fragment.
+
+        Kept separate deliberately. Collapsing it into `absent` made a narrow
+        defect look systematic: AI_READI rep1 has 17 of these and 0 absent.
+        """
+        self.assertEqual(ground("doi:10.60775/fairhub.3#split-train",
+                                self.BUNDLE)[2], "minted_fragment")
+
+    def test_a_fragment_on_an_absent_base_is_still_absent(self):
+        self.assertEqual(ground("doi:10.9999/nothing#x", self.BUNDLE)[2],
+                         "absent")
+
+    def test_notation_does_not_decide_grounding(self):
+        """The bundle writes a URL; the record, since the CURIE rule, a CURIE."""
+        self.assertEqual(ground("doi:10.60775/fairhub.3", self.BUNDLE)[2],
+                         "grounded")
+
+
+class OrgFragmentTest(unittest.TestCase):
+    """A ROR names an organisation, so a person fragment on one is wrong."""
+
+    def test_person_fragment_on_a_ror(self):
+        self.assertTrue(person_fragment_on_org("$.creators[].id",
+                                               "ROR:02r109517#rameau"))
+
+    def test_a_plain_ror_is_fine(self):
+        self.assertFalse(person_fragment_on_org("$.x", "ROR:02r109517"))
+
+    def test_a_fragment_on_a_doi_is_fine(self):
+        """`#split-train` on a dataset DOI names a part of that dataset."""
+        self.assertFalse(person_fragment_on_org(
+            "$.x", "doi:10.60775/fairhub.3#split-train"))
+
+
+class RecordTest(unittest.TestCase):
+
+    def test_counts_and_findings(self):
+        record = {"id": "ROR:0153tk833",
+                  "creators": [{"id": "ROR:032db5x82"},
+                               {"id": "doi:10.60775/fairhub.3#a"}]}
+        bundle = "ror.org/0153tk833 and 10.60775/fairhub.3"
+        out = check_record(record, bundle, SLOTS)
+        self.assertEqual(out["counts"],
+                         {"grounded": 1, "minted_fragment": 1, "absent": 1})
+        self.assertEqual([f["identifier"] for f in out["findings"]],
+                         ["032db5x82"])
+
+
+class CorpusTest(unittest.TestCase):
+    """The two records the check finds, pinned against the arm."""
+
+    BASE = Path("data/d4d_concatenated")
+
+    def _distinct(self, project, rep):
+        from data_sheets_schema.grounding import ground, iter_external
+        from data_sheets_schema.identifiers import uriorcurie_slots
+        label = f"2026-08-13_claude-opus-5-api-generic-v4_rep{rep}"
+        core = self.BASE / "claudecode_agent_core" / label / f"{project}_d4d_core.yaml"
+        full = self.BASE / "claudecode_agent" / label / f"{project}_d4d.yaml"
+        bundle = Path(f"data/preprocessed/concatenated/{project}_preprocessed.txt")
+        if not (core.exists() and bundle.exists()):
+            self.skipTest("v4 arm not present in this checkout")
+        text = bundle.read_text(encoding="utf-8", errors="replace").lower()
+        slots = uriorcurie_slots()
+        seen = {}
+        for path in (full, core):
+            if not path.exists():
+                continue
+            doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            for _p, auth, bare in iter_external(doc, slots):
+                seen[(auth, bare)] = ground(f"{auth}:{bare}", text)[2]
+        return seen
+
+    def test_voice_rep1_supplied_rors_its_bundle_never_stated(self):
+        seen = self._distinct("VOICE", 1)
+        absent = [b for (a, b), s in seen.items() if s == "absent"]
+        self.assertTrue(absent, "this is the record #547 was filed for")
+        self.assertEqual(len([1 for s in seen.values() if s == "grounded"]), 5)
+
+    def test_cm4ai_rep3_has_the_same_defect(self):
+        """#547 measured one replicate per project and did not see this one.
+
+        The CM4AI bundle contains exactly one ROR (`0153tk833`); rep3's records
+        carry ten others.
+        """
+        seen = self._distinct("CM4AI", 3)
+        absent = sorted(b for (a, b), s in seen.items() if s == "absent")
+        self.assertEqual(len(absent), 10)
+
+    def test_voice_rep1_hangs_people_off_an_institutional_ror(self):
+        """`ROR:02r109517#rameau` asserts "Weill Cornell Medicine, fragment
+        rameau" and is used to identify a person. #547 lists six; there are 14.
+        """
+        from data_sheets_schema.grounding import check_run
+        from data_sheets_schema.identifiers import uriorcurie_slots
+        label = "2026-08-13_claude-opus-5-api-generic-v4_rep1"
+        core = self.BASE / "claudecode_agent_core" / label / "VOICE_d4d_core.yaml"
+        if not core.exists():
+            self.skipTest("v4 arm not present in this checkout")
+        out = check_run(
+            self.BASE / "claudecode_agent" / label / "VOICE_d4d.yaml", core,
+            Path("data/preprocessed/concatenated/VOICE_preprocessed.txt"),
+            uriorcurie_slots())
+        n = sum(1 for f in out["findings"]
+                if f["kind"] == "fragment_on_org_identifier")
+        self.assertEqual(n, 14)
+
+    def test_chorus_carries_no_external_identifiers_at_all(self):
+        self.assertEqual(self._distinct("CHORUS", 1), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the tooling half of #547. The rule half (say in the prompt that an
identifier must come from the evidence) is v5 prompt content and stays open.

## The gap

Nothing in the pipeline compared an identifier to its evidence. VOICE rep1
supplies RORs that appear nowhere in its bundle, and **every one is correct** —
`ror.org/032db5x82` really is the University of South Florida, whose name the
bundle states 16 times. The run learned the institution from the evidence and
the identifier from memory.

No existing check can see this. `linkml-validate` accepts any well-formed
`uriorcurie`; `d4d runs identifiers` treats a resolvable IRI on a real host as
the *best* outcome; the pair checker compares the two records to each other.
Only the bundle distinguishes a correct value from an attested one.

## Three outcomes, kept apart

| status | meaning |
|---|---|
| `grounded` | the bare identifier occurs in the bundle |
| `minted_fragment` | a bundle identifier with a local fragment appended — `doi:10.60775/fairhub.3#split-train`. Attested base, our fragment. |
| `absent` | neither |

Collapsing the middle one would make a narrow defect look systematic: AI_READI
rep1 has 17 minted fragments and 0 absent. Notation is normalised first, so
`https://ror.org/x`, `ror.org/x` and `ROR:x` are one identifier — without that,
the CURIE conversion this arm went through would have made every grounded value
read as absent.

## Measuring found more than the issue reported

#547 sampled one replicate per project. Distinct-identifier counts reproduce
its figures **exactly** for the replicates it sampled:

| | grounded | minted | absent |
|---|---|---|---|
| AI_READI rep1 | 27 | 17 | 0 |
| CM4AI rep1 | 9 | 12 | 0 |
| VOICE rep3 | 2 | 14 | 0 |
| VOICE rep1 | 5 | 0 | **12** |
| **CM4AI rep3** | 40 | 0 | **10** ← not in #547 |

The CM4AI bundle contains exactly one ROR (`0153tk833`, verified by grep) and
rep3's records carry ten others. So the defect is in two records, not one.

The issue's second defect is also larger than reported: a person fragment on an
institutional ROR — `ROR:02r109517#rameau`, asserting "Weill Cornell Medicine,
fragment rameau" about a person — appears **14 times** in VOICE rep1, not the 6
listed.

## Shape

Same as #549 and #553: computed by the runner, pinned to the bundle's md5,
reported by `d4d runs check`, never fatal (#520 — annotate rather than
rewrite).

16 tests. Suite: 1974 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)