### PR TITLE
Apply #520's schema_moved guard to the pair check (#550)

### DIFF
--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/AI_READI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CHORUS_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/AI_READI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CHORUS_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep2/VOICE_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 3
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/AI_READI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CHORUS_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 3
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 2
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.resources[id='https://physionet.org/content/b2ai-voice-pediatric/'].related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 3
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
@@ -96,6 +96,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CHORUS_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/CM4AI_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep1/VOICE_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 2
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.resources[id='https://physionet.org/content/b2ai-voice-pediatric/'].related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CHORUS_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/CM4AI_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep2/VOICE_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CHORUS_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/CM4AI_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 5
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-generic_rep3/VOICE_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 5
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -159,14 +159,11 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 2
-  warnings: 0
+  errors: 1
+  warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
-  - code: shared-slot-presence
-    path: $.version_access
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: resource-projection-presence
     path: $.resources
     message: resources must be represented in both records when present in either

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_canary_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_canary_rep1/CHORUS_provenance.yaml
@@ -175,6 +175,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: resource-projection-presence
     path: $.resources

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 5
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.external_resources[13].description

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -181,6 +181,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: resource-projection-presence
     path: $.resources

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: resource-projection-presence
     path: $.resources

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -170,9 +170,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 6
-  warnings: 0
+  errors: 5
+  warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].description
@@ -192,10 +193,6 @@ pair_consistency:
     message: 'value differs: full=''Participants are grouped into five disease cohort
       categories for which voice changes have been associated with specific diseases
       with well-recognised unmet needs: voice disorders,'
-  - code: shared-slot-presence
-    path: $.use_repository
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: distribution-relation-presence
     path: $.distributions
     message: full file_collections exist without core distributions

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 13
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.collection_mechanisms[5].description

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: resource-projection-presence
     path: $.resources

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 2
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.is_deidentified.description

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -135,9 +135,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 19
-  warnings: 1
+  errors: 18
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].description
@@ -195,10 +196,6 @@ pair_consistency:
     message: 'value differs: full=''Curates the dataset, performs internal audits
       for missingness and consistency, and issues versioned releases. General dataset
       questions are directed to the corresponding author li'
-  - code: shared-slot-presence
-    path: $.other_tasks
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.preprocessing_strategies[3].description
     message: 'value differs: full=''Torchaudio pitch contours are extracted with minimum

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
@@ -183,14 +183,11 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 9
-  warnings: 1
+  errors: 8
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
-  - code: shared-slot-presence
-    path: $.annotation_analyses
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.at_risk_populations
     message: 'type differs: full=list, core=dict'

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -173,6 +173,7 @@ pair_consistency:
   errors: 5
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 2
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: resource-projection-presence
     path: $.resources

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -138,6 +138,7 @@ pair_consistency:
   errors: 5
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
@@ -160,14 +160,11 @@ canonical_superseded_by:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 3
-  warnings: 1
+  errors: 2
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
-  - code: shared-slot-presence
-    path: $.informed_consent
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.instances[0].description
     message: 'value differs: full=''Each instance represents an individual study participant.

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CHORUS_provenance.yaml
@@ -159,6 +159,7 @@ pair_consistency:
   errors: 5
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.conforms_to

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CM4AI_provenance.yaml
@@ -136,6 +136,7 @@ pair_consistency:
   errors: 4
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.funders[0].description

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/VOICE_provenance.yaml
@@ -141,9 +141,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 16
-  warnings: 1
+  errors: 12
+  warnings: 5
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods
@@ -154,10 +155,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.collection_timeframes
     message: 'list length differs: full=3, core=4'
-  - code: shared-slot-presence
-    path: $.confidential_elements
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.creators[17].description
     message: 'value differs: full=''The Bridge2AI-Voice Consortium as a collective
@@ -187,18 +184,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.instances
     message: 'list length differs: full=4, core=5'
