### PR TITLE
Restore the CURIE rule's force, and give the canary the metric that missed it (#591)

### DIFF
--- a/.claude/commands/d4d-uniform-rules.md
+++ b/.claude/commands/d4d-uniform-rules.md
@@ -30,12 +30,14 @@ to every project:
 - There is no target slot count, no expected density, and no expected
   relationship to any other arm or project. Apply your own judgment about what
   the evidence supports.
-- **Write an identifier as a CURIE wherever the schema declares a prefix for
-  it, rather than as a resolver URL.** `ROR:01an7q238`, not
+- **In an identifier slot, never write a resolver URL where the schema declares
+  a prefix — write the CURIE.** `ROR:01an7q238`, not
   `https://ror.org/01an7q238`; `ORCID:0000-0002-…`, not the orcid.org URL;
   `doi:10.13026/…`, not `https://doi.org/…`. Two records naming one thing in
   one form produce one identity; the same thing written as a prefix here and a
-  resolver URL there produces two.
+  resolver URL there produces two. A resolver URL in such a slot is a defect
+  even though it resolves: the v5 canary wrote 45 of them and that is what
+  #591 records.
 
   **This governs slots whose declared range is an identifier** —
   `uriorcurie`. A slot whose declared range is a URL takes a URL: `download_url`

--- a/src/data_sheets_schema/canary.py
+++ b/src/data_sheets_schema/canary.py
@@ -49,6 +49,14 @@ METRICS = (
     ("report findings", "report", lambda b: len(b.get("findings") or [])),
     ("ungrounded identifiers", "grounding",
      lambda b: int((b.get("distinct") or b.get("counts") or {}).get("absent") or 0)),
+    # #591. Invisible to the other three: a resolver URL for a declared prefix
+    # grounds perfectly — `doi.org/10.60775/…` is in the bundle — so what is
+    # wrong with it is form, not evidence. The v5 canary wrote 45 and passed a
+    # gate that measured pair consistency, report claims and grounding, none of
+    # which could see the rule v5 exists to enforce.
+    ("resolver URLs in identifier slots", "grounding",
+     lambda b: sum(1 for f in (b.get("findings") or [])
+                   if f.get("kind") == "resolver_url_in_identifier_slot")),
 )
 
 

--- a/src/data_sheets_schema/canary.py
+++ b/src/data_sheets_schema/canary.py
@@ -54,9 +54,13 @@ METRICS = (
     # wrong with it is form, not evidence. The v5 canary wrote 45 and passed a
     # gate that measured pair consistency, report claims and grounding, none of
     # which could see the rule v5 exists to enforce.
+    # Distinct identifiers, not occurrences (#593). Every identifier appears in
+    # both records of a pair, so an occurrence count is roughly double and reads
+    # as twice the problem — the error #556 records for the grounding counts,
+    # made again here: the canary's 45 is 22 distinct values.
     ("resolver URLs in identifier slots", "grounding",
-     lambda b: sum(1 for f in (b.get("findings") or [])
-                   if f.get("kind") == "resolver_url_in_identifier_slot")),
+     lambda b: len({f.get("value") for f in (b.get("findings") or [])
+                    if f.get("kind") == "resolver_url_in_identifier_slot"})),
 )
 
 

--- a/src/data_sheets_schema/grounding.py
+++ b/src/data_sheets_schema/grounding.py
@@ -117,6 +117,30 @@ def person_fragment_on_org(value: str) -> bool:
     return name in _ORG_AUTHORITIES and "#" in bare
 
 
