### PR TITLE
Let a fact the core phase found reach the full record (#566)

### DIFF
--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -43,6 +43,40 @@ Stated so they can be wrong.
    arm.** This is the parity fix's own test. If the agentic arm moves, something
    other than the rule moved with it.
 
+## Measured v4 baselines
+
+Taken 2026-08-15 from the 12 records of `2026-08-13_claude-opus-5-api-generic-v4`,
+before any v5 run. Predictions above are unfalsifiable without them.
+
+| quantity | v4 baseline | which prediction |
+|---|---|---|
+| ungrounded external identifiers (distinct) | 19 in VOICE rep1, 10 in CM4AI rep3, 0 in the other ten | 1 |
+| minted fragments on an attested base (distinct) | 17 / 12 / 14 in AI_READI rep1, CM4AI rep1, VOICE rep3; 0 elsewhere | 2 |
+| person fragments on an organisational ROR (distinct) | 7 in VOICE rep1, 0 elsewhere | 3 |
+| undeclared CURIE prefixes (occurrences) | **370** — `chorus:` 226, `cm4ai:` 86, `urn:` 41, `ark:` 9, `nih:` 8 | 4 |
+| identifier slots holding a URL | **397** — `b2ai-voice.org` 302, `chorus4ai.org` 38, `reporter.nih.gov` 18, `fairhub.io` 16 | 4 |
+| British spellings in record prose | **627** — `licence` 199, `analyse` 85, `organisation` 81, `enrolment` 71, `programme` 67 | 5 |
+| full/core pairs diverging on content | 11 of 12 | regression watch |
+
+Two notes on how these were counted, because both were got wrong once:
+
+- **Distinct identifiers, not occurrences.** Every identifier appears in both
+  records of a pair, so an occurrence count is exactly double and reads as twice
+  the problem (#556).
+- **`B2AI_TOPIC` and `B2AI_SUBSTRATE` are declared prefixes**, not invented ones.
+  Counting them among the undeclared put 192 legitimate values in the defect
+  column on the first pass.
+
+The 397 URL-valued slots are not all defects under the v4 rules: the playbook in
+force for that arm said a resolvable URL is correct where no prefix is declared.
+They are a baseline for v5's rule 3, which redirects them onto attested
+identifiers, not evidence that v4 broke its own rule.
+
+British spellings were checked to be in generated prose rather than only in
+quoted titles — "prohibited by section 3.F of the licence", "is a custom licence
+tailored to" — so the rule's carve-out for quoted material does not account for
+them.
+
 ## What would falsify the block rather than confirm it
 
 - `absent` falls but total external identifiers falls further — the model

--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -90,6 +90,19 @@ them.
   the corpus already diverges (#550). This is a regression watch, not a
   prediction.
 
+## The canary is AI-READI, not CHORUS
+
+The v4 arm canaried CHORUS, whose `reconcile_full` request is 52k tokens against
+AI-READI's 249k. #566 adds the core record to that phase, taking the largest
+request to roughly 279k, and the corpus does not record what context ceiling was
+in force — the model is named `claude-opus-5` with no `[1m]` suffix and the
+249k requests nonetheless succeeded.
+
+So the canary must be **AI-READI**, and it must be verified to have completed
+`reconcile_full`, not merely to have started. A CHORUS canary exercises
+credentials, persistence, the run lock and every gate, and says nothing about
+the one thing this arm changed that could fail. See #568.
+
 ## What this plan does not license
 
 Comparing v5 against anything other than v4. Every earlier arm sits at a

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -483,7 +483,8 @@ PHASE_INSTRUCTIONS = {
         "evidence boundary. Report, as a JSON object with keys `findings` (a "
         "list of {severity, record, slot, issue}) and `summary`: any slot whose "
         "value the bundle does not support, any omission the bundle clearly "
-        "supports, any internal inconsistency, and any value whose shape does "
+        "supports, any content the core record states that the full record "
+        "does not, any internal inconsistency, and any value whose shape does "
         "not conform to the schema digest supplied above — prose where the "
         "schema requires a list, enum values the schema does not define, or "
         "source commentary embedded inside a name, identifier or affiliation "
@@ -491,6 +492,12 @@ PHASE_INSTRUCTIONS = {
     "reconcile_full": (
         "Phase 4a. Apply the audit findings that concern the FULL record and "
         "emit the corrected full record in its entirety, header block included. "
+        "The core record is supplied above: anything it states that the full "
+        "record does not, absorb into the full record, in the slot that fits "
+        "it. The core record is a projection of the full one and cannot "
+        "outrank it, so a fact reaching only core is a fact the full record "
+        "lost. Absorb the content, not the wording — put it where the schema "
+        "says it belongs, which may not be where core put it. "
         "Every value you write or change must conform to the schema digest "
         "supplied above — a repair that fixes evidence but breaks shape is "
         "still a defect. If no finding requires a change, emit it unchanged. "
@@ -523,7 +530,14 @@ PHASE_NEEDS = {
     "full": (),
     "core": ("Completed full record",),
     "audit": ("Completed full record", "Completed core record"),
-    "reconcile_full": ("Completed full record", "Audit findings"),
+    # The core record too (#566). Without it there was no path by which a fact
+    # the core phase found in the bundle could reach the full record, and 10 of
+    # the 12 v4 records ended with core-only prose the full record lacks —
+    # 25,417 characters, including AI-READI's recommended train/validation/test
+    # split and CHORUS's holdout test set. The full record is the comprehensive
+    # one; a reader of it never saw them.
+    "reconcile_full": ("Completed full record", "Completed core record",
+                       "Audit findings"),
     "reconcile_core": ("Reconciled full record", "Completed core record", "Audit findings"),
     "report": ("Audit findings",),
 }

--- a/tests/test_pair_gate.py
+++ b/tests/test_pair_gate.py
@@ -276,3 +276,62 @@ class SchemaMovedTest(unittest.TestCase):
         block = yaml.safe_load(p.read_text(encoding="utf-8"))["pair_consistency"]
         self.assertTrue(block["schema_moved"])
         self.assertTrue(block["consistent"])
+
+
+class ReconcileFullSeesCoreTest(unittest.TestCase):
+    """A fact the core phase found must have a path back into full (#566).
+
+    `reconcile_full` used to receive only the full record and the audit
+    findings. The core phase gets the bundle, so it finds material the full
+    phase missed — and with no path back, that material stopped in core. Across
+    the v4 arm, 10 of 12 records ended with core-only prose the full record
+    lacks, 25,417 characters of it, including AI-READI's recommended
+    train/validation/test split and CHORUS's holdout test set.
+
+    The full record is the comprehensive one. A reader of it never saw them.
+    """
+
+    def _spec(self):
+        from data_sheets_schema.api_runner import RunSpec
+        return RunSpec(
+            project="CHORUS", arm="baseline", method="claudecode_agent",
+            bundle=Path("data/preprocessed/concatenated/CHORUS_preprocessed.txt"),
+            label="test", condition="generic_v5")
+
+    def test_the_core_record_is_carried_into_reconcile_full(self):
+        import dataclasses
+
+        from data_sheets_schema.api_runner import PHASE_NEEDS, build_phase
+        self.assertIn("Completed core record", PHASE_NEEDS["reconcile_full"])
+        req = build_phase(self._spec(), "reconcile_full", carry={
+            "Completed full record": "FULL-MARKER",
+            "Completed core record": "CORE-MARKER",
+            "Audit findings": "AUDIT-MARKER"})
+        blob = str(dataclasses.asdict(req))
+        for marker in ("FULL-MARKER", "CORE-MARKER", "AUDIT-MARKER"):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, blob)
+
+    def test_the_instruction_says_what_to_do_with_it(self):
+        """Carrying the record without saying why would leave the model to
+        guess, and the guess that matches the old behaviour is to ignore it."""
+        from data_sheets_schema.api_runner import PHASE_INSTRUCTIONS
+        text = PHASE_INSTRUCTIONS["reconcile_full"]
+        self.assertIn("absorb into the full record", text)
+        self.assertIn("cannot outrank it", text)
+
+    def test_the_audit_is_told_to_look_for_it_too(self):
+        """The audit already reads both records, so it is the cheapest place to
+        catch a recurrence — and it is the phase that should have caught this."""
+        from data_sheets_schema.api_runner import PHASE_INSTRUCTIONS
+        self.assertIn("core record states that the full record does not",
+                      PHASE_INSTRUCTIONS["audit"])
+
+    def test_the_change_is_attestable(self):
+        """`assembly_digest` covers the phase instructions and their order
+        (#353), so this moves without a prompt pin rotation — and a v4 record
+        and a v5 record are distinguishable by it.
+        """
+        from data_sheets_schema.api_runner import assembly_digest
+        self.assertNotEqual(assembly_digest()["sha256"][:16], "77331f08a663e5b9",
+                            "the digest the 2026-08-13 v4 arm recorded")


### PR DESCRIPTION
Closes #566. Found analysing the v4 arm before v5, and it is the most
consequential thing that analysis turned up.

## The full record is missing facts the core record has

AI-READI rep3's **core** record states, and its **full** record does not:

> Version 3.0.0 ships a recommended split into training, validation and testing
> partitions in proportions of 70%, 15% and 15% (1,576 / 352 / 352
> participants), distributed in the participants.tsv file.

along with the balancing statistics (mean age by partition, race/ethnicity, sex
and diabetes-status counts), the 200 USD participant stipend and its payment
terms, and the biospecimen collection. CHORUS rep1's core record carries the
holdout test set — the dataset's most distinctive structural feature — that its
full record lacks.

**10 of 12 records, 25,417 characters.** Classifying all 66 content
divergences: 28 paraphrase, **19 where full is a truncation of core**, 17
materially different, 2 where core truncates full, 1 whitespace.

## The cause is wiring, not judgement

```
core            <- Completed full record
audit           <- Completed full record, Completed core record
reconcile_full  <- Completed full record, Audit findings      <-- no core
reconcile_core  <- Reconciled full record, Completed core record, Audit findings
```

The core phase reads the bundle, so it finds material the full phase missed.
`reconcile_full` never saw the core record, so there was no path back.
Meanwhile `reconcile_core` is told core "must assert nothing the full record
does not support" — by the pipeline's own rule those 25,417 characters are a
violation in 10 of 12 records, and nothing checked it until #544.

## Three changes, composing

1. `reconcile_full` receives the core record.
2. Its instruction says what to do with it: absorb what core states and full
   does not, into the slot the schema says it belongs in — core is a projection
   and cannot outrank the record it projects. Carrying it silently would leave
   the model to guess, and the guess matching the old behaviour is to ignore it.
3. The audit is told that content in core and absent from full is a finding. It
   already reads both records, so it is the cheapest place to catch a
   recurrence — and it is the phase that should have caught this one. Its
   existing clauses ask what the *bundle* supports, and core-only facts are
   bundle-supported, so they tripped nothing.

**No pin rotation.** `assembly_digest` covers the phase instructions and their
order (#353), so this moves `77331f08` → `b47c4c6d` and a v4 record stays
distinguishable from a v5 one.

## Also: the v5 plan now has measured baselines

Its predictions were unfalsifiable without them.

| quantity | v4 baseline |
|---|---|
| undeclared CURIE prefixes | **370** (`chorus:` 226, `cm4ai:` 86, `urn:` 41) |
| identifier slots holding a URL | **397** (`b2ai-voice.org` 302) |
| British spellings in prose | **627** (`licence` 199, `analyse` 85) |
| ungrounded identifiers | 19 VOICE rep1, 10 CM4AI rep3, 0 elsewhere |
| person fragments on an org ROR | 7 VOICE rep1 |

Counted distinct rather than by occurrence, and with `B2AI_TOPIC` /
`B2AI_SUBSTRATE` excluded as declared prefixes — both were got wrong on a first
pass, and the note records why.

Suite: 2026 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)