-  - code: shared-slot-presence
-    path: $.is_tabular
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.other_tasks
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.subpopulations
     message: 'list length differs: full=5, core=10'

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/AI_READI_provenance.yaml
@@ -140,9 +140,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 10
-  warnings: 1
+  errors: 9
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.creators[0].description
@@ -180,10 +181,6 @@ pair_consistency:
     message: 'value differs: full=''The REDCap instance hosted at the University of
       Washington holds patient-reported questionnaire responses, consent records,
       and clinical data entered at the visit (medications ass'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.subpopulations[0].description
     message: 'value differs: full=''380 of 2,280 participants in version 3.0.0 (204

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
@@ -169,6 +169,7 @@ pair_consistency:
   errors: 3
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.license_and_use_terms.description

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
@@ -160,23 +160,16 @@ canonical_superseded_by:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 6
-  warnings: 0
+  errors: 4
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
-  - code: shared-slot-presence
-    path: $.at_risk_populations
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.confidential_elements[0].description
     message: 'value differs: full=''The June 2026 release record marks the external
       data links for perturb-seq data in KOLF2.1J iPSCs (undifferentiated) and perturb-seq
       data in MDA-MB-468 breast cancer cells (with a'
-  - code: shared-slot-presence
-    path: $.content_warnings
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.distribution_formats[0].description
     message: 'value differs: full=''All ten files in the June 2026 release are distributed

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/VOICE_provenance.yaml
@@ -130,9 +130,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 13
-  warnings: 1
+  errors: 11
+  warnings: 3
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods
@@ -169,10 +170,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.missing_data_documentation
     message: 'list length differs: full=4, core=5'
-  - code: shared-slot-presence
-    path: $.other_tasks
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.preprocessing_strategies
     message: 'list length differs: full=11, core=12'
@@ -181,10 +178,6 @@ pair_consistency:
     message: 'value differs: full=''The unprocessed source data are WAV audio recordings
       of the acoustic task battery, captured at  the collection sites. The raw data,
       post de-identification, was saved in addition t'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_provenance.yaml
@@ -190,9 +190,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 47
-  warnings: 1
+  errors: 44
+  warnings: 4
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].description
@@ -205,10 +206,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.anomalies
     message: 'list length differs: full=6, core=5'
-  - code: shared-slot-presence
-    path: $.at_risk_populations
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.cleaning_strategies
     message: 'list length differs: full=7, core=4'
@@ -266,7 +263,12 @@ pair_consistency:
   - code: shared-slot-content
     path: $.informed_consent
     message: 'list length differs: full=4, core=6'
-  findings_truncated: 27
+  - code: shared-slot-content
+    path: $.instances[0].description
+    message: 'value differs: full=''Each instance represents an individual participant
+      (patient). There are 2,280 instances in version 3.0.0 of the dataset. An instance
+      comprises all data available for that individu'
+  findings_truncated: 24
   artifacts:
     full:
       path: data/d4d_concatenated/claudecode_agent/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_d4d.yaml

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CHORUS_provenance.yaml
@@ -159,6 +159,7 @@ pair_consistency:
   errors: 3
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.collection_timeframes[0].description

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CM4AI_provenance.yaml
@@ -146,19 +146,16 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 4
-  warnings: 1
+  errors: 3
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.license_and_use_terms.description
     message: 'value differs: full=''The dataset is licensed for reuse under CC BY-NC-SA
       4.0 (https://creativecommons.org/licenses/by-nc-sa/4.0/). Users are free to
       share (copy and redistribute the material in any me'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.tasks[0].description
     message: 'value differs: full=''Integration of protein localization and protein

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/VOICE_provenance.yaml
@@ -204,9 +204,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 5
-  warnings: 0
+  errors: 4
+  warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.external_resources
@@ -219,10 +220,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.informed_consent
     message: 'list length differs: full=3, core=8'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: distribution-relation-presence
     path: $.distributions
     message: full file_collections exist without core distributions

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep1/CHORUS_provenance.yaml
@@ -168,6 +168,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep2/CHORUS_provenance.yaml
@@ -176,6 +176,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: resource-projection-presence
     path: $.resources

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep3/CHORUS_provenance.yaml
@@ -184,6 +184,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: resource-projection-presence
     path: $.resources

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/AI_READI_provenance.yaml
@@ -260,25 +260,14 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 7
-  warnings: 0
+  errors: 4
+  warnings: 3
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.creators
     message: 'list length differs: full=20, core=21'
-  - code: shared-slot-presence
-    path: $.ip_restrictions
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.issued
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.sampling_strategies[0]
     message: 'mapping keys differ: missing from core=[], missing from full=[''is_random'']'

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/CHORUS_provenance.yaml
@@ -220,9 +220,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 9
-  warnings: 0
+  errors: 8
+  warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].acquisition_details[0]
@@ -252,10 +253,6 @@ pair_consistency:
     message: 'value differs: full=''Provision a sequestered holdout test set accessible
       for external model validation, to aid marketplace adoption of AI-developed models
       for implementation in acute and critical care'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: resource-projection-presence
     path: $.resources
     message: resources must be represented in both records when present in either

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep2/AI_READI_provenance.yaml
@@ -249,9 +249,10 @@ intermediates:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 7
-  warnings: 1
+  errors: 5
+  warnings: 3
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.collection_timeframes[2]
@@ -260,10 +261,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.creators[0]
     message: 'mapping keys differ: missing from core=[], missing from full=[''affiliations'']'
-  - code: shared-slot-presence
-    path: $.data_protection_impacts
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.funders[3].grants[0].id
     message: 'value differs: full=''https://doi.org/10.60775/fairhub.3#grant-microsoft-ai-for-good-lab'',
@@ -271,10 +268,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.missing_data_documentation[0].missing_data_patterns
     message: 'list length differs: full=2, core=1'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: resource-projection-presence
     path: $.resources
     message: resources must be represented in both records when present in either

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep3/AI_READI_provenance.yaml
@@ -265,9 +265,10 @@ intermediates:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 10
-  warnings: 0
+  errors: 8
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.anomalies
@@ -276,10 +277,6 @@ pair_consistency:
     path: $.creators[0]
     message: 'mapping keys differ: missing from core=[''affiliations''], missing from
       full=[]'
-  - code: shared-slot-presence
-    path: $.distribution_formats
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.ethical_reviews[2]
     message: 'mapping keys differ: missing from core=[], missing from full=[''contact_person'']'
@@ -297,10 +294,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.missing_data_documentation
     message: 'list length differs: full=1, core=2'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: distribution-relation-presence
     path: $.distributions
     message: full file_collections exist without core distributions

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_provenance.yaml
@@ -232,15 +232,12 @@ validation:
       under any of the given schemas in /creators/3/affiliations/0'
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 1
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 2
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/CHORUS_provenance.yaml
@@ -189,6 +189,7 @@ pair_consistency:
   errors: 2
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: resource-projection-presence
     path: $.resources

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/AI_READI_provenance.yaml
@@ -319,9 +319,10 @@ intermediates:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 14
-  warnings: 1
+  errors: 13
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.creators[0]
@@ -371,10 +372,6 @@ pair_consistency:
     message: 'value differs: full=''Transcribed from the University of Washington
       AI-READI Data License Agreement v1.0 (Zenodo record 10.5281/zenodo.10642459),
       which is the only license text present in the source bu'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.sampling_strategies[0].strategies
     message: 'value differs: full=''Triple balancing: participants are recruited in

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/CHORUS_provenance.yaml
@@ -228,6 +228,7 @@ pair_consistency:
   errors: 4
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.funders[0].notes

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/AI_READI_provenance.yaml
@@ -299,9 +299,10 @@ intermediates:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 26
-  warnings: 0
+  errors: 12
+  warnings: 14
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[3].acquisition_details
@@ -313,30 +314,6 @@ pair_consistency:
     message: 'value differs: full=''Affiliations: University of Washington; University
       of Alabama at Birmingham; University of California, San Diego; Johns Hopkins
       University; Stanford University; Oregon Health & Sc'
-  - code: shared-slot-presence
-    path: $.discouraged_uses
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.distribution_dates
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.distribution_formats
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.existing_uses
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.extension_mechanism
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.external_resources
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.funders[0].notes
     message: 'value differs: full=''Award OT2OD032644 ("Bridge2AI: Salutogenesis Data
@@ -357,23 +334,11 @@ pair_consistency:
     message: 'value differs: full="Each instance consists of all of the data available
       for one individual participating in the study. Data are organised in the release
       with one folder per participant within each de'
-  - code: shared-slot-presence
-    path: $.ip_restrictions
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.is_deidentified.identifiers_removed
     message: 'value differs: full=''Protected Health Information as defined by the
       HIPAA Privacy Rule (Safe Harbor method).\nSex.\nRace and ethnicity.\nMedications
       used.\n5-digit zip code (held under controlled acce'
-  - code: shared-slot-presence
-    path: $.license_and_use_terms
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.maintainers
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.missing_data_documentation[0].missing_data_causes
     message: 'value differs: full=''Participants elected not to participate in some
@@ -387,11 +352,17 @@ pair_consistency:
   - code: shared-slot-content
     path: $.raw_data_sources
     message: 'list length differs: full=3, core=9'
-  - code: shared-slot-presence
-    path: $.regulatory_restrictions
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
-  findings_truncated: 6
+  - code: shared-slot-content
+    path: $.sampling_strategies[0].strategies
+    message: 'value differs: full=''Non-probability sampling.\nTriple-balanced recruitment
+      in equal proportions across four race/ethnic groups (Asian, Black, Hispanic,
+      White), four T2DM categories (no diabetes; pre-'
+  - code: shared-slot-content
+    path: $.subpopulations[0].notes
+    message: 'value differs: full=''Race and ethnicity are held under controlled access
+      and are not released in the public dataset; the FAIRhub healthsheet therefore
+      answers "No" to whether the dataset identifies de'
+  findings_truncated: null
   artifacts:
     full:
       path: data/d4d_concatenated/claudecode_agent/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/AI_READI_d4d.yaml

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/CHORUS_provenance.yaml
@@ -228,6 +228,7 @@ pair_consistency:
   errors: 9
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].notes

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/AI_READI_provenance.yaml
@@ -277,9 +277,10 @@ intermediates:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 11
-  warnings: 1
+  errors: 10
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.collection_mechanisms[0]
@@ -318,10 +319,6 @@ pair_consistency:
     message: 'value differs: full=''Additional documented facts that fit no dedicated
       slot. (1) No labels or annotations were assigned to instances; the healthsheet
       states the dataset is hypothesis-agnostic and that'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.sampling_strategies[0].strategies
     message: 'value differs: full=''(1) Triple-balanced recruitment: participants

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/CHORUS_provenance.yaml
@@ -260,6 +260,7 @@ pair_consistency:
   errors: 11
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0]

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/AI_READI_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/CHORUS_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/CM4AI_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep1/VOICE_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/AI_READI_provenance.yaml
@@ -113,6 +113,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/CHORUS_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/CM4AI_provenance.yaml
@@ -113,6 +113,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/VOICE_PEDIATRIC_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep2/VOICE_provenance.yaml
@@ -113,6 +113,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/AI_READI_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/CHORUS_provenance.yaml
@@ -113,6 +113,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/CM4AI_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/VOICE_PEDIATRIC_provenance.yaml
@@ -113,6 +113,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-07_claude-opus-5-claudecode-generic-v3_rep3/VOICE_provenance.yaml
@@ -109,6 +109,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -347,9 +347,10 @@ intermediates:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 19
-  warnings: 1
+  errors: 18
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].notes
@@ -404,10 +405,6 @@ pair_consistency:
   - code: shared-slot-content
     path: $.regulatory_restrictions.regulatory_restrictions
     message: 'list length differs: full=1, core=2'
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.sampling_strategies
     message: 'list length differs: full=2, core=1'

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -296,6 +296,7 @@ pair_consistency:
   errors: 7
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].acquisition_details

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/AI_READI_provenance.yaml
@@ -135,15 +135,12 @@ validation:
   recorded_by: d4d runs validate
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 1
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 2
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CHORUS_provenance.yaml
@@ -139,6 +139,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/CM4AI_provenance.yaml
@@ -139,6 +139,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_PEDIATRIC_provenance.yaml
@@ -135,15 +135,12 @@ validation:
   recorded_by: d4d runs validate
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 1
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 2
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep1/VOICE_provenance.yaml
@@ -135,15 +135,12 @@ validation:
   recorded_by: d4d runs validate
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 1
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 2
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/AI_READI_provenance.yaml
@@ -135,19 +135,12 @@ validation:
   recorded_by: d4d runs validate
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 2
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 3
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CHORUS_provenance.yaml
@@ -155,15 +155,12 @@ canonical:
   - 2026-08-07_claude-opus-5-claudecode-generic-v3_rep3
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 1
-  warnings: 0
+  consistent: true
+  errors: 0
+  warnings: 1
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/CM4AI_provenance.yaml
@@ -155,19 +155,12 @@ canonical:
   - 2026-08-07_claude-opus-5-claudecode-generic-v3_rep2
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 2
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 3
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_PEDIATRIC_provenance.yaml
@@ -155,19 +155,12 @@ canonical:
   - 2026-08-07_claude-opus-5-claudecode-generic-v3_rep3
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 2
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 3
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep2/VOICE_provenance.yaml
@@ -155,19 +155,12 @@ canonical:
   - 2026-08-07_claude-opus-5-claudecode-generic-v3_rep2
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 2
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 3
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/AI_READI_provenance.yaml
@@ -155,19 +155,12 @@ canonical:
   - 2026-08-07_claude-opus-5-claudecode-generic-v3_rep2
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 2
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 3
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CHORUS_provenance.yaml
@@ -135,15 +135,12 @@ validation:
   recorded_by: d4d runs validate
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 1
-  warnings: 0
+  consistent: true
+  errors: 0
+  warnings: 1
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/CM4AI_provenance.yaml
@@ -135,19 +135,12 @@ validation:
   recorded_by: d4d runs validate
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 2
-  warnings: 0
+  consistent: true
+  errors: 0
+  warnings: 2
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_PEDIATRIC_provenance.yaml
@@ -135,19 +135,12 @@ validation:
   recorded_by: d4d runs validate
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 2
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 3
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-claudecode-generic_rep3/VOICE_provenance.yaml
@@ -135,19 +135,12 @@ validation:
   recorded_by: d4d runs validate
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 2
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 3
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.data_governance
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/AI_READI_provenance.yaml
@@ -296,6 +296,7 @@ pair_consistency:
   errors: 10
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.collection_mechanisms[11].notes

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CHORUS_provenance.yaml
@@ -264,6 +264,7 @@ pair_consistency:
   errors: 6
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CM4AI_provenance.yaml
@@ -264,6 +264,7 @@ pair_consistency:
   errors: 6
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.data_governance.committee_contact

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/VOICE_provenance.yaml
@@ -346,6 +346,7 @@ pair_consistency:
   errors: 9
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.data_governance.committee_contact

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/AI_READI_provenance.yaml
@@ -328,6 +328,7 @@ pair_consistency:
   errors: 8
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.creators[0].id

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CHORUS_provenance.yaml
@@ -264,6 +264,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CM4AI_provenance.yaml
@@ -296,6 +296,7 @@ pair_consistency:
   errors: 9
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.creators

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/VOICE_provenance.yaml
@@ -328,6 +328,7 @@ pair_consistency:
   errors: 4
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.creators[0].source_caveats

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/AI_READI_provenance.yaml
@@ -345,6 +345,7 @@ pair_consistency:
   errors: 6
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0]

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CHORUS_provenance.yaml
@@ -296,6 +296,7 @@ pair_consistency:
   errors: 3
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].source_caveats

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CM4AI_provenance.yaml
@@ -296,6 +296,7 @@ pair_consistency:
   errors: 3
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.distribution_formats[0]

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/VOICE_provenance.yaml
@@ -296,6 +296,7 @@ pair_consistency:
   errors: 6
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.distribution_formats[0]

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -274,6 +274,7 @@ pair_consistency:
   errors: 2
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.is_deidentified.deidentification_details

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CHORUS_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep1/VOICE_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CHORUS_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/CM4AI_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep2/VOICE_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CHORUS_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-27_claude-opus-5_rep3/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/CHORUS_provenance.yaml
@@ -83,6 +83,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep1/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/CHORUS_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep2/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/CHORUS_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-deprimed_rep3/VOICE_provenance.yaml
@@ -83,6 +83,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep1/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep2/CM4AI_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-28_claude-opus-5-programme-deprimed_rep3/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -134,6 +134,7 @@ pair_consistency:
   errors: 4
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -144,15 +144,12 @@ validation:
       ''references'', ''is_identical_to''] in /related_datasets/3/relationship_type'
 pair_consistency:
   ran: true