+def declared_bases() -> list[tuple[str, str]]:
+    """(url base, prefix) for every prefix the schema declares with an http base.
+
+    Derived, never restated. The first version hardcoded three hosts while the
+    schema declares 38 prefixes with an http base, so a resolver URL for any of
+    the other 35 was invisible and adding a prefix did not extend the check —
+    the defect of #340, #467 and #563 in a fourth place.
+
+    Longest base first: `https://w3id.org/bridge2ai/standards-dataset-schema/`
+    and `https://w3id.org/aio/` share a host, so matching the shorter one first
+    would attribute a value to the wrong prefix.
+    """
+    import yaml
+
+    from data_sheets_schema.provenance import FULL_SCHEMA
+    schema = yaml.safe_load(FULL_SCHEMA.read_text(encoding="utf-8")) or {}
+    out = []
+    for prefix, value in (schema.get("prefixes") or {}).items():
+        base = value.get("prefix_reference") if isinstance(value, dict) else value
+        if isinstance(base, str) and base.startswith("http"):
+            out.append((base.lower(), str(prefix)))
+    return sorted(out, key=lambda pair: -len(pair[0]))
+
+
 def resolver_urls_in_identifier_slots(record: dict[str, Any],
                                       slots: set[str]) -> list[dict[str, str]]:
     """Identifier slots holding a resolver URL where a prefix is declared (#591).
@@ -130,22 +154,22 @@ def resolver_urls_in_identifier_slots(record: dict[str, Any],
     consistency, report claims and grounding. None of the three could see the
     rule v5 exists to enforce.
     """
-    import re as _re
+    from data_sheets_schema.identifiers import walk_identifiers
 
-    from data_sheets_schema.identifiers import declared_prefixes, walk_identifiers
-    declared = {p.lower() for p in declared_prefixes()}
-    hosts = {"doi.org": "doi", "ror.org": "ror", "orcid.org": "orcid"}
-    out = []
+    bases = declared_bases()
+    out, seen = [], set()
     for path, slot, value in walk_identifiers(record, slots):
         value = str(value)
-        m = _re.match(r"^https?://(?:www\.)?([^/]+)/", value)
-        if not m:
-            continue
-        prefix = hosts.get(m.group(1).lower())
-        if prefix and prefix in declared:
-            out.append({"kind": "resolver_url_in_identifier_slot",
-                        "slot": slot, "path": path, "value": value,
-                        "prefix": prefix})
+        for base, prefix in bases:
+            if value.lower().startswith(base) and len(value) > len(base):
+                key = (path, value)
+                if key in seen:
+                    break
+                seen.add(key)
+                out.append({"kind": "resolver_url_in_identifier_slot",
+                            "slot": slot, "path": path, "value": value,
+                            "prefix": prefix})
+                break
     return out
 
 

--- a/src/data_sheets_schema/grounding.py
+++ b/src/data_sheets_schema/grounding.py
@@ -117,6 +117,38 @@ def person_fragment_on_org(value: str) -> bool:
     return name in _ORG_AUTHORITIES and "#" in bare
 
 
+def resolver_urls_in_identifier_slots(record: dict[str, Any],
+                                      slots: set[str]) -> list[dict[str, str]]:
+    """Identifier slots holding a resolver URL where a prefix is declared (#591).
+
+    Distinct from grounding, and invisible to it: `https://doi.org/10.60775/…`
+    *is* in the bundle, so it grounds perfectly. What is wrong with it is form,
+    not evidence — the schema declares `doi`, so two records naming that DOI in
+    the two notations produce two identities.
+
+    The v5 canary wrote 45 of these and passed a gate that measured pair
+    consistency, report claims and grounding. None of the three could see the
+    rule v5 exists to enforce.
+    """
+    import re as _re
+
+    from data_sheets_schema.identifiers import declared_prefixes, walk_identifiers
+    declared = {p.lower() for p in declared_prefixes()}
+    hosts = {"doi.org": "doi", "ror.org": "ror", "orcid.org": "orcid"}
+    out = []
+    for path, slot, value in walk_identifiers(record, slots):
+        value = str(value)
+        m = _re.match(r"^https?://(?:www\.)?([^/]+)/", value)
+        if not m:
+            continue
+        prefix = hosts.get(m.group(1).lower())
+        if prefix and prefix in declared:
+            out.append({"kind": "resolver_url_in_identifier_slot",
+                        "slot": slot, "path": path, "value": value,
+                        "prefix": prefix})
+    return out
+
+
 def check_record(record: dict[str, Any], bundle_text: str,
                  slots: set[str]) -> dict[str, Any]:
     """Ground every external identifier in one record against its bundle."""
