### PR TITLE
Pin the prompt body separately from its rationale (#560)

### DIFF
--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -440,15 +440,20 @@ def prompts_check_cmd(strict):
     # record may legitimately name a prompt the registry does not cover; the
     # working tree has no such excuse. A condition prompt nobody pinned is
     # text that was never declared, which is the hole (#432), not a gap in it.
-    bad = [r for r in rows if r["status"] != pr.CANONICAL]
+    # `annotated` is reported and not counted against the gate: the
+    # instruction is at its pin and only rationale moved (#560).
+    bad = [r for r in rows if r["status"] not in (pr.CANONICAL, pr.ANNOTATED)]
+    annotated = [r for r in rows if r["status"] == pr.ANNOTATED]
     for r in rows:
-        mark = {"canonical": "✓", "superseded": "⚠️ ",
+        mark = {"canonical": "✓", "superseded": "⚠️ ", "annotated": "ⓘ ",
                 "uncanonical": "❌", "unpinned": "❌",
                 "missing": "❌"}[r["status"]]
         click.echo(f" {mark} {r['status']:12} {r['path']}")
         if r["reason"]:
             click.echo(f"       {r['reason']}")
-    click.echo(f"\n{len(rows)} prompt file(s), {len(bad)} not at their pin")
+    click.echo(f"\n{len(rows)} prompt file(s), {len(bad)} not at their pin"
+               + (f", {len(annotated)} annotated (body unchanged)"
+                  if annotated else ""))
     if bad:
         click.echo("Declare them with `d4d api prompts pin --file <path> "
                    "--reason '<why this is the condition's text>'`. Editing a "

--- a/src/data_sheets_schema/prompt_registry.py
+++ b/src/data_sheets_schema/prompt_registry.py
@@ -57,6 +57,30 @@ UNPINNED = "unpinned"
 # record named it and hashed nothing. Distinct from `unpinned`, which is an
 # absence of evidence — this is evidence of an absence (#437).
 MISSING = "missing"
+# The instruction is at its pin; something else in the file is not. A prompt
+# file carries a rationale that `prompt_body` never sends to the model, and
+# under whole-file hashing correcting a sentence of it cost exactly what
+# changing a decision rule costs — so rationale errors went uncorrected during
+# an arm, because correcting them looked like tampering (#560).
+ANNOTATED = "annotated"
+
+
+def body_sha256_of(path: Path) -> str | None:
+    """Hash of the text a run actually sends, or None if the file has no body.
+
+    `prompt_body` splits on `## Prompt body`; everything above it is rationale
+    that documents the condition without being part of it. Component files and
+    the tuned block have no such section, and for those this returns None and
+    the whole-file hash stays the only check — which is correct, because for
+    them every byte is sent.
+    """
+    if not path or not Path(path).exists():
+        return None
+    text = Path(path).read_text(encoding="utf-8", errors="replace")
+    if "## Prompt body" not in text:
+        return None
+    body = text.split("## Prompt body", 1)[1].strip()
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
 
 
 def sha256_of(path: Path) -> str | None:
@@ -178,7 +202,24 @@ def disk_status(path: str | Path,
             return MISSING, (f"{normalise(path)} is pinned but not on disk; "
                              "the declared text of its condition is gone")
         return UNPINNED, f"{normalise(path)} is neither pinned nor on disk"
-    return status_of_hash(path, sha, registry)
+    status, why = status_of_hash(path, sha, registry)
+    # Only here, never in `status_of_hash`. That function judges a hash a
+    # *record* wrote, for bytes that need not exist any more — so decomposing
+    # it into body and rationale is impossible, and comparing today's body
+    # against the pin would let a record whose prompt matches nothing pass as
+    # `annotated` because an unrelated file on disk happens to agree. The
+    # existing test for that caught this when the check was misplaced.
+    if status == UNCANONICAL:
+        pinned_body = (entry_for(path, registry) or {}).get("body_sha256")
+        here = body_sha256_of(Path(path))
+        # A pin taken before #560 records no body hash and cannot tell
+        # rationale from instruction; those keep failing closed.
+        if pinned_body and here and here == pinned_body:
+            return ANNOTATED, (
+                f"{normalise(path)}: the prompt body is at its pin; only text "
+                "outside `## Prompt body` differs, which is rationale the model "
+                "is never sent. Rotate the pin when convenient (#560).")
+    return status, why
 
 
 def registered_paths(registry: Path = REGISTRY) -> list[str]:
@@ -275,6 +316,18 @@ def pin(path: str | Path, reason: str, registry: Path = REGISTRY,
     key = normalise(p)
     prev = files.get(key)
     if prev and prev.get("sha256") == sha:
+        # Same bytes, but the entry may predate #560 and carry no body hash.
+        # Adding one is arithmetic over bytes already pinned — no new claim,
+        # and without it every pre-#560 pin stays unable to tell a rationale
+        # edit from an instruction edit, which is the whole point.
+        body = body_sha256_of(p)
+        if body and not prev.get("body_sha256"):
+            prev["body_sha256"] = body
+            Path(registry).write_text(
+                _HEADER + yaml.safe_dump(data, sort_keys=True, width=88),
+                encoding="utf-8")
+            _REGISTRY_CACHE.clear()
+            return {"path": key, "status": "body_hash_added", "sha256": sha}
         return {"path": key, "status": "unchanged", "sha256": sha}
 
     superseded = list((prev or {}).get("superseded") or [])
@@ -283,7 +336,8 @@ def pin(path: str | Path, reason: str, registry: Path = REGISTRY,
                            "pinned_on": prev.get("pinned_on"),
                            "retired_on": today,
                            "reason": prev.get("reason")})
-    files[key] = {"sha256": sha, "bytes": p.stat().st_size,
+    files[key] = {"sha256": sha, "body_sha256": body_sha256_of(p),
+                  "bytes": p.stat().st_size,
                   "pinned_on": today, "pinned_at_commit": _head_commit(),
                   "reason": reason.strip()}
     if superseded:

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -53,6 +53,7 @@ files:
       \ is left to the manifest scope declaration rather than restated here (#422)."
     sha256: b7db067c2852b57287cb68bd1fd4f3bfc229496cc2a4bd33065bb9558a35b215
   src/download/prompts/d4d_generic_arm_prompt.md:
+    body_sha256: 0e16a8a8dc35d6fe242bdb55972918ad6dc39875df069caed4be998369a99436
     bytes: 6737
     pinned_at_commit: 7141fdc63e43f5049bf98289a142c85bd63107ed
     pinned_on: '2026-08-13'
@@ -69,6 +70,7 @@ files:
       retired_on: '2026-08-13'
       sha256: 0fbc626bc3a51d74a8ba3d8e2813752f3bc5ce9366ee5f19c99089afdfd9e8dc
   src/download/prompts/d4d_generic_arm_prompt_v2.md:
+    body_sha256: 6b639abb906c44af91a5b3a7f6391da3fc6dd8f039de9e7d6544858e1fb17410
     bytes: 10099
     pinned_at_commit: 7141fdc63e43f5049bf98289a142c85bd63107ed
     pinned_on: '2026-08-13'
@@ -85,6 +87,7 @@ files:
       retired_on: '2026-08-13'
       sha256: 4780613475ef2a629f98b69a934228b58eccd5fe93915fcd259a62cff6583de6
   src/download/prompts/d4d_generic_arm_prompt_v3.md:
+    body_sha256: 5a4d7ab16e04caa124f3c9d6ceccc84384bd7cd6d8657a2f23a4a565fa9bb847
     bytes: 8193
     pinned_at_commit: 7141fdc63e43f5049bf98289a142c85bd63107ed
     pinned_on: '2026-08-13'
@@ -101,6 +104,7 @@ files:
       retired_on: '2026-08-13'
       sha256: 2126da06d0834c2501c55fe9838720fe3ee33ab38c4775f2af329bc4759da45a
   src/download/prompts/d4d_generic_arm_prompt_v4.md:
+    body_sha256: 3d31f5a15fab7b62091d119f9401ac981eed8e9ffaded5637521105115df799b
     bytes: 8659
     pinned_at_commit: 7141fdc63e43f5049bf98289a142c85bd63107ed
     pinned_on: '2026-08-13'
@@ -117,6 +121,7 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
+    body_sha256: baf755f808f84c7d92e817d936300f1baeedb69a7d95f0a9e9028ca5f39f0c15
     bytes: 11812
     pinned_at_commit: 9b6dd51d2940f976b85682b53e7191fd6d4347b0
     pinned_on: '2026-08-14'

--- a/tests/test_pin_granularity.py
+++ b/tests/test_pin_granularity.py
@@ -1,0 +1,171 @@
+"""A rationale edit and an instruction edit must not cost the same (#560).
+
+The pin hashed the whole prompt file, including the rationale sections that
+`prompt_body` never sends to the model. Correcting a sentence of documentation
+therefore failed `check --strict` exactly as changing a decision rule does, and
+resolving it rotated the pin — leaving a history that reads as a condition
+re-baselined when the instruction had not moved by a byte.
+
+The predictable consequence is the one the rule was written against: rationale
+errors go uncorrected during an arm, because correcting them looks like
+tampering.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from data_sheets_schema import prompt_registry as pr
+
+PROMPT = """# A condition
+
+## Why it exists
+
+Rationale the model never sees.
+
+## Prompt body
+
+Do the thing.
+"""
+
+
+class BodyHashTest(unittest.TestCase):
+
+    def test_only_the_body_is_hashed(self):
+        with tempfile.TemporaryDirectory() as d:
+            a = Path(d) / "a.md"
+            b = Path(d) / "b.md"
+            a.write_text(PROMPT, encoding="utf-8")
+            b.write_text(PROMPT.replace("Rationale the model never sees.",
+                                        "Different rationale entirely."),
+                         encoding="utf-8")
+            self.assertNotEqual(pr.sha256_of(a), pr.sha256_of(b))
+            self.assertEqual(pr.body_sha256_of(a), pr.body_sha256_of(b))
+
+    def test_a_body_change_changes_the_body_hash(self):
+        with tempfile.TemporaryDirectory() as d:
+            a = Path(d) / "a.md"
+            b = Path(d) / "b.md"
+            a.write_text(PROMPT, encoding="utf-8")
+            b.write_text(PROMPT.replace("Do the thing.", "Do another thing."),
+                         encoding="utf-8")
+            self.assertNotEqual(pr.body_sha256_of(a), pr.body_sha256_of(b))
+
+    def test_a_file_with_no_body_section_has_no_body_hash(self):
+        """Component files and the tuned block send every byte, so for them the
+        whole-file hash is the only correct check."""
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c.md"
+            p.write_text("# just a component\n\nSome text.\n", encoding="utf-8")
+            self.assertIsNone(pr.body_sha256_of(p))
+
+
+class StatusTest(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.prompt = self.root / "p.md"
+        self.prompt.write_text(PROMPT, encoding="utf-8")
+        self.registry = self.root / "hashes.yaml"
+        self.registry.write_text(yaml.safe_dump({
+            "hash_algorithm": "sha256",
+            "files": {pr.normalise(self.prompt): {
+                "sha256": pr.sha256_of(self.prompt),
+                "body_sha256": pr.body_sha256_of(self.prompt),
+                "pinned_on": "2026-01-01", "reason": "test"}}}),
+            encoding="utf-8")
+        pr._REGISTRY_CACHE.clear()
+        self.addCleanup(pr._REGISTRY_CACHE.clear)
+
+    def test_untouched_is_canonical(self):
+        self.assertEqual(pr.disk_status(self.prompt, self.registry)[0],
+                         pr.CANONICAL)
+
+    def test_a_rationale_edit_is_annotated(self):
+        self.prompt.write_text(
+            PROMPT.replace("Rationale the model never sees.", "Corrected."),
+            encoding="utf-8")
+        status, why = pr.disk_status(self.prompt, self.registry)
+        self.assertEqual(status, pr.ANNOTATED)
+        self.assertIn("the model is never sent", why)
+
+    def test_a_body_edit_is_uncanonical(self):
+        self.prompt.write_text(PROMPT.replace("Do the thing.", "Do otherwise."),
+                               encoding="utf-8")
+        self.assertEqual(pr.disk_status(self.prompt, self.registry)[0],
+                         pr.UNCANONICAL)
+
+    def test_a_pin_with_no_body_hash_still_fails_closed(self):
+        """A pin taken before #560 cannot tell rationale from instruction.
+
+        Guessing would turn an unchecked file into a passing one, so those keep
+        the old whole-file behaviour.
+        """
+        data = yaml.safe_load(self.registry.read_text(encoding="utf-8"))
+        del data["files"][pr.normalise(self.prompt)]["body_sha256"]
+        self.registry.write_text(yaml.safe_dump(data), encoding="utf-8")
+        pr._REGISTRY_CACHE.clear()
+        self.prompt.write_text(
+            PROMPT.replace("Rationale the model never sees.", "Corrected."),
+            encoding="utf-8")
+        self.assertEqual(pr.disk_status(self.prompt, self.registry)[0],
+                         pr.UNCANONICAL)
+
+
+class RealRegistryTest(unittest.TestCase):
+
+    def test_every_condition_prompt_now_carries_a_body_hash(self):
+        """Without this the feature is inert for the files it was built for."""
+        missing = []
+        for path, entry in pr.pins().items():
+            p = Path(path)
+            if pr.body_sha256_of(p) and not entry.get("body_sha256"):
+                missing.append(path)
+        self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class RecordGateIsNotSoftenedTest(unittest.TestCase):
+    """The body check belongs to the disk gate alone.
+
+    `status_of_hash` judges a hash a *record* wrote, for bytes that need not
+    exist any more. Those bytes cannot be decomposed into body and rationale,
+    so comparing today's on-disk body against the pin would let a record whose
+    prompt hash matches nothing pass as `annotated` merely because an unrelated
+    file on disk happens to agree.
+
+    The first version of #560 did exactly that, and
+    `test_a_hash_that_was_never_pinned_is_the_finding` caught it.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self.prompt = root / "p.md"
+        self.prompt.write_text(PROMPT, encoding="utf-8")
+        self.registry = root / "hashes.yaml"
+        self.registry.write_text(yaml.safe_dump({
+            "hash_algorithm": "sha256",
+            "files": {pr.normalise(self.prompt): {
+                "sha256": pr.sha256_of(self.prompt),
+                "body_sha256": pr.body_sha256_of(self.prompt),
+                "pinned_on": "2026-01-01", "reason": "test"}}}),
+            encoding="utf-8")
+        pr._REGISTRY_CACHE.clear()
+        self.addCleanup(pr._REGISTRY_CACHE.clear)
+
+    def test_an_unknown_recorded_hash_stays_uncanonical(self):
+        import hashlib
+        stranger = hashlib.sha256(b"bytes nobody pinned").hexdigest()
+        status, _ = pr.status_of_hash(self.prompt, stranger, self.registry)
+        self.assertEqual(status, pr.UNCANONICAL,
+                         "a record gate must not be softened by what happens "
+                         "to be on disk today")

--- a/tests/test_pin_granularity.py
+++ b/tests/test_pin_granularity.py
@@ -116,6 +116,29 @@ class StatusTest(unittest.TestCase):
                          pr.UNCANONICAL)
 
 
+class TheTwoBodyExtractorsAgreeTest(unittest.TestCase):
+    """`body_sha256_of` must hash exactly what `prompt_body` sends.
+
+    They are separate implementations in separate modules — `prompt_registry`
+    cannot import `api_runner` without a cycle — and this codebase's recurring
+    defect is one piece of content maintained in two places (#518, #521, #545,
+    #563). If they drift, the pin would vouch for text the model never receives,
+    which is the opposite of what #560 is for.
+    """
+
+    def test_they_hash_the_same_text_for_every_condition_prompt(self):
+        import hashlib
+
+        from data_sheets_schema.api_runner import CONDITION_PROMPTS, prompt_body
+        for name, path in sorted(CONDITION_PROMPTS.items()):
+            if not path.exists():
+                continue
+            with self.subTest(condition=name):
+                sent = hashlib.sha256(
+                    prompt_body(path).encode("utf-8")).hexdigest()
+                self.assertEqual(pr.body_sha256_of(path), sent)
+
+
 class RealRegistryTest(unittest.TestCase):
 
     def test_every_condition_prompt_now_carries_a_body_hash(self):


### PR DESCRIPTION
Closes #560.

The pin hashed the whole prompt file, including the rationale sections that
`prompt_body` never sends to the model. Correcting a sentence of documentation
failed `check --strict` exactly as changing a decision rule does, and resolving
it rotated the pin — leaving a history that reads as a condition re-baselined
when the instruction had not moved by a byte. **That happened once already**,
while adding v5.

The predictable consequence is the one the rule exists to prevent: rationale
errors go uncorrected during an arm, because correcting them looks like
tampering.

## Three statuses

| status | meaning | `--strict` |
|---|---|---|
| `canonical` | file and body both at their pin | passes |
| `annotated` | body at its pin; only rationale differs | **passes**, reported |
| `uncanonical` | the body moved, or the pin cannot tell | fails |

Demonstrated on the real v5 prompt:

```
rationale-only edit → strict exit 0
  ⓘ  annotated  …_v5.md: the prompt body is at its pin; only text outside
     `## Prompt body` differs, which is rationale the model is never sent.

body edit → strict exit 1
  ❌ uncanonical  …_v5.md hashed 52f6838017…, which is neither the pinned
     606e7382cd… nor any hash it was pinned at before
```

## Existing pins gain a body hash without rotating

The bytes are unchanged, so deriving a second hash from them adds no claim —
the same ground as `backfill-effort`. A pin that still lacks one **fails
closed**: guessing would turn an unchecked file into a passing one. Files with
no `## Prompt body` section (components, the tuned block) get no body hash and
keep whole-file checking, which is right because every byte of those is sent.

## The record gate is deliberately not softened

`status_of_hash` judges a hash a *record* wrote, for bytes that need not exist
any more. Those cannot be decomposed into body and rationale, and comparing
today's on-disk body against the pin would let a record whose prompt matches
nothing pass as `annotated` because an unrelated file happens to agree.

The first version of this did exactly that, and the existing
`test_a_hash_that_was_never_pinned_is_the_finding` caught it. The check now
lives only in `disk_status`, and a new test asserts the separation so it cannot
drift back.

9 tests. Suite: 2035 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)