-  consistent: false
-  errors: 1
-  warnings: 1
+  consistent: true
+  errors: 0
+  warnings: 2
   identity_slots: 79
-  findings:
-  - code: shared-slot-presence
-    path: $.related_datasets
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
+  schema_moved: true
+  findings: []
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -180,6 +180,7 @@ pair_consistency:
   errors: 11
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -211,9 +211,10 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 8
-  warnings: 1
+  errors: 7
+  warnings: 2
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.data_collectors
@@ -237,10 +238,6 @@ pair_consistency:
     message: 'value differs: full=''Access is governed by a controlled-access framework.
       The license is stated as "Data Use Agreement available at \''https://chorus4ai.org/dataset/\''",
       with the agreement document at '
-  - code: shared-slot-presence
-    path: $.publisher
-    message: schema-identical slot is present only in full; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.sampling_strategies
     message: 'list length differs: full=2, core=3'

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -175,6 +175,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -145,6 +145,7 @@ pair_consistency:
   errors: 5
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.creators[0].description

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -176,6 +176,7 @@ pair_consistency:
   errors: 5
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.data_protection_impacts

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.ip_restrictions.description

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 7
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep1/CM4AI_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep2/CM4AI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-denoised_rep3/CM4AI_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CHORUS_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/CM4AI_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep1/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CHORUS_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 2
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.resources[id='urn:uuid:08cf7419-b94d-4508-8f64-c99c557351d7'].related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/CM4AI_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep2/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CHORUS_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/CM4AI_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly-deprimed_rep3/VOICE_provenance.yaml
@@ -83,6 +83,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/CHORUS_provenance.yaml
@@ -84,6 +84,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep1/VOICE_provenance.yaml
@@ -83,6 +83,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/CHORUS_provenance.yaml
@@ -84,6 +84,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep2/VOICE_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/CHORUS_provenance.yaml
@@ -84,6 +84,7 @@ pair_consistency:
   errors: 0
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-28_claude-opus-5-crateonly_rep3/VOICE_provenance.yaml
@@ -87,6 +87,7 @@ pair_consistency:
   errors: 1
   warnings: 1
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 3
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].description

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 6
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -168,6 +168,7 @@ pair_consistency:
   errors: 11
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].description

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -173,6 +173,7 @@ pair_consistency:
   errors: 3
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.anomalies[0].description

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -202,6 +202,7 @@ pair_consistency:
   errors: 8
   warnings: 1
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods[0].description

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 3
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.instances

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -134,6 +134,7 @@ pair_consistency:
   errors: 6
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -170,26 +170,19 @@ validation:
 pair_consistency:
   ran: true
   consistent: false
