### PR TITLE
Make the CURIE rule say one thing to both runtimes (#573)

### DIFF
--- a/.claude/commands/d4d-uniform-rules.md
+++ b/.claude/commands/d4d-uniform-rules.md
@@ -30,21 +30,24 @@ to every project:
 - There is no target slot count, no expected density, and no expected
   relationship to any other arm or project. Apply your own judgment about what
   the evidence supports.
-- **Write an identifier as a CURIE wherever a declared prefix exists, not as a
-  URL.** `ROR:01an7q238`, not `https://ror.org/01an7q238`; `ORCID:0000-0002-…`,
-  not the orcid.org URL; `doi:10.13026/…`, not `https://doi.org/…`. The two
-  expand to the same IRI, and the CURIE says which namespace the identifier
-  belongs to instead of leaving a reader to infer it from a hostname.
+- **Write an identifier as a CURIE wherever the schema declares a prefix for
+  it, rather than as a resolver URL.** `ROR:01an7q238`, not
+  `https://ror.org/01an7q238`; `ORCID:0000-0002-…`, not the orcid.org URL;
+  `doi:10.13026/…`, not `https://doi.org/…`. Two records naming one thing in
+  one form produce one identity; the same thing written as a prefix here and a
+  resolver URL there produces two.
 
-  **Where no prefix is declared, a resolvable URL is the correct answer and an
-  invented prefix is not.** Do not mint `b2ai-voice:` or similar to satisfy
-  this rule — the schema's declared prefixes are the whole list, and a CURIE on
-  an undeclared prefix resolves to nothing while the URL at least resolves
-  (#531). Check the schema's `prefixes:` block rather than guessing.
+  **This governs slots whose declared range is an identifier** —
+  `uriorcurie`. A slot whose declared range is a URL takes a URL: `download_url`
+  and `access_urls` are declared `uri` and a CURIE there is wrong. A URL inside
+  prose or a citation is text, not an identifier, and must be left exactly as
+  written.
 
-  This applies to identifier slots — those whose declared range is
-  `uriorcurie` — and never to prose. A URL inside a sentence or a citation is
-  text, not an identifier, and must be left exactly as written.
+  **Where no declared prefix fits, never invent one.** A prefix the schema does
+  not declare resolves to nothing, so do not mint `b2ai-voice:` or similar
+  (#531). Hang the identifier off one the evidence supplies — see the fragment
+  rule below — and where no fragment is possible either, a resolvable URL is the
+  better answer. Check the schema's `prefixes:` block rather than guessing.
 
 - **An identifier is a fact and comes from the evidence.** Take it from the
   declared bundle or omit it; do not supply an identifier you recognise but the

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -121,15 +121,19 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    body_sha256: baf755f808f84c7d92e817d936300f1baeedb69a7d95f0a9e9028ca5f39f0c15
-    bytes: 11812
-    pinned_at_commit: 9b6dd51d2940f976b85682b53e7191fd6d4347b0
-    pinned_on: '2026-08-14'
-    reason: 'rotation before any v5 run: corrects an attribution in the rationale (#531 established
-      1,094 VOICE values, not the corpus-wide ~12,000). The prompt body is byte-identical
-      to the previous pin; only rationale prose, which prompt_body does not send, changed.
-      Free to rotate because no record names generic_v5 yet.'
-    sha256: 606e7382cd4ee5214d7a910fc5b89f8e9faa053cb193dbaeff02ac65b672904d
+    body_sha256: 7b226a9bbe604f181d9aa18c60df964377a14b8fea6d26fe34084414e9ab5f18
+    bytes: 12167
+    pinned_at_commit: e12cc7913b38649b5b3091c01ef775c5e8d8fe1a
+    pinned_on: '2026-08-15'
+    reason: "reconcile the CURIE rule with the playbook before any v5 run (#573). The first\
+      \ version said an identifier is \"never as a URL\" with no scope, contradicting the\
+      \ playbook \u2014 which says a URL is correct where no prefix is declared, that URL-ranged\
+      \ slots take URLs, and that prose is exempt. `download_url` and `access_urls` are declared\
+      \ `uri`, so the unscoped rule told the API arm to put a CURIE where the schema requires\
+      \ a URL. Both texts now state one rule: CURIE where a prefix is declared, URL-ranged\
+      \ slots and prose untouched, never an invented prefix, fragment on an attested identifier\
+      \ where none fits. Free to rotate because no record names generic_v5."
+    sha256: bc239c3ab991b18e67cac19c25c4a374b5fec867d707c781e78c902606d5815a
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -141,6 +145,13 @@ files:
         \ in notes/generic_v5_analysis_plan.md, not in the prompt."
       retired_on: '2026-08-14'
       sha256: e4d0570921f84f2024a8166bbd6284557d1c7f65471d8356a18edd957bf42e52
+    - pinned_on: '2026-08-14'
+      reason: 'rotation before any v5 run: corrects an attribution in the rationale (#531
+        established 1,094 VOICE values, not the corpus-wide ~12,000). The prompt body is byte-identical
+        to the previous pin; only rationale prose, which prompt_body does not send, changed.
+        Free to rotate because no record names generic_v5 yet.'
+      retired_on: '2026-08-15'
+      sha256: 606e7382cd4ee5214d7a910fc5b89f8e9faa053cb193dbaeff02ac65b672904d
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -210,10 +210,13 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
 --- END ADDED IN v3 ---
 --- ADDED IN v5 ---
 
-- Write every identifier as a CURIE — a declared prefix, a colon, and the local
-  part — never as a URL, a resolver link or a bare IRI. Two records naming one
-  thing in one form produce one identity; the same thing written as a prefix
-  here and a URL there produces two.
+- Write an identifier as a CURIE wherever the schema declares a prefix for it —
+  a prefix, a colon, and the local part — rather than as a resolver URL. Two
+  records naming one thing in one form produce one identity; the same thing
+  written as a prefix here and a resolver URL there produces two. This governs
+  slots whose declared range is an identifier. A slot whose declared range is a
+  URL takes a URL, and a URL inside prose or a citation is text: leave both
+  exactly as written.
 - An identifier is a fact about the dataset, subject to the same rule as any
   other fact: take it from the evidence or omit it. Do not supply an identifier
   you recognise but the input documents do not state. A correct identifier the
@@ -223,8 +226,10 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
   registry identifier from your own knowledge is not.
 - Where something needs an identifier and the evidence supplies none, hang it
   off one the evidence does supply: a fragment appended to the identifier of the
-  thing it is part of. Do not invent a prefix for it. A person is identified by
-  a personal-identifier registry entry and an organisation by an organisation
+  thing it is part of. Never invent a prefix — a prefix the schema does not
+  declare resolves to nothing, and where no fragment is possible either, a
+  resolvable URL is the better answer. A person is identified by a
+  personal-identifier registry entry and an organisation by an organisation
   registry entry; a fragment appended to an organisation's identifier does not
   identify a person, it makes a false claim about that organisation.
 - Write American English throughout — characterize, organization, standardized,

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -207,6 +207,45 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
         self.assertEqual(holders, [str(p) for p in AGENT_PLAYBOOKS
                                    if p.name == PLAYBOOK.name])
 
+    #: Claims that must hold in *both* texts, phrased as a probe that should
+    #: match and a probe that must not. Co-occurrence of a topic is not
+    #: agreement about it (#573): both files said "as a CURIE" while one told
+    #: the model to write a URL where no prefix is declared and the other said
+    #: never to write one.
+    AGREEMENTS = (
+        ("a URL-ranged slot still takes a URL",
+         ("declared range is a URL",), ()),
+        ("prose and citations are left alone",
+         ("prose or a citation",), ()),
+        ("an undeclared prefix is never invented",
+         ("invent a prefix", "invent one"), ()),
+        ("no unqualified ban on URLs",
+         (), ("never as a URL",)),
+    )
+
+    def test_the_two_texts_do_not_contradict_each_other(self):
+        """The check that would have caught #573.
+
+        The parity table above asks whether a rule *reaches* both runtimes. It
+        cannot see two rules that both arrive and disagree — and that is what
+        shipped: the prompt said an identifier is "never as a URL" with no
+        scope, while the playbook said a URL is correct where no prefix is
+        declared and that URL-ranged slots and prose are exempt.
+
+        `download_url` and `access_urls` are declared `uri`, so the unscoped
+        version told the API arm to put a CURIE where the schema requires a URL.
+        """
+        playbook, prompt = self._texts()
+        problems = []
+        for name, required, forbidden in self.AGREEMENTS:
+            for text, where in ((playbook, "playbook"), (prompt, "prompt")):
+                if required and not any(r.lower() in text for r in required):
+                    problems.append(f"{where} does not say: {name}")
+                for f in forbidden:
+                    if f.lower() in text:
+                        problems.append(f"{where} still says {f!r}: {name}")
+        self.assertEqual(problems, [])
+
     def test_the_new_v5_rules_reached_the_playbook_too(self):
         """The mirror direction, which nothing checked before.
 


### PR DESCRIPTION
Closes #573.

The v5 prompt said an identifier is **"never as a URL"**, with no scope. The
playbook said a resolvable URL **is the correct answer** where no prefix is
declared, that the rule governs `uriorcurie` slots only, and that a URL in prose
or a citation is text to be left alone.

The API path reads only the prompt. The agentic path reads both. Two runtimes,
one condition name, opposite instructions.

## Worse than the issue recorded

The prompt dropped **two** qualifications, not one — and the second is the
damaging one:

```
Dataset.download_url               range: uri
DistributionFormat.download_url    range: uri
DistributionFormat.access_urls     range: uri
```

An unscoped "never as a URL" tells the API arm to put a CURIE where **the schema
requires a URL**. The v4 arm has 397 URL-valued identifier slots, 302 of them the
no-declared-prefix case the two texts disagreed about.

## One rule, in both files

- a CURIE wherever the schema declares a prefix, rather than a resolver URL;
- governing slots whose declared range is an identifier — a URL-ranged slot
  takes a URL, and a URL in prose or a citation is text;
- never an invented prefix, because one the schema does not declare resolves to
  nothing;
- where no declared prefix fits, a fragment on an identifier the evidence
  supplies; where no fragment is possible either, a resolvable URL.

The last clause keeps the old playbook answer but subordinates it: fragment
first, URL as last resort, invented prefix never.

## The guard that would have caught it

The parity table asks whether a rule *reaches* both runtimes, and both texts
contain "as a CURIE" — co-occurrence of a topic is not agreement about it.
`test_the_two_texts_do_not_contradict_each_other` now checks four claims as
probes that must match and probes that must **not**: URL-ranged slots, prose,
invented prefixes, and the absence of an unqualified ban on URLs.

## Incidentally, #560 working

The pin gate reported this edit `uncanonical` rather than `annotated` — the
first live demonstration that body edits and rationale edits are now
distinguished. Pin rotated; free, because no record names `generic_v5` yet.

Suite: 2061 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)