### PR TITLE
Gate a generation run on the merged schema being built from current source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,10 @@ gen-examples:
 
 # Build the combined schema
 # Also write proper yaml header to it
+.PHONY: check-digest
+check-digest: ## Is the merged schema built from today's source? (gate before generating)
+	$(RUN) d4d schema check-digest --strict
+
 .PHONY: full-schema
 full-schema: $(SOURCE_SCHEMA_ALL)
 

--- a/notes/codex_v5_readiness_review_2026-08-15.md
+++ b/notes/codex_v5_readiness_review_2026-08-15.md
@@ -1,0 +1,130 @@
+# Codex readiness review for a v5 generation arm — 2026-08-15
+
+Independent adversarial review, run because six prior in-session review rounds
+had each found real defects and a seventh opinion was wanted before spending a
+generation arm.
+
+| | |
+|---|---|
+| date | 2026-08-15 |
+| reviewer | Codex (GPT-5.x), via the `codex:rescue` plugin |
+| session id | `01a0086b-383a-7d71-9e54-00f380278a3f` |
+| resume | `codex resume 01a0086b-383a-7d71-9e54-00f380278a3f` |
+| repo state | `main` at `d709c86c` |
+| scope | PRs #548–#571 |
+
+**Verdict: not ready.** Five blocking defects, eight should-fix-before-run, one
+minor. Notably it contradicts claims made in this repository's own PR
+descriptions and in `notes/generic_v5_analysis_plan.md` — see items 10 and 11,
+which say the measured baselines are not reproducible and that a v4-vs-v5
+comparison is confounded beyond what the plan admits.
+
+The review is reproduced **verbatim** below. Nothing has been corrected,
+softened, or re-ordered, including where it disagrees with figures recorded
+elsewhere in this repository. Any of its findings that are later disputed
+should be disputed in a separate document or issue, not by editing this one.
+
+---
+
+## 1. Verdict
+
+**No.** The v5 prompt body is correctly pinned, but the API and agentic runtimes receive materially conflicting identifier and spelling rules; `reconcile_full` can promote unsupported core hallucinations into the full record; and the proposed v4-vs-v5 comparison is confounded by pipeline and schema changes. Several new checks also silently skip inputs, over-suppress findings, or remain non-fatal while the batch command reports success.
+
+## 2. Confirmed defects
+
+1. [d4d_generic_arm_prompt_v5.md:213](src/download/prompts/d4d_generic_arm_prompt_v5.md) requires every identifier to be a CURIE, while [d4d-uniform-rules.md:33](.claude/commands/d4d-uniform-rules.md) permits—and at line 39 requires—URLs when no prefix exists. Agentic runs read both; API runs read only the prompt body, so the runtimes implement different conditions. Introduced by #559/#564. **Severity: blocking.**
+
+2. The parity test checks only phrases such as "as a CURIE" and "American English," not semantic equivalence ([test_playbook_reach.py:87](tests/test_playbook_reach.py)). It therefore passes despite the conflict above and despite agentic-only project examples such as `b2ai-voice:` and a Fairhub DOI ([d4d-uniform-rules.md:39](.claude/commands/d4d-uniform-rules.md), [d4d-uniform-rules.md:59](.claude/commands/d4d-uniform-rules.md)). **Severity: blocking.**
+
+3. `reconcile_full` is told to absorb *anything* stated only by core ([api_runner.py:492](src/data_sheets_schema/api_runner.py)), even though the preceding audit explicitly detects unsupported core content ([api_runner.py:481](src/data_sheets_schema/api_runner.py)). A core hallucination can therefore become authoritative in both records. Introduced by #566/#567. **Severity: blocking.**
+
+4. The resume path silently builds phases with whichever prerequisites happen to exist instead of requiring all `PHASE_NEEDS` ([api_runner.py:1895](src/data_sheets_schema/api_runner.py)). Missing artifacts do not invalidate downstream completed phases, while an invalid core only clears `core` and `reconcile_core`, leaving stale audit/reconcile/report phases marked complete ([api_runner.py:1865](src/data_sheets_schema/api_runner.py)). An interrupted v5 run can resume with stale audit findings or run reconciliation without core. **Severity: blocking.**
+
+5. `plan()` claims to render the whole assembly but carries only the Phase-1 full placeholder ([api_runner.py:595](src/data_sheets_schema/api_runner.py)); its audit lacks core, `reconcile_full` lacks core and audit, and later phases lack all declared inputs. `approx_tokens()` also counts cached blocks separately even though those same blocks are already inside `messages` ([api_runner.py:449](src/data_sheets_schema/api_runner.py), [api_runner.py:577](src/data_sheets_schema/api_runner.py)). Dry-run cost/context estimates are not estimates of requests that will actually run. **Severity: should-fix-before-run.**
+
+6. The report phase is asked to describe what reconciliation changed but receives only the audit findings, not either reconciled output ([api_runner.py:513](src/data_sheets_schema/api_runner.py), [api_runner.py:542](src/data_sheets_schema/api_runner.py)). Reports must reconstruct or invent actions they cannot observe. The report-claim verdict then pins only the report, not the full/core records or schema it checked against ([api_runner.py:1320](src/data_sheets_schema/api_runner.py)). **Severity: should-fix-before-run.**
+
+7. `grounding.check_run` returns `checked: true` with zero findings when both record files are absent because missing paths are simply skipped ([grounding.py:165](src/data_sheets_schema/grounding.py)). Its distinct sets also preserve identifier case ([grounding.py:145](src/data_sheets_schema/grounding.py)), so case-insensitive DOI variants are miscounted as distinct; a direct check counted `doi:10.1234/ABC` and `doi:10.1234/abc` as two. Introduced by #547/#555. **Severity: should-fix-before-run.**
+
+8. Report claims explicitly concerning both records fall into `_target == "either"` and are checked only against core ([report_claims.py:148](src/data_sheets_schema/report_claims.py), [report_claims.py:273](src/data_sheets_schema/report_claims.py)); a "removed from full and core" claim passes if core removed it while full retained it. Dotted schema claims are checked using only their root slot ([report_claims.py:361](src/data_sheets_schema/report_claims.py)), so "`distributions.bogus` is undeclared" is falsely contradicted because `distributions` exists. Introduced by #546/#553. **Severity: should-fix-before-run.**
+
+9. `schema_moved` is true after any change to the full-schema digest ([d4d_pair_consistency.py:703](src/data_sheets_schema/d4d_pair_consistency.py)), then downgrades every shared-slot presence mismatch to a warning ([d4d_pair_consistency.py:267](src/data_sheets_schema/d4d_pair_consistency.py)). It does not establish that the particular slot was added after the run, so unrelated schema edits suppress real historical pair defects. Introduced by #550/#561. **Severity: should-fix-before-run.**
+
+10. The v5 plan's baselines are not reproducible against current data ([generic_v5_analysis_plan.md:46](notes/generic_v5_analysis_plan.md)): current checks find minted fragments in AI_READI rep2/rep3 that its "0 elsewhere" omits, 320 undeclared CURIEs rather than 370, and 618 generated-prose British occurrences rather than 627. **Severity: blocking.**
+
+11. `comparable_conditions()` treats adjacent bases as an isolating comparison ([api_runner.py:114](src/data_sheets_schema/api_runner.py)), so it labels v4-v5 comparable even though v5 adds four rules and #566 changes request assembly. The v4 records also pin schema digest `622e…`, while current v5 would use `44d…`. This comparison cannot measure only "the v5 block." **Severity: blocking.**
+
+12. The agentic phase log accepts arbitrary phase names and treats any bare name as completed ([cli/provenance.py:21](src/data_sheets_schema/cli/provenance.py)); downstream status checks only that a nonempty list exists ([runs.py:1179](src/data_sheets_schema/runs.py)). It does not require the four phases or verify their completion, so it can report a phase account without proving reconciliation ran. Introduced by #562/#571. **Severity: should-fix-before-run.**
+
+13. API batch success depends only on individual schema validation ([cli/api.py:325](src/data_sheets_schema/cli/api.py)); pair divergence, a failed report/grounding check, or ungrounded identifiers still enter the "succeeded" count. The canary will not automatically stop the sweep on the defects v5 is intended to measure. **Severity: should-fix-before-run.**
+
+14. `--project VOICE` in `backfill-checks` matches `VOICE_PEDIATRIC_provenance.yaml` because filtering uses `startswith("VOICE_")` ([cli/provenance.py:556](src/data_sheets_schema/cli/provenance.py)). A scoped overwrite can modify records outside the requested project. Introduced by #552/#557. **Severity: minor.**
+
+## 3. Answers to questions 1–5
+
+### 1. Prompt genericity, pinning, and runtime reach
+
+The executable body is generic: `prompt_body()` strips everything above `## Prompt body` ([api_runner.py:315](src/data_sheets_schema/api_runner.py)), and no project name or rationale count occurs in that body. The whole file is not generic—its rationale names VOICE, CM4AI, identifiers, and measured counts ([d4d_generic_arm_prompt_v5.md:26](src/download/prompts/d4d_generic_arm_prompt_v5.md))—but the documented launch path renders only the body.
+
+Pinning is correct. The on-disk whole-file SHA-256 is `606e7382…`, body SHA-256 is `baf755f8…`, and size is 11,812 bytes, matching [canonical_hashes.yaml:123](src/download/prompts/canonical_hashes.yaml) and commit `9b6dd51d`. `d4d api prompts check --strict` reported 11 canonical files, zero failures.
+
+All four topics reach both runtimes, but they are not equivalently enforced. API sees the body; agentic sees the body plus the uniform-rules file. Their CURIE/URL and American-English scopes conflict, the agentic path gets project-specific examples the API path does not, and the parity test only probes phrases. None of the four is a fatal post-generation gate.
+
+### 2. Effects of giving `reconcile_full` core
+
+No prior-run cache or cross-project context is directly introduced: core is carried as an uncached same-run artifact after the bundle/schema prefix. The material risks are:
+
+- A confirmed feedback loop: unsupported core-only content is ordered into full.
+- A confirmed resume-invalidation defect: stale audit/reconciliation can survive a regenerated or missing core.
+- Copying wording verbatim is discouraged at [api_runner.py:499](src/data_sheets_schema/api_runner.py), but no check detects it. Whether a real v5 model does so remains unverified.
+- The dry-run planner does not include the added core artifact, so it cannot assess the context increase it claims to estimate.
+
+### 3. Correctness of the new checks
+
+They are not fully correct.
+
+- Grounding silently passes missing/empty record input and miscounts case variants as distinct.
+- Report checking misses explicit both-record claims, can falsely contradict dotted-path schema claims, and does not bind its verdict to the records/schema checked.
+- Backfill's project filter is not exact.
+- The pair checker correctly distinguishes exceptions/missing files as `ran: false`, and its finding truncation is explicit, but `schema_moved` suppresses too broad a class of historical presence errors.
+- All three API-side checks are recorded after repair, which is correct, but batch success ignores their outcomes.
+
+Read-only executions reproduced 11/12 v4 pair divergences and the documented 19/10 ungrounded identifiers. A dry-run of `backfill-checks` processed all four rep1 projects and reported its findings without writes. The full pytest invocation could not start because this sandbox exposes no writable temporary directory.
+
+### 4. Honesty and reproducibility of the analysis plan
+
+The plan is honest only about one limitation: four prompt rules move together, so effects cannot be attributed within that block ([generic_v5_analysis_plan.md:9](notes/generic_v5_analysis_plan.md)). It is not honest about the larger comparison: v4-v5 also changes reconciliation inputs/instructions, provenance behavior, phase logging, checks, and schema digest. Therefore even attribution to "the v5 block" is unavailable.
+
+Current-data reproduction produced:
+
+- Correct: absent identifiers 19 in VOICE rep1 and 10 in CM4AI rep3; URL-valued identifier slots 397; pair divergence 11/12.
+- Incorrect/stale: minted fragments omit AI_READI rep2=14 and rep3=13; undeclared CURIEs are 320 because `urn:`/`ark:` are classified as no-authority URIs, not undeclared CURIEs; generated-prose British occurrences are 618 across the pair, with 626 total including quoted occurrences, not 627.
+
+### 5. Fresh-run reproducibility and interpretation
+
+Prompt pinning, resolved-request hashing, bundle/schema hashes, assembly digest, phase snapshots, and observed API context usage are useful and correctly present. Ordering of normal phase execution is deterministic.
+
+A fresh run remains uninterpretable as an experiment because:
+
+- the two runtimes do not implement the same rules;
+- v4-v5 is confounded by procedure and schema changes;
+- planner context/cost numbers do not describe actual requests;
+- resume can reuse stale dependencies;
+- reports cannot observe the changes they claim to summarize;
+- agentic phase completion is unvalidated self-report;
+- batch calls pair/claim/grounding failures "success."
+
+## 4. Open questions / things requiring a real v5 batch
+
+- Whether the model copies core wording verbatim into full after the new feedback instruction.
+- Whether conflicting CURIE/URL instructions produce systematically different API and agentic identifiers.
+- Whether AI-READI's enlarged `reconcile_full` request fits the provider's unstated context ceiling.
+- Actual v5 pair-divergence, grounding, spelling, and omission rates.
+- Whether the model follows unsupported-core audit findings instead of the unconditional absorption instruction.
+
+Codex session ID: 01a0086b-383a-7d71-9e54-00f380278a3f
+Resume in Codex: codex resume 01a0086b-383a-7d71-9e54-00f380278a3f
+
+---
+
+*End of verbatim review.*

