### PR TITLE
Add the generic-v5 condition: four rules, and why it is four (#547, #531, #545)

### DIFF
--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -232,6 +232,23 @@ to every project. Enforce them whether or not a prompt file was used to launch:
   `uriorcurie` — and never to prose. A URL inside a sentence or a citation is
   text, not an identifier, and must be left exactly as written.
 
+- **An identifier is a fact and comes from the evidence.** Take it from the
+  declared bundle or omit it; do not supply an identifier you recognise but the
+  bundle does not state. A correct identifier the evidence does not contain is
+  still an unsupported claim, and to a reader who was not present it is
+  indistinguishable from a wrong one. Naming an organisation the bundle names is
+  grounded; adding that organisation's ROR from your own knowledge is not — the
+  2026-08-13 arm did exactly this, supplying RORs for institutions the bundle
+  names only in prose (#547). `grounding.absent` in the provenance record counts
+  them.
+
+- **Where something needs an identifier and the bundle supplies none, hang it
+  off one the bundle does supply** — a fragment on the identifier of the thing
+  it is part of, `doi:10.60775/fairhub.3#split-train`, rather than a new
+  namespace (#531). A person is identified by an ORCID and an organisation by a
+  ROR; **a fragment appended to an organisation's ROR does not identify a
+  person**, it asserts something false about that organisation.
+
 - **Write generated prose in American English** — `program`, `organization`,
   `analyze`, `license`, `center`, `labeling`, `enrollment`. This is house style
   for the text *you* compose, and it applies to identifiers you mint as well as

--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -1,0 +1,64 @@
+# generic v5 — what the block predicts, registered before any run
+
+Written 2026-08-14, before any v5 generation. Its purpose is to hold the
+predictions **out** of the prompt: a prompt that states the result a run is
+meant to test instructs the model to produce it.
+
+## What v5 changes
+
+Four rules, in one block. This breaks the one-rule-per-version convention that
+v2, v3 and v4 kept, and the cost is stated rather than hidden: **a v4-against-v5
+comparison measures the whole block and cannot attribute any effect to a rule
+within it.**
+
+Two of the four are not new instructions. American English (#502) and CURIE form
+were added to `.claude/commands/d4d-full-core.md` mid-arm, deliberately, to
+avoid rotating a pin while runs were in flight. They have reached the agentic
+path since and the API path never (#545). Bringing them into the condition
+prompt is a parity fix, and their expected effect on the agentic arm is nil by
+construction — that arm has been reading them all along.
+
+The other two are new and are one subject: where an identifier may come from
+(#547) and what to write when the evidence supplies none (#531).
+
+## Predictions
+
+Stated so they can be wrong.
+
+1. **Ungrounded external identifiers fall toward zero on the API arm.** The
+   measurement exists: `grounding.absent`, distinct per pair, now recorded by
+   every run and backfilled across the corpus (#552). The v4 baseline is 19 in
+   VOICE rep1 and 10 in CM4AI rep3, 0 in the other ten records.
+2. **Minted-fragment counts rise, or hold.** Rule three redirects invention
+   rather than forbidding it. If `absent` falls while `minted_fragment` does not
+   rise, the model is omitting identifiers rather than anchoring them — a
+   different outcome from the intended one, and not obviously worse, but it must
+   not be reported as the intended one.
+3. **Organisational identifiers carry no person fragments.** v4 baseline: 7
+   distinct in VOICE rep1, 0 elsewhere.
+4. **The invented-prefix population stops growing.** ~12,000 values across the
+   corpus today (#531), five spellings for the VOICE namespace alone. v5 records
+   should add none; existing records are not rewritten (#520).
+5. **British spellings fall on the API arm and are unchanged on the agentic
+   arm.** This is the parity fix's own test. If the agentic arm moves, something
+   other than the rule moved with it.
+
+## What would falsify the block rather than confirm it
+
+- `absent` falls but total external identifiers falls further — the model
+  responded by dropping identifiers wholesale, including grounded ones. Watch
+  `grounded` as well; it should hold.
+- `minted_fragment` rises on values whose base is not in the bundle. The
+  grounding check reports those as `absent`, so this shows up as rule three
+  being followed in form and not in substance.
+- Pair divergence rises. Four new rules touching `id` fields across both records
+  is exactly the kind of change that can push full and core apart, and 80% of
+  the corpus already diverges (#550). This is a regression watch, not a
+  prediction.
+
+## What this plan does not license
+
+Comparing v5 against anything other than v4. Every earlier arm sits at a
+different schema digest and most at a different pin. And attributing any part of
+the result to one of the four rules — see above; that resolution is not
+available from this design.

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -67,10 +67,12 @@ GENERIC_PROMPT_V3 = PROMPTS / "d4d_generic_arm_prompt_v3.md"
 # isolating one change, and `notes/generic_v3_analysis_plan.md` was registered
 # before any run naming that one rule (#338).
 GENERIC_PROMPT_V4 = PROMPTS / "d4d_generic_arm_prompt_v4.md"
+GENERIC_PROMPT_V5 = PROMPTS / "d4d_generic_arm_prompt_v5.md"
 CONDITION_PROMPTS = {"generic": GENERIC_PROMPT,
                      "generic_v2": GENERIC_PROMPT_V2,
                      "generic_v3": GENERIC_PROMPT_V3,
                      "generic_v4": GENERIC_PROMPT_V4,
+                     "generic_v5": GENERIC_PROMPT_V5,
                      "tuned": GENERIC_PROMPT}
 
 # Which generic base each condition is built on. The generic/tuned comparison
@@ -88,6 +90,7 @@ CONDITION_AXES = {
     "generic_v2": {"base": "v2", "tuned": False},
     "generic_v3": {"base": "v3", "tuned": False},
     "generic_v4": {"base": "v4", "tuned": False},
+    "generic_v5": {"base": "v5", "tuned": False},
     "tuned":      {"base": "v1", "tuned": True},
 }
 

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -117,17 +117,25 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    bytes: 11689
-    pinned_at_commit: 1af6309c2c3468a9f495fab94d69cea240a8e982
+    bytes: 11812
+    pinned_at_commit: 9b6dd51d2940f976b85682b53e7191fd6d4347b0
     pinned_on: '2026-08-14'
-    reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
-      \ block of four rules \u2014 CURIE form and American English brought over from the playbook\
-      \ to close the #545 divergence, plus identifier-must-come-from-the-evidence (#547) and\
-      \ fragment-on-an-attested-identifier rather than an invented prefix (#531). The block\
-      \ states no quantity, names no project and contains no dataset identifier; tests/test_download/test_generic_v5_prompt.py\
-      \ asserts that. Predictions are registered in notes/generic_v5_analysis_plan.md, not\
-      \ in the prompt."
-    sha256: e4d0570921f84f2024a8166bbd6284557d1c7f65471d8356a18edd957bf42e52
+    reason: 'rotation before any v5 run: corrects an attribution in the rationale (#531 established
+      1,094 VOICE values, not the corpus-wide ~12,000). The prompt body is byte-identical
+      to the previous pin; only rationale prose, which prompt_body does not send, changed.
+      Free to rotate because no record names generic_v5 yet.'
+    sha256: 606e7382cd4ee5214d7a910fc5b89f8e9faa053cb193dbaeff02ac65b672904d
+    superseded:
+    - pinned_on: '2026-08-14'
+      reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
+        \ block of four rules \u2014 CURIE form and American English brought over from the\
+        \ playbook to close the #545 divergence, plus identifier-must-come-from-the-evidence\
+        \ (#547) and fragment-on-an-attested-identifier rather than an invented prefix (#531).\
+        \ The block states no quantity, names no project and contains no dataset identifier;\
+        \ tests/test_download/test_generic_v5_prompt.py asserts that. Predictions are registered\
+        \ in notes/generic_v5_analysis_plan.md, not in the prompt."
+      retired_on: '2026-08-14'
+      sha256: e4d0570921f84f2024a8166bbd6284557d1c7f65471d8356a18edd957bf42e52
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -116,6 +116,18 @@ files:
         retroactively.'
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
+  src/download/prompts/d4d_generic_arm_prompt_v5.md:
+    bytes: 11689
+    pinned_at_commit: 1af6309c2c3468a9f495fab94d69cea240a8e982
+    pinned_on: '2026-08-14'
+    reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
+      \ block of four rules \u2014 CURIE form and American English brought over from the playbook\
+      \ to close the #545 divergence, plus identifier-must-come-from-the-evidence (#547) and\
+      \ fragment-on-an-attested-identifier rather than an invented prefix (#531). The block\
+      \ states no quantity, names no project and contains no dataset identifier; tests/test_download/test_generic_v5_prompt.py\
+      \ asserts that. Predictions are registered in notes/generic_v5_analysis_plan.md, not\
+      \ in the prompt."
+    sha256: e4d0570921f84f2024a8166bbd6284557d1c7f65471d8356a18edd957bf42e52
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -31,7 +31,9 @@ from.
   rules already say to prefer omission over inference for facts; nothing said
   that an identifier is one.
 - **A minted identifier hangs off an attested one.** #531 found one namespace
-  written five ways and ~12,000 minted ids across the corpus, invented because
+  written five ways — 1,094 VOICE values across five spellings. Counting the
+  same way across every project while implementing this brought the total to
+  roughly 12,000 minted ids, invented because
   the schema never offered a prefix. Declaring all the spellings would make
   every value valid and join nothing. The remedy that needs no new namespace is
   the pattern the corpus already contains and the grounding check already

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -1,0 +1,246 @@
+# D4D generic-arm generation prompt — v5
+
+**This is v4 plus a block of four rules, and nothing else.** That is a
+departure from the one-rule-per-version convention, and the reason is stated
+under "Why v5 exists" rather than left to be inferred. The
+substitution fields, outputs, header block, constraints, the four original rules
+earlier additions are byte-identical to
+`src/download/prompts/d4d_generic_arm_prompt_v4.md` apart from the version stamp;
+a test asserts that the only difference is the block marked `ADDED IN v5`.
+
+## Why v5 exists
+
+Four rules, not one. Two of them are not new instructions at all — they already
+reach the agentic arm through the playbook and reach the API arm through
+nothing, which is the divergence #545 measured. Bringing them here is a parity
+fix; a condition whose two runtimes read different rules is not one condition.
+
+- **American English** (#502) and **CURIE form** were added to
+  `.claude/commands/d4d-full-core.md` mid-arm, deliberately, to avoid rotating a
+  pin while runs were in flight. That was the right call then and leaves the two
+  paths unequal until a version boundary, which this is.
+
+The other two are new, and they are one subject: where an identifier may come
+from.
+
+- **An identifier is a fact and must come from the evidence.** VOICE rep1
+  supplied 19 RORs that appear nowhere in its bundle and CM4AI rep3 another ten
+  (#547). Every one is correct — `ror.org/032db5x82` really is the University
+  of South Florida, whose name the bundle states 16 times. The run learned the
+  institution from the evidence and the identifier from memory. The uniform
+  rules already say to prefer omission over inference for facts; nothing said
+  that an identifier is one.
+- **A minted identifier hangs off an attested one.** #531 found one namespace
+  written five ways and ~12,000 minted ids across the corpus, invented because
+  the schema never offered a prefix. Declaring all the spellings would make
+  every value valid and join nothing. The remedy that needs no new namespace is
+  the pattern the corpus already contains and the grounding check already
+  recognises: a fragment on the dataset's own identifier.
+
+These two would be incoherent apart. A rule forbidding unattested identifiers,
+without saying what to write instead, would push a model toward inventing a
+local namespace — the defect #531 records.
+
+## Why v5 is not a clean single-rule increment, and what that costs
+
+The v2→v3→v4 series each isolated one rule so a delta could be attributed to it.
+v5 cannot: four rules move together, and a v4-against-v5 comparison measures
+their sum.
+
+That is accepted rather than hidden. Two of the four are parity fixes whose
+effect on the agentic arm is by construction nil — they are already there — so
+the arms are the natural place to separate them. Any attribution finer than
+"the v5 block" is not available from this comparison, and no analysis should
+claim it.
+
+## Why these additions are generic and not priming
+
+Measured against the taxonomy in `.claude/commands/d4d-full-core.md`:
+
+- it applies identically to every project, naming no project, dataset or input
+  set;
+- it states no target count, no expected density, and no expected relationship
+  to any other arm — it is a decision rule, not an outcome expectation;
+- it concerns the schema, which every arm shares.
+
+## What is NOT in this file, deliberately
+
+The prediction that these rules reduce ungrounded identifiers without
+suppressing legitimate ones. Writing it here would instruct the model to produce
+the result the run is meant to test. It belongs in the v5 analysis plan,
+registered before any generation run.
+
+## Relationship to earlier versions
+
+None is superseded and none may be edited once run. v4 against v5 measures the
+whole v5 block and not any rule within it — see above.
+
+## Prompt body
+
+Generate paired full and core D4D records for the {PROJECT} project.
+
+READ FIRST, IN THIS ORDER, AND FOLLOW EXACTLY:
+
+1. `.claude/agents/d4d-provenance-guard.md` — the factual evidence boundary.
+   Enforce it in every phase.
+2. `.claude/commands/d4d-full-core.md` — the four-phase playbook.
+
+Execution mode: four-phase project agent. Phase 1 full generation, Phase 2 core
+generation, Phase 3 source/provenance audit, Phase 4 strict reconciliation.
+Phase 2 must wait for a validated Phase 1 file.
+
+VERSION LABEL — use verbatim in every output path: {LABEL}
+
+ARM: {ARM}
+
+DECLARED INPUT BUNDLE — your only source of dataset facts:
+    {BUNDLE}
+
+Full schema: `src/data_sheets_schema/schema/data_sheets_schema_all.yaml` (class
+`Dataset`)
+Core schema: `src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml`
+(class `CoreDataset`)
+
+OUTPUTS — do not write outside these three:
+
+- Full:   `data/d4d_concatenated/{METHOD}/{LABEL}/{PROJECT}_d4d.yaml`
+- Core:   `data/d4d_concatenated/{METHOD}_core/{LABEL}/{PROJECT}_d4d_core.yaml`
+- Report: `data/d4d_concatenated/{METHOD}_core/{LABEL}/{PROJECT}_reconciliation.md`
+
+HEADER BLOCK — use exactly:
+
+    # D4D Datasheet for {PROJECT} Dataset
+    # Generation Method: schema-grounded agentic, phase 1
+    # Agent runtime: {RUNTIME}
+    # Provider: {PROVIDER}
+    # Model: {MODEL}
+    # Mode: four-phase project agent, generic-v5 prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v5.md (identical for all projects)
+    # Arm: {ARM}
+    # Source bundle: {BUNDLE}
+    {MANIFEST_LINE}
+    # Schema: src/data_sheets_schema/schema/data_sheets_schema_all.yaml
+    # Prior D4D factual reuse: prohibited
+    # Temperature: 0.0
+    # Generated: {DATE}
+
+CORE HEADER BLOCK — use exactly (it is not the full-record block with two
+words changed; four lines differ and two have no counterpart above):
+
+    # D4D Core Datasheet for {PROJECT} Dataset
+    # Generation Method: schema-grounded agentic, phase 2
+    # Agent runtime: {RUNTIME}
+    # Provider: {PROVIDER}
+    # Model: {MODEL}
+    # Mode: four-phase project agent, generic-v5 prompt
+    # Prompt: src/download/prompts/d4d_generic_arm_prompt_v5.md (identical for all projects)
+    # Arm: {ARM}
+    # Source bundle: {BUNDLE}
+    # Sources: {BUNDLE} + data/d4d_concatenated/{METHOD}/{LABEL}/{PROJECT}_d4d.yaml
+    {MANIFEST_LINE}
+    # Schema: src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml
+    # Prior D4D factual reuse: prohibited
+    # Temperature: 0.0
+    # Generated: {DATE}
+    # Phase 4 reconciliation: completed
+
+`# Sources:` is required, not decorative: it is what ties a core record to the
+full record it was projected from, and the provenance guard checks for it. Write
+`# Phase 4 reconciliation: completed` only once phase 4 has actually run.
+
+AFTER Phase 4, write a LIVE provenance record:
+
+    poetry run d4d provenance record --project {PROJECT} --method {METHOD} --label {LABEL} --input-bundle {BUNDLE}
+
+VALIDATE both files before finishing:
+
+    poetry run linkml-validate -s src/data_sheets_schema/schema/data_sheets_schema_all.yaml -C Dataset <full>
+    poetry run linkml-validate -s src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml -C CoreDataset <core>
+
+ABSOLUTE CONSTRAINT — do not read, open, grep, or consult any previously
+generated D4D record, from any arm, any label, or any date. This includes
+everything under `data/d4d_concatenated/` and any `*_crate_d4d.yaml` or
+`*_crate_mapped_d4d.yaml` under `data/ro-crate_packages/`. Your only factual
+inputs are the declared bundle above and the schema files. Prior-D4D reuse is a
+defect under the provenance guard.
+
+UNIFORM DECISION RULES — these apply identically to every project and every arm:
+
+- Populate a slot only where the declared bundle supports it. Prefer omission
+  over inference: an absent slot is a correct answer when the evidence is
+  absent, and a plausible guess is not.
+- Where the declared bundle contains sources that disagree, represent what the
+  evidence states rather than silently selecting one. Do not merge distinct
+  entities into a single claim.
+- `Dataset` admits one referent. Choose the one the declared bundle best
+  supports, state that choice in the reconciliation report, and hold to it
+  consistently across both records.
+- There is no target slot count, no expected density, and no expected
+  relationship to any other arm or project. Apply your own judgment about what
+  the evidence supports.
+
+--- ADDED IN v2 ---
+
+- When a slot's declared range is multivalued, emit one object per distinct
+  entity. Collapsing several entities into a single object — several creators in
+  one Creator, several uses in one intended_use — populates the slot without
+  representing what it declares.
+- Populate a slot with the information the field asks for, not with a pointer to
+  where that information lives, and not with a statement that it is pending or
+  absent. A value recording that documentation exists elsewhere has not answered
+  the field; omit the slot instead.
+- Read the slot's description before populating it. Where the evidence answers a
+  neighbouring field — the access route rather than the distribution formats,
+  the release cadence rather than the future-use impacts — put it in the field it
+  answers, or omit it.
+
+--- END ADDED IN v2 ---
+
+--- ADDED IN v3 ---
+
+- When a slot's declared range is a class, populate the fields that class
+  declares. Placing the content in a free-text field such as `description` while
+  the declared fields — a name, an identifier, dates, affiliations — stay empty
+  produces an object of the correct shape holding none of the structure it
+  exists to carry. Where the evidence answers a declared field, populate that
+  field rather than restating it in prose.
+
+--- END ADDED IN v3 ---
+--- ADDED IN v5 ---
+
+- Write every identifier as a CURIE — a declared prefix, a colon, and the local
+  part — never as a URL, a resolver link or a bare IRI. Two records naming one
+  thing in one form produce one identity; the same thing written as a prefix
+  here and a URL there produces two.
+- An identifier is a fact about the dataset, subject to the same rule as any
+  other fact: take it from the evidence or omit it. Do not supply an identifier
+  you recognise but the input documents do not state. A correct identifier the
+  evidence does not contain is still an unsupported claim, and to every reader
+  who was not present it is indistinguishable from an incorrect one. Naming an
+  organisation the documents name is grounded; adding that organisation's
+  registry identifier from your own knowledge is not.
+- Where something needs an identifier and the evidence supplies none, hang it
+  off one the evidence does supply: a fragment appended to the identifier of the
+  thing it is part of. Do not invent a prefix for it. A person is identified by
+  a personal-identifier registry entry and an organisation by an organisation
+  registry entry; a fragment appended to an organisation's identifier does not
+  identify a person, it makes a false claim about that organisation.
+- Write American English throughout — characterize, organization, standardized,
+  analyze, behavior, license. This governs the prose the record states, not
+  quoted material: a title, a name or a direct quotation keeps the spelling its
+  source used.
+
+--- END ADDED IN v5 ---
+
+--- ADDED IN v4 ---
+
+- Where a slot's declared range is a scalar, populate it with the identifier of
+  the thing it refers to, not with the thing itself. An object placed in a
+  string-ranged slot fails validation and loses the reference it was meant to
+  record, even where that thing is richly described elsewhere in the record.
+
+--- END ADDED IN v4 ---
+
+
+RETURN: full slot count, core slot count, whether both validated, and the
+reconciliation outcome. Return data, not prose.

--- a/tests/test_american_english_rule.py
+++ b/tests/test_american_english_rule.py
@@ -51,11 +51,50 @@ class TestTheRuleIsStated(unittest.TestCase):
 class TestItDidNotRedefineACondition(unittest.TestCase):
     """The reason it is in the playbook rather than the prompts."""
 
-    def test_no_condition_prompt_carries_the_rule(self):
+    #: The condition created *with* the rule, so it re-baselines nothing.
+    NEW_CONDITION = "d4d_generic_arm_prompt_v5.md"
+
+    def test_no_existing_condition_prompt_acquired_the_rule(self):
+        """#502's actual constraint, which v5 does not breach.
+
+        The rule went into the playbook rather than the prompts because adding
+        it to a prompt that had already been run would change what that
+        condition means for every record naming it, and require a pin rotation
+        mid-arm. That is still forbidden, and it is about *existing* conditions.
+
+        v5 carries the rule from birth (#545). No record names generic_v5 yet,
+        so nothing is re-baselined — which is exactly why a version boundary is
+        where a playbook-only rule is allowed to move.
+        """
         for path in sorted(PROMPTS.glob("d4d_*_arm_prompt*.md")):
+            if path.name == self.NEW_CONDITION:
+                continue
             with self.subTest(prompt=path.name):
                 self.assertNotIn("American English",
                                  path.read_text(encoding="utf-8"))
+
+    def test_the_new_condition_does_carry_it(self):
+        """Otherwise the exemption above is an unguarded hole rather than a
+        statement about one file."""
+        text = (PROMPTS / self.NEW_CONDITION).read_text(encoding="utf-8")
+        self.assertIn("American English", text)
+
+    def test_no_record_yet_names_the_new_condition(self):
+        """The premise of the exemption, asserted rather than assumed.
+
+        The moment a run is generated under generic_v5, this test should be
+        deleted — not because the rule changed, but because from then on the
+        prompt may not be edited at all, which is a stronger guarantee than
+        this one and is enforced by the pin.
+        """
+        import yaml
+        from data_sheets_schema.provenance import CONCAT_DIR
+        named = []
+        for rec in CONCAT_DIR.glob("*_core/*/*_provenance.yaml"):
+            data = yaml.safe_load(rec.read_text(encoding="utf-8")) or {}
+            if "generic_v5" in str(data.get("condition") or ""):
+                named.append(rec.parts[-2])
+        self.assertEqual(named, [])
 
     def test_every_pinned_prompt_is_still_at_its_pin(self):
         import subprocess

--- a/tests/test_download/test_generic_v5_prompt.py
+++ b/tests/test_download/test_generic_v5_prompt.py
@@ -1,0 +1,262 @@
+"""generic-v5 must stay generic, and must be v5 plus its block.
+
+Mirrors `test_generic_v5_prompt.py`, with one deliberate difference: **v5 adds
+four rules, not one.** Two are parity fixes for rules that already reach the
+agentic path through the playbook and reached the API path through nothing
+(#545); two are new and inseparable — where an identifier may come from (#547)
+and what to write when the evidence supplies none (#531).
+
+The cost is that a v5-against-v5 delta cannot be attributed to any single rule.
+`notes/generic_v5_analysis_plan.md` says so, registered before any run, which is
+the same discipline #338 established and not an exception to it.
+
+The genericity assertions below are unchanged and are why the block reads as it
+does: a first draft used a real dataset DOI as its example of a minted fragment,
+which `test_no_dataset_identifiers` refused. A generic arm that illustrates a
+rule with one project's identifier is priming every other project.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from data_sheets_schema.api_runner import (
+    CONDITION_AXES,
+    CONDITION_PROMPTS,
+    GENERIC_PROMPT,
+    GENERIC_PROMPT_V2,
+    GENERIC_PROMPT_V3,
+    GENERIC_PROMPT_V4,
+    GENERIC_PROMPT_V5,
+    comparable_conditions,
+    condition_delta,
+    prompt_body,
+)
+from data_sheets_schema.constants import PROJECTS
+
+# PROJECTS is imported, not restated. A four-project literal here made
+# the per-project assertions below exclude VOICE_PEDIATRIC from the day
+# #298 made it a project, so a guard that reads as covering every
+# project covered four of five (#467).
+MARK_START = "--- ADDED IN v5 ---"
+MARK_END = "--- END ADDED IN v5 ---"
+
+
+def _added_block(text):
+    return text.split(MARK_START, 1)[1].split(MARK_END, 1)[0]
+
+
+def _norm(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+class TestV5IsV4PlusTheAddedBlock(unittest.TestCase):
+
+    #: The header lines that name the version, which must differ (#337).
+    VERSION_STAMP = re.compile(r"#\s*(?:Mode|Prompt):[^\n]*")
+
+    def test_body_differs_from_v4_only_by_the_marked_block(self):
+        v3 = prompt_body(GENERIC_PROMPT_V4)
+        v5 = prompt_body(GENERIC_PROMPT_V5)
+        stripped = (v5.split(MARK_START, 1)[0]
+                    + v5.split(MARK_END, 1)[1]).strip()
+        self.assertEqual(_norm(self.VERSION_STAMP.sub("", stripped)),
+                         _norm(self.VERSION_STAMP.sub("", v3)),
+                         "v5 must be v3 plus the marked block, the version "
+                         "stamp, and nothing else")
+
+    def test_the_version_stamp_names_v5(self):
+        v5 = prompt_body(GENERIC_PROMPT_V5)
+        self.assertIn("generic-v5 prompt", v5)
+        self.assertIn("d4d_generic_arm_prompt_v5.md", v5)
+        self.assertNotIn("generic-v3 prompt", v5)
+        self.assertNotIn("d4d_generic_arm_prompt_v4.md", v5)
+
+    def test_the_earlier_additions_survive_intact(self):
+        """v5 supplements v2's three and v3's one; it replaces neither.
+
+        If they were dropped, a v3-vs-v5 difference would measure their removal
+        as well as the addition.
+        """
+        v5 = prompt_body(GENERIC_PROMPT_V5)
+        for mark, expected in (("v2", 3), ("v3", 1), ("v4", 1)):
+            block = (v5.split(f"--- ADDED IN {mark} ---", 1)[1]
+                       .split(f"--- END ADDED IN {mark} ---", 1)[0])
+            with self.subTest(version=mark):
+                self.assertEqual(
+                    len([l for l in block.splitlines() if l.startswith("- ")]),
+                    expected)
+
+    def test_the_added_block_holds_exactly_four_rules(self):
+        """Four, and the number is asserted so a fifth cannot arrive quietly.
+
+        The convention is one rule per version; v5 departs from it for the
+        reason in the module docstring. A departure that is counted is a
+        decision — one that is not is a drift.
+        """
+        rules = [l for l in _added_block(GENERIC_PROMPT_V5.read_text()).splitlines()
+                 if l.startswith("- ")]
+        self.assertEqual(len(rules), 4)
+
+    def test_earlier_versions_are_untouched_by_v5(self):
+        for path in (GENERIC_PROMPT, GENERIC_PROMPT_V2, GENERIC_PROMPT_V3,
+                     GENERIC_PROMPT_V4):
+            with self.subTest(path=path.name):
+                self.assertNotIn(MARK_START, path.read_text(),
+                                 "an earlier version produced a baseline and "
+                                 "must not acquire v5's rule")
+
+
+class TestTheAddedRuleIsGeneric(unittest.TestCase):
+
+    def setUp(self):
+        self.block = _added_block(GENERIC_PROMPT_V5.read_text())
+
+    def test_no_project_is_named(self):
+        for project in PROJECTS:
+            with self.subTest(project=project):
+                self.assertNotIn(project, self.block)
+
+    def test_no_dataset_identifiers(self):
+        for token in ("fairhub", "physionet", "dataverse", "10.18130",
+                      "cm4ai.org", "HIGT4C", "B35XWX"):
+            with self.subTest(token=token):
+                self.assertNotIn(token.lower(), self.block.lower())
+
+    def test_no_slot_is_named(self):
+        """Sharper than v3's check, and the trap this rule was most likely to
+        fall into: it was written to fix `target_dataset`, so naming that slot
+        would turn a generic decision rule into an instruction about one field.
+        """
+        for slot in ("target_dataset", "related_datasets", "relationship_type"):
+            with self.subTest(slot=slot):
+                self.assertNotIn(slot, self.block)
+
+    def test_no_expected_quantities(self):
+        numbers = re.findall(r"\b\d+\b", self.block)
+        self.assertEqual(numbers, [],
+                         f"the rule must state no quantities, found {numbers}")
+        for phrase in ("expect", "should yield", "typically", "at least",
+                       "roughly", "approximately"):
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, self.block.lower())
+
+    def test_no_reference_to_prior_runs(self):
+        for phrase in ("earlier run", "previous run", "prior run", "last time",
+                       "has been observed", "tends to", "replicate"):
+            with self.subTest(phrase=phrase):
+                self.assertNotIn(phrase, self.block.lower())
+
+    def test_the_prediction_lives_outside_the_prompt(self):
+        text = GENERIC_PROMPT_V5.read_text().lower()
+        self.assertNotIn("we expect", text)
+        self.assertTrue(Path("notes/generic_v5_analysis_plan.md").exists(),
+                        "the prediction must be registered before running")
+
+
+class TestTheConditionIsWiredComparably(unittest.TestCase):
+
+    def test_v5_resolves_to_its_own_prompt(self):
+        self.assertEqual(CONDITION_PROMPTS["generic_v5"], GENERIC_PROMPT_V5)
+
+    def test_v4_against_v5_is_the_isolating_comparison(self):
+        self.assertTrue(comparable_conditions("generic_v4", "generic_v5"))
+        self.assertEqual(condition_delta("generic_v4", "generic_v5"), ["base"])
+
+    def test_v2_against_v5_is_not_isolating(self):
+        """Two rule additions apart. `condition_delta` reports the single axis
+        `base`, which is why comparability needs adjacency and not just a
+        one-axis difference (#338)."""
+        self.assertEqual(condition_delta("generic_v2", "generic_v5"), ["base"])
+        self.assertFalse(comparable_conditions("generic_v2", "generic_v5"))
+
+    def test_v5_against_tuned_is_confounded(self):
+        self.assertFalse(comparable_conditions("generic_v5", "tuned"))
+        self.assertEqual(sorted(condition_delta("generic_v5", "tuned")),
+                         ["base", "tuned"])
+
+    def test_each_generic_base_is_distinct(self):
+        bases = [CONDITION_AXES[c]["base"]
+                 for c in ("generic", "generic_v2", "generic_v4", "generic_v5")]
+        self.assertEqual(len(set(bases)), 4,
+                         "two conditions sharing a base would be indistinguishable")
+
+    def test_v5_is_launchable_from_the_cli(self):
+        """`generic_v2` was once staged, tested and unreachable because the
+        condition list was written out inline three times."""
+        from data_sheets_schema.cli.api import _CONDITIONS
+        self.assertIn("generic_v5", _CONDITIONS)
+
+
+@unittest.skipUnless(GENERIC_PROMPT_V5.exists(), "v5 prompt not present")
+class TestConditionIsRecoverableFromProvenance(unittest.TestCase):
+    """`condition_of` returned None for every v3 and v5 run (#340).
+
+    Its hardcoded chain knew v1, v2 and tuned. `d4d_generic_arm_prompt_v4.md`
+    does not contain `d4d_generic_arm_prompt.md` as a substring — the `_v4` sits
+    between `prompt` and `.md` — so a v3 run fell through every branch and the
+    function reported nothing, silently, on the path the rerun takes.
+    """
+
+    def _infer(self, *prompt_paths):
+        import tempfile
+
+        import yaml
+
+        from data_sheets_schema.runs import condition_of
+        with tempfile.TemporaryDirectory() as tmp:
+            # `record_path_for` appends `_core` to the method, which is where
+            # provenance is written for both arms.
+            root = Path(tmp) / "claudecode_agent_core" / "LBL"
+            root.mkdir(parents=True)
+            # Entries are mappings in real provenance, not bare strings.
+            (root / "CHORUS_provenance.yaml").write_text(yaml.safe_dump(
+                {"prompts": {"files": [{"path": p, "sha256": "x"}
+                                       for p in prompt_paths]}}))
+            return condition_of("claudecode_agent", "LBL", "CHORUS",
+                                concat_dir=Path(tmp))
+
+    def test_every_registered_condition_is_recoverable(self):
+        for condition, path in CONDITION_PROMPTS.items():
+            if condition == "tuned":
+                continue
+            with self.subTest(condition=condition):
+                self.assertEqual(self._infer(f"src/download/prompts/{path.name}"),
+                                 condition)
+
+    def test_the_tuned_arm_is_still_distinguished_from_its_generic_base(self):
+        """It shares v1's file, so testing the generic bases first would report
+        it as `generic`."""
+        self.assertEqual(
+            self._infer("src/download/prompts/d4d_generic_arm_prompt.md",
+                        "src/download/prompts/d4d_tuned_arm_prompt.md"),
+            "tuned")
+
+    def test_the_more_specific_version_wins_when_several_are_listed(self):
+        """Provenance may name more than one prompt — `tuned` already does.
+
+        Iterating the registry in an arbitrary order would return whichever
+        matched first, so a run listing both the v1 base and v5 could be
+        reported as `generic`. That failure is silent and wrong in the same way
+        #340 was, which is why the registry is walked longest-name-first rather
+        than in dict order.
+
+        No provenance on disk lists two generic prompts today; this is the case
+        the ordering exists for, exercised rather than assumed.
+        """
+        self.assertEqual(
+            self._infer("src/download/prompts/d4d_generic_arm_prompt.md",
+                        "src/download/prompts/d4d_generic_arm_prompt_v5.md"),
+            "generic_v5")
+
+    def test_an_unrecognised_prompt_still_returns_none(self):
+        self.assertIsNone(self._infer("src/download/prompts/something_else.md"))
+
+    def test_no_condition_is_reported_for_a_run_without_provenance(self):
+        from data_sheets_schema.runs import condition_of
+        self.assertIsNone(condition_of("claudecode_agent", "no-such-label",
+                                       "CHORUS", concat_dir=Path("/nonexistent")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -66,58 +66,115 @@ class TestTheRecordSaysWhich(unittest.TestCase):
 class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
     """The duplication that caused this.
 
-    The four original rules are maintained byte-identically in the playbook and
-    in every condition prompt. That is the pattern #518 and #521 kept finding in
-    the build — one list of content, several hand-kept copies — and it diverged
-    the moment two rules were added to one copy only.
+    One list of decision rules, kept by hand in the playbook and in every
+    condition prompt. That is the pattern #518 and #521 kept finding in the
+    build, and it diverged the moment two rules were added to one copy only
+    (#545).
 
-    This does not forbid divergence; a rule may legitimately be
-    playbook-scope. It requires that any rule present in the playbook and
-    absent from the prompts is one somebody chose, by listing it here.
+    Until v5 the copies were byte-identical, so a text-prefix probe could check
+    correspondence. They no longer can be: the playbook cites issue numbers and
+    real identifiers, and the generic prompt may contain neither — a first draft
+    of the v5 block used a real dataset DOI as an example and
+    `test_no_dataset_identifiers` refused it, correctly.
+
+    So the correspondence is **declared** below rather than inferred from the
+    text. That is weaker than byte-identity and it is the honest weaker thing:
+    a table someone must edit beats a probe that silently stops matching.
     """
 
-    #: Rules the playbook carries that the condition prompts deliberately do
-    #: not, each with the reason. Emptying this list is the goal, and v5 is
-    #: where the two below are expected to move into the prompt (#547).
-    PLAYBOOK_ONLY = {
-        "American English": "#502 — added to the playbook to avoid rotating "
-                            "pins mid-arm; reaches the agentic path only",
-        "CURIE": "same, added this session; reaches the agentic path only",
+    #: rule → (a phrase only that rule has in the playbook,
+    #:         a phrase only that rule has in the current condition prompt)
+    SHARED_RULES = {
+        "prefer omission":
+            ("prefer omission", "prefer omission"),
+        "sources that disagree":
+            ("sources that disagree", "sources that disagree"),
+        "one referent":
+            ("admits one referent", "admits one referent"),
+        "no target count":
+            ("no target slot count", "no target slot count"),
+        "curie form":
+            ("as a CURIE", "as a CURIE"),
+        "identifier provenance":
+            ("comes from the evidence", "take it from the evidence"),
+        "minted fragment":
+            ("does not identify a person", "does not identify a person"),
+        "american english":
+            ("American English", "American English"),
     }
 
-    def _rule_bullets(self, text, start, end):
-        block = text[text.index(start):text.index(end)]
-        return [b.strip() for b in re.findall(r"^- (.+?)(?=\n- |\n\n)",
-                                              block, re.S | re.M)]
+    #: Rules the playbook carries that the condition prompts deliberately do
+    #: not, each with the reason. **Empty as of v5**, which is what this guard
+    #: was for: American English (#502) and CURIE form were playbook-only
+    #: because they were added mid-arm to avoid rotating a pin, and v5 is the
+    #: version boundary where they move into the prompt.
+    #:
+    #: Emptying it does not retire the guard. A rule added to the playbook
+    #: tomorrow, mid-arm, for the same good reason, belongs here again — with
+    #: its reason, so the divergence is a decision rather than a discovery.
+    PLAYBOOK_ONLY: dict[str, str] = {}
 
-    def test_every_playbook_only_rule_is_declared_here(self):
-        """A rule that reaches one path and not the other is a decision. If a
-        third appears without being listed, this fails and someone has to say
-        whether that was intended."""
+    CURRENT_PROMPT = "d4d_generic_arm_prompt_v5.md"
+
+    def _texts(self):
         playbook = PLAYBOOK.read_text(encoding="utf-8")
-        rules = self._rule_bullets(playbook, "### Uniform decision rules",
-                                   "### Recording the condition")
-        v4 = (PROMPTS / "d4d_generic_arm_prompt_v4.md").read_text(
-            encoding="utf-8")
-        undeclared = []
-        for rule in rules:
-            head = rule.split(".")[0][:60]
-            key = next((k for k in self.PLAYBOOK_ONLY if k in rule), None)
-            if key:
-                continue
-            # a shared rule: some distinctive phrase of it must appear in v4
-            probe = re.sub(r"[*`]", "", rule).split(".")[0][:40]
-            if probe and probe not in re.sub(r"[*`]", "", v4):
-                undeclared.append(head)
-        self.assertEqual(undeclared, [],
-                         "playbook rules absent from the v4 prompt and not "
-                         "declared as playbook-only")
+        prompt = (PROMPTS / self.CURRENT_PROMPT).read_text(encoding="utf-8")
+        return (re.sub(r"[*`\s]+", " ", playbook).lower(),
+                re.sub(r"[*`\s]+", " ", prompt).lower())
 
-    def test_the_declared_ones_really_are_absent_from_the_prompts(self):
-        """If a listed rule reaches the prompts after all, the entry is stale
-        and should be removed rather than left asserting a gap that closed."""
-        v4 = (PROMPTS / "d4d_generic_arm_prompt_v4.md").read_text(
-            encoding="utf-8")
+    def test_every_shared_rule_reaches_both(self):
+        playbook, prompt = self._texts()
+        missing = []
+        for name, (in_book, in_prompt) in self.SHARED_RULES.items():
+            if in_book.lower() not in playbook:
+                missing.append(f"{name}: absent from the playbook")
+            if in_prompt.lower() not in prompt:
+                missing.append(f"{name}: absent from {self.CURRENT_PROMPT}")
+        self.assertEqual(missing, [])
+
+    def test_the_playbook_has_no_rule_this_table_does_not_know(self):
+        """A rule added to the playbook and to no prompt is the original defect.
+
+        Counting bullets rather than matching their text: the count is what
+        catches an addition, and the table above is what says where it reaches.
+        """
+        text = PLAYBOOK.read_text(encoding="utf-8")
+        block = text[text.index("### Uniform decision rules"):
+                     text.index("### Recording the condition")]
+        bullets = re.findall(r"^- (.+?)(?=\n- |\n\n)", block, re.S | re.M)
+        self.assertEqual(
+            len(bullets), len(self.SHARED_RULES) + len(self.PLAYBOOK_ONLY),
+            "a uniform decision rule was added or removed; say in SHARED_RULES "
+            "or PLAYBOOK_ONLY where it reaches")
+
+    def test_the_declared_playbook_only_rules_really_are_absent(self):
+        """A stale entry asserts a gap that has closed."""
+        _playbook, prompt = self._texts()
         for key in self.PLAYBOOK_ONLY:
             with self.subTest(rule=key):
-                self.assertNotIn(key, v4)
+                self.assertNotIn(key.lower(), prompt)
+
+    def test_the_two_rules_v5_was_for_actually_reached_it(self):
+        """PLAYBOOK_ONLY is empty; this is what makes that mean something.
+
+        An empty declaration is satisfied both by "the gap closed" and by
+        "someone deleted the entries". This asserts the first.
+        """
+        block = (PROMPTS / self.CURRENT_PROMPT).read_text(encoding="utf-8")
+        block = block.split("--- ADDED IN v5 ---", 1)[1].split(
+            "--- END ADDED IN v5 ---", 1)[0]
+        self.assertIn("American English", block)
+        self.assertIn("CURIE", block)
+
+    def test_the_new_v5_rules_reached_the_playbook_too(self):
+        """The mirror direction, which nothing checked before.
+
+        This guard was built for rules that reach the agentic path and not the
+        API path. Two of v5's four arrived the other way round — written for the
+        prompt, out of #547 and #531 — and a rule the API arm follows while the
+        agentic arm does not is the same defect wearing the other shoe.
+        """
+        playbook, _prompt = self._texts()
+        for probe in ("comes from the evidence", "does not identify a person"):
+            with self.subTest(probe=probe):
+                self.assertIn(probe, playbook)

--- a/tests/test_prompt_registry.py
+++ b/tests/test_prompt_registry.py
@@ -403,9 +403,17 @@ class TestTheCLI(unittest.TestCase):
         self.prompt = Path("src/download/prompts/d4d_generic_arm_prompt.md")
         self.prompt.parent.mkdir(parents=True)
         self.prompt.write_text("# v1\n\n## Prompt body\nbody\n")
-        for name in ("_v2", "_v3", "_v4"):
-            p = self.prompt.with_name(f"d4d_generic_arm_prompt{name}.md")
-            p.write_text(f"# {name}\n\n## Prompt body\nbody\n")
+        # Derived from the condition registry, not restated. A hardcoded
+        # ("_v2", "_v3", "_v4") meant that adding generic_v5 left `check
+        # --strict` reporting a real file the fixture had not created, and two
+        # tests failed for a reason that had nothing to do with what they test.
+        # Same shape as #467, where a four-project literal silently excluded
+        # VOICE_PEDIATRIC.
+        from data_sheets_schema.api_runner import CONDITION_PROMPTS
+        for real in set(CONDITION_PROMPTS.values()):
+            here = self.prompt.with_name(real.name)
+            if not here.exists():
+                here.write_text(f"# {real.stem}\n\n## Prompt body\nbody\n")
         self.prompt.with_name("d4d_tuned_arm_prompt.md").write_text("# tuned\n")
 
 


### PR DESCRIPTION
Closes the rule half of #547 and settles #531. Completes #545 by emptying
`PLAYBOOK_ONLY`.

v5 = v4 plus one marked block. **The block holds four rules**, which breaks the
one-rule-per-version convention v2, v3 and v4 kept.

## Why four, and what it costs

Two of them are not new instructions. American English (#502) and CURIE form
were added to the playbook mid-arm, deliberately, to avoid rotating a pin while
runs were in flight — so they have reached the agentic path ever since and the
API path never. Bringing them into the condition prompt is a **parity fix**, and
their expected effect on the agentic arm is nil by construction.

The other two are new and inseparable:

- **an identifier is a fact and comes from the evidence** (#547). VOICE rep1
  supplied 19 RORs absent from its bundle, CM4AI rep3 another ten. Every one
  correct, none attested.
- **where the evidence supplies no identifier, hang one off an identifier it
  does** — a fragment, not a new prefix (#531, decided). A fragment on an
  organisation's ROR does not name a person.

Stated apart they would be incoherent: forbidding unattested identifiers without
saying what to write instead pushes a model toward inventing a local namespace,
which is the ~12,000-value defect #531 records.

**The cost is stated, not hidden.** A v4-against-v5 comparison measures the
block and cannot attribute any effect to a rule inside it.
`notes/generic_v5_analysis_plan.md` says so, is registered before any run, and
lists what would falsify the block rather than only what would confirm it.

## Both directions of the divergence guard

The #545 guard looked only for rules reaching the agentic path and not the API
path. Two of v5's four arrived the other way round — written for the prompt —
and a rule only the API arm follows is the same defect wearing the other shoe.
Both new rules go into the playbook too, and the guard now checks both ways.

It also stops probing by text prefix. Until v5 the copies were byte-identical so
a prefix matched; they cannot be now, because the playbook cites issue numbers
and real identifiers while the generic prompt may contain neither. The
correspondence is a declared table instead — weaker than byte-identity, and the
honest weaker thing, since a table someone must edit beats a probe that silently
stops matching.

## The genericity tests earned their keep

A first draft of the block used a real dataset DOI as its example of a minted
fragment. `test_no_dataset_identifiers` refused it. A generic arm that
illustrates a rule with one project's identifier is priming every other project.
The block now contains no digits at all, names no project and names no slot.

## Two guards that assumed v5 could not exist

- the prompt-registry CLI fixture built its temp prompts from a hardcoded
  `("_v2", "_v3", "_v4")`. Derived from `CONDITION_PROMPTS` now — same shape as
  #467.
- `test_american_english_rule` asserted no condition prompt carries the rule.
  #502's real constraint is that a prompt *already run* may not acquire it. v5
  carries it from birth and no record names v5. The test now says that, and
  asserts the premise instead of assuming it.

Pin taken at the commit the bytes were committed in; `d4d api prompts check
--strict` reports 11 files, 0 off-pin.

Suite: 2016 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)