-  errors: 4
-  warnings: 1
+  errors: 2
+  warnings: 3
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.anomalies
     message: 'list length differs: full=4, core=3'
-  - code: shared-slot-presence
-    path: $.data_protection_impacts
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   - code: shared-slot-content
     path: $.external_resources[0].description
     message: 'value differs: full=''Associated publication and dataset citation: Bensoussan,
       Y., et al. (2025). Bridge2AI-Voice: An ethically-sourced, diverse voice dataset
       linked to health information (version 3.0.'
-  - code: shared-slot-presence
-    path: $.informed_consent
-    message: schema-identical slot is present only in core; it must be present in
-      both or neither
   findings_truncated: null
   artifacts:
     full:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep1/AI_READI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep2/AI_READI_provenance.yaml
@@ -80,6 +80,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-27_claude-opus-5_rep3/AI_READI_provenance.yaml
@@ -81,6 +81,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep1/AI_READI_provenance.yaml
@@ -83,6 +83,7 @@ pair_consistency:
   errors: 0
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings: []
   findings_truncated: null
   artifacts:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep2/AI_READI_provenance.yaml
@@ -86,6 +86,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-deprimed_rep3/AI_READI_provenance.yaml
@@ -83,6 +83,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep1/AI_READI_provenance.yaml
@@ -99,6 +99,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep2/AI_READI_provenance.yaml
@@ -96,6 +96,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-28_claude-opus-5-generic_rep3/AI_READI_provenance.yaml
@@ -96,6 +96,7 @@ pair_consistency:
   errors: 1
   warnings: 0
   identity_slots: 79
+  schema_moved: false
   findings:
   - code: shared-slot-presence
     path: $.related_datasets

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 6
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
@@ -165,6 +165,7 @@ pair_consistency:
   errors: 5
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
@@ -175,6 +175,7 @@ pair_consistency:
   errors: 8
   warnings: 0
   identity_slots: 79
+  schema_moved: true
   findings:
   - code: shared-slot-content
     path: $.acquisition_methods

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1178,7 +1178,21 @@ def pair_consistency(spec: RunSpec) -> dict[str, Any] | None:
         pair = load_pair_schema(FULL_SCHEMA_PATH, CORE_SCHEMA_PATH)
         full = _yaml.safe_load(spec.full_path.read_text(encoding="utf-8")) or {}
         core = _yaml.safe_load(spec.core_path.read_text(encoding="utf-8")) or {}
-        report = validate_pair_data(full, core, pair)
+        # `schema_moved` is what #520 is for: a slot added to core after a pair
+        # was written is absent from that pair because it could not have been
+        # present, which is a fact about the schema's history rather than a
+        # defect in the record. Presence then warns; content disagreement stays
+        # an error, because two records asserting different values were wrong
+        # when written.
+        #
+        # For a fresh run this is always False — the run just consumed the
+        # current schema. Computed rather than hardcoded so the answer stays
+        # right if this is ever called on an older pair, which is exactly how
+        # the backfill got it wrong (#550).
+        from data_sheets_schema.d4d_pair_consistency import (
+            pair_predates_current_schema)
+        moved = pair_predates_current_schema(spec.core_path)
+        report = validate_pair_data(full, core, pair, schema_moved=moved)
     except Exception as exc:                                       # noqa: BLE001
         # A checker that cannot run must say so rather than report agreement.
         return {"ran": False, "reason": str(exc)[:200]}
@@ -1203,6 +1217,9 @@ def pair_consistency(spec: RunSpec) -> dict[str, Any] | None:
         "errors": len(report.errors),
         "warnings": len(report.warnings),
         "identity_slots": len(report.identity_slots),
+        # Recorded, because it changes what the verdict means: with it true,
+        # a presence divergence is a warning and the pair can pass.
+        "schema_moved": moved,
         # Bounded, and says so. A list silently cut at 20 reads as a complete
         # one; `errors` above is the true count either way.
         "findings": [{"code": i.code, "path": i.path, "message": i.message[:200]}

--- a/src/data_sheets_schema/backfill_checks.py
+++ b/src/data_sheets_schema/backfill_checks.py
@@ -107,16 +107,24 @@ def compute(provenance: Path, declared: dict[str, set[str]] | None = None
                                    "recorded_by": RECORDED_BY}
     else:
         from data_sheets_schema.d4d_pair_consistency import (
-            load_pair_schema, validate_pair_data,
+            load_pair_schema, pair_predates_current_schema, validate_pair_data,
         )
         pair = load_pair_schema(FULL_SCHEMA, CORE_SCHEMA)
+        # The whole point of a backfill is that these pairs are old, so this is
+        # exactly where #520 applies and exactly where the first version left
+        # it out (#550). Without it, `related_datasets` — added to core after
+        # most of the corpus was written — reported as a defect in 70 pairs
+        # that could not have carried it.
+        moved = pair_predates_current_schema(core)
         rep = validate_pair_data(
             yaml.safe_load(full.read_text(encoding="utf-8")) or {},
-            yaml.safe_load(core.read_text(encoding="utf-8")) or {}, pair)
+            yaml.safe_load(core.read_text(encoding="utf-8")) or {}, pair,
+            schema_moved=moved)
         out["pair_consistency"] = {
             "ran": True, "consistent": rep.passed, "errors": len(rep.errors),
             "warnings": len(rep.warnings),
             "identity_slots": len(rep.identity_slots),
+            "schema_moved": moved,
             "findings": [{"code": i.code, "path": i.path,
                           "message": i.message[:200]} for i in rep.errors[:20]],
             "findings_truncated": max(0, len(rep.errors) - 20) or None,

--- a/tests/test_backfill_checks.py
+++ b/tests/test_backfill_checks.py
@@ -113,21 +113,40 @@ class CorpusTest(unittest.TestCase):
         self.assertEqual(set(rec["pair_consistency"]["schema"]),
                          {"full_sha256", "core_sha256"})
 
-    def test_the_agentic_arm_is_not_clean(self):
-        """Corrects the figure #544 and #550 were filed on.
+    def test_the_agentic_arm_is_clean_once_the_guard_is_applied(self):
+        """Reverses what this test asserted when it was first written (#550).
 
-        I reported the 2026-08-11 agentic arm as 0 divergent pairs of 15. It is
-        not: `related_datasets` sits in the full record and not in core, and it
-        is a schema-identity slot. The schema pin above rules out a stale-schema
-        artifact — those hashes are today's bytes.
+        It asserted the agentic arm was not clean, on a backfill that omitted
+        `schema_moved`. `related_datasets` was added to `CoreDataset` after
+        these records were written, so its absence from core is a fact about
+        the schema's history — #520 makes that a warning, and the first version
+        of the backfill made it an error in 70 pairs.
+
+        With the guard the arm is clean, which is what I originally reported
+        and then wrongly corrected.
         """
         rec = self._record("2026-08-11_claude-opus-5-claudecode-generic_rep1",
                            "AI_READI")
         pair = rec["pair_consistency"]
         self.assertTrue(pair["ran"])
+        self.assertTrue(pair["schema_moved"],
+                        "the premise: this pair predates the current schema")
+        self.assertTrue(pair["consistent"])
+
+    def test_the_v4_arm_still_diverges_with_the_guard(self):
+        """The guard does not explain the API arm away.
+
+        All 12 v4 pairs predate the current schema too, so the guard applies to
+        both arms equally. This one fails on content, which no schema change
+        excuses.
+        """
+        rec = self._record("2026-08-13_claude-opus-5-api-generic-v4_rep1",
+                           "CHORUS")
+        pair = rec["pair_consistency"]
+        self.assertTrue(pair["schema_moved"])
         self.assertFalse(pair["consistent"])
-        self.assertIn("related_datasets",
-                      " ".join(f["path"] for f in pair["findings"]))
+        self.assertTrue(any("content" in f["code"] for f in pair["findings"]),
+                        "content divergence, not a presence artifact")
 
     def test_grounding_is_declined_for_a_drifted_bundle(self):
         """Checking against today's bundle would test a file the run never read.

--- a/tests/test_pair_gate.py
+++ b/tests/test_pair_gate.py
@@ -201,3 +201,78 @@ class RecordGateTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SchemaMovedTest(unittest.TestCase):
+    """#520's guard, which the first version of this check left out (#550).
+
+    A slot added to `CoreDataset` after a pair was written is absent from that
+    pair because it *could not have been present*. That is a fact about the
+    schema's history, not a defect in the record, so presence divergence warns
+    rather than errors when the pair predates the current schema. Content
+    disagreement stays an error either way: two records asserting different
+    values for one slot were wrong when they were written.
+
+    Omitting the flag made `related_datasets` — added to core after most of the
+    corpus existed — report as a defect in 70 pairs, and led me to tell the user
+    the agentic arm had 100 divergent pairs of 125 when it has none of 15.
+    """
+
+    BASE = Path("data/d4d_concatenated")
+
+    def _pairs(self, series):
+        from data_sheets_schema.backfill_checks import record_paths
+        out = []
+        for p in sorted(self.BASE.glob(f"*_core/{series}_rep*/*_provenance.yaml")):
+            q = record_paths(p)
+            if q["full"].exists() and q["core"].exists():
+                out.append(q)
+        return out
+
+    def _divergent(self, series, guard):
+        from data_sheets_schema.d4d_pair_consistency import (
+            load_pair_schema, pair_predates_current_schema, validate_pair_data,
+        )
+        from data_sheets_schema.provenance import CORE_SCHEMA, FULL_SCHEMA
+        pairs = self._pairs(series)
+        if not pairs:
+            self.skipTest(f"{series} not present in this checkout")
+        schema = load_pair_schema(FULL_SCHEMA, CORE_SCHEMA)
+        n = 0
+        for q in pairs:
+            full = yaml.safe_load(q["full"].read_text(encoding="utf-8")) or {}
+            core = yaml.safe_load(q["core"].read_text(encoding="utf-8")) or {}
+            moved = pair_predates_current_schema(q["core"]) if guard else False
+            if not validate_pair_data(full, core, schema,
+                                      schema_moved=moved).passed:
+                n += 1
+        return n, len(pairs)
+
+    def test_the_agentic_arm_is_clean_and_the_guard_is_why_that_is_visible(self):
+        series = "2026-08-11_claude-opus-5-claudecode-generic"
+        self.assertEqual(self._divergent(series, guard=True), (0, 15))
+        # Without the guard, 13 of the 15 report — the two exceptions state
+        # `related_datasets` in neither record, so there is no presence
+        # divergence to misread. 13 reported defects where there are none is
+        # what I sent upstream as "the agentic arm is not clean".
+        self.assertEqual(self._divergent(series, guard=False)[0], 13)
+
+    def test_the_v4_arm_diverges_with_the_guard_applied(self):
+        """The guard does not explain the API arm away.
+
+        All 12 v4 pairs have a moved digest too, so the guard applies to both
+        arms equally. Eleven still fail, on content rather than presence.
+        """
+        self.assertEqual(
+            self._divergent("2026-08-13_claude-opus-5-api-generic-v4",
+                            guard=True), (11, 12))
+
+    def test_the_recorded_block_says_which_reading_it_used(self):
+        p = (self.BASE / "claudecode_agent_core"
+             / "2026-08-11_claude-opus-5-claudecode-generic_rep1"
+             / "AI_READI_provenance.yaml")
+        if not p.exists():
+            self.skipTest("record not present in this checkout")
+        block = yaml.safe_load(p.read_text(encoding="utf-8"))["pair_consistency"]
+        self.assertTrue(block["schema_moved"])
+        self.assertTrue(block["consistent"])


### PR DESCRIPTION
Investigating #550 found the defect in the check I shipped, not in the corpus.

## What was wrong

`validate_pair_data` takes a `schema_moved` flag. #520 added it for exactly this
case: a slot added to `CoreDataset` after a pair was written is absent from that
pair **because it could not have been present**. With the flag, presence
divergence is a warning; content disagreement stays an error, because two
records asserting different values for one slot were wrong when written and no
schema change excuses that.

Neither `api_runner.pair_consistency` nor `backfill_checks.compute` passed it.
For a fresh run that is harmless — the run just consumed the current schema —
but the backfill exists precisely to check old pairs, and **92 of 188 predate
the current digest**.

The module's own docstring had already said what would happen:

> Adding `related_datasets` to core made 70 historical pairs report this, all
> correctly and none actionably; back-filling them would have made a 2026-07-28
> record assert content no run of that date produced.

## This reverses the correction I made in #557

| | with the guard | without (what I reported) |
|---|---|---|
| 2026-08-11 agentic | **0 divergent of 15** | 13 of 15 |
| 2026-08-13 API v4 | **11 divergent of 12** | 11 of 12 |

So the original figures were right and my retraction was wrong. I have corrected
#550 and #549 accordingly.

**The guard does not favour the agentic arm**: all 15 agentic and all 12 v4
pairs predate the current schema, so it applies to both. The v4 failures survive
it because they are content divergence — `$.acquisition_methods`,
`$.informed_consent`, `$.instances` — not presence artifacts.

Corpus-wide: 108 → 94 divergent, and what remains is dominated by series that
predate the pair checker entirely.

## Changes

- both call sites compute `pair_predates_current_schema` rather than defaulting
  the flag
- the recorded block carries `schema_moved`, so a reader can tell which reading
  a verdict used — without it the two readings are indistinguishable in the
  record, which is how this survived review
- 192 records re-backfilled
- `test_backfill_checks.CorpusTest.test_the_agentic_arm_is_not_clean` replaced
  by its opposite, with the reversal named in the docstring rather than quietly
  swapped

Suite: 2020 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)