### PR TITLE
Let an agentic run record which phases it performed (#562)

### DIFF
--- a/.claude/commands/d4d-full-core.md
+++ b/.claude/commands/d4d-full-core.md
@@ -495,8 +495,27 @@ poetry run d4d provenance record \
   --input-bundle {EXACT INPUT BUNDLE PATH} \
   --prompt {EACH PROMPT FILE THE RUN CONSUMED} \
   --prompt-text {THE INSTRUCTION AS SENT} \
-  --reasoning-effort {EFFORT, ONLY IF YOU KNOW IT}
+  --reasoning-effort {EFFORT, ONLY IF YOU KNOW IT} \
+  --phase '{"name":"generate_full","completed":true,"artifacts":["{PROJECT}_d4d.yaml"]}' \
+  --phase '{"name":"generate_core","completed":true,"artifacts":["{PROJECT}_d4d_core.yaml"]}' \
+  --phase '{"name":"source_audit","completed":true}' \
+  --phase '{"name":"reconcile","completed":true,"iterations":{HOW MANY TIMES YOU RAN VALIDATE-AND-ITERATE}}'
 ```
+
+**Pass one `--phase` per phase you actually performed, in order.** The API path
+records eight `api_usage` entries per run; this path recorded nothing, so its
+phase structure existed only as prose in the reconciliation report — and #546
+showed a report is not a reliable account of what happened. Every comparison
+between the two arms was one-sided as a result (#562).
+
+Record what you did, not what this file describes. A phase you skipped is
+omitted; a phase that did not complete gets `"completed": false`. `iterations`
+belongs only on a phase that actually loops — writing `1` on a phase that
+cannot iterate implies the number was measured.
+
+Timing and token counts are not asked for, and must not be estimated: this
+runtime has no access to its own accounting (#400). The record names them as
+unavailable so the gap reads as a limit rather than an oversight.
 
 Writes `{METHOD}_core/{VERSION}/{PROJECT}_provenance.yaml` capturing schema
 md5s, model and runtime identity, input bundle hash, repo commit, software

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -18,6 +18,38 @@ def provenance():
     pass
 
 
+def _parse_phases(specs) -> list[dict]:
+    """`--phase` values into phase dicts, in the order given (#562).
+
+    Two forms, because the caller is sometimes a person and sometimes an agent
+    writing a shell command: a bare name, or a JSON object for the cases where
+    completion, iteration count or artifacts are worth stating.
+
+    A malformed value raises rather than being dropped. A phase log missing one
+    phase is worse than no phase log: it reads as a run that skipped a step.
+    """
+    import json
+
+    out = []
+    for raw in specs or ():
+        text = str(raw).strip()
+        if not text:
+            continue
+        if text.startswith("{"):
+            try:
+                obj = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise click.BadParameter(
+                    f"--phase {text!r} is not valid JSON: {exc}") from exc
+            if not isinstance(obj, dict) or not obj.get("name"):
+                raise click.BadParameter(
+                    f"--phase {text!r} must be an object with a 'name'")
+            out.append(obj)
+        else:
+            out.append({"name": text, "completed": True})
+    return out
+
+
 @provenance.command()
 @click.option('--project', required=True)
 @click.option('--method', required=True, help='e.g. claudecode_agent')
@@ -61,9 +93,15 @@ def provenance():
                    '(#450), because `PLACEHOLDER_VALUES` in runs.py would '
                    'discard it downstream and the record and the analysis '
                    'would then disagree.')
+@click.option('--phase', 'phase_specs', multiple=True,
+              help='a phase this run performed, in order. Either a bare name '
+                   '("reconcile") or a JSON object '
+                   '(\'{"name":"reconcile","completed":true,"iterations":3}\'). '
+                   'Repeat once per phase. Records what the API path records '
+                   'as api_usage and the agentic path recorded nowhere (#562).')
 def record(project, method, label, input_bundle, prompts, prompt_text,
            condition, arm, runtime, provider, bundle_for_spec,
-           reasoning_effort):
+           reasoning_effort, phase_specs):
     """Write a LIVE provenance record for a run just produced.
 
     Every field is observed at run time — hardware, software versions, input
@@ -114,7 +152,8 @@ def record(project, method, label, input_bundle, prompts, prompt_text,
                                        if prompt_text else None),
                        prompt_request_spec=spec,
                        schema_digest_md5=digest,
-                       reasoning_effort=reasoning_effort)
+                       reasoning_effort=reasoning_effort,
+                       phases=_parse_phases(phase_specs))
     out = rec.write(record_path_for(project, method, label))
     click.echo(f"✓ {out}")
 

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -603,6 +603,21 @@ def check_cmd(method, label, project, strict):
         if st == PAIR_DIVERGENT:
             divergent.append((r["project"], r["label"], errs))
 
+    # What each run said about its own phases (#562). The API path has always
+    # written `api_usage`; the agentic path wrote nothing, so its phase
+    # structure lived only in prose and no arm comparison could reach it.
+    from data_sheets_schema.runs import (
+        PHASES_ABSENT, PHASES_API, PHASES_RECORDED, phase_log_status,
+    )
+    logs: collections.Counter = collections.Counter()
+    for r in rows:
+        logs[phase_log_status(r["method"], r["label"], r["project"])[0]] += 1
+    if logs[PHASES_ABSENT]:
+        click.echo(f"\nⓘ  {logs[PHASES_ABSENT]} record(s) say nothing about "
+                   f"which phases they ran ({logs[PHASES_API]} carry "
+                   f"`api_usage`, {logs[PHASES_RECORDED]} a `phase_log`).")
+        click.echo("   An arm comparison over a phase cannot include these.")
+
     # External identifiers checked against the bundle they were read from
     # (#547). The hardest fabrication class: right answer, no evidence. VOICE
     # rep1's RORs are all correct and none of them is in its bundle.

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -137,6 +137,61 @@ AGENT_PLAYBOOKS = (
 )
 
 
+#: Fields the API path records per phase that an agentic run cannot supply.
+#: Named rather than omitted, so a reader sees a limit instead of a gap — the
+#: same three-way distinction `d4d provenance reasoning` draws (#400).
+PHASE_FIELDS_UNAVAILABLE_TO_AGENTS = ("seconds", "input_tokens",
+                                      "output_tokens", "stop_reason")
+
+
+def phase_facts(phases: list[dict[str, Any]],
+                runtime: str | None = None) -> dict[str, Any] | None:
+    """What an agentic run can honestly say about its own phases (#562).
+
+    The API path records eight `api_usage` entries per run — phase, attempt,
+    seconds, tokens, stop reason. The agentic path recorded nothing, so its
+    phase structure existed only as prose in the reconciliation report, which
+    #546 showed cannot be trusted as an account of what happened. Every arm
+    comparison was therefore one-sided in a way easy to miss: #544's finding
+    was about a phase, and the same question could not be asked of the other
+    arm from the record.
+
+    This is not the #400 limitation. A Claude Code subagent cannot report its
+    own token accounting, which is why no reasoning log is written for it —
+    but *which phase ran*, *whether it completed* and *how many times a loop
+    iterated* are things the agent knows, and the playbook already tells it to
+    write them into the report in prose.
+
+    So timing and tokens are named as unavailable rather than left absent,
+    because an absent field reads as an oversight and a named one reads as a
+    limit.
+    """
+    if not phases:
+        return None
+    out = []
+    for i, ph in enumerate(phases, start=1):
+        entry: dict[str, Any] = {"phase": ph.get("name") or f"phase_{i}",
+                                 "ordinal": int(ph.get("ordinal") or i)}
+        if "completed" in ph:
+            entry["completed"] = bool(ph["completed"])
+        # Only when a phase actually loops. `iterations: 1` on a phase that
+        # cannot iterate would imply the number was measured.
+        if ph.get("iterations") is not None:
+            entry["iterations"] = int(ph["iterations"])
+        if ph.get("artifacts"):
+            entry["artifacts"] = list(ph["artifacts"])
+        if ph.get("notes"):
+            entry["notes"] = str(ph["notes"])
+        out.append(entry)
+    return {"phases": out,
+            "recorded_by": "the run itself, as the playbook directs",
+            "unavailable": list(PHASE_FIELDS_UNAVAILABLE_TO_AGENTS),
+            "unavailable_basis": (
+                "this runtime has no access to its own token accounting or "
+                "per-call timing (#400); these are named rather than omitted "
+                "so the gap reads as a limit and not an oversight")}
+
+
 def repo_relative(path: Path | str) -> str:
     """A path as this repository names it, whatever the caller passed (#398).
 
@@ -899,6 +954,7 @@ def build_record(project: str, method: str, label: str, *, mode: str,
                  prompt_request_spec: dict[str, Any] | None = None,
                  schema_digest_md5: str | None = None,
                  reasoning_effort: str | None = None,
+                 phases: list[dict[str, Any]] | None = None,
                  extra_notes: list[str] | None = None) -> ProvenanceRecord:
     """Assemble a provenance record for one project-run.
 
@@ -1134,6 +1190,11 @@ def build_record(project: str, method: str, label: str, *, mode: str,
         "prompts": prompt_facts(prompt_paths, prompt_request,
                                 prompt_request_spec),
         "playbooks": playbooks,
+        # The agentic path's answer to the API path's `api_usage` (#562).
+        # None when the run said nothing, which is honest: the phases are not
+        # inferred from the artifacts on disk, because a phase that ran and a
+        # phase whose output happens to exist are different claims.
+        "phase_log": phase_facts(phases or []),
         "schema": schema_facts() | (
             {"digest_md5": schema_digest_md5} if schema_digest_md5 else {}),
         "software": software_facts() if mode == "live" else {

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1172,6 +1172,36 @@ def bundle_drift_detail(method: str, label: str, project: str,
                             f"record pinned {recorded[:8]}"), declared
 
 
+PHASES_RECORDED, PHASES_API = "recorded", "api_usage"
+PHASES_ABSENT = "absent"
+
+
+def phase_log_status(method: str, label: str, project: str,
+                     concat_dir: Path | None = None) -> tuple[str, int]:
+    """(status, phase count) for what a run said about its own steps (#562).
+
+    Three answers, not two. `api_usage` and `phase_log` are both real accounts
+    of a run's phases, written by different runtimes recording different
+    things — the API path can report seconds and tokens, the agentic path
+    cannot. Collapsing them would suggest the two are comparable in detail,
+    and they are not; counting the agentic path's as absent would be false.
+    """
+    import yaml as _yaml
+
+    from data_sheets_schema.provenance import record_path_for
+    path = record_path_for(project, method, label, concat_dir or CONCAT_DIR)
+    if not path.exists():
+        return PHASES_ABSENT, 0
+    rec = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    block = rec.get("phase_log")
+    if isinstance(block, dict) and block.get("phases"):
+        return PHASES_RECORDED, len(block["phases"])
+    usage = rec.get("api_usage")
+    if isinstance(usage, list) and usage:
+        return PHASES_API, len({u.get("phase") for u in usage})
+    return PHASES_ABSENT, 0
+
+
 GROUNDED_ALL, GROUNDED_GAPS = "all_grounded", "gaps"
 GROUNDED_NOT_RUN, GROUNDED_UNRECORDED = "not_run", "unrecorded"
 

--- a/tests/test_phase_log.py
+++ b/tests/test_phase_log.py
@@ -1,0 +1,102 @@
+"""What a run says about its own phases (#562).
+
+The API path records eight `api_usage` entries per run — phase, attempt,
+seconds, tokens, stop reason. The agentic path recorded nothing, so its phase
+structure existed only as prose in the reconciliation report, and #546 showed a
+report is not a reliable account of what happened.
+
+That made every arm comparison one-sided in a way easy to miss: #544's finding
+was about a phase, and the same question could not be asked of the other arm
+from the record at all.
+"""
+
+import unittest
+
+from data_sheets_schema.provenance import (
+    PHASE_FIELDS_UNAVAILABLE_TO_AGENTS,
+    phase_facts,
+)
+
+
+class PhaseFactsTest(unittest.TestCase):
+
+    def test_order_is_kept_and_numbered(self):
+        block = phase_facts([{"name": "a"}, {"name": "b"}, {"name": "c"}])
+        self.assertEqual([p["phase"] for p in block["phases"]], ["a", "b", "c"])
+        self.assertEqual([p["ordinal"] for p in block["phases"]], [1, 2, 3])
+
+    def test_nothing_recorded_is_none_not_an_empty_log(self):
+        """An empty phase log reads as a run that performed no phases."""
+        self.assertIsNone(phase_facts([]))
+
+    def test_iterations_only_appear_when_given(self):
+        """`iterations: 1` on a phase that cannot loop implies it was measured."""
+        block = phase_facts([{"name": "a"}, {"name": "b", "iterations": 3}])
+        self.assertNotIn("iterations", block["phases"][0])
+        self.assertEqual(block["phases"][1]["iterations"], 3)
+
+    def test_an_incomplete_phase_says_so(self):
+        block = phase_facts([{"name": "a", "completed": False}])
+        self.assertFalse(block["phases"][0]["completed"])
+
+    def test_timing_and_tokens_are_named_unavailable_not_omitted(self):
+        """#400 is a runtime limit, and a named limit reads differently from
+        an absent field: one is a fact about the instrument, the other looks
+        like an oversight."""
+        block = phase_facts([{"name": "a"}])
+        self.assertEqual(set(block["unavailable"]),
+                         set(PHASE_FIELDS_UNAVAILABLE_TO_AGENTS))
+        self.assertIn("#400", block["unavailable_basis"])
+        for field in PHASE_FIELDS_UNAVAILABLE_TO_AGENTS:
+            with self.subTest(field=field):
+                self.assertNotIn(field, block["phases"][0])
+
+
+class ParseTest(unittest.TestCase):
+
+    def _parse(self, *specs):
+        from data_sheets_schema.cli.provenance import _parse_phases
+        return _parse_phases(specs)
+
+    def test_a_bare_name_is_a_completed_phase(self):
+        self.assertEqual(self._parse("audit"),
+                         [{"name": "audit", "completed": True}])
+
+    def test_json_carries_the_detail(self):
+        got = self._parse('{"name":"reconcile","completed":true,"iterations":3}')
+        self.assertEqual(got[0]["iterations"], 3)
+
+    def test_malformed_json_raises_rather_than_being_dropped(self):
+        """A log missing one phase is worse than no log: it reads as a run
+        that skipped a step."""
+        import click
+        with self.assertRaises(click.BadParameter):
+            self._parse('{"name": "broken"')
+        with self.assertRaises(click.BadParameter):
+            self._parse('{"completed": true}')
+
+
+class StatusTest(unittest.TestCase):
+    """Three answers, because two would misdescribe one of the arms."""
+
+    def test_the_three_statuses_are_distinct(self):
+        from data_sheets_schema.runs import (
+            PHASES_ABSENT, PHASES_API, PHASES_RECORDED,
+        )
+        self.assertEqual(len({PHASES_ABSENT, PHASES_API, PHASES_RECORDED}), 3)
+
+    def test_an_api_record_reports_its_api_usage(self):
+        from pathlib import Path
+
+        from data_sheets_schema.runs import PHASES_API, phase_log_status
+        label = "2026-08-13_claude-opus-5-api-generic-v4_rep1"
+        if not (Path("data/d4d_concatenated/claudecode_agent_core") / label
+                / "CHORUS_provenance.yaml").exists():
+            self.skipTest("v4 arm not present in this checkout")
+        status, n = phase_log_status("claudecode_agent", label, "CHORUS")
+        self.assertEqual(status, PHASES_API)
+        self.assertGreaterEqual(n, 6, "six phases plus repair")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #562.

The API path writes eight `api_usage` entries per run — phase, attempt,
seconds, tokens, stop reason. The agentic path wrote **nothing**, so its phase
structure existed only as prose in the reconciliation report, and #546 showed a
report is not a reliable account of what happened.

That made every arm comparison one-sided in a way easy to miss. #544's entire
finding was about a phase — reconciliation reporting success without achieving
it — and the same question could not be asked of the other arm from the record.

## This is not the #400 limitation

A Claude Code subagent cannot report its own token accounting, which is why no
reasoning log is written for it. But **which phase ran, whether it completed,
and how many times a loop iterated** are things the agent knows — the playbook
already tells it to write them into the report in prose.

So timing and tokens are **named as unavailable** rather than left absent. A
named limit reads as a fact about the instrument; an absent field reads as an
oversight. Same three-way distinction `d4d provenance reasoning` already draws.

## Shape

```bash
d4d provenance record ... \
  --phase '{"name":"generate_full","completed":true,"artifacts":["CHORUS_d4d.yaml"]}' \
  --phase source_audit \
  --phase '{"name":"reconcile","completed":true,"iterations":3}'
```

- A bare name, or JSON where completion, iterations or artifacts matter.
- **Malformed values raise** rather than being dropped — a log missing one
  phase is worse than no log, because it reads as a run that skipped a step.
- `iterations` appears only when given; writing `1` on a phase that cannot loop
  would imply the number was measured.
- Phases are never inferred from artifacts on disk. A phase that ran and a
  phase whose output happens to exist are different claims.

## `runs check` reports three states, not two

| state | count today |
|---|---|
| nothing recorded | 72 |
| `api_usage` | 50 |
| `phase_log` | **0** |

Collapsing the first two would suggest the arms are comparable in detail, which
they are not. Calling the agentic path's absent would be false once it starts
writing one. The last figure is what v5 changes.

10 tests. Suite: 2044 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)