--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -90,6 +90,23 @@ them.
   the corpus already diverges (#550). This is a regression watch, not a
   prediction.
 
+## Before the arm starts: the schema must be current
+
+`make check-digest` (or `d4d schema check-digest --strict`) rebuilds each merged
+schema from its source and compares. `d4d api run` now performs the same check
+and refuses to start when it fails, because a merged schema built from stale
+source makes every record in the arm attest to a digest describing a schema this
+repository no longer holds — invisibly, since the record correctly hashes the
+file it did read.
+
+Verified in sync at the time of writing: `Dataset` `44d29023`, `CoreDataset`
+`dff487bc`, both byte-identical to a fresh build.
+
+**This does not resolve #576.** The check establishes that the digest describes
+today's source; it says nothing about whether today's source is the same one v4
+was generated against. It is not — v4 recorded `622e6d03` — and that remains a
+decision about the comparison rather than a defect to fix here.
+
 ## The canary is AI-READI, and the context risk is smaller than first stated
 
 The v4 arm canaried CHORUS, whose largest request is 64k tokens against

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -1778,6 +1778,28 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     if dry_run:
         return plan(spec)
 
+    # Before a token is spent. The digest this run is about to send, the schema
+    # it validates against and the identity slots its pair check uses all come
+    # from the *merged* schemas, which are generated artifacts — so a module
+    # edited without regenerating makes every record in the arm attest to a
+    # schema this repository no longer holds, invisibly, because the record
+    # correctly hashes the file it actually read.
+    #
+    # Fatal, unlike every other check here. Bundle drift, pair divergence,
+    # report claims and grounding all describe a record that remains usable
+    # evidence; this corrupts the run's central input, and there would be
+    # nothing to preserve by continuing.
+    from data_sheets_schema.schema_sync import blocking, check as _schema_check
+    stale = blocking(_schema_check())
+    if stale:
+        detail = "; ".join(f"{r['class']}: {r.get('reason', r['status'])}"
+                           for r in stale)
+        raise RuntimeError(
+            "the merged schema is not built from the current source, so this "
+            f"run would record a digest for a schema that does not exist — "
+            f"{detail}. Run `make regen-all`, review the diff and commit it, "
+            "or check with `d4d schema check-digest`.")
+
     from data_sheets_schema.provenance import build_record, record_path_for
 
     settings = _model_settings()

--- a/src/data_sheets_schema/cli/schema.py
+++ b/src/data_sheets_schema/cli/schema.py
@@ -98,3 +98,49 @@ def validate(d4d_file, schema_file):
         import traceback
         traceback.print_exc()
         sys.exit(1)
+
+
+@schema.command("check-digest")
+@click.option("--strict", is_flag=True,
+              help="exit 1 when a merged schema is stale or cannot be checked")
+def check_digest(strict):
+    """Is the merged schema a run would consume built from today's source?
+
+    The digest sent to the model, the schema records are validated against and
+    the identity slots the pair checker uses all come from the *merged*
+    schemas, which are generated artifacts. Editing a module without
+    regenerating leaves every record in an arm attesting to a digest that
+    describes an older schema than the repository holds — and nothing in the
+    record can reveal it, because the record correctly hashes the merged file
+    it actually read.
+
+    Rebuilds each merged schema from its source into a temporary directory and
+    compares, rather than trusting timestamps: a merged file can be newer than
+    its modules and still be wrong (the reason `audit-bundles` works the same
+    way, #446).
+    """
+    import sys
+
+    from data_sheets_schema.schema_sync import IN_SYNC, blocking, check
+
+    rows = check()
+    for r in rows:
+        mark = {"in_sync": "✓", "stale": "❌", "unchecked": "❌"}[r["status"]]
+        click.echo(f" {mark} {r['status']:9} {r['class']:12} "
+                   f"digest {str(r.get('digest') or '-')[:12]}  {r['merged']}")
+        if r.get("reason"):
+            click.echo(f"       {r['reason']}")
+        if r.get("rebuilt_at"):
+            click.echo(f"       a fresh build is at {r['rebuilt_at']} — "
+                       f"diff it against {r['merged']}")
+
+    bad = blocking(rows)
+    if not bad:
+        click.echo(f"\n{len(rows)} merged schema(s) built from current source.")
+    else:
+        click.echo(f"\n{len(bad)} of {len(rows)} merged schema(s) not current. "
+                   "Run `make regen-all`, review the diff, and commit it before "
+                   "generating: a run started now would record a digest for a "
+                   "schema this repository no longer holds.")
+    if strict and bad:
+        sys.exit(1)

--- a/src/data_sheets_schema/schema_digest.py
+++ b/src/data_sheets_schema/schema_digest.py
@@ -266,7 +266,20 @@ def _build_uncached(class_name: str, schema_path: Path | None = None) -> ClassDi
             f"No schema known for class {class_name!r}; pass schema_path "
             f"explicitly. Known: {sorted(CLASS_SCHEMA)}")
     sv = SchemaView(str(path))
