### PR TITLE
Make the canary able to stop the sweep, and fix what it reads (#579, #578, #577)

### DIFF
--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -94,37 +94,58 @@ Stated so they can be wrong.
 
 ## Measured v4 baselines
 
-Taken 2026-08-15 from the 12 records of `2026-08-13_claude-opus-5-api-generic-v4`,
-before any v5 run. Predictions above are unfalsifiable without them.
+Produced by `poetry run python scripts/v5_baselines.py`, committed so the v5
+figures are produced the same way. **Three of these were wrong or undefined in
+the first version** (#577), which is why the script exists rather than an ad-hoc
+pass.
 
-| quantity | v4 baseline | which prediction |
-|---|---|---|
-| ungrounded external identifiers (distinct) | 19 in VOICE rep1, 10 in CM4AI rep3, 0 in the other ten | 1 |
-| minted fragments on an attested base (distinct) | 17 / 12 / 14 in AI_READI rep1, CM4AI rep1, VOICE rep3; 0 elsewhere | 2 |
-| person fragments on an organisational ROR (distinct) | 7 in VOICE rep1, 0 elsewhere | 3 |
-| undeclared CURIE prefixes (occurrences) | **370** — `chorus:` 226, `cm4ai:` 86, `urn:` 41, `ark:` 9, `nih:` 8 | 4 |
-| identifier slots holding a URL | **397** — `b2ai-voice.org` 302, `chorus4ai.org` 38, `reporter.nih.gov` 18, `fairhub.io` 16 | 4 |
-| British spellings in record prose | **627** — `licence` 199, `analyse` 85, `organisation` 81, `enrolment` 71, `programme` 67 | 5 |
-| full/core pairs diverging on content | 11 of 12 | regression watch |
+| project | rep | grounded | minted | absent | org-frag |
+|---|---|---|---|---|---|
+| AI_READI | 1 | 27 | 17 | 0 | 0 |
+| AI_READI | 2 | 10 | **14** | 0 | 0 |
+| AI_READI | 3 | 10 | **13** | 0 | 0 |
+| CHORUS | 1–3 | 0 | 0 | 0 | 0 |
+| CM4AI | 1 | 9 | 12 | 0 | 0 |
+| CM4AI | 2 | 2 | 0 | 0 | 0 |
+| CM4AI | 3 | 40 | 0 | **10** | 0 |
+| VOICE | 1 | 5 | 0 | **19** | **7** |
+| VOICE | 2 | 2 | 0 | 0 | 0 |
+| VOICE | 3 | 2 | 14 | 0 | 0 |
 
-Two notes on how these were counted, because both were got wrong once:
+| corpus-wide | |
+|---|---|
+| undeclared CURIE prefixes (occurrences) | **370** — `chorus:` 226, `cm4ai:` 86, `urn:` 41, `ark:` 9, `nih:` 8 |
+| URL-valued identifier slots | **397** — VOICE 330, CHORUS 40, AI_READI 21, CM4AI 6 |
+| British spellings in generated prose | **613** — `licence` 199, `analyse` 85, `organisation` 81 |
+| full/core pairs diverging on content | 11 of 12 |
 
-- **Distinct identifiers, not occurrences.** Every identifier appears in both
-  records of a pair, so an occurrence count is exactly double and reads as twice
-  the problem (#556).
-- **`B2AI_TOPIC` and `B2AI_SUBSTRATE` are declared prefixes**, not invented ones.
-  Counting them among the undeclared put 192 legitimate values in the defect
-  column on the first pass.
+### The counting rules, stated so the v5 figure matches
 
-The 397 URL-valued slots are not all defects under the v4 rules: the playbook in
+- **Distinct per record pair, not per occurrence.** Every identifier appears in
+  both records, so an occurrence count is exactly double and reads as twice the
+  problem (#556).
+- **"Undeclared" means the schema's `prefixes:` block does not declare it.**
+  `urn:` and `ark:` are counted here. Classifying them instead as no-authority
+  URI schemes gives 320; both are defensible and the plan previously stated
+  neither, so the v5 figure could have been compared against the other one.
+- **British spellings in generated prose only** — spans inside double quotes
+  are removed first, because the rule exempts quoted material. That is the
+  difference between 613 and the ~626 a naive count gives.
+- **`B2AI_TOPIC` and `B2AI_SUBSTRATE` are declared prefixes**, not invented
+  ones. Counting them among the undeclared put 192 legitimate values in the
+  defect column on a first pass.
+
+### What the first version got wrong
+
+It said minted fragments were "17 / 12 / 14 in AI_READI rep1, CM4AI rep1, VOICE
+rep3; **0 elsewhere**". AI-READI rep2 and rep3 have 14 and 13. Prediction 2 —
+that minted-fragment counts rise or hold — would have been evaluated against a
+baseline 27 too low.
+
+The 397 URL-valued slots are not defects under the v4 rules: the playbook in
 force for that arm said a resolvable URL is correct where no prefix is declared.
-They are a baseline for v5's rule 3, which redirects them onto attested
-identifiers, not evidence that v4 broke its own rule.
-
-British spellings were checked to be in generated prose rather than only in
-quoted titles — "prohibited by section 3.F of the licence", "is a custom licence
-tailored to" — so the rule's carve-out for quoted material does not account for
-them.
+Since #573 both texts say the same thing, so this is a baseline for v5's rule,
+not evidence v4 broke its own.
 
 ## What would falsify the block rather than confirm it
 

--- a/scripts/v5_baselines.py
+++ b/scripts/v5_baselines.py
@@ -1,0 +1,137 @@
+"""Recompute the v4 baselines the v5 plan is measured against (#577).
+
+Committed rather than run ad hoc, because three of the seven figures in the
+first version were wrong or undefined: minted fragments omitted two records
+outright, and the undeclared-prefix and British-spelling counts each had a
+defensible counting rule that was never written down, so the v5 figure could be
+compared against a differently-defined v4 one.
+
+Every rule this applies is stated in the output, so the number and its
+definition travel together.
+
+    poetry run python scripts/v5_baselines.py [--label-prefix ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import re
+from pathlib import Path
+
+import yaml
+
+DEFAULT_PREFIX = "2026-08-13_claude-opus-5-api-generic-v4"
+PROJECTS = ("AI_READI", "CHORUS", "CM4AI", "VOICE")
+BASE = Path("data/d4d_concatenated")
+
+#: Counted only in generated prose. The rule exempts quoted material, so a
+#: title or a direct quotation keeping its source's spelling is not a defect.
+BRITISH = ("licence", "analyse", "organisation", "enrolment", "programme",
+           "standardis", "labelling", "centre", "recognise", "utilise",
+           "catalogue", "summarise", "behaviour")
+
+#: A quoted span: anything inside double quotes on one line. Crude, and stated
+#: as such — it is the difference between 618 and 626, not between 618 and 0.
+QUOTED = re.compile(r'"[^"\n]*"')
+
+
+def records(prefix: str):
+    for rep in (1, 2, 3):
+        label = f"{prefix}_rep{rep}"
+        for project in PROJECTS:
+            core = BASE / "claudecode_agent_core" / label / f"{project}_d4d_core.yaml"
+            full = BASE / "claudecode_agent" / label / f"{project}_d4d.yaml"
+            if core.exists():
+                yield project, rep, full, core
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label-prefix", default=DEFAULT_PREFIX)
+    args = ap.parse_args()
+
+    from data_sheets_schema.grounding import (ground, iter_external,
+                                              person_fragment_on_org)
+    from data_sheets_schema.identifiers import (declared_prefixes,
+                                                uriorcurie_slots,
+                                                walk_identifiers)
+    slots = uriorcurie_slots()
+    declared = {p.lower() for p in declared_prefixes()}
+
+    per: dict[tuple[str, int], dict] = {}
+    undeclared = collections.Counter()
+    urls = collections.Counter()
+    british = collections.Counter()
+    seen_any = False
+
+    for project, rep, full, core in records(args.label_prefix):
+        seen_any = True
+        bundle = Path(f"data/preprocessed/concatenated/{project}_preprocessed.txt")
+        text = bundle.read_text(encoding="utf-8", errors="replace").lower() \
+            if bundle.exists() else ""
+        status: dict[tuple[str, str], str] = {}
+        frags = set()
+        for path in (full, core):
+            if not path.exists():
+                continue
+            raw = path.read_text(encoding="utf-8")
+            doc = yaml.safe_load(raw) or {}
+            for _p, auth, bare in iter_external(doc, slots):
+                status[(auth, bare)] = ground(f"{auth}:{bare}", text)[2]
+            for _p, _s, value in walk_identifiers(doc, slots):
+                value = str(value)
+                m = re.match(r"^([A-Za-z][\w.\-]*):(?!//)", value)
+                if m and m.group(1).lower() not in declared:
+                    undeclared[m.group(1)] += 1
+                if re.match(r"^https?://", value):
+                    urls[project] += 1
+                if person_fragment_on_org(value):
+                    frags.add(value.lower())
+            prose = QUOTED.sub(" ", raw).lower()
+            for word in BRITISH:
+                british[word] += prose.count(word)
+
+        counts = collections.Counter(status.values())
+        per[(project, rep)] = {"grounded": counts["grounded"],
+                               "minted": counts["minted_fragment"],
+                               "absent": counts["absent"],
+                               "org_fragments": len(frags)}
+
+    if not seen_any:
+        print(f"no records found under {args.label_prefix}")
+        return 1
+
+    print(f"v4 baselines — {args.label_prefix}\n")
+    print("Counting rules, stated so the v5 figure is produced the same way:")
+    print("  · identifiers are counted DISTINCT per record pair, not per")
+    print("    occurrence: every identifier appears in both records, so an")
+    print("    occurrence count is exactly double (#556).")
+    print("  · a prefix is 'undeclared' when the schema's prefixes block does")
+    print("    not declare it. `urn:` and `ark:` are counted here; classifying")
+    print("    them instead as no-authority URI schemes gives a lower figure,")
+    print("    and both are defensible — this is the one applied.")
+    print("  · British spellings are counted in generated prose only: spans")
+    print("    inside double quotes are removed first, because the rule exempts")
+    print("    quoted material.\n")
+
+    print(f"{'project':9} {'rep':4} {'grounded':>8} {'minted':>7} {'absent':>7} {'org-frag':>9}")
+    for (project, rep), c in sorted(per.items()):
+        print(f"{project:9} rep{rep} {c['grounded']:8} {c['minted']:7} "
+              f"{c['absent']:7} {c['org_fragments']:9}")
+
+    print(f"\nundeclared CURIE prefixes (occurrences): {sum(undeclared.values())}")
+    for name, n in undeclared.most_common():
+        print(f"   {name:22} {n}")
+    print(f"\nURL-valued identifier slots: {sum(urls.values())}")
+    for name, n in urls.most_common():
+        print(f"   {name:22} {n}")
+    print(f"\nBritish spellings in generated prose: {sum(british.values())}")
+    for name, n in british.most_common(8):
+        if n:
+            print(f"   {name:22} {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -2176,6 +2176,13 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
 
     return {"label": spec.label, "project": spec.project, "usage": usage,
             "skipped": skipped, "validation_problems": problems,
+            # The three post-generation checks, returned rather than only
+            # written to the record (#579). A batch that cannot see them counts
+            # a run with 11 pair errors and 19 ungrounded identifiers as a
+            # success, which is how the v4 arm swept clean.
+            "checks": {"pair": rec.data.get("pair_consistency"),
+                       "report": rec.data.get("report_claims"),
+                       "grounding": rec.data.get("grounding")},
             "outputs": {"full": str(spec.full_path), "core": str(spec.core_path),
                         "report": str(spec.report_path),
                         "provenance": str(spec.provenance_path)}}

--- a/src/data_sheets_schema/canary.py
+++ b/src/data_sheets_schema/canary.py
@@ -1,0 +1,123 @@
+"""Hold the first run of a sweep to a higher bar than the rest (#579).
+
+`d4d api batch` counted a run as succeeded on schema validation alone. A run
+whose full/core pair diverges, whose reconciliation report contradicts its own
+record, or which carries identifiers absent from its bundle entered the
+"succeeded" column. That is how the 2026-08-13 arm swept clean: twelve records,
+all valid, `runs check --strict` exit 0, and eleven divergent pairs and
+twenty-nine ungrounded identifiers inside them.
+
+The canary rule says one unit is verified before the batch fans out. But the
+canary's verdict *was* the batch's verdict, and the batch did not look at the
+three checks — so a canary could pass while exhibiting precisely the defects the
+arm was built to fix, and the sweep would proceed to spend the rest.
+
+## A regression gate, not a perfection gate
+
+v5 is a production run. Requiring zero pair errors would refuse to start, since
+eleven of twelve v4 records have some. What the gate asks instead is whether the
+canary is **worse than the worst v4 record for the same project** — a bar known
+to be achievable, with room for the replicate variance that arm showed.
+
+Three outcomes, and the middle one is the point:
+
+``ok``
+    no check regressed against the baseline.
+``regressed``
+    a check is worse than the worst baseline run for that project. Stop; the
+    remaining runs would spend on a known regression.
+``unmeasurable``
+    a check could not run. Also stops: a canary whose instruments were blind
+    has not verified anything, which is the failure #565 recorded one level
+    down.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+OK = "ok"
+REGRESSED = "regressed"
+UNMEASURABLE = "unmeasurable"
+
+#: (label, how to read a count out of a check block, lower-is-better)
+#: Each is a count of a defect in one record, so it is comparable across arms
+#: even when the schema has moved — unlike anything schema-dependent (#576).
+METRICS = (
+    ("pair errors", "pair", lambda b: int(b.get("errors") or 0)),
+    ("report findings", "report", lambda b: len(b.get("findings") or [])),
+    ("ungrounded identifiers", "grounding",
+     lambda b: int((b.get("distinct") or b.get("counts") or {}).get("absent") or 0)),
+)
+
+
+def _ran(block: Any) -> bool:
+    if not isinstance(block, dict):
+        return False
+    if "ran" in block:
+        return bool(block["ran"])
+    return bool(block.get("checked"))
+
+
+def counts_from(checks: dict[str, Any]) -> dict[str, int | None]:
+    """One number per metric, or None where the check did not run."""
+    out: dict[str, int | None] = {}
+    for name, key, read in METRICS:
+        block = (checks or {}).get(key)
+        out[name] = read(block) if _ran(block) else None
+    return out
+
+
+def baseline_for(project: str, label_prefix: str,
+                 method: str = "claudecode_agent",
+                 concat_dir: Path | None = None) -> dict[str, int | None]:
+    """The worst value each metric took across a baseline arm, for one project.
+
+    The *worst*, deliberately. The best would make normal replicate variance
+    read as a regression, and this gate stops a paid sweep — it should fire on
+    a real step backwards, not on a run landing at the unlucky end of a spread
+    the baseline arm itself showed.
+    """
+    import yaml
+
+    from data_sheets_schema.provenance import CONCAT_DIR
+    base = concat_dir or CONCAT_DIR
+    worst: dict[str, int | None] = {name: None for name, _, _ in METRICS}
+    for path in sorted(base.glob(
+            f"{method}_core/{label_prefix}*/{project}_provenance.yaml")):
+        rec = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        counts = counts_from({"pair": rec.get("pair_consistency"),
+                              "report": rec.get("report_claims"),
+                              "grounding": rec.get("grounding")})
+        for name, value in counts.items():
+            if value is None:
+                continue
+            worst[name] = value if worst[name] is None else max(worst[name],
+                                                                value)
+    return worst
+
+
+def verdict(checks: dict[str, Any], baseline: dict[str, int | None]
+            ) -> dict[str, Any]:
+    """Compare one run's checks against a baseline. See module docstring."""
+    counts = counts_from(checks)
+    blind = [name for name, value in counts.items() if value is None]
+    rows = []
+    regressions = []
+    for name, value in counts.items():
+        bar = baseline.get(name)
+        row = {"metric": name, "run": value, "baseline_worst": bar}
+        if value is not None and bar is not None and value > bar:
+            row["regressed"] = True
+            regressions.append(f"{name}: {value} against a baseline worst of {bar}")
+        rows.append(row)
+
+    if blind:
+        status = UNMEASURABLE
+    elif regressions:
+        status = REGRESSED
+    else:
+        status = OK
+    return {"status": status, "rows": rows, "blind": blind,
+            "regressions": regressions}

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -267,9 +267,15 @@ def run_cmd(project, arm, label, condition, bundle, out_dir, yes):
 @click.option("--dry-run", is_flag=True, help="cost the sweep without calling the API")
 @click.option("--continue-on-error", is_flag=True,
               help="keep going after a failed run instead of stopping")
+@click.option("--canary-baseline", default=None,
+              help="label prefix of the arm the first run is held against; it "
+                   "must be no worse on any check or the sweep stops (#579)")
+@click.option("--no-canary-gate", is_flag=True,
+              help="fan out even if the first run regresses against the "
+                   "baseline; the comparison is still printed")
 @click.option("--yes", is_flag=True)
 def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
-              continue_on_error, yes):
+              continue_on_error, canary_baseline, no_canary_gate, yes):
     """Run a sweep of projects x replicates, reporting cumulative cost.
 
     Each run resumes independently, so a sweep interrupted partway costs only
@@ -338,6 +344,36 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
                     break
                 continue
             click.echo(f"   ✓ in={spent_in:,} out={spent_out:,} cache_read={cached:,}{note}")
+
+            # The three post-generation checks, printed for every run so a
+            # sweep cannot look clean while they fail (#579) — and, on the
+            # first run, gating the fan-out.
+            from data_sheets_schema import canary as _canary
+            counts = _canary.counts_from(res.get("checks") or {})
+            click.echo("     " + "  ".join(
+                f"{name}={'—' if v is None else v}"
+                for name, v in counts.items()))
+
+            if i == 1 and canary_baseline and not no_canary_gate:
+                v = _canary.verdict(res.get("checks") or {},
+                                    _canary.baseline_for(s.project,
+                                                         canary_baseline))
+                for row in v["rows"]:
+                    mark = "❌" if row.get("regressed") else "  "
+                    click.echo(f"     {mark} {row['metric']:24} "
+                               f"{row['run']} vs baseline worst "
+                               f"{row['baseline_worst']}")
+                if v["status"] != _canary.OK:
+                    for line in v["regressions"] or v["blind"]:
+                        click.echo(f"     {line}", err=True)
+                    run_lock.release(lock_path)
+                    raise click.ClickException(
+                        f"canary {v['status']}: the first run is worse than "
+                        f"the {canary_baseline} baseline for {s.project}, or a "
+                        "check could not run. Fanning out would spend the rest "
+                        "of the sweep on a known regression. Re-run with "
+                        "--no-canary-gate to proceed anyway.")
+                click.echo("     canary ok — fanning out")
             ok.append(s.label)
         except Exception as exc:                       # noqa: BLE001
             click.echo(f"   ❌ {type(exc).__name__}: {exc}", err=True)

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -320,6 +320,7 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
         raise click.ClickException(str(exc)) from exc
 
     ok, failed, spent_in, spent_out = [], [], 0, 0
+    canary_stop: str | None = None
     for i, s in enumerate(specs, 1):
         click.echo(f"\n[{i}/{len(specs)}] {s.project} {s.label}")
         try:
@@ -366,14 +367,19 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
                 if v["status"] != _canary.OK:
                     for line in v["regressions"] or v["blind"]:
                         click.echo(f"     {line}", err=True)
-                    run_lock.release(lock_path)
-                    raise click.ClickException(
+                    # Recorded, not raised here: this block is inside the
+                    # per-run `try`, whose bare `except Exception` would catch
+                    # a ClickException and — under --continue-on-error — fan
+                    # out anyway, which is the one thing this gate exists to
+                    # prevent. Raised after the loop, once the lock is released.
+                    canary_stop = (
                         f"canary {v['status']}: the first run is worse than "
                         f"the {canary_baseline} baseline for {s.project}, or a "
                         "check could not run. Fanning out would spend the rest "
                         "of the sweep on a known regression. Re-run with "
                         "--no-canary-gate to proceed anyway.")
-                click.echo("     canary ok — fanning out")
+                else:
+                    click.echo("     canary ok — fanning out")
             ok.append(s.label)
         except Exception as exc:                       # noqa: BLE001
             click.echo(f"   ❌ {type(exc).__name__}: {exc}", err=True)
@@ -381,12 +387,17 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
             if not continue_on_error:
                 click.echo("stopping; re-run to resume unfinished phases", err=True)
                 break
+        if canary_stop:
+            break
 
     # Released even when the sweep failed or was interrupted mid-loop: a lock
     # outliving its process would make the next attempt refuse to start, which
     # turns a crash into a permanent block. `live()` also checks the pid, so a
     # lock left by a hard kill is recognised as stale rather than believed.
     run_lock.release(lock_path)
+
+    if canary_stop:
+        raise click.ClickException(canary_stop)
 
     click.echo(f"\n{len(ok)} succeeded, {len(failed)} failed")
     click.echo(f"tokens: {spent_in:,} in, {spent_out:,} out")

--- a/src/data_sheets_schema/grounding.py
+++ b/src/data_sheets_schema/grounding.py
@@ -90,10 +90,15 @@ def ground(value: str, bundle: str) -> tuple[str, str, str] | None:
     if not found:
         return None
     name, bare = found
+    # Normalised before anything compares or counts it. DOIs are
+    # case-insensitive in the local part by convention and case-varying in
+    # practice, so `doi:10.1234/ABC` and `doi:10.1234/abc` were counted as two
+    # distinct identifiers (#578).
+    bare = bare.lower()
     base = bare.split("#", 1)[0]
-    if bare.lower() in bundle:
+    if bare in bundle:
         return name, bare, "grounded"
-    if "#" in bare and base.lower() in bundle:
+    if "#" in bare and base in bundle:
         return name, bare, "minted_fragment"
     return name, bare, "absent"
 
@@ -171,6 +176,14 @@ def check_run(full: Path, core: Path, bundle: Path,
     if not bundle.exists():
         return {"checked": False, "reason": f"bundle absent: {bundle}"}
     slots = slots if slots is not None else uriorcurie_slots()
+    # Both records absent read as `checked: true` with three zeroes, which
+    # `runs check` reported as fully grounded (#578). Zero identifiers found in
+    # a file that is not there is not a measurement — the same distinction
+    # `pair_consistency` draws with `ran: false`, missed here.
+    missing = [str(p) for p in (full, core) if not p.exists()]
+    if len(missing) == 2:
+        return {"checked": False,
+                "reason": f"neither record is on disk: {', '.join(missing)}"}
     text = bundle.read_text(encoding="utf-8", errors="replace")
     out: dict[str, Any] = {"checked": True,
                            "counts": {"grounded": 0, "minted_fragment": 0,

--- a/src/data_sheets_schema/report_claims.py
+++ b/src/data_sheets_schema/report_claims.py
@@ -162,6 +162,12 @@ def _target(text: str) -> str:
         return "core"
     if full and not core:
         return "full"
+    if core and full:
+        # Named both, so both must have performed it. This fell into `either`
+        # and was read against core alone, so "removed from the full and core
+        # records" passed while the full record still held it (#578) — which is
+        # the very direction #566 is about.
+        return "both"
     return "either"
 
 
@@ -274,6 +280,8 @@ def check_report(report: Path, full: dict, core: dict,
             in_core, v_core = resolve(core, name)
             live = {"core": in_core and _populated(v_core),
                     "full": in_full and _populated(v_full),
+                    "both": (in_core and _populated(v_core))
+                            or (in_full and _populated(v_full)),
                     "either": in_core and _populated(v_core)}[where]
             if live:
                 v = v_full if where == "full" else v_core
@@ -360,7 +368,15 @@ def check_report(report: Path, full: dict, core: dict,
 
         for names, claim in sentence_subjects:
             for name in names:
-                root = re.split(r"[.\[]", name)[0]
+                # A dotted path names a slot on a nested class, not the root.
+                # Resolving `distributions.bogus` to `distributions` reported a
+                # true claim as false, because the root does exist (#578).
+                # Only unqualified names are checkable against a class
+                # inventory; a nested one needs the range class, which this
+                # does not resolve, so it is skipped rather than guessed.
+                if re.search(r"[.\[]", name):
+                    continue
+                root = name
                 holders = sorted(c for c, sl in declared.items() if root in sl)
                 if holders:
                     findings.append({

--- a/tests/test_canary_gate.py
+++ b/tests/test_canary_gate.py
@@ -1,0 +1,128 @@
+"""The first run of a sweep is held to a higher bar than the rest (#579).
+
+`d4d api batch` counted a run as succeeded on schema validation alone, so a run
+whose pair diverges, whose report contradicts its record, or which carries
+identifiers absent from its bundle entered the "succeeded" column. That is how
+the 2026-08-13 arm swept clean: twelve valid records, `runs check --strict` exit
+0, eleven divergent pairs and twenty-nine ungrounded identifiers inside them.
+
+The canary rule says one unit is verified before fanning out — but the canary's
+verdict *was* the batch's verdict, and the batch did not look. A canary could
+pass while showing exactly the defects the arm was built to fix.
+"""
+
+import unittest
+
+from data_sheets_schema.canary import (
+    OK,
+    REGRESSED,
+    UNMEASURABLE,
+    baseline_for,
+    counts_from,
+    verdict,
+)
+
+BASELINE = "2026-08-13_claude-opus-5-api-generic-v4"
+
+GOOD = {"pair": {"ran": True, "errors": 2},
+        "report": {"checked": True, "findings": []},
+        "grounding": {"checked": True, "distinct": {"absent": 0}}}
+
+
+class CountsTest(unittest.TestCase):
+
+    def test_a_check_that_did_not_run_counts_as_none_not_zero(self):
+        """Zero is a measurement; None is the absence of one. Collapsing them
+        is the mistake the grounding check itself made (#578)."""
+        counts = counts_from({"pair": {"ran": False, "reason": "x"},
+                              "report": {"checked": False},
+                              "grounding": {"checked": False}})
+        self.assertEqual(set(counts.values()), {None})
+
+    def test_counts_are_read_from_each_block(self):
+        self.assertEqual(counts_from(GOOD),
+                         {"pair errors": 2, "report findings": 0,
+                          "ungrounded identifiers": 0})
+
+
+class BaselineTest(unittest.TestCase):
+
+    def test_the_bar_is_the_worst_run_not_the_best(self):
+        """The best would make ordinary replicate variance read as a
+        regression, and this gate stops a paid sweep."""
+        bar = baseline_for("AI_READI", BASELINE)
+        if bar["pair errors"] is None:
+            self.skipTest("v4 arm not present in this checkout")
+        self.assertEqual(bar["pair errors"], 10)     # reps are 10, 8, 6
+        self.assertEqual(bar["ungrounded identifiers"], 0)
+
+    def test_voice_carries_its_own_ungrounded_baseline(self):
+        """VOICE rep1's 19 ungrounded identifiers are in the baseline, so a v5
+        VOICE run is not failed for inheriting them — only for exceeding."""
+        bar = baseline_for("VOICE", BASELINE)
+        if bar["ungrounded identifiers"] is None:
+            self.skipTest("v4 arm not present in this checkout")
+        self.assertEqual(bar["ungrounded identifiers"], 19)
+
+    def test_an_unknown_project_yields_no_bar(self):
+        self.assertEqual(set(baseline_for("NOPE", BASELINE).values()), {None})
+
+
+class VerdictTest(unittest.TestCase):
+
+    BAR = {"pair errors": 10, "report findings": 2,
+           "ungrounded identifiers": 0}
+
+    def test_no_worse_than_the_baseline_passes(self):
+        self.assertEqual(verdict(GOOD, self.BAR)["status"], OK)
+
+    def test_equalling_the_worst_baseline_is_not_a_regression(self):
+        at_bar = {"pair": {"ran": True, "errors": 10},
+                  "report": {"checked": True, "findings": [1, 2]},
+                  "grounding": {"checked": True, "distinct": {"absent": 0}}}
+        self.assertEqual(verdict(at_bar, self.BAR)["status"], OK)
+
+    def test_one_metric_worse_stops_the_sweep(self):
+        worse = {**GOOD,
+                 "grounding": {"checked": True, "distinct": {"absent": 5}}}
+        v = verdict(worse, self.BAR)
+        self.assertEqual(v["status"], REGRESSED)
+        self.assertIn("ungrounded identifiers", v["regressions"][0])
+
+    def test_a_blind_check_stops_the_sweep_too(self):
+        """A canary whose instruments could not run has verified nothing —
+        the failure #565 recorded one level down, where a snippet was proved
+        against the only project that had nothing to find."""
+        blind = {**GOOD, "pair": {"ran": False, "reason": "schema missing"}}
+        v = verdict(blind, self.BAR)
+        self.assertEqual(v["status"], UNMEASURABLE)
+        self.assertEqual(v["blind"], ["pair errors"])
+
+    def test_a_missing_baseline_never_regresses(self):
+        """No bar is not a failed bar. A first-ever arm has nothing to compare
+        against and must not be blocked by that."""
+        self.assertEqual(
+            verdict(GOOD, {k: None for k in self.BAR})["status"], OK)
+
+
+class RealArmTest(unittest.TestCase):
+
+    def test_a_v4_record_does_not_regress_against_its_own_arm(self):
+        """The gate must be satisfiable by the arm that defined it, or it is
+        not a regression test but a wish."""
+        import yaml
+        from pathlib import Path
+        p = (Path("data/d4d_concatenated/claudecode_agent_core")
+             / f"{BASELINE}_rep1" / "AI_READI_provenance.yaml")
+        if not p.exists():
+            self.skipTest("v4 arm not present in this checkout")
+        rec = yaml.safe_load(p.read_text(encoding="utf-8"))
+        checks = {"pair": rec.get("pair_consistency"),
+                  "report": rec.get("report_claims"),
+                  "grounding": rec.get("grounding")}
+        self.assertEqual(
+            verdict(checks, baseline_for("AI_READI", BASELINE))["status"], OK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_canary_gate.py
+++ b/tests/test_canary_gate.py
@@ -126,3 +126,40 @@ class RealArmTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class GateControlFlowTest(unittest.TestCase):
+    """Where the refusal is raised decides whether it works at all.
+
+    The first version raised inside the per-run `try`, whose bare
+    `except Exception` catches everything — so under `--continue-on-error` the
+    sweep caught its own canary refusal, logged it as a failed run, and fanned
+    out. The gate existed and did nothing, which is worse than not having it,
+    because the summary then says a canary passed.
+    """
+
+    def _source(self):
+        import inspect
+
+        from data_sheets_schema.cli.api import batch_cmd
+        return inspect.getsource(batch_cmd.callback)
+
+    def test_the_refusal_is_raised_outside_the_per_run_handler(self):
+        src = self._source()
+        self.assertGreater(src.index("raise click.ClickException(canary_stop)"),
+                           src.index("except Exception as exc:"))
+
+    def test_the_loop_breaks_rather_than_continuing(self):
+        """`--continue-on-error` must not override the canary: it governs
+        individual run failures, not the decision to fan out at all."""
+        self.assertIn("if canary_stop:", self._source())
+
+    def test_the_lock_is_released_exactly_once(self):
+        """Releasing twice on the refusal path, or not at all, turns a stopped
+        sweep into a permanently blocked label prefix (#513)."""
+        self.assertEqual(self._source().count("run_lock.release(lock_path)"), 1)
+
+    def test_the_gate_is_opt_in_and_says_how_to_bypass(self):
+        src = self._source()
+        self.assertIn("--no-canary-gate", src)
+        self.assertIn("canary_baseline and not no_canary_gate", src)

--- a/tests/test_report_claims.py
+++ b/tests/test_report_claims.py
@@ -150,6 +150,32 @@ class PrecisionTest(Harness):
         self.assertEqual(out["claims_unnamed"], 1)
 
 
+class BothRecordsTest(Harness):
+    """A claim naming both records must be checked against both (#578).
+
+    `_target` returned `either` for a claim that named no record *and* for one
+    that named both, and `either` was read against core alone. So "removed from
+    the full and core records" passed when core removed it and full did not —
+    the direction #566 exists to catch.
+    """
+
+    MD = ("**Action:** the `distributions` block was removed from the full "
+          "record and the core record.\n")
+
+    def test_survival_in_full_alone_is_reported(self):
+        self.assertEqual(
+            self.kinds(self.MD, full={"distributions": [1, 2]}, core={}),
+            [("removal_not_performed", "distributions")])
+
+    def test_survival_in_core_alone_is_reported(self):
+        self.assertEqual(
+            self.kinds(self.MD, full={}, core={"distributions": [1]}),
+            [("removal_not_performed", "distributions")])
+
+    def test_a_removal_from_both_passes(self):
+        self.assertEqual(self.kinds(self.MD, full={}, core={}), [])
+
+
 class SchemaClaimTest(Harness):
 
     def test_a_slot_said_not_to_exist_but_declared(self):
@@ -181,6 +207,18 @@ class SchemaClaimTest(Harness):
 
     def test_a_true_absence_claim_is_not_reported(self):
         md = "**Finding:** `invented_slot` is not declared on `CoreDataset`.\n"
+        self.assertEqual(self.kinds(md), [])
+
+    def test_a_dotted_claim_is_not_answered_by_its_root(self):
+        """`distributions.bogus` is not `distributions` (#578).
+
+        Resolving a dotted path to its root contradicted a report that was
+        right, because the root exists. Checking it properly needs the range
+        class of the parent slot, which this does not resolve — so it is
+        skipped rather than guessed at, and a true claim is left alone.
+        """
+        md = ("**Finding:** `distributions.bogus` is not declared on "
+              "`CoreDistribution`.\n")
         self.assertEqual(self.kinds(md), [])
 
 


### PR DESCRIPTION
Closes #579, #578, #577 — the three remaining findings from the Codex readiness
review, in the order they matter for a v5 run.

## #579 — the canary could not stop anything

`d4d api batch` counted success on schema validation alone. A run whose pair
diverges, whose report contradicts its own record, or which carries identifiers
absent from its bundle entered the "succeeded" column. **That is how the v4 arm
swept clean**: twelve valid records, `runs check --strict` exit 0, eleven
divergent pairs and twenty-nine ungrounded identifiers inside them.

The canary rule verifies one unit before fanning out — but the canary's verdict
*was* the batch's verdict, and the batch never looked at the three checks.

- `execute()` returns the check blocks; the batch prints them for every run.
- `--canary-baseline <prefix>` holds the first run against a previous arm and
  refuses to fan out on a regression.

**A regression gate, not a perfection gate.** Requiring zero pair errors would
refuse to start, since eleven of twelve v4 records have some. The bar is the
*worst* value each metric took across the baseline arm for that project:

```
AI_READI   pair errors 10   report findings 2   ungrounded 0
CHORUS     pair errors  6   report findings 0   ungrounded 0
VOICE      pair errors  9   report findings 2   ungrounded 19
```

VOICE's 19 ungrounded identifiers are in its own baseline, so a v5 VOICE run is
not failed for inheriting them — only for exceeding. A v4 record replayed
against its own arm returns `ok`, which is the test that the gate is satisfiable
by the arm that defined it rather than a wish.

A check that **could not run** also stops the sweep: a canary whose instruments
were blind has verified nothing — #565 one level down.

## #578 — two checks passed where nothing was checked

| defect | now |
|---|---|
| `check_run` returned `checked: true` + three zeroes when both records were absent | `checked: false`, naming them |
| identifier case preserved, so `doi:…/ABC` and `doi:…/abc` were two identifiers | normalised before counting |
| `_target` returned `either` for a claim naming *both* records, read against core alone | `both` is its own case, checked against both |
| a dotted schema claim resolved to its root — "`distributions.bogus` is not declared" reported false because `distributions` exists | skipped rather than guessed; checking it needs the parent's range class |

The third mattered most: "removed from the full and core records" passed while
the full record still held it — the direction #566 is about.

## #577 — three baselines wrong or undefined

`scripts/v5_baselines.py` is committed so v5's figures are produced the same way
as v4's, and it prints the counting rules beside the numbers.

The plan claimed minted fragments were "0 elsewhere" outside three records.
**AI-READI rep2 and rep3 have 14 and 13** — prediction 2 would have been
evaluated against a baseline 27 too low. The undeclared-prefix count (370 with
`urn:`/`ark:`, 320 without) and the British-spelling count (613 in generated
prose, ~626 including quoted) each had a defensible rule that was never stated.

23 new tests. Suite: 2092 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)