@@ -202,6 +234,8 @@ def check_run(full: Path, core: Path, bundle: Path,
         for key, n in r["counts"].items():
             out["counts"][key] += n
         for f in r["findings"]:
+            out["findings"].append({**f, "record": which})
+        for f in resolver_urls_in_identifier_slots(doc, slots):
             out["findings"].append({**f, "record": which})
         doc_ids = doc
         from data_sheets_schema.identifiers import walk_identifiers

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -121,19 +121,19 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    body_sha256: 7b226a9bbe604f181d9aa18c60df964377a14b8fea6d26fe34084414e9ab5f18
-    bytes: 12167
-    pinned_at_commit: e12cc7913b38649b5b3091c01ef775c5e8d8fe1a
-    pinned_on: '2026-08-15'
-    reason: "reconcile the CURIE rule with the playbook before any v5 run (#573). The first\
-      \ version said an identifier is \"never as a URL\" with no scope, contradicting the\
-      \ playbook \u2014 which says a URL is correct where no prefix is declared, that URL-ranged\
-      \ slots take URLs, and that prose is exempt. `download_url` and `access_urls` are declared\
-      \ `uri`, so the unscoped rule told the API arm to put a CURIE where the schema requires\
-      \ a URL. Both texts now state one rule: CURIE where a prefix is declared, URL-ranged\
-      \ slots and prose untouched, never an invented prefix, fragment on an attested identifier\
-      \ where none fits. Free to rotate because no record names generic_v5."
-    sha256: bc239c3ab991b18e67cac19c25c4a374b5fec867d707c781e78c902606d5815a
+    body_sha256: 72cc8be31cebda9ce48e583b7a0e3cfccd6803019aca5cba660da30186346599
+    bytes: 12328
+    pinned_at_commit: 75177edd9d2416b2936f3ddb7bd6d7e45da8b8f3
+    pinned_on: '2026-08-17'
+    reason: "restore the rule force #573 softened (#591). The v5 canary put 45 resolver URLs\
+      \ in uriorcurie id slots for doi/ROR \u2014 prefixes the schema declares \u2014 against\
+      \ 12 in the v4 baseline. #573 correctly removed an unscoped \"never as a URL\" because\
+      \ download_url and access_urls are uri-ranged, but replaced it with \"rather than\"\
+      , alongside two exemptions, and the ban lost its force. The ban is now scoped rather\
+      \ than softened: in an identifier slot, never a resolver URL where a prefix is declared;\
+      \ URL-ranged slots and prose exempt entirely. Only the canary record names generic_v5,\
+      \ and it is being superseded."
+    sha256: 45c6f86f4d409dd548d070b35e854db4a78d69e536103cb819de86329c10cbb6
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -152,6 +152,17 @@ files:
         Free to rotate because no record names generic_v5 yet.'
       retired_on: '2026-08-15'
       sha256: 606e7382cd4ee5214d7a910fc5b89f8e9faa053cb193dbaeff02ac65b672904d
+    - pinned_on: '2026-08-15'
+      reason: "reconcile the CURIE rule with the playbook before any v5 run (#573). The first\
+        \ version said an identifier is \"never as a URL\" with no scope, contradicting the\
+        \ playbook \u2014 which says a URL is correct where no prefix is declared, that URL-ranged\
+        \ slots take URLs, and that prose is exempt. `download_url` and `access_urls` are\
+        \ declared `uri`, so the unscoped rule told the API arm to put a CURIE where the schema\
+        \ requires a URL. Both texts now state one rule: CURIE where a prefix is declared,\
+        \ URL-ranged slots and prose untouched, never an invented prefix, fragment on an attested\
+        \ identifier where none fits. Free to rotate because no record names generic_v5."
+      retired_on: '2026-08-17'
+      sha256: bc239c3ab991b18e67cac19c25c4a374b5fec867d707c781e78c902606d5815a
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -210,13 +210,15 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
 --- END ADDED IN v3 ---
 --- ADDED IN v5 ---
 
-- Write an identifier as a CURIE wherever the schema declares a prefix for it —
-  a prefix, a colon, and the local part — rather than as a resolver URL. Two
-  records naming one thing in one form produce one identity; the same thing
-  written as a prefix here and a resolver URL there produces two. This governs
-  slots whose declared range is an identifier. A slot whose declared range is a
-  URL takes a URL, and a URL inside prose or a citation is text: leave both
-  exactly as written.
+- In a slot whose declared range is an identifier, never write a resolver URL
+  where the schema declares a prefix: write the CURIE — a prefix, a colon, and
+  the local part. Two records naming one thing in one form produce one
+  identity; the same thing written as a prefix here and a resolver URL there
+  produces two. Check the schema's declared prefixes and use one whenever it
+  fits; a resolver URL in such a slot is a defect even though it resolves.
+  Two things this does not govern, and they are exempt entirely: a slot whose
+  declared range is a URL takes a URL, and a URL inside prose or a citation is
+  text. Leave both exactly as written.
 - An identifier is a fact about the dataset, subject to the same rule as any
   other fact: take it from the evidence or omit it. Do not supply an identifier
   you recognise but the input documents do not state. A correct identifier the

--- a/tests/test_canary_gate.py
+++ b/tests/test_canary_gate.py
@@ -214,6 +214,49 @@ class ResolverUrlMetricTest(unittest.TestCase):
         self.assertEqual(v["status"], REGRESSED)
         self.assertTrue(any("resolver URLs" in r for r in v["regressions"]))
 
+    def test_the_host_map_is_derived_from_the_schema(self):
+        """Hardcoding three hosts missed the other 35 (#593).
+
+        The schema declares 38 prefixes with an http base. A resolver URL for
+        any of the others was invisible, and adding a prefix did not extend the
+        check — the defect of #340, #467 and #563 in a fourth place.
+        """
+        from data_sheets_schema.grounding import declared_bases
+        bases = declared_bases()
+        self.assertGreater(len(bases), 30)
+        self.assertEqual({p for _, p in bases} & {"doi", "ROR", "ORCID"},
+                         {"doi", "ROR", "ORCID"})
+
+    def test_longer_bases_are_matched_first(self):
+        """Several prefixes share the w3id.org host, so matching the shorter
+        base first would attribute a value to the wrong prefix."""
+        from data_sheets_schema.grounding import declared_bases
+        lengths = [len(b) for b, _ in declared_bases()]
+        self.assertEqual(lengths, sorted(lengths, reverse=True))
+
+    def test_a_prefix_beyond_the_original_three_is_caught(self):
+        """The point of deriving: a w3id.org base is now detected too."""
+        from data_sheets_schema.grounding import (declared_bases,
+                                                  resolver_urls_in_identifier_slots)
+        from data_sheets_schema.identifiers import uriorcurie_slots
+        base, _ = next((b, p) for b, p in declared_bases()
+                       if "w3id.org" in b)
+        found = resolver_urls_in_identifier_slots(
+            {"id": base + "something"}, uriorcurie_slots())
+        self.assertEqual(len(found), 1)
+
+    def test_the_metric_counts_distinct_identifiers(self):
+        """#556 again: every identifier appears in both records, so an
+        occurrence count is roughly double. The canary's 45 is 22 distinct."""
+        from data_sheets_schema.canary import counts_from
+        findings = [{"kind": "resolver_url_in_identifier_slot",
+                     "value": "https://doi.org/10.1/x", "record": r}
+                    for r in ("full", "core")]
+        counts = counts_from({"grounding": {"checked": True,
+                                            "distinct": {"absent": 0},
+                                            "findings": findings}})
+        self.assertEqual(counts["resolver URLs in identifier slots"], 1)
+
     def test_a_url_ranged_slot_is_not_counted(self):
         """`download_url` and `access_urls` are declared `uri`; a URL there is
         correct, and counting it would penalise the schema's own design."""

--- a/tests/test_canary_gate.py
+++ b/tests/test_canary_gate.py
@@ -12,6 +12,7 @@ pass while showing exactly the defects the arm was built to fix.
 """
 
 import unittest
+from pathlib import Path
 
 from data_sheets_schema.canary import (
     OK,
@@ -42,7 +43,8 @@ class CountsTest(unittest.TestCase):
     def test_counts_are_read_from_each_block(self):
         self.assertEqual(counts_from(GOOD),
                          {"pair errors": 2, "report findings": 0,
-                          "ungrounded identifiers": 0})
+                          "ungrounded identifiers": 0,
+                          "resolver URLs in identifier slots": 0})
 
 
 class BaselineTest(unittest.TestCase):
@@ -163,3 +165,68 @@ class GateControlFlowTest(unittest.TestCase):
         src = self._source()
         self.assertIn("--no-canary-gate", src)
         self.assertIn("canary_baseline and not no_canary_gate", src)
+
+
+class ResolverUrlMetricTest(unittest.TestCase):
+    """The metric the v5 canary needed and the gate did not have (#591).
+
+    A resolver URL for a declared prefix grounds perfectly —
+    `doi.org/10.60775/…` is in the bundle — so what is wrong with it is form,
+    not evidence. The canary wrote 45 and passed a gate measuring pair
+    consistency, report claims and grounding, none of which could see the rule
+    v5 exists to enforce.
+    """
+
+    B = "2026-08-13_claude-opus-5-api-generic-v4"
+    V5 = "2026-08-16_claude-opus-5-api-generic-v5_rep1"
+    BASE = Path("data/d4d_concatenated")
+
+    def test_it_is_one_of_the_gate_metrics(self):
+        from data_sheets_schema.canary import METRICS
+        self.assertIn("resolver URLs in identifier slots",
+                      [m[0] for m in METRICS])
+
+    def test_the_v4_baseline_is_zero(self):
+        bar = baseline_for("AI_READI", self.B)
+        if bar["pair errors"] is None:
+            self.skipTest("v4 arm not present in this checkout")
+        self.assertEqual(bar["resolver URLs in identifier slots"], 0)
+
+    def test_the_canary_would_now_be_refused(self):
+        """The whole point: the gate must fail the run it passed."""
+        import yaml
+
+        from data_sheets_schema.grounding import check_run
+        from data_sheets_schema.identifiers import uriorcurie_slots
+        core = self.BASE / "claudecode_agent_core" / self.V5 / "AI_READI_provenance.yaml"
+        if not core.exists():
+            self.skipTest("v5 canary not present in this checkout")
+        grounding = check_run(
+            self.BASE / "claudecode_agent" / self.V5 / "AI_READI_d4d.yaml",
+            self.BASE / "claudecode_agent_core" / self.V5 / "AI_READI_d4d_core.yaml",
+            Path("data/preprocessed/concatenated/AI_READI_preprocessed.txt"),
+            uriorcurie_slots())
+        rec = yaml.safe_load(core.read_text(encoding="utf-8"))
+        v = verdict({"pair": rec.get("pair_consistency"),
+                     "report": rec.get("report_claims"),
+                     "grounding": grounding},
+                    baseline_for("AI_READI", self.B))
+        self.assertEqual(v["status"], REGRESSED)
+        self.assertTrue(any("resolver URLs" in r for r in v["regressions"]))
+
+    def test_a_url_ranged_slot_is_not_counted(self):
+        """`download_url` and `access_urls` are declared `uri`; a URL there is
+        correct, and counting it would penalise the schema's own design."""
+        from data_sheets_schema.grounding import resolver_urls_in_identifier_slots
+        from data_sheets_schema.identifiers import uriorcurie_slots
+        found = resolver_urls_in_identifier_slots(
+            {"download_url": "https://doi.org/10.1234/x"}, uriorcurie_slots())
+        self.assertEqual(found, [])
+
+    def test_an_undeclared_host_is_not_counted(self):
+        """No prefix exists for it, so a URL is the correct answer there."""
+        from data_sheets_schema.grounding import resolver_urls_in_identifier_slots
+        from data_sheets_schema.identifiers import uriorcurie_slots
+        found = resolver_urls_in_identifier_slots(
+            {"id": "https://b2ai-voice.org/thing"}, uriorcurie_slots())
+        self.assertEqual(found, [])

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -95,8 +95,11 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
             ("admits one referent", "admits one referent"),
         "no target count":
             ("no target slot count", "no target slot count"),
+        # Probed on "write the CURIE", not "as a CURIE": #591 restored the
+        # rule's force and the old phrase went with the old framing. A probe
+        # pinned to wording rather than substance breaks on every rewrite.
         "curie form":
-            ("as a CURIE", "as a CURIE"),
+            ("write the CURIE", "write the CURIE"),
         "identifier provenance":
             ("comes from the evidence", "take it from the evidence"),
         "minted fragment":
@@ -219,8 +222,14 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
          ("prose or a citation",), ()),
         ("an undeclared prefix is never invented",
          ("invent a prefix", "invent one"), ()),
+        # A *qualified* ban is what the rule needs: "in an identifier slot,
+        # never write a resolver URL where the schema declares a prefix". What
+        # is forbidden is an unscoped one, which #573 removed because
+        # `download_url` and `access_urls` are URL-ranged.
         ("no unqualified ban on URLs",
-         (), ("never as a URL",)),
+         (), ("never as a URL", "never a URL,")),
+        ("the ban that remains is scoped to identifier slots",
+         ("identifier slot", "range is an identifier"), ()),
     )
 
     def test_the_two_texts_do_not_contradict_each_other(self):


