### PR TITLE
Record the context a run used, and correct my own risk assessment (#568)

### DIFF
--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 45055
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-29_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_canary_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_canary_rep1/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 47612
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_canary_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_canary_rep1/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 201809
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 45203
+    peak_phase: audit
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 197690
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 206575
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 216406
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 49935
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 194289
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 211794
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 46350
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 196789
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 210273
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 206490
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 38745
+    peak_phase: reconcile_full
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep1/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 48078
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 173511
+    peak_phase: reconcile_full
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep2/CM4AI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 205909
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 36202
+    peak_phase: reconcile_full
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/VOICE_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-07-31_claude-opus-5-generic-v2_rep3/VOICE_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 205596
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep1/CHORUS_provenance.yaml
@@ -25,6 +25,13 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 47068
+    peak_phase: audit
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep1/CHORUS_provenance.yaml
@@ -32,6 +32,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep2/CHORUS_provenance.yaml
@@ -25,6 +25,13 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 46526
+    peak_phase: audit
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep2/CHORUS_provenance.yaml
@@ -32,6 +32,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep3/CHORUS_provenance.yaml
@@ -25,6 +25,13 @@ model:
     report: 12000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 45064
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-02_claude-opus-5-bare_rep3/CHORUS_provenance.yaml
@@ -32,6 +32,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 213912
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 53223
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep1/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep2/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep2/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 207727
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep3/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-1m-generic-v3_rep3/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 205697
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 210548
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 51959
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-05_claude-opus-5-generic-v3_rep1/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 233153
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep1/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 53870
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 227088
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep2/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 57898
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 221102
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-06_claude-opus-5-1m-generic-v3-schema2_rep3/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 53049
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 221392
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-11_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 55748
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 285113
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 64209
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CM4AI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/CM4AI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 205764
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/VOICE_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep1/VOICE_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 227203
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 273465
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 60055
+    peak_phase: audit
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CM4AI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/CM4AI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 203780
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/VOICE_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep2/VOICE_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 229140
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/AI_READI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 272299
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/AI_READI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 61301
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CM4AI_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/CM4AI_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 202968
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/VOICE_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic-v4_rep3/VOICE_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 227335
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -34,6 +34,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_core/2026-08-13_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -27,6 +27,13 @@ model:
     report: 24000
   temperature: null
   temperature_basis: not applicable to this model
+  context:
+    peak_request_tokens: 64600
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 67009
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 244930
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 359552
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 68427
+    peak_phase: audit
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/CM4AI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 252837
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 363261
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 41711
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 96946
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/CM4AI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 198899
+    peak_phase: audit
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep1/VOICE_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 42276
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 99877
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/CM4AI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 201408
+    peak_phase: audit
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep2/VOICE_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 38076
+    peak_phase: audit
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/CHORUS_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 190551
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_crate_only_core/2026-07-31_claude-opus-5-api-generic_rep3/VOICE_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 61713
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep1/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 53210
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep2/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
@@ -28,6 +28,13 @@ model:
   reasoning_effort: high
   reasoning_effort_basis: read from the model route; the provider exposes effort as
     a model-name suffix, not a parameter
+  context:
+    peak_request_tokens: 52074
+    peak_phase: reconcile_core
+    peak_basis: 'observed: input + cache_read + cache_write of the largest request'
+    limit_tokens: null
+    limit_basis: not stated by the route and not returned by the provider; headroom
+      cannot be computed from this record
 prompts:
   hash_algorithm: sha256
   files:

--- a/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
+++ b/data/d4d_concatenated/claudecode_agent_healthsheet_core/2026-07-31_claude-opus-5-api-generic_rep3/AI_READI_provenance.yaml
@@ -35,6 +35,7 @@ model:
     limit_tokens: null
     limit_basis: not stated by the route and not returned by the provider; headroom
       cannot be computed from this record
+    recorded_by: backfill_context
 prompts:
   hash_algorithm: sha256
   files:

--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -90,18 +90,31 @@ them.
   the corpus already diverges (#550). This is a regression watch, not a
   prediction.
 
-## The canary is AI-READI, not CHORUS
+## The canary is AI-READI, and the context risk is smaller than first stated
 
-The v4 arm canaried CHORUS, whose `reconcile_full` request is 52k tokens against
-AI-READI's 249k. #566 adds the core record to that phase, taking the largest
-request to roughly 279k, and the corpus does not record what context ceiling was
-in force — the model is named `claude-opus-5` with no `[1m]` suffix and the
-249k requests nonetheless succeeded.
-
-So the canary must be **AI-READI**, and it must be verified to have completed
-`reconcile_full`, not merely to have started. A CHORUS canary exercises
+The v4 arm canaried CHORUS, whose largest request is 64k tokens against
+AI-READI's 285k. #566 adds the core record to `reconcile_full`, so the canary
+must be **AI-READI** — the project that can actually fail — and it must be
+verified to have completed, not merely started. A CHORUS canary exercises
 credentials, persistence, the run lock and every gate, and says nothing about
-the one thing this arm changed that could fail. See #568.
+the one thing this arm changed that could break.
+
+**Two corrections to the first version of this section**, both from measuring
+rather than reasoning (#568):
+
+- The peak phase is `reconcile_core`, not `reconcile_full`. It receives the
+  reconciled full record, the core record and the audit findings, and it is the
+  largest request in 56 of 67 API runs; `reconcile_full` peaks in 3.
+- **The corpus has already sent 363,261 tokens successfully** — VOICE, rep3 of
+  the 2026-07-31 arm. AI-READI's v4 peak of 285,113 is well inside that, and
+  #566 raising `reconcile_full` toward ~279k puts it below a size this pipeline
+  has demonstrably handled. The risk is real but it is headroom-unknown, not
+  headroom-exceeded.
+
+Every API record now carries `model.context.peak_request_tokens`, so the next
+person answers this from the corpus instead of re-deriving it. The *limit*
+stays null and says why: no route states it and the provider does not return
+it, and a guess would make headroom computable and wrong.
 
 ## What this plan does not license
 

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1242,6 +1242,53 @@ def pair_consistency(spec: RunSpec) -> dict[str, Any] | None:
     }
 
 
+#: Context windows a model name states outright. The route is the only place
+#: this appears — CBORG returns no limit in its responses — so a name that does
+#: not carry one leaves the limit genuinely unknown (#568).
+CONTEXT_FROM_NAME = ((r"\[1m\]|-1m\b|:1m\b", 1_000_000),)
+
+
+def context_facts(model_name: str,
+                  usage: list[dict[str, Any]]) -> dict[str, Any]:
+    """What the run can honestly say about its context window (#568).
+
+    Two different claims, kept apart:
+
+    `peak_request_tokens` is **observed** — the largest request this run
+    actually sent, summing input, cache reads and cache writes, because cached
+    tokens occupy the window just as fresh ones do. It is what answers "did it
+    fit", and it is available whatever the model says about itself.
+
+    `limit_tokens` is the ceiling, and is usually **not knowable here**. The
+    v4 arm named `claude-opus-5` and sent a 249,015-token request that
+    succeeded, so the name understated the truth by at least a quarter. A guess
+    would be worse than the gap: it would make headroom computable and wrong.
+    Recorded only when the route states it, and named as a gap otherwise —
+    the same rule `reasoning_effort` follows (#397, #470).
+    """
+    peak, phase = 0, None
+    for u in usage:
+        total = (int(u.get("input_tokens") or 0) + int(u.get("cache_read") or 0)
+                 + int(u.get("cache_write") or 0))
+        if total > peak:
+            peak, phase = total, u.get("phase")
+    out: dict[str, Any] = {"peak_request_tokens": peak or None,
+                           "peak_phase": phase,
+                           "peak_basis": "observed: input + cache_read + "
+                                         "cache_write of the largest request"}
+    for pattern, limit in CONTEXT_FROM_NAME:
+        if re.search(pattern, model_name or "", re.I):
+            out["limit_tokens"] = limit
+            out["limit_basis"] = f"the model route names it ({model_name})"
+            break
+    else:
+        out["limit_tokens"] = None
+        out["limit_basis"] = ("not stated by the route and not returned by the "
+                              "provider; headroom cannot be computed from this "
+                              "record")
+    return out
+
+
 def report_claims_block(spec: RunSpec) -> dict[str, Any] | None:
     """Check the reconciliation report against the record and the schema (#546).
 
@@ -1984,6 +2031,11 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         "base_url": ident["base_url"],
         "model": settings["name"],
         "max_tokens_by_phase": PHASE_MAX_TOKENS,
+        # What the run sent, and what it was allowed to send. The second is
+        # usually unknown, and #568 exists because that could not be told from
+        # the record: AI-READI's reconcile_full ran at 249,015 tokens under a
+        # name suggesting far less.
+        "context": context_facts(settings["name"], usage),
     }
     if settings["temperature_applies"]:
         rec.data["model"]["temperature"] = settings["temperature"]

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -592,6 +592,10 @@ def backfill_context(execute, label):
             continue
         model = rec.get("model") or {}
         facts = context_facts(str(model.get("model") or ""), usage)
+        # Marked, like every other backfill (#552): a value the run wrote and
+        # one computed afterwards are different claims even when the arithmetic
+        # is the same, and only the record can say which this is.
+        facts["recorded_by"] = "backfill_context"
         rows.append((p, facts))
         if execute:
             model["context"] = facts

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -551,3 +551,59 @@ def backfill_checks(execute, method, label, project, overwrite):
                + (f", {skipped} already carried the blocks" if skipped else ""))
     if not execute:
         click.echo("Nothing was changed. Re-run with --execute to write.")
+
+
+@provenance.command("backfill-context")
+@click.option('--execute', is_flag=True,
+              help='write the records; without it this reports and changes nothing')
+@click.option('--label', default=None, help='restrict to one run label')
+def backfill_context(execute, label):
+    """Record the context each API run actually used (#568).
+
+    Adds no claim the record was not already making: `peak_request_tokens` is
+    computed from the `api_usage` the run wrote itself, so this is arithmetic
+    over existing evidence rather than a new assertion — the same ground on
+    which `backfill-effort` is defensible and a temperature backfill would not
+    be.
+
+    The *limit* is not backfilled. It was not knowable at the time and is not
+    knowable now; recording a guess would make headroom computable and wrong.
+
+    Agentic records have no `api_usage` and are skipped, not filled with zero.
+    """
+    import yaml as _yaml
+
+    from data_sheets_schema.api_runner import context_facts
+    from data_sheets_schema.backfill_checks import _split_header
+    from data_sheets_schema.provenance import CONCAT_DIR
+
+    paths = sorted(CONCAT_DIR.glob("*_core/*/*_provenance.yaml"))
+    if label:
+        paths = [p for p in paths if p.parts[-2] == label]
+    rows, skipped = [], 0
+    for p in paths:
+        header, body = _split_header(p.read_text(encoding="utf-8"))
+        rec = _yaml.safe_load(body)
+        if not isinstance(rec, dict):
+            continue
+        usage = rec.get("api_usage")
+        if not isinstance(usage, list) or not usage:
+            skipped += 1
+            continue
+        model = rec.get("model") or {}
+        facts = context_facts(str(model.get("model") or ""), usage)
+        rows.append((p, facts))
+        if execute:
+            model["context"] = facts
+            rec["model"] = model
+            p.write_text(header + _yaml.safe_dump(rec, sort_keys=False,
+                                                  allow_unicode=True),
+                         encoding="utf-8")
+    for p, f in sorted(rows, key=lambda r: -(r[1]["peak_request_tokens"] or 0))[:12]:
+        click.echo(f"   {'✔' if execute else '·'} {p.parts[-2][:38]:38} "
+                   f"{p.name[:-16]:16} peak {f['peak_request_tokens']:>8,} "
+                   f"({f['peak_phase']})")
+    click.echo(f"\n{len(rows)} API record(s) {'written' if execute else 'would be written'}"
+               f"; {skipped} skipped as having no api_usage (agentic runs)")
+    if not execute:
+        click.echo("Nothing was changed. Re-run with --execute to write.")

--- a/tests/test_context_facts.py
+++ b/tests/test_context_facts.py
@@ -1,0 +1,99 @@
+"""What a run can honestly say about the context it used (#568).
+
+The v4 arm named its model `claude-opus-5` and sent a 285,113-token request
+that succeeded. Nothing in the record said what the ceiling was, so "will the
+next change fit" could not be answered from the corpus — only by running it.
+
+Two claims, deliberately kept apart: what the run *sent*, which is arithmetic
+over evidence the run already wrote, and what it was *allowed* to send, which is
+usually unknowable and is left as a named gap rather than guessed.
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema.api_runner import context_facts
+
+USAGE = [
+    {"phase": "full", "input_tokens": 3042, "cache_read": 0, "cache_write": 29402},
+    {"phase": "reconcile_core", "input_tokens": 51074, "cache_read": 197941,
+     "cache_write": 0},
+]
+
+
+class ContextFactsTest(unittest.TestCase):
+
+    def test_cached_tokens_count_toward_the_peak(self):
+        """They occupy the window exactly as fresh tokens do.
+
+        Counting only `input_tokens` would have reported AI-READI's largest
+        request as 51k rather than 249k, which is the difference between
+        "plenty of headroom" and "unknown".
+        """
+        self.assertEqual(context_facts("m", USAGE)["peak_request_tokens"],
+                         51074 + 197941)
+
+    def test_the_peak_names_its_phase(self):
+        self.assertEqual(context_facts("m", USAGE)["peak_phase"],
+                         "reconcile_core")
+
+    def test_an_unstated_limit_is_null_and_says_why(self):
+        """A guess would make headroom computable and wrong."""
+        facts = context_facts("claude-opus-5", USAGE)
+        self.assertIsNone(facts["limit_tokens"])
+        self.assertIn("not stated by the route", facts["limit_basis"])
+
+    def test_a_route_that_states_its_window_is_believed(self):
+        for name in ("claude-opus-5[1m]", "claude-opus-5-1m", "vendor/model:1m"):
+            with self.subTest(name=name):
+                facts = context_facts(name, USAGE)
+                self.assertEqual(facts["limit_tokens"], 1_000_000)
+                self.assertIn(name, facts["limit_basis"])
+
+    def test_no_usage_gives_no_peak_rather_than_zero(self):
+        """An agentic run sent no measured request; zero would be a claim."""
+        self.assertIsNone(context_facts("m", [])["peak_request_tokens"])
+
+
+class CorpusTest(unittest.TestCase):
+    """What the backfill put on disk, and the fact that changed the plan."""
+
+    BASE = Path("data/d4d_concatenated")
+
+    def _peaks(self):
+        out = []
+        for p in self.BASE.glob("*_core/*/*_provenance.yaml"):
+            rec = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            ctx = (rec.get("model") or {}).get("context") or {}
+            if ctx.get("peak_request_tokens"):
+                out.append((ctx["peak_request_tokens"], ctx["peak_phase"]))
+        if not out:
+            self.skipTest("no API records in this checkout")
+        return out
+
+    def test_the_corpus_has_already_run_far_above_the_v4_peak(self):
+        """The measurement that corrected my own #568 reasoning.
+
+        I raised the context risk of #566 against AI-READI's 249k
+        `reconcile_full`. The corpus had already sent 363,261 tokens
+        successfully — so a v5 request near 279k is well inside demonstrated
+        behaviour, and the risk I flagged was smaller than I stated.
+        """
+        self.assertGreaterEqual(max(t for t, _ in self._peaks()), 363_000)
+
+    def test_the_peak_phase_is_reconcile_core_not_reconcile_full(self):
+        """Also corrects #568: I reasoned about the wrong phase.
+
+        `reconcile_core` receives the reconciled full record, the core record
+        and the audit findings, so it is the largest request in 56 of 67 runs.
+        `reconcile_full` — the phase #566 enlarges — peaks in 3.
+        """
+        from collections import Counter
+        phases = Counter(ph for _, ph in self._peaks())
+        self.assertEqual(phases.most_common(1)[0][0], "reconcile_core")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_context_facts.py
+++ b/tests/test_context_facts.py
@@ -83,6 +83,17 @@ class CorpusTest(unittest.TestCase):
         """
         self.assertGreaterEqual(max(t for t, _ in self._peaks()), 363_000)
 
+    def test_backfilled_context_says_it_was_backfilled(self):
+        """A value the run wrote and one computed afterwards are different
+        claims even when the arithmetic is identical (#552)."""
+        p = (self.BASE / "claudecode_agent_core"
+             / "2026-08-13_claude-opus-5-api-generic-v4_rep1"
+             / "AI_READI_provenance.yaml")
+        if not p.exists():
+            self.skipTest("record not present in this checkout")
+        ctx = yaml.safe_load(p.read_text(encoding="utf-8"))["model"]["context"]
+        self.assertEqual(ctx["recorded_by"], "backfill_context")
+
     def test_the_peak_phase_is_reconcile_core_not_reconcile_full(self):
         """Also corrects #568: I reasoned about the wrong phase.
 


### PR DESCRIPTION
Closes #568.

## What could not be answered from the record

The v4 arm named its model `claude-opus-5` and sent a **285,113-token** request
that succeeded. The record said nothing about the ceiling, so "will #566's extra
30k fit" was unanswerable from the corpus.

`model.context` now records two claims, kept apart:

- **`peak_request_tokens`** — observed: the largest request the run sent,
  summing input, cache reads and cache writes, because cached tokens occupy the
  window exactly as fresh ones do. Counting only `input_tokens` reports
  AI-READI's largest request as 51k rather than 249k, which is the difference
  between "plenty of headroom" and "unknown".
- **`limit_tokens`** — null, with the reason recorded. No route states it and
  CBORG does not return it. A guess would make headroom computable and wrong,
  the same reason `reasoning_effort` is left absent rather than defaulted
  (#397, #470). A route that *does* name a window (`[1m]`, `-1m`, `:1m`) is
  believed and says so.

`d4d provenance backfill-context` fills the 67 API records from `api_usage` they
already wrote — arithmetic over existing evidence, not a new assertion. The 125
agentic records are skipped rather than filled with zero. Canaried on one label
(28 additions, 0 deletions, header intact), then 67 records, 469 additions, 0
deletions.

## Measuring corrected the risk I raised, twice

I flagged #566 as pushing AI-READI's `reconcile_full` from 249k to ~279k and
recommended AI-READI as the canary. Both corrections come from the backfill:

**1. The peak phase is `reconcile_core`, not `reconcile_full`.**

| phase | peaks in |
|---|---|
| reconcile_core | 56 of 67 runs |
| audit | 8 |
| reconcile_full | 3 |

`reconcile_core` carries the reconciled full record, the core record *and* the
audit findings. I reasoned about the wrong phase.

**2. The corpus has already sent 363,261 tokens successfully** — VOICE rep3 of
the 2026-07-31 arm.

| run | peak | phase |
|---|---|---|
| VOICE 2026-07-31 rep3 | **363,261** | reconcile_core |
| VOICE 2026-07-31 rep2 | 359,552 | reconcile_core |
| AI_READI v4 rep1 | 285,113 | reconcile_core |

So #566 taking `reconcile_full` toward ~279k is **below a size this pipeline has
demonstrably handled**. The risk is headroom-unknown, not headroom-exceeded, and
I overstated it.

## What stands

The canary decision. Within the v4 arm AI-READI is the largest at 285k and
CHORUS is 64k — a CHORUS canary still tests everything except the thing most
likely to break.

7 tests, two of which pin the corrections so they cannot quietly revert.
Suite: 2033 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)