### PR TITLE
Give both agentic entry points one copy of the uniform rules (#563)

### DIFF
--- a/.claude/agents/d4d-provenance-guard.md
+++ b/.claude/agents/d4d-provenance-guard.md
@@ -8,6 +8,13 @@ model: inherit
 color: yellow
 ---
 
+
+> **The uniform decision rules are in `.claude/commands/d4d-uniform-rules.md`.**
+> Read them with this file. The evidence boundary and the rule that an
+> identifier must come from the evidence are the same principle applied to two
+> kinds of value, and enforcing one without the other is how a run supplied
+> correct RORs its bundle never stated (#547, #563).
+
 # D4D Provenance Guard
 
 Apply this policy to every D4D generation run, regardless of whether the runtime

--- a/.claude/commands/d4d-agent.md
+++ b/.claude/commands/d4d-agent.md
@@ -8,8 +8,19 @@ approach.
 > full D4D, audits both against current sources in Phase 3, and performs strict
 > schema-derived full/core reconciliation in Phase 4.
 
-Before generation, read and enforce
-`.claude/agents/d4d-provenance-guard.md`.
+Before generation, read and enforce **both**:
+
+- `.claude/agents/d4d-provenance-guard.md` — the evidence boundary;
+- `.claude/commands/d4d-uniform-rules.md` — the uniform decision rules that
+  apply to every condition, every project and both runtimes.
+
+The rules are not restated here. Until #563 they lived only in
+`d4d-full-core.md`, so a run entered through this command — which is a complete
+standalone method for full records — followed none of them: not
+omission-over-inference, not identifier-from-evidence, not CURIE form. Every
+record in the corpus happens to have been generated through `/d4d-full-core`,
+which reads them and delegates extraction here, so nothing on disk is affected.
+The gap was in what this file permitted, not in what it produced.
 
 ## Task Overview
 

--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -443,7 +443,12 @@ identical slot and proves consistency across the pair.
    from data_sheets_schema.identifiers import uriorcurie_slots
    r = check_run(Path('<full_file>'), Path('<core_file>'), Path('<bundle>'),
                  uriorcurie_slots())
-   print(r['distinct']); [print(f) for f in r['findings']]"
+   if not r.get('checked'):
+       print('NOT CHECKED:', r['reason'])
+   else:
+       print(r['distinct'])
+       for f in {(x['kind'], x['identifier']) for x in r['findings']}:
+           print(*f)"
    ```
    Any identifier reported `absent` is one this record states and the bundle
    does not (#547). Correct it or remove it — a correct identifier the evidence
@@ -462,6 +467,10 @@ identical slot and proves consistency across the pair.
    out = check_report(Path('<report_file>'), full, core, declared_slots())
    [print(f) for f in out['findings']]"
    ```
+   Findings are printed once per identifier, not once per slot that repeats
+   it: VOICE rep1 has 19 ungrounded identifiers across 78 occurrences, and the
+   number to act on is 19.
+
    `removal_not_performed` means the report says a slot was removed and it is
    still there; `false_schema_claim` means the report says a slot is not
    declared and it is. Both are decidable, and in the 2026-08-13 API arm every

--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -201,75 +201,9 @@ the record; do not create new ones.
 
 ### Uniform decision rules (all conditions, all projects)
 
-These are part of the method rather than tuning, because each applies identically
-to every project. Enforce them whether or not a prompt file was used to launch:
-
-- Populate a slot only where the declared bundle supports it. **Prefer omission
-  over inference:** an absent slot is a correct answer when the evidence is
-  absent, and a plausible guess is not.
-- Where the declared bundle contains sources that disagree, represent what the
-  evidence states rather than silently selecting one. Do not merge distinct
-  entities into a single claim.
-- `Dataset` admits one referent. Choose the one the declared bundle best
-  supports, state that choice in the reconciliation report, and hold to it
-  consistently across both records.
-- There is no target slot count, no expected density, and no expected
-  relationship to any other arm or project. Apply your own judgment about what
-  the evidence supports.
-- **Write an identifier as a CURIE wherever a declared prefix exists, not as a
-  URL.** `ROR:01an7q238`, not `https://ror.org/01an7q238`; `ORCID:0000-0002-…`,
-  not the orcid.org URL; `doi:10.13026/…`, not `https://doi.org/…`. The two
-  expand to the same IRI, and the CURIE says which namespace the identifier
-  belongs to instead of leaving a reader to infer it from a hostname.
-
-  **Where no prefix is declared, a resolvable URL is the correct answer and an
-  invented prefix is not.** Do not mint `b2ai-voice:` or similar to satisfy
-  this rule — the schema's declared prefixes are the whole list, and a CURIE on
-  an undeclared prefix resolves to nothing while the URL at least resolves
-  (#531). Check the schema's `prefixes:` block rather than guessing.
-
-  This applies to identifier slots — those whose declared range is
-  `uriorcurie` — and never to prose. A URL inside a sentence or a citation is
-  text, not an identifier, and must be left exactly as written.
-
-- **An identifier is a fact and comes from the evidence.** Take it from the
-  declared bundle or omit it; do not supply an identifier you recognise but the
-  bundle does not state. A correct identifier the evidence does not contain is
-  still an unsupported claim, and to a reader who was not present it is
-  indistinguishable from a wrong one. Naming an organisation the bundle names is
-  grounded; adding that organisation's ROR from your own knowledge is not — the
-  2026-08-13 arm did exactly this, supplying RORs for institutions the bundle
-  names only in prose (#547). `grounding.absent` in the provenance record counts
-  them.
-
-- **Where something needs an identifier and the bundle supplies none, hang it
-  off one the bundle does supply** — a fragment on the identifier of the thing
-  it is part of, `doi:10.60775/fairhub.3#split-train`, rather than a new
-  namespace (#531). A person is identified by an ORCID and an organisation by a
-  ROR; **a fragment appended to an organisation's ROR does not identify a
-  person**, it asserts something false about that organisation.
-
-- **Write generated prose in American English** — `program`, `organization`,
-  `analyze`, `license`, `center`, `labeling`, `enrollment`. This is house style
-  for the text *you* compose, and it applies to identifiers you mint as well as
-  to descriptions.
-
-  Three carve-outs, and they are not optional:
-
-  - **Quoted source text keeps its original spelling.** Changing a quotation to
-    match house style corrupts evidence, which is the one thing the provenance
-    guard exists to prevent. The bundles contain `licence` 13 times and
-    `programme` 6.
-  - **Proper nouns keep their spelling** — "Wellcome Trust Sanger Centre",
-    "Medical Research Council Programme Grant". A name is not prose.
-  - **Identifiers copied from a source keep the source's spelling.** An id you
-    take from a crate or a DOI is a token, not a sentence. Only ids *you* mint
-    follow house style.
-
-The rule about there being no target slot count is the load-bearing one: it is
-what makes a slot count an observation rather than a target. Named rather than
-referred to by position, so inserting a rule cannot silently point this sentence
-at a different one.
+**Read `.claude/commands/d4d-uniform-rules.md` and enforce every rule in it.**
+It is the single copy; this section deliberately does not restate them, because
+a second copy is what #563 was filed about.
 
 ### Recording the condition
 
@@ -498,8 +432,42 @@ identical slot and proves consistency across the pair.
    ```
    Validator warnings mark related content that still requires the semantic
    review in step 4; warnings are not evidence that review occurred.
-6. Re-run schema and term validation for both records.
-7. Write `{PROJECT}_reconciliation.md` with separate Phase 3 and Phase 4
+6. **Check the identifiers against the bundle, and the report against the
+   record.** The API path runs both automatically at the end of every run; this
+   path ran neither, so the arm that reads the rules was the arm that did not
+   verify them (#563).
+   ```bash
+   poetry run python -c "
+   from pathlib import Path
+   from data_sheets_schema.grounding import check_run
+   from data_sheets_schema.identifiers import uriorcurie_slots
+   r = check_run(Path('<full_file>'), Path('<core_file>'), Path('<bundle>'),
+                 uriorcurie_slots())
+   print(r['distinct']); [print(f) for f in r['findings']]"
+   ```
+   Any identifier reported `absent` is one this record states and the bundle
+   does not (#547). Correct it or remove it — a correct identifier the evidence
+   does not contain is still an unsupported claim. `minted_fragment` is fine:
+   the base is attested and the fragment is ours.
+
+   After writing the reconciliation report in step 8, check its claims against
+   the record you actually produced:
+   ```bash
+   poetry run python -c "
+   from pathlib import Path
+   from data_sheets_schema.report_claims import check_report, declared_slots
+   import yaml
+   full = yaml.safe_load(Path('<full_file>').read_text())
+   core = yaml.safe_load(Path('<core_file>').read_text())
+   out = check_report(Path('<report_file>'), full, core, declared_slots())
+   [print(f) for f in out['findings']]"
+   ```
+   `removal_not_performed` means the report says a slot was removed and it is
+   still there; `false_schema_claim` means the report says a slot is not
+   declared and it is. Both are decidable, and in the 2026-08-13 API arm every
+   record that emitted a `distributions` block claimed to have removed it (#546).
+7. Re-run schema and term validation for both records.
+8. Write `{PROJECT}_reconciliation.md` with separate Phase 3 and Phase 4
    sections: source/provenance findings, schema-derived shared-slot count,
    corrections, related-content mapping and review, files changed, all commands,
    and final results. If nothing diverged, say so explicitly.

--- a/.claude/commands/d4d-uniform-rules.md
+++ b/.claude/commands/d4d-uniform-rules.md
@@ -1,0 +1,86 @@
+# Uniform decision rules (all conditions, all projects, both runtimes)
+
+**This file is the single copy.** It was extracted from
+`.claude/commands/d4d-full-core.md` because the rules lived there and nowhere
+else, so `/d4d-agent` — a standalone entry point that generates full records —
+ran under none of them (#563). That is the same duplication defect as #518,
+#521 and #545, one level further out: a list of content maintained by hand in
+several places diverges the moment one copy is edited.
+
+Every playbook that generates a record reads this file. The condition prompts
+carry the same rules in their own words, because a prompt is sent to a model
+that cannot open files; `tests/test_playbook_reach.py` checks that
+correspondence in both directions.
+
+Enforce these whether or not a prompt file was used to launch.
+
+
+These are part of the method rather than tuning, because each applies identically
+to every project:
+
+- Populate a slot only where the declared bundle supports it. **Prefer omission
+  over inference:** an absent slot is a correct answer when the evidence is
+  absent, and a plausible guess is not.
+- Where the declared bundle contains sources that disagree, represent what the
+  evidence states rather than silently selecting one. Do not merge distinct
+  entities into a single claim.
+- `Dataset` admits one referent. Choose the one the declared bundle best
+  supports, state that choice in the reconciliation report, and hold to it
+  consistently across both records.
+- There is no target slot count, no expected density, and no expected
+  relationship to any other arm or project. Apply your own judgment about what
+  the evidence supports.
+- **Write an identifier as a CURIE wherever a declared prefix exists, not as a
+  URL.** `ROR:01an7q238`, not `https://ror.org/01an7q238`; `ORCID:0000-0002-…`,
+  not the orcid.org URL; `doi:10.13026/…`, not `https://doi.org/…`. The two
+  expand to the same IRI, and the CURIE says which namespace the identifier
+  belongs to instead of leaving a reader to infer it from a hostname.
+
+  **Where no prefix is declared, a resolvable URL is the correct answer and an
+  invented prefix is not.** Do not mint `b2ai-voice:` or similar to satisfy
+  this rule — the schema's declared prefixes are the whole list, and a CURIE on
+  an undeclared prefix resolves to nothing while the URL at least resolves
+  (#531). Check the schema's `prefixes:` block rather than guessing.
+
+  This applies to identifier slots — those whose declared range is
+  `uriorcurie` — and never to prose. A URL inside a sentence or a citation is
+  text, not an identifier, and must be left exactly as written.
+
+- **An identifier is a fact and comes from the evidence.** Take it from the
+  declared bundle or omit it; do not supply an identifier you recognise but the
+  bundle does not state. A correct identifier the evidence does not contain is
+  still an unsupported claim, and to a reader who was not present it is
+  indistinguishable from a wrong one. Naming an organisation the bundle names is
+  grounded; adding that organisation's ROR from your own knowledge is not — the
+  2026-08-13 arm did exactly this, supplying RORs for institutions the bundle
+  names only in prose (#547). `grounding.absent` in the provenance record counts
+  them.
+
+- **Where something needs an identifier and the bundle supplies none, hang it
+  off one the bundle does supply** — a fragment on the identifier of the thing
+  it is part of, `doi:10.60775/fairhub.3#split-train`, rather than a new
+  namespace (#531). A person is identified by an ORCID and an organisation by a
+  ROR; **a fragment appended to an organisation's ROR does not identify a
+  person**, it asserts something false about that organisation.
+
+- **Write generated prose in American English** — `program`, `organization`,
+  `analyze`, `license`, `center`, `labeling`, `enrollment`. This is house style
+  for the text *you* compose, and it applies to identifiers you mint as well as
+  to descriptions.
+
+  Three carve-outs, and they are not optional:
+
+  - **Quoted source text keeps its original spelling.** Changing a quotation to
+    match house style corrupts evidence, which is the one thing the provenance
+    guard exists to prevent. The bundles contain `licence` 13 times and
+    `programme` 6.
+  - **Proper nouns keep their spelling** — "Wellcome Trust Sanger Centre",
+    "Medical Research Council Programme Grant". A name is not prose.
+  - **Identifiers copied from a source keep the source's spelling.** An id you
+    take from a crate or a DOI is a token, not a sentence. Only ids *you* mint
+    follow house style.
+
+The rule about there being no target slot count is the load-bearing one: it is
+what makes a slot count an observation rather than a target. Named rather than
+referred to by position, so inserting a rule cannot silently point this sentence
+at a different one.

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -129,6 +129,11 @@ AGENT_PLAYBOOKS = (
     Path(".claude/commands/d4d-full-core.md"),
     Path(".claude/commands/d4d-agent.md"),
     Path(".claude/agents/d4d-provenance-guard.md"),
+    # The uniform decision rules, extracted from d4d-full-core.md so that both
+    # entry points read one copy (#563). Hashed like the rest: it is now where
+    # the rules live, so a record that did not hash it could not show which
+    # rules it followed.
+    Path(".claude/commands/d4d-uniform-rules.md"),
 )
 
 

--- a/tests/test_american_english_rule.py
+++ b/tests/test_american_english_rule.py
@@ -13,7 +13,9 @@ import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-PLAYBOOK = ROOT / ".claude/commands/d4d-full-core.md"
+#: The rules live in one file since #563; before that they were inside
+#: d4d-full-core.md, where /d4d-agent could not see them.
+PLAYBOOK = ROOT / ".claude/commands/d4d-uniform-rules.md"
 PROMPTS = ROOT / "src/download/prompts"
 
 
@@ -28,9 +30,10 @@ class TestTheRuleIsStated(unittest.TestCase):
     def test_it_sits_among_the_uniform_decision_rules(self):
         """Not in a section a run might skip. The uniform rules are the ones
         the playbook says to enforce whether or not a prompt file was used."""
+        # The rules are a file of their own since #563, so the section is the
+        # file below its heading rather than a span between two headings.
         start = self.text.index("Uniform decision rules")
-        end = self.text.index("### Recording the condition")
-        self.assertIn("American English", self.text[start:end])
+        self.assertIn("American English", self.text[start:])
 
     def test_the_three_carve_outs_are_present(self):
         """Without them the rule instructs a run to corrupt evidence — the

--- a/tests/test_cli/test_prompt_condition_consistency.py
+++ b/tests/test_cli/test_prompt_condition_consistency.py
@@ -128,7 +128,11 @@ class TestPlaybooksAreNotFabricatedForOldRuns(unittest.TestCase):
         if not self.BUNDLE.exists():
             self.skipTest("bundles not present")
         d = self._record("live", input_bundle=self.BUNDLE, input_verified=True)
-        self.assertEqual(3, len(d["playbooks"]["files"]))
+        # Derived, not restated: a literal 3 broke when #563 made the uniform
+        # rules a fourth playbook, failing a test about fabrication for a
+        # reason that had nothing to do with fabrication.
+        from data_sheets_schema.provenance import AGENT_PLAYBOOKS
+        self.assertEqual(len(AGENT_PLAYBOOKS), len(d["playbooks"]["files"]))
 
     def test_a_reconstructed_record_does_not(self):
         d = self._record("reconstructed")

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -20,7 +20,9 @@ from data_sheets_schema.provenance import (AGENT_PLAYBOOKS, playbook_facts,
                                            runtime_reads_playbooks)
 
 ROOT = Path(__file__).resolve().parents[1]
-PLAYBOOK = ROOT / ".claude/commands/d4d-full-core.md"
+#: The rules live in one file since #563; before that they were inside
+#: d4d-full-core.md, where /d4d-agent could not see them.
+PLAYBOOK = ROOT / ".claude/commands/d4d-uniform-rules.md"
 PROMPTS = ROOT / "src/download/prompts"
 
 
@@ -139,8 +141,8 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
         catches an addition, and the table above is what says where it reaches.
         """
         text = PLAYBOOK.read_text(encoding="utf-8")
-        block = text[text.index("### Uniform decision rules"):
-                     text.index("### Recording the condition")]
+        # The whole file below its heading, since #563 made the rules a file.
+        block = text[text.index("# Uniform decision rules"):]
         bullets = re.findall(r"^- (.+?)(?=\n- |\n\n)", block, re.S | re.M)
         self.assertEqual(
             len(bullets), len(self.SHARED_RULES) + len(self.PLAYBOOK_ONLY),
@@ -165,6 +167,45 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
             "--- END ADDED IN v5 ---", 1)[0]
         self.assertIn("American English", block)
         self.assertIn("CURIE", block)
+
+    def test_every_hashed_playbook_reaches_the_rules(self):
+        """The blind spot #563 was filed for.
+
+        This guard only ever opened `d4d-full-core.md`. The rules lived there
+        and nowhere else, so `/d4d-agent` — a standalone entry point producing
+        full records — ran under none of them, and the file that could silently
+        diverge was the one nothing checked.
+
+        Now every playbook a record hashes must either state the rules or name
+        the file that does. Reading `AGENT_PLAYBOOKS` rather than a list here,
+        so a fifth playbook arrives already covered.
+        """
+        from data_sheets_schema.provenance import AGENT_PLAYBOOKS
+        rules_file = PLAYBOOK.name
+        missing = []
+        for rel in AGENT_PLAYBOOKS:
+            path = ROOT / rel
+            if path.name == rules_file:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if rules_file not in text:
+                missing.append(str(rel))
+        self.assertEqual(missing, [],
+                         "a hashed playbook neither states the uniform rules "
+                         f"nor points at {rules_file}")
+
+    def test_the_rules_are_not_restated_anywhere_else(self):
+        """One copy, or the extraction bought nothing.
+
+        A pointer that sits beside a stale duplicate is worse than either alone:
+        two sources of truth and no signal about which is current.
+        """
+        from data_sheets_schema.provenance import AGENT_PLAYBOOKS
+        probe = "no target slot count"
+        holders = [str(rel) for rel in AGENT_PLAYBOOKS
+                   if probe in (ROOT / rel).read_text(encoding="utf-8")]
+        self.assertEqual(holders, [str(p) for p in AGENT_PLAYBOOKS
+                                   if p.name == PLAYBOOK.name])
 
     def test_the_new_v5_rules_reached_the_playbook_too(self):
         """The mirror direction, which nothing checked before.


### PR DESCRIPTION
Closes #563.

## The gap

The uniform decision rules lived in `d4d-full-core.md` and nowhere else.
`/d4d-agent` is a **standalone entry point that produces full records**, and it
carried none of them — grepping it for all eight returns zero.

Nothing on disk is affected: every record in the corpus was generated through
`/d4d-full-core`, which holds the rules and delegates extraction to
`d4d-agent.md`. The gap was in what that file permitted, not in what it
produced. It would have mattered the first time someone ran `/d4d-agent`
directly for a v5 record.

## One copy, named by everything that needs it

Extracted to `.claude/commands/d4d-uniform-rules.md`. Both entry points and the
provenance guard now point at it and none restates it — a fourth hand-kept copy
is the defect, and this is #518 / #521 / #545 one level further out.

Hashed like the other playbooks, because it is now where the rules live and a
record that did not hash it could not show which rules it followed. Records made
after this hash four files rather than three.

## The guard had the same blind spot

`test_playbook_reach` only ever opened `d4d-full-core.md` — so the file that
could silently diverge was precisely the one nothing checked. It now reads
`AGENT_PLAYBOOKS` and requires every hashed playbook to state the rules or name
the file that does, so a fifth playbook arrives already covered.

A second test asserts the rules are restated nowhere else. A pointer sitting
beside a stale duplicate is worse than either alone: two sources of truth and no
signal about which is current.

## Phase 4 now runs the checks the API path already runs

The agentic phase 4 ran `d4d_pair_consistency` and nothing else. The grounding
check (#547) and report check (#546) run automatically on every API run and not
at all here — so the arm that reads the rules was the arm that did not verify
them. Both are now steps 6 and 7, with what each finding means and what to do
about it.

## One unrelated fixture

`test_prompt_condition_consistency` asserted a literal `3` playbooks, so a test
about *fabricated* playbooks failed for a reason having nothing to do with
fabrication. Derived from `AGENT_PLAYBOOKS` now.

Suite: 2022 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)