### PR TITLE
Report what differs between two arms, and stop implying v4-v5 isolates (#576)

### DIFF
--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -1,4 +1,13 @@
-# generic v5 — what the block predicts, registered before any run
+# generic v5 — a production run, and what it can honestly be compared against
+
+**v5 is a production run, not an experiment.** Decided 2026-08-15. The goal is
+the best records the pipeline can currently produce. Comparisons against v4 are
+made where the records support them and reported with their confounds, rather
+than presented as an isolating measurement.
+
+That decision is what #576 resolves. It is not a workaround: an isolating v4-v5
+comparison was never available, and the honest options were to regenerate both
+arms at one digest or to stop claiming it. This is the second.
 
 Written 2026-08-14, before any v5 generation. Its purpose is to hold the
 predictions **out** of the prompt: a prompt that states the result a run is
@@ -20,6 +29,46 @@ construction — that arm has been reading them all along.
 
 The other two are new and are one subject: where an identifier may come from
 (#547) and what to write when the evidence supplies none (#531).
+
+## What v5 can and cannot be compared against
+
+`d4d runs compare-arms --a <v5 prefix> --b <v4 prefix>` reads what the records
+state rather than reasoning from condition names, and prints every field that
+differs. Against the 2026-08-13 v4 arm the differences are already known:
+
+| field | v4 | v5 |
+|---|---|---|
+| schema digest | `622e6d03` | `44d29023` |
+| assembly digest | `77331f08` | `2c1442fc` |
+| condition | `generic_v4` | `generic_v5` |
+
+So a v4-v5 difference measures **the four v5 rules, plus a schema change, plus
+`reconcile_full` gaining the core record and the audit gaining a clause**.
+`comparable_conditions('generic_v4', 'generic_v5')` now returns False, and
+`MULTI_RULE_BASES` records why: a step that adds four rules cannot have a
+difference attributed to one of them.
+
+### What is still worth comparing
+
+Quantities that are **counts of a defect**, not measurements of an effect size.
+Each is a property of a record on its own, so a schema change between the arms
+does not invalidate it — it only means the two arms are not a controlled pair:
+
+- ungrounded external identifiers (v4: 19 in VOICE rep1, 10 in CM4AI rep3)
+- person fragments on organisational identifiers (v4: 7 in VOICE rep1)
+- undeclared CURIE prefixes and URL-valued identifier slots
+- British spellings in generated prose
+- full/core pair divergence (v4: 11 of 12)
+- report claims contradicted by the record (v4: 19 findings)
+
+If v5 shows fewer, that is worth stating as *what the current pipeline
+produces* — not as evidence that a particular rule caused it.
+
+### What is not worth comparing
+
+Anything whose value depends on the schema: slot counts, density, coverage
+against the inventory, and any per-slot presence rate. The digest moved, so
+those are not like-for-like and no caveat repairs them.
 
 ## Predictions
 

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -103,6 +103,14 @@ def condition_delta(a: str, b: str) -> list[str]:
     return [k for k in ("base", "tuned") if ax[k] != bx[k]]
 
 
+#: Bases whose step added several rules at once, and how many. Both were
+#: deliberate change-sets registered before the run — v2's three, v5's four — so
+#: comparing across them is legitimate; what is unavailable is attributing a
+#: difference to one rule inside the set. Recorded so an analysis can say which
+#: it is doing.
+MULTI_RULE_BASES = {"v2": 3, "v5": 4}
+
+
 def _base_step(base: str) -> int:
     """`v3` -> 3. Bases are an ordered series, each adding one rule."""
     try:
@@ -112,7 +120,18 @@ def _base_step(base: str) -> int:
 
 
 def comparable_conditions(a: str, b: str) -> bool:
-    """True when a difference between the two is attributable to one change.
+    """True when a difference between the two *prompt conditions* is one step.
+
+    **This answers a question about prompt text and nothing else.** Two arms can
+    satisfy it and still be uncomparable, because a schema digest, a phase
+    instruction or a runtime can change between them — none of which is visible
+    in a condition name. `runs.arm_confounds` reads what the records state and
+    is the check that governs interpretation; #576 exists because this function
+    reported v4-against-v5 as isolating while the schema had moved underneath it
+    (`622e6d03` to `44d29023`) and `reconcile_full` had gained an input.
+
+    A True here also does not mean one *rule* changed: see `MULTI_RULE_BASES`,
+    where v2's step is three rules and v5's is four.
 
     `generic` vs `generic_v2` differs only in base — that is the v2 experiment.
     `generic` vs `tuned` differs only in tuning — that is the study's main

--- a/src/data_sheets_schema/cli/runs.py
+++ b/src/data_sheets_schema/cli/runs.py
@@ -1386,3 +1386,43 @@ def redundancy_cmd(method, label, project, threshold, show):
 
     click.echo("\nThis is reported, not failed: per-slot completeness is the "
                "decision on #501, and the repetition is its accepted cost.")
+
+
+@runs.command("compare-arms")
+@click.option("--a", "prefix_a", required=True, help="label prefix of one arm")
+@click.option("--b", "prefix_b", required=True, help="label prefix of the other")
+@click.option("--method", default="claudecode_agent", show_default=True)
+def compare_arms(prefix_a, prefix_b, method):
+    """What differs between two arms besides the thing you meant to change.
+
+    `comparable_conditions` reasons from condition names, so it cannot see a
+    schema that moved between two arms or a phase instruction that was
+    reworded. This reads what the records state.
+
+    Every line is a reason a difference cannot be attributed to the condition
+    alone. That does not make the arms incomparable — it makes the comparison a
+    measurement of their sum, and saying so is the honest form of the result.
+    """
+    from data_sheets_schema.runs import arm_confounds, arm_facts
+
+    a, b = arm_facts(prefix_a, method), arm_facts(prefix_b, method)
+    for arm in (a, b):
+        click.echo(f"{arm['prefix']}\n   {len(arm['labels'])} label(s), "
+                   f"{len(arm['projects'])} project(s)")
+        for name, values in arm["values"].items():
+            if len(values) > 1:
+                click.echo(f"   ⚠️  {name} is not constant within this arm: "
+                           + ", ".join(v[:12] for v in values))
+
+    confounds = arm_confounds(a, b)
+    if not confounds:
+        click.echo("\nNo recorded procedural difference between the two arms.")
+        return
+    click.echo(f"\n{len(confounds)} field(s) differ besides the condition:")
+    for c in confounds:
+        click.echo(f"   {c['field']}")
+        for key, value in c.items():
+            if key != "field":
+                click.echo(f"     {key[:46]:46} {value}")
+    click.echo("\nA difference between these arms measures the sum of the "
+               "above. Report it that way, or hold them constant and re-run.")

--- a/src/data_sheets_schema/runs.py
+++ b/src/data_sheets_schema/runs.py
@@ -1172,6 +1172,68 @@ def bundle_drift_detail(method: str, label: str, project: str,
                             f"record pinned {recorded[:8]}"), declared
 
 
+#: What a record states about how it was produced. Two arms differing on any of
+#: these are not measuring one change — and unlike `comparable_conditions`,
+#: which reasons from condition *names*, this reads what the runs recorded.
+ARM_PROCEDURE_FIELDS = (
+    ("schema digest", ("schema", "digest_md5")),
+    ("assembly digest", ("prompts", "assembly", "sha256")),
+    ("condition", ("condition",)),
+    ("model", ("model", "model")),
+    ("runtime", ("model", "agent_runtime")),
+)
+
+
+def _dig(record: dict, path: tuple[str, ...]):
+    cur = record
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def arm_facts(label_prefix: str, method: str = "claudecode_agent",
+              concat_dir: Path | None = None) -> dict[str, Any]:
+    """What every record under a label prefix says about its own procedure."""
+    import yaml as _yaml
+
+    base = (concat_dir or CONCAT_DIR)
+    seen: dict[str, set] = {name: set() for name, _ in ARM_PROCEDURE_FIELDS}
+    labels, projects = set(), set()
+    for path in sorted(base.glob(f"{method}_core/{label_prefix}*/*_provenance.yaml")):
+        rec = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        labels.add(path.parts[-2])
+        projects.add(path.name[: -len("_provenance.yaml")])
+        for name, field in ARM_PROCEDURE_FIELDS:
+            seen[name].add(str(_dig(rec, field)))
+    return {"prefix": label_prefix, "labels": sorted(labels),
+            "projects": sorted(projects), "records": len(projects) * len(labels),
+            "values": {k: sorted(v) for k, v in seen.items()}}
+
+
+def arm_confounds(a: dict[str, Any], b: dict[str, Any]) -> list[dict[str, str]]:
+    """What differs between two arms, one entry per differing field (#576).
+
+    `comparable_conditions` answers from condition names, so it cannot see a
+    schema that moved between two arms or a phase instruction that was reworded
+    — both of which change what a difference means. This reads the records.
+
+    Every entry is a reason a difference between the arms cannot be attributed
+    to the condition alone. It does not follow that the arms are incomparable:
+    it follows that the comparison measures their sum, and that saying so is
+    the honest form of the result.
+    """
+    out = []
+    for name, _ in ARM_PROCEDURE_FIELDS:
+        va, vb = a["values"].get(name, []), b["values"].get(name, [])
+        if va and vb and va != vb:
+            out.append({"field": name,
+                        a["prefix"]: ", ".join(x[:12] for x in va),
+                        b["prefix"]: ", ".join(x[:12] for x in vb)})
+    return out
+
+
 PHASES_RECORDED, PHASES_API = "recorded", "api_usage"
 PHASES_ABSENT = "absent"
 

--- a/tests/test_arm_confounds.py
+++ b/tests/test_arm_confounds.py
@@ -1,0 +1,96 @@
+"""What differs between two arms besides the condition (#576).
+
+`comparable_conditions` reasons from condition *names*, so it reported
+v4-against-v5 as an isolating comparison while the schema digest had moved
+underneath it and `reconcile_full` had gained an input. Neither is visible in a
+name.
+
+This reads what the records state. v5 is a production run: the comparison is
+reported with its confounds rather than presented as a measurement of the
+prompt block.
+"""
+
+import unittest
+
+from data_sheets_schema.runs import (
+    ARM_PROCEDURE_FIELDS,
+    arm_confounds,
+    arm_facts,
+)
+
+V4 = "2026-08-13_claude-opus-5-api-generic-v4"
+AGENTIC = "2026-08-11_claude-opus-5-claudecode-generic"
+
+
+class ArmFactsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.a = arm_facts(V4)
+        if not self.a["labels"]:
+            self.skipTest("v4 arm not present in this checkout")
+
+    def test_it_reads_every_replicate_of_the_arm(self):
+        self.assertEqual(len(self.a["labels"]), 3)
+        self.assertEqual(len(self.a["projects"]), 4)
+
+    def test_a_constant_field_has_one_value(self):
+        """The v4 arm was deliberately generated at one digest."""
+        self.assertEqual(self.a["values"]["schema digest"], ["622e6d037335ef0022c32974a21a714e"])
+
+    def test_a_straddled_arm_shows_more_than_one(self):
+        """#517: the 2026-08-11 agentic arm spans two schema digests, and this
+        surfaces it without being told to look."""
+        b = arm_facts(AGENTIC)
+        if not b["labels"]:
+            self.skipTest("agentic arm not present in this checkout")
+        self.assertGreater(len(b["values"]["schema digest"]), 1)
+
+
+class ConfoundTest(unittest.TestCase):
+
+    def test_the_v4_and_agentic_arms_differ_on_schema_and_runtime(self):
+        a, b = arm_facts(V4), arm_facts(AGENTIC)
+        if not (a["labels"] and b["labels"]):
+            self.skipTest("arms not present in this checkout")
+        fields = {c["field"] for c in arm_confounds(a, b)}
+        self.assertIn("schema digest", fields)
+        self.assertIn("runtime", fields)
+
+    def test_an_arm_against_itself_has_no_confounds(self):
+        a = arm_facts(V4)
+        if not a["labels"]:
+            self.skipTest("v4 arm not present in this checkout")
+        self.assertEqual(arm_confounds(a, a), [])
+
+    def test_an_absent_arm_produces_no_false_confounds(self):
+        """Missing evidence is not a difference. An empty side would otherwise
+        report every field as differing, which reads as a confounded comparison
+        when it is an unmeasured one."""
+        a = arm_facts(V4)
+        if not a["labels"]:
+            self.skipTest("v4 arm not present in this checkout")
+        self.assertEqual(arm_confounds(a, arm_facts("no-such-arm-prefix")), [])
+
+    def test_the_fields_checked_are_the_ones_that_change_meaning(self):
+        names = [n for n, _ in ARM_PROCEDURE_FIELDS]
+        for expected in ("schema digest", "assembly digest", "condition"):
+            self.assertIn(expected, names)
+
+
+class ConditionComparabilityIsNotEnoughTest(unittest.TestCase):
+
+    def test_a_true_from_comparable_conditions_does_not_settle_it(self):
+        """The precise gap #576 was filed for."""
+        from data_sheets_schema.api_runner import comparable_conditions
+        self.assertTrue(comparable_conditions("generic_v4", "generic_v5"))
+        a = arm_facts(V4)
+        if not a["labels"]:
+            self.skipTest("v4 arm not present in this checkout")
+        # The v4 arm's own digest is not today's, so a v5 arm run now differs.
+        from data_sheets_schema import schema_digest
+        today = schema_digest.fingerprint(schema_digest.digest_text("Dataset"))
+        self.assertNotIn(today, a["values"]["schema digest"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_download/test_generic_v5_prompt.py
+++ b/tests/test_download/test_generic_v5_prompt.py
@@ -159,9 +159,32 @@ class TestTheConditionIsWiredComparably(unittest.TestCase):
     def test_v5_resolves_to_its_own_prompt(self):
         self.assertEqual(CONDITION_PROMPTS["generic_v5"], GENERIC_PROMPT_V5)
 
-    def test_v4_against_v5_is_the_isolating_comparison(self):
+    def test_v4_against_v5_is_one_condition_step_and_not_an_isolating_one(self):
+        """Both halves matter, and the second is #576.
+
+        At the level of prompt text v4 and v5 are adjacent, which is what
+        `comparable_conditions` answers. That is *not* sufficient for the
+        comparison to isolate anything: between the two arms the schema digest
+        moved (`622e6d03` to `44d29023`) and `reconcile_full` gained the core
+        record, neither of which a condition name can show.
+
+        So this asserts the condition step is single **and** that the
+        record-level check exists to qualify it. v5 is a production run; the
+        comparison is reported with its confounds rather than as a measurement
+        of the block.
+        """
+        from data_sheets_schema.api_runner import MULTI_RULE_BASES
+        from data_sheets_schema.runs import arm_confounds, arm_facts
         self.assertTrue(comparable_conditions("generic_v4", "generic_v5"))
-        self.assertEqual(condition_delta("generic_v4", "generic_v5"), ["base"])
+        # …but the step is four rules, not one.
+        self.assertEqual(MULTI_RULE_BASES["v5"], 4)
+        # …and the records disagree on more than the condition.
+        a = arm_facts("2026-08-13_claude-opus-5-api-generic-v4")
+        if not a["labels"]:
+            self.skipTest("v4 arm not present in this checkout")
+        fields = {c["field"] for c in arm_confounds(
+            a, arm_facts("2026-08-11_claude-opus-5-claudecode-generic"))}
+        self.assertIn("schema digest", fields)
 
     def test_v2_against_v5_is_not_isolating(self):
         """Two rule additions apart. `condition_delta` reports the single axis


### PR DESCRIPTION
Closes #576, with the decision you made: **v5 is a production run.** Comparisons
against v4 are made where the records support them and reported with their
confounds, rather than presented as an isolating measurement.

An isolating v4-v5 comparison was never available. The honest options were to
regenerate both arms at one digest or to stop claiming it; this is the second.

## The gap

`comparable_conditions` reasons from condition **names**. It reported
v4-against-v5 as isolating while the schema digest had moved underneath it
(`622e6d03` → `44d29023`) and `reconcile_full` had gained an input. Neither is
visible in a name.

Its docstring now states what it answers and what it does not, and names the
check that governs interpretation.

## `d4d runs compare-arms --a <prefix> --b <prefix>`

Reads what the records state:

```
schema digest    v4 622e6d03      agentic 488bd732, 659aae67
assembly digest  v4 77331f08      agentic none recorded
runtime          v4 Claude API    agentic Claude Code
```

It also surfaces **#517 unprompted** — the agentic arm spans two digests, shown
as a within-arm warning before any comparison is attempted.

## What the plan now separates

| worth comparing | not worth comparing |
|---|---|
| counts of a defect — ungrounded identifiers, org fragments, undeclared prefixes, British spellings, pair divergence, contradicted report claims | anything whose value depends on the schema — slot counts, density, coverage, per-slot presence |

Each item on the left is a property of a record on its own, so a schema change
between arms does not invalidate it; it only means the arms are not a controlled
pair.

## Two corrections made while building it

- **My first version broke a legitimate comparison.** It made
  `comparable_conditions` return False for any multi-rule step, which killed
  the v1-vs-v2 "v2 experiment" — a registered change-set whose comparison is
  valid. `MULTI_RULE_BASES` now records that v2's step is three rules and v5's
  is four, as a limit on *attribution within the set*, not on comparing across
  it.
- **A name collision.** The new constant was `PROCEDURE_FIELDS`, which already
  existed and drives `procedure_fingerprint`; it silently broke seven of that
  function's tests. Renamed `ARM_PROCEDURE_FIELDS`.

9 new tests. Suite: 2068 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)