### PR TITLE
Condition absorption on the evidence, and stop resuming short of declared inputs (#574, #575)

### DIFF
--- a/.claude/commands/d4d-uniform-rules.md
+++ b/.claude/commands/d4d-uniform-rules.md
@@ -30,21 +30,24 @@ to every project:
 - There is no target slot count, no expected density, and no expected
   relationship to any other arm or project. Apply your own judgment about what
   the evidence supports.
-- **Write an identifier as a CURIE wherever a declared prefix exists, not as a
-  URL.** `ROR:01an7q238`, not `https://ror.org/01an7q238`; `ORCID:0000-0002-…`,
-  not the orcid.org URL; `doi:10.13026/…`, not `https://doi.org/…`. The two
-  expand to the same IRI, and the CURIE says which namespace the identifier
-  belongs to instead of leaving a reader to infer it from a hostname.
+- **Write an identifier as a CURIE wherever the schema declares a prefix for
+  it, rather than as a resolver URL.** `ROR:01an7q238`, not
+  `https://ror.org/01an7q238`; `ORCID:0000-0002-…`, not the orcid.org URL;
+  `doi:10.13026/…`, not `https://doi.org/…`. Two records naming one thing in
+  one form produce one identity; the same thing written as a prefix here and a
+  resolver URL there produces two.
 
-  **Where no prefix is declared, a resolvable URL is the correct answer and an
-  invented prefix is not.** Do not mint `b2ai-voice:` or similar to satisfy
-  this rule — the schema's declared prefixes are the whole list, and a CURIE on
-  an undeclared prefix resolves to nothing while the URL at least resolves
-  (#531). Check the schema's `prefixes:` block rather than guessing.
+  **This governs slots whose declared range is an identifier** —
+  `uriorcurie`. A slot whose declared range is a URL takes a URL: `download_url`
+  and `access_urls` are declared `uri` and a CURIE there is wrong. A URL inside
+  prose or a citation is text, not an identifier, and must be left exactly as
+  written.
 
-  This applies to identifier slots — those whose declared range is
-  `uriorcurie` — and never to prose. A URL inside a sentence or a citation is
-  text, not an identifier, and must be left exactly as written.
+  **Where no declared prefix fits, never invent one.** A prefix the schema does
+  not declare resolves to nothing, so do not mint `b2ai-voice:` or similar
+  (#531). Hang the identifier off one the evidence supplies — see the fragment
+  rule below — and where no fragment is possible either, a resolvable URL is the
+  better answer. Check the schema's `prefixes:` block rather than guessing.
 
 - **An identifier is a fact and comes from the evidence.** Take it from the
   declared bundle or omit it; do not supply an identifier you recognise but the

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -492,12 +492,18 @@ PHASE_INSTRUCTIONS = {
     "reconcile_full": (
         "Phase 4a. Apply the audit findings that concern the FULL record and "
         "emit the corrected full record in its entirety, header block included. "
-        "The core record is supplied above: anything it states that the full "
-        "record does not, absorb into the full record, in the slot that fits "
-        "it. The core record is a projection of the full one and cannot "
-        "outrank it, so a fact reaching only core is a fact the full record "
-        "lost. Absorb the content, not the wording — put it where the schema "
-        "says it belongs, which may not be where core put it. "
+        "The core record is supplied above. Anything it states that the full "
+        "record does not, **and that the input bundle supports**, absorb into "
+        "the full record, in the slot that fits it: the core record is a "
+        "projection of the full one and cannot outrank it, so a bundle-"
+        "supported fact reaching only core is a fact the full record lost. "
+        "Absorb the content, not the wording — put it where the schema says it "
+        "belongs, which may not be where core put it. "
+        "Do not absorb anything the audit findings above identify as "
+        "unsupported: content the core record invented must be removed from "
+        "core, never copied into full. A fabrication the two records agree on "
+        "is worse than one only core carries, because agreement is what a "
+        "reader checks. "
         "Every value you write or change must conform to the schema digest "
         "supplied above — a repair that fixes evidence but breaks shape is "
         "still a defect. If no finding requires a change, emit it unchanged. "
@@ -1901,8 +1907,13 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             carry[name] = body
         else:
             # Not a record: forget the phases that claim to have written it so
-            # they run again, rather than resuming on top of a fragment.
+            # they run again, rather than resuming on top of a fragment — and
+            # the phases that *consumed* it too (#575). Dropping only the
+            # producers left `audit` marked done with findings computed against
+            # the artifact just discarded, and `reconcile_full` marked done
+            # having absorbed from it.
             done -= set(produced_by)
+            done -= {ph for ph in PHASES if name in PHASE_NEEDS.get(ph, ())}
     if "reconcile_full" in done and "Completed full record" in carry:
         carry["Reconciled full record"] = carry["Completed full record"]
 
@@ -1914,7 +1925,20 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             skipped.append(ph)
             continue
 
-        needed = {k: carry[k] for k in PHASE_NEEDS[ph] if k in carry}
+        # Every declared input, or none. Filtering to whatever happened to be
+        # present let a phase run short of its context and write a record
+        # indistinguishable from one where there was nothing to use — the
+        # resumed `reconcile_full` that silently absorbs nothing because the
+        # core record never reached it (#575).
+        absent = [k for k in PHASE_NEEDS[ph] if k not in carry]
+        if absent:
+            raise RuntimeError(
+                f"phase {ph!r} declares inputs {list(PHASE_NEEDS[ph])} and "
+                f"{absent} are not available on this resume. Re-run with "
+                "--no-resume to regenerate from the phase that produces them; "
+                "continuing would write a record that cannot be told from one "
+                "produced with the full context.")
+        needed = {k: carry[k] for k in PHASE_NEEDS[ph]}
         req = build_phase(spec, ph, carry=needed)
 
         # A 200 whose body is unusable is not a permanent failure, and treating

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -121,15 +121,19 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    body_sha256: baf755f808f84c7d92e817d936300f1baeedb69a7d95f0a9e9028ca5f39f0c15
-    bytes: 11812
-    pinned_at_commit: 9b6dd51d2940f976b85682b53e7191fd6d4347b0
-    pinned_on: '2026-08-14'
-    reason: 'rotation before any v5 run: corrects an attribution in the rationale (#531 established
-      1,094 VOICE values, not the corpus-wide ~12,000). The prompt body is byte-identical
-      to the previous pin; only rationale prose, which prompt_body does not send, changed.
-      Free to rotate because no record names generic_v5 yet.'
-    sha256: 606e7382cd4ee5214d7a910fc5b89f8e9faa053cb193dbaeff02ac65b672904d
+    body_sha256: 7b226a9bbe604f181d9aa18c60df964377a14b8fea6d26fe34084414e9ab5f18
+    bytes: 12167
+    pinned_at_commit: e12cc7913b38649b5b3091c01ef775c5e8d8fe1a
+    pinned_on: '2026-08-15'
+    reason: "reconcile the CURIE rule with the playbook before any v5 run (#573). The first\
+      \ version said an identifier is \"never as a URL\" with no scope, contradicting the\
+      \ playbook \u2014 which says a URL is correct where no prefix is declared, that URL-ranged\
+      \ slots take URLs, and that prose is exempt. `download_url` and `access_urls` are declared\
+      \ `uri`, so the unscoped rule told the API arm to put a CURIE where the schema requires\
+      \ a URL. Both texts now state one rule: CURIE where a prefix is declared, URL-ranged\
+      \ slots and prose untouched, never an invented prefix, fragment on an attested identifier\
+      \ where none fits. Free to rotate because no record names generic_v5."
+    sha256: bc239c3ab991b18e67cac19c25c4a374b5fec867d707c781e78c902606d5815a
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -141,6 +145,13 @@ files:
         \ in notes/generic_v5_analysis_plan.md, not in the prompt."
       retired_on: '2026-08-14'
       sha256: e4d0570921f84f2024a8166bbd6284557d1c7f65471d8356a18edd957bf42e52
+    - pinned_on: '2026-08-14'
+      reason: 'rotation before any v5 run: corrects an attribution in the rationale (#531
+        established 1,094 VOICE values, not the corpus-wide ~12,000). The prompt body is byte-identical
+        to the previous pin; only rationale prose, which prompt_body does not send, changed.
+        Free to rotate because no record names generic_v5 yet.'
+      retired_on: '2026-08-15'
+      sha256: 606e7382cd4ee5214d7a910fc5b89f8e9faa053cb193dbaeff02ac65b672904d
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -210,10 +210,13 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
 --- END ADDED IN v3 ---
 --- ADDED IN v5 ---
 
-- Write every identifier as a CURIE — a declared prefix, a colon, and the local
-  part — never as a URL, a resolver link or a bare IRI. Two records naming one
-  thing in one form produce one identity; the same thing written as a prefix
-  here and a URL there produces two.
+- Write an identifier as a CURIE wherever the schema declares a prefix for it —
+  a prefix, a colon, and the local part — rather than as a resolver URL. Two
+  records naming one thing in one form produce one identity; the same thing
+  written as a prefix here and a resolver URL there produces two. This governs
+  slots whose declared range is an identifier. A slot whose declared range is a
+  URL takes a URL, and a URL inside prose or a citation is text: leave both
+  exactly as written.
 - An identifier is a fact about the dataset, subject to the same rule as any
   other fact: take it from the evidence or omit it. Do not supply an identifier
   you recognise but the input documents do not state. A correct identifier the
@@ -223,8 +226,10 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
   registry identifier from your own knowledge is not.
 - Where something needs an identifier and the evidence supplies none, hang it
   off one the evidence does supply: a fragment appended to the identifier of the
-  thing it is part of. Do not invent a prefix for it. A person is identified by
-  a personal-identifier registry entry and an organisation by an organisation
+  thing it is part of. Never invent a prefix — a prefix the schema does not
+  declare resolves to nothing, and where no fragment is possible either, a
+  resolvable URL is the better answer. A person is identified by a
+  personal-identifier registry entry and an organisation by an organisation
   registry entry; a fragment appended to an organisation's identifier does not
   identify a person, it makes a false claim about that organisation.
 - Write American English throughout — characterize, organization, standardized,

--- a/tests/test_pair_gate.py
+++ b/tests/test_pair_gate.py
@@ -317,8 +317,37 @@ class ReconcileFullSeesCoreTest(unittest.TestCase):
         guess, and the guess that matches the old behaviour is to ignore it."""
         from data_sheets_schema.api_runner import PHASE_INSTRUCTIONS
         text = PHASE_INSTRUCTIONS["reconcile_full"]
-        self.assertIn("absorb into the full record", text)
+        self.assertIn("absorb into", text)
         self.assertIn("cannot outrank it", text)
+
+    def test_absorption_is_conditioned_on_the_evidence(self):
+        """#574: as first written this said "anything it states", full stop.
+
+        The core phase reads the bundle and can hallucinate. Before #566 a
+        core-only fabrication stayed in core, where the pair check would show
+        it as a divergence. Unconditional absorption would copy it into the
+        full record and make it authoritative in both — and the pair check
+        would then report the pair *consistent*, because they agree.
+
+        That is strictly worse than the defect #566 fixed. Losing a true fact
+        is recoverable from the bundle; gaining a false one that both records
+        assert is not.
+        """
+        from data_sheets_schema.api_runner import PHASE_INSTRUCTIONS
+        text = PHASE_INSTRUCTIONS["reconcile_full"]
+        self.assertIn("the input bundle supports", text)
+        self.assertIn("identify as unsupported", text)
+
+    def test_the_audit_supplies_the_finding_this_relies_on(self):
+        """The exclusion is only enforceable because the audit already looks.
+
+        `audit` runs before `reconcile_full` and receives both records, so the
+        finding is available at the point of use — no new phase or input.
+        """
+        from data_sheets_schema.api_runner import PHASE_INSTRUCTIONS, PHASES
+        self.assertLess(PHASES.index("audit"), PHASES.index("reconcile_full"))
+        self.assertIn("the bundle does not support",
+                      PHASE_INSTRUCTIONS["audit"])
 
     def test_the_audit_is_told_to_look_for_it_too(self):
         """The audit already reads both records, so it is the cheapest place to

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -207,6 +207,45 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
         self.assertEqual(holders, [str(p) for p in AGENT_PLAYBOOKS
                                    if p.name == PLAYBOOK.name])
 
+    #: Claims that must hold in *both* texts, phrased as a probe that should
+    #: match and a probe that must not. Co-occurrence of a topic is not
+    #: agreement about it (#573): both files said "as a CURIE" while one told
+    #: the model to write a URL where no prefix is declared and the other said
+    #: never to write one.
+    AGREEMENTS = (
+        ("a URL-ranged slot still takes a URL",
+         ("declared range is a URL",), ()),
+        ("prose and citations are left alone",
+         ("prose or a citation",), ()),
+        ("an undeclared prefix is never invented",
+         ("invent a prefix", "invent one"), ()),
+        ("no unqualified ban on URLs",
+         (), ("never as a URL",)),
+    )
+
+    def test_the_two_texts_do_not_contradict_each_other(self):
+        """The check that would have caught #573.
+
+        The parity table above asks whether a rule *reaches* both runtimes. It
+        cannot see two rules that both arrive and disagree — and that is what
+        shipped: the prompt said an identifier is "never as a URL" with no
+        scope, while the playbook said a URL is correct where no prefix is
+        declared and that URL-ranged slots and prose are exempt.
+
+        `download_url` and `access_urls` are declared `uri`, so the unscoped
+        version told the API arm to put a CURIE where the schema requires a URL.
+        """
+        playbook, prompt = self._texts()
+        problems = []
+        for name, required, forbidden in self.AGREEMENTS:
+            for text, where in ((playbook, "playbook"), (prompt, "prompt")):
+                if required and not any(r.lower() in text for r in required):
+                    problems.append(f"{where} does not say: {name}")
+                for f in forbidden:
+                    if f.lower() in text:
+                        problems.append(f"{where} still says {f!r}: {name}")
+        self.assertEqual(problems, [])
+
     def test_the_new_v5_rules_reached_the_playbook_too(self):
         """The mirror direction, which nothing checked before.
 

--- a/tests/test_resume_inputs.py
+++ b/tests/test_resume_inputs.py
@@ -1,0 +1,88 @@
+"""A resumed phase must not run short of its declared inputs (#575).
+
+`PHASE_NEEDS` states what each phase requires. The resume path built each
+request from whichever of those happened to be on hand:
+
+    needed = {k: carry[k] for k in PHASE_NEEDS[ph] if k in carry}
+
+so a phase whose prerequisite was missing ran anyway, with less context than its
+instruction assumes, and wrote a record indistinguishable from one produced with
+everything. #566 made that concrete: `reconcile_full` now depends on the core
+record, and a resume that lost core would absorb nothing while looking normal.
+
+Interrupted runs are not hypothetical — #513 documents a sweep that had to be
+stopped, and the resume path exists because an arm takes hours.
+"""
+
+import unittest
+
+from data_sheets_schema.api_runner import PHASE_ARTIFACT, PHASE_NEEDS, PHASES
+
+
+class DeclaredInputsTest(unittest.TestCase):
+
+    def test_every_phase_input_is_produced_by_an_earlier_phase(self):
+        """Otherwise a required input could never be satisfiable on resume."""
+        produced = {"Completed full record": "full",
+                    "Completed core record": "core",
+                    "Audit findings": "audit",
+                    "Reconciled full record": "reconcile_full"}
+        for i, ph in enumerate(PHASES):
+            for need in PHASE_NEEDS[ph]:
+                with self.subTest(phase=ph, need=need):
+                    src = produced.get(need)
+                    self.assertIsNotNone(src, f"nothing produces {need!r}")
+                    self.assertLess(PHASES.index(src), i,
+                                    f"{ph} needs {need}, produced later")
+
+    def test_reconcile_full_declares_the_core_record(self):
+        """The dependency #566 added, and the one #575 can strand."""
+        self.assertIn("Completed core record", PHASE_NEEDS["reconcile_full"])
+
+
+class ResumeGuardTest(unittest.TestCase):
+    """Read from the source of `execute`, which is where the logic lives.
+
+    Exercising it for real would need a live client and six phases of spend;
+    these assert the two properties that were wrong, both of which are visible
+    in the control flow.
+    """
+
+    def _source(self):
+        import inspect
+
+        from data_sheets_schema.api_runner import execute
+        return inspect.getsource(execute)
+
+    def test_a_missing_declared_input_stops_the_phase(self):
+        src = self._source()
+        self.assertIn("declares inputs", src)
+        self.assertNotIn("for k in PHASE_NEEDS[ph] if k in carry", src,
+                         "the filtering form is what allowed a short run")
+
+    def test_discarding_an_artifact_also_discards_its_consumers(self):
+        """Dropping only the producers left `audit` marked done with findings
+        computed against the artifact just discarded, and `reconcile_full`
+        marked done having absorbed from it."""
+        src = self._source()
+        self.assertIn("PHASE_NEEDS.get(ph, ())", src)
+
+    def test_the_message_names_the_way_out(self):
+        """A gate that stops a paid run must say what to do next."""
+        self.assertIn("--no-resume", self._source())
+
+
+class ArtifactConsumerTest(unittest.TestCase):
+
+    def test_the_core_record_has_consumers_that_would_be_stranded(self):
+        """The concrete case: dropping `core` must also drop `audit` and
+        `reconcile_full`, or they resume against a record that is gone."""
+        consumers = {ph for ph in PHASES
+                     if "Completed core record" in PHASE_NEEDS.get(ph, ())}
+        self.assertIn("audit", consumers)
+        self.assertIn("reconcile_full", consumers)
+        self.assertEqual(PHASE_ARTIFACT.get("core"), "core")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #574 and #575. Two defects the Codex review found in #566 — I introduced
them together and they fail together.

## #574 — absorption was unconditional

`reconcile_full` was told:

> anything it states that the full record does not, absorb into the full record

The audit immediately before it is asked for "any value the bundle does not
support". **Nothing connected the two.**

The core phase reads the bundle and can hallucinate. Before #566 a core-only
fabrication stayed in core, where the pair check (#544) surfaced it as a
divergence. Unconditional absorption copies it into the full record, makes it
authoritative in both — **and the pair check then reports the pair consistent,
because they now agree.**

That is strictly worse than the defect #566 fixed:

| | recoverable? |
|---|---|
| a true fact reaching only core (#566) | yes — it is in the bundle |
| a fabrication in both records, pair reported consistent | **no** |

Absorption is now conditioned on the bundle supporting the content and
explicitly excludes anything the audit identified as unsupported: *"content the
core record invented must be removed from core, never copied into full. A
fabrication the two records agree on is worse than one only core carries,
because agreement is what a reader checks."*

No new machinery — `audit` already runs first and already receives both records.

## #575 — a resumed phase could run short of its inputs

```python
needed = {k: carry[k] for k in PHASE_NEEDS[ph] if k in carry}
```

`PHASE_NEEDS` declares what a phase requires; this took whichever happened to be
present. A resumed `reconcile_full` missing the core record ran and absorbed
nothing, writing a record **indistinguishable from one where there was nothing
to absorb**.

Separately, when an artifact failed to parse only its *producers* were dropped
from `done`. Its *consumers* stayed complete — `audit` keeping findings computed
against the discarded record, `reconcile_full` keeping an absorption from it.

Now every declared input is required or the phase stops, naming what is missing
and that `--no-resume` regenerates it; and discarding an artifact discards its
consumers as well as its producers, derived from `PHASE_NEEDS` rather than a
hand-written list.

Not hypothetical: #513 documents a sweep that had to be stopped, and the resume
path exists because an arm takes hours.

## Provenance

Assembly digest `77331f08` → `2c1442fc`, so v4 and v5 records stay
distinguishable by procedure as well as by prompt.

8 new tests. Suite: 2069 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)