-    digest = ClassDigest(class_name=class_name, schema_path=str(path))
+    # The digest names the schema it came from, and that name is rendered into
+    # the digest text — so an identical schema read from a different location
+    # produced a different fingerprint. Verifying a digest by rebuilding the
+    # merged schema into a temp directory and re-digesting it, which is exactly
+    # what a pre-run gate must do, therefore always disagreed.
+    #
+    # Canonicalised to the path this class's schema is known by, so the
+    # fingerprint is a function of the schema's content and not of where the
+    # file happens to sit. The default path already rendered this string, so
+    # no existing digest moves.
+    known = CLASS_SCHEMA.get(class_name)
+    named = str(known) if known and Path(path).name == Path(known).name \
+        else str(path)
+    digest = ClassDigest(class_name=class_name, schema_path=named)
 
     for slot in sv.class_induced_slots(class_name):
         enum_values: list[str] = []

--- a/src/data_sheets_schema/schema_sync.py
+++ b/src/data_sheets_schema/schema_sync.py
@@ -1,0 +1,141 @@
+"""Is the schema a run is about to be generated against the real schema?
+
+The digest sent to the model, the schema every record is validated against, and
+the identity slots the pair checker uses are all read from the **merged**
+schemas — `data_sheets_schema_all.yaml` and `data_sheets_schema_core_all.yaml`.
+Those are generated artifacts. The source of truth is
+`data_sheets_schema.yaml` and the `D4D_*.yaml` modules it imports.
+
+Nothing checked that the two agree before a generation run. If a module is
+edited without regenerating, every record in the arm attests to a digest that
+describes an older schema than the repository holds — and there is no field in
+the record that could reveal it, because the record correctly hashes the merged
+file it actually read.
+
+`make check-sync` exists and is not on the generation path; #521 records a
+period when it reported staleness and the remedy it named was a silent no-op.
+
+## Rebuild and compare, not mtime
+
+The check regenerates each merged schema into a temporary directory and
+compares the bytes, for the reason `audit-bundles` does the same for bundles
+(#446): a timestamp says when a file was written, not what it was written
+from. A merged file can be newer than its modules and still be wrong.
+
+This costs a `gen-linkml` invocation per schema — seconds, once per run,
+against an arm that takes hours.
+
+## Fatal, unlike the other pre-run checks
+
+Bundle drift, pair divergence, report claims and identifier grounding are all
+reported and never fatal, because each describes a record that remains usable
+evidence. A stale merged schema is different in kind: it corrupts the run's
+central input before a token is spent, and every record produced would have to
+be discarded. There is nothing to preserve by continuing.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+#: (merged artifact, source it is generated from, digest class, leading `---`)
+#:
+#: The document marker is per-schema because the Makefile is: the full-schema
+#: rule pipes `---` onto its output and the core rule does not. Assuming both
+#: had it made this check report the core schema stale on its first run, for a
+#: one-line difference the check itself had introduced.
+MERGED_SCHEMAS = (
+    (Path("src/data_sheets_schema/schema/data_sheets_schema_all.yaml"),
+     Path("src/data_sheets_schema/schema/data_sheets_schema.yaml"),
+     "Dataset", True),
+    (Path("src/data_sheets_schema/schema/data_sheets_schema_core_all.yaml"),
+     Path("src/data_sheets_schema/schema/data_sheets_schema_core.yaml"),
+     "CoreDataset", False),
+)
+
+IN_SYNC = "in_sync"
+STALE = "stale"
+UNCHECKED = "unchecked"
+
+
+def _regenerate(source: Path, target: Path,
+                marker: bool) -> tuple[bool, str | None]:
+    """Run the same generation the Makefile runs. (ok, why not)"""
+    try:
+        result = subprocess.run(
+            ["poetry", "run", "gen-linkml", "-o", str(target), "-f", "yaml",
+             str(source)],
+            capture_output=True, text=True, timeout=600)
+    except Exception as exc:                                   # noqa: BLE001
+        return False, f"gen-linkml could not run: {exc}"
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "").strip()[-300:]
+        return False, f"gen-linkml failed: {tail}"
+    if not target.exists():
+        return False, "gen-linkml wrote nothing"
+    if marker:
+        target.write_text("---\n" + target.read_text(encoding="utf-8"),
+                          encoding="utf-8")
+    return True, None
+
+
+def check_one(merged: Path, source: Path, class_name: str,
+              marker: bool = False) -> dict[str, Any]:
+    """Rebuild `merged` from `source` and compare."""
+    from data_sheets_schema import schema_digest
+
+    out: dict[str, Any] = {"merged": str(merged), "source": str(source),
+                           "class": class_name}
+    if not source.exists():
+        return {**out, "status": UNCHECKED,
+                "reason": f"source schema {source} is not on disk"}
+    if not merged.exists():
+        return {**out, "status": STALE,
+                "reason": f"{merged} has never been generated"}
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Same filename, because the digest names the schema it came from and
+        # a differing name would be a spurious difference.
+        rebuilt = Path(tmp) / merged.name
+        ok, why = _regenerate(source, rebuilt, marker)
+        if not ok:
+            return {**out, "status": UNCHECKED, "reason": why}
+        same = rebuilt.read_bytes() == merged.read_bytes()
+        try:
+            live = schema_digest.fingerprint(
+                schema_digest.digest_text(class_name, merged))
+            fresh = schema_digest.fingerprint(
+                schema_digest.digest_text(class_name, rebuilt))
+        except Exception as exc:                               # noqa: BLE001
+            return {**out, "status": UNCHECKED,
+                    "reason": f"digest could not be computed: {exc}"}
+        out["digest"] = live
+        out["digest_rebuilt"] = fresh
+        if same and live == fresh:
+            return {**out, "status": IN_SYNC}
+        # Keep the rebuilt file so a human can diff it, rather than reporting
+        # a difference and deleting the evidence of it.
+        kept = Path(tempfile.mkdtemp(prefix="d4d-schema-rebuild-")) / merged.name
+        shutil.copy2(rebuilt, kept)
+        return {**out, "status": STALE, "rebuilt_at": str(kept),
+                "reason": ("the merged schema differs from a fresh build of "
+                           "its source" if not same else
+                           "the merged schema matches but its digest does not")}
+
+
+def check(schemas=MERGED_SCHEMAS) -> list[dict[str, Any]]:
+    return [check_one(m, s, c, k) for m, s, c, k in schemas]
+
+
+def blocking(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Rows that must stop a generation run.
+
+    `unchecked` blocks as well as `stale`. A gate that cannot run has not
+    passed, and the whole point here is that the failure it guards against is
+    invisible in the record afterwards.
+    """
+    return [r for r in rows if r["status"] != IN_SYNC]

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -1,0 +1,121 @@
+"""Is the schema a run is generated against the schema this repo holds?
+
+The digest sent to the model, the schema records are validated against and the
+identity slots the pair checker uses are all read from the *merged* schemas,
+which are generated artifacts. A module edited without regenerating makes every
+record in an arm attest to a digest describing an older schema — and no field
+in the record can reveal it, because the record correctly hashes the merged
+file it actually read.
+
+Nothing checked this before a generation run. `make check-sync` exists and is
+not on the generation path; #521 records a period when it reported staleness
+and the remedy it named was a silent no-op.
+"""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from data_sheets_schema import schema_digest
+from data_sheets_schema.schema_sync import (
+    IN_SYNC,
+    MERGED_SCHEMAS,
+    STALE,
+    blocking,
+    check,
+    check_one,
+)
+
+
+class DigestIsAFunctionOfContentTest(unittest.TestCase):
+    """The digest must not depend on where the file sits.
+
+    It did: the rendered digest names the schema it came from, so identical
+    bytes in a temp directory fingerprinted differently. That silently broke
+    the check this module exists to perform, because rebuild-and-compare builds
+    into a temp directory — three digests for one schema:
+    `44d29023` in place, `2c93af56` rebuilt, `173abe3e` copied.
+    """
+
+    SCHEMA = Path("src/data_sheets_schema/schema/data_sheets_schema_all.yaml")
+
+    def test_identical_bytes_elsewhere_fingerprint_the_same(self):
+        if not self.SCHEMA.exists():
+            self.skipTest("merged schema not present in this checkout")
+        with tempfile.TemporaryDirectory() as tmp:
+            copy = Path(tmp) / self.SCHEMA.name
+            shutil.copy2(self.SCHEMA, copy)
+            here = schema_digest.fingerprint(
+                schema_digest.digest_text("Dataset", self.SCHEMA))
+            there = schema_digest.fingerprint(
+                schema_digest.digest_text("Dataset", copy))
+            self.assertEqual(here, there)
+
+    def test_the_committed_digest_did_not_move(self):
+        """Canonicalising the name must not re-baseline anything.
+
+        The default path already rendered the canonical string, so every digest
+        recorded in the corpus stays valid. If this fails, the corpus and the
+        code disagree about what schema every record was generated against.
+        """
+        if not self.SCHEMA.exists():
+            self.skipTest("merged schema not present in this checkout")
+        self.assertEqual(
+            schema_digest.fingerprint(schema_digest.digest_text("Dataset")),
+            "44d290239cedcd8bb38488f4fa11d0fb")
+
+
+class SyncCheckTest(unittest.TestCase):
+
+    def test_the_repository_is_in_sync(self):
+        """If this fails, do not generate — regenerate and commit first."""
+        rows = check()
+        self.assertEqual(blocking(rows), [],
+                         "a merged schema is not built from current source")
+        self.assertTrue(all(r["status"] == IN_SYNC for r in rows))
+
+    def test_a_tampered_merged_schema_is_caught(self):
+        """A check that never fails is indistinguishable from no check."""
+        merged, source, cls, marker = MERGED_SCHEMAS[0]
+        if not merged.exists():
+            self.skipTest("merged schema not present in this checkout")
+        original = merged.read_bytes()
+        try:
+            merged.write_bytes(original + b"\n# not a line any rebuild emits\n")
+            row = check_one(merged, source, cls, marker)
+            self.assertEqual(row["status"], STALE)
+            self.assertIn("differs from a fresh build", row["reason"])
+            # The evidence is kept rather than deleted with the temp dir.
+            self.assertTrue(Path(row["rebuilt_at"]).exists())
+        finally:
+            merged.write_bytes(original)
+        self.assertEqual(check_one(merged, source, cls, marker)["status"],
+                         IN_SYNC, "the fixture must restore the schema")
+
+    def test_a_missing_source_is_unchecked_and_still_blocks(self):
+        """A gate that could not run has not passed."""
+        row = check_one(Path("nope_all.yaml"), Path("nope.yaml"), "Dataset")
+        self.assertEqual(row["status"], "unchecked")
+        self.assertEqual(blocking([row]), [row])
+
+
+class GateTest(unittest.TestCase):
+
+    def test_execute_refuses_to_start_when_the_schema_is_stale(self):
+        """Fatal, unlike every other check on this path.
+
+        The others describe records that remain usable evidence; this one
+        corrupts the run's central input before a token is spent.
+        """
+        import inspect
+
+        from data_sheets_schema.api_runner import execute
+        source = inspect.getsource(execute)
+        self.assertIn("schema_sync", source)
+        # Before the client is built, or the check is decoration.
+        self.assertLess(source.index("schema_sync"), source.index("_client()"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Answers "is the schema digest current?" — **yes** — and adds the process that
keeps it so.

| | digest | vs a fresh rebuild |
|---|---|---|
| `Dataset` | `44d29023` | byte-identical |
| `CoreDataset` | `dff487bc` | byte-identical |

## Nothing was checking this before a run

The digest sent to the model, the schema every record validates against, and
the identity slots the pair checker uses all come from the **merged** schemas —
generated artifacts, not the source of truth. A module edited without
regenerating makes every record in an arm attest to a digest describing a schema
this repository no longer holds, and **no field in the record can reveal it**,
because the record correctly hashes the merged file it actually read.

`make check-sync` exists and was never on the generation path. #521 records a
period when it reported staleness and the remedy it named was a silent no-op.

- **`d4d schema check-digest [--strict]`** / **`make check-digest`** — rebuilds
  each merged schema from its source into a temp directory and compares bytes
  *and* digest. Not timestamps: a merged file can be newer than its modules and
  still be wrong, the reason `audit-bundles` works this way (#446).
- **`d4d api run` refuses to start** when it fails.

**Fatal, unlike every other check on this path.** Bundle drift, pair divergence,
report claims and grounding each describe a record that remains usable evidence.
This corrupts the run's central input before a token is spent. `unchecked`
blocks too — a gate that could not run has not passed.

## A prerequisite defect: the digest was not a function of the schema

The rendered digest names the file it came from, so identical bytes elsewhere
fingerprinted differently. One schema, three digests:

```
44d29023   in place
2c93af56   rebuilt into a temp dir
173abe3e   byte-identical copy in a temp dir
```

That silently defeats rebuild-and-compare, which is exactly what this check
does. The name is now canonicalised to the path the class's schema is known by.
The default path already rendered that string, so **no recorded digest moves** —
pinned by a test against the literal `44d290239cedcd8bb38488f4fa11d0fb`, because
if that ever changes the corpus and the code disagree about what every record
was generated against.

## Verified by breaking it

A check that never fails is indistinguishable from no check. With one line
appended to the merged schema:

```
d4d schema check-digest --strict   → exit 1, "differs from a fresh build"
execute()                          → RuntimeError before a client is built
```

The test does the same and restores the file.

Worth noting: the check's **first** run reported the core schema stale — for a
`---` marker the check itself had added, because the Makefile prepends one to
the full schema and not to core. Encoded per-schema now, and the comment says
why.

## Scope

This does **not** resolve #576. It establishes that the digest describes today's
source; it says nothing about whether today's source is what v4 was generated
against. It is not — v4 recorded `622e6d03` — and that stays a decision about
the comparison.

6 tests. Suite: 2060 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)