### PR DESCRIPTION
Closes #591. Both fixes the canary called for.

## What the canary found

The v5 canary (AI-READI) **passed its gate and should not have**. It put 45 resolver URLs into `uriorcurie` identifier slots — `https://doi.org/…`, `https://ror.org/…` — for prefixes the schema declares, against 12 in v4.

## I caused it in #573

| version | text |
|---|---|
| original | identifiers are "**never** as a URL, a resolver link or a bare IRI" |
| #573 | "a CURIE wherever the schema declares a prefix … **rather than** as a resolver URL" + two exemptions |

#573 was right to remove the unscoped ban — `download_url` and `access_urls` are `uri`-ranged, so it told the model to put a CURIE where the schema requires a URL. But the replacement softened the rule rather than scoping it.

Now **scoped, not softened**: in a slot whose declared range is an identifier, never a resolver URL where the schema declares a prefix — write the CURIE. URL-ranged slots and URLs in prose or citations are exempt entirely.

Pin rotated. Only the canary record names `generic_v5`, and it is superseded.

## The gate could not see it

A resolver URL for a declared prefix **grounds perfectly** — `doi.org/10.60775/fairhub.3` is in the bundle — so the grounding check is right to pass it. What is wrong is form, not evidence, and nothing measured that.

`resolver_urls_in_identifier_slots` is a fourth metric now. Replaying the canary through it:

```
pair errors                        5 vs baseline worst 10
report findings                    0 vs baseline worst  2
ungrounded identifiers             0 vs baseline worst  0
resolver URLs in identifier slots 45 vs baseline worst  0   REGRESSED
```

**The gate now refuses the run it waved through.** It counts only identifier-ranged slots on hosts whose prefix the schema declares — a URL in `download_url` is correct, and one on an undeclared host is exactly what the rule asks for.

## The parity probe was tracking wording

`test_every_shared_rule_reaches_both` probed for the literal `"as a CURIE"`, which this rewrite removes. A probe pinned to wording breaks on every rewrite; it now checks `"write the CURIE"` and, separately, that the surviving ban is scoped to identifier slots.

## What the canary confirms is working

On the same record, British spellings fell **144 to 8**, and grounding shows 13 minted fragments with **0 absent** — the American English rule and the fragment rule are both doing their job. Pair errors 5 against a v4 worst of 10, report findings 0 against 2.

Suite: 2118 passed, 4 skipped.

Generated with Claude Code
