### PR TITLE
Let the manifest say which source wins a disagreement (Harry, 2026-08-17)

### DIFF
--- a/.claude/commands/d4d-uniform-rules.md
+++ b/.claude/commands/d4d-uniform-rules.md
@@ -24,6 +24,22 @@ to every project:
 - Where the declared bundle contains sources that disagree, represent what the
   evidence states rather than silently selecting one. Do not merge distinct
   entities into a single claim.
+
+- **Where two sources disagree, prefer the one the manifest ranks higher.**
+  State its value, and record in the caveat that the sources disagreed, what
+  each said, and which was preferred. The ranking is `source_priority` in
+  `data/preprocessed/source_manifest.yaml`, lowest tier strongest;
+  `d4d download priority --project X` lists it and
+  `d4d download priority --project X --decide a,b` answers a specific pair.
+
+  **Where the disagreeing sources share the same rank the ranking cannot
+  decide**: represent what the evidence states, as the rule above says. This
+  refines that rule rather than replacing it.
+
+  It exists because a v4 CHORUS record wrote that no instance count was
+  asserted "because the two sources give different figures … and the bundle
+  offers no basis for preferring one". The rule was right; the basis was
+  missing.
 - `Dataset` admits one referent. Choose the one the declared bundle best
   supports, state that choice in the reconciliation report, and hold to it
   consistently across both records.

--- a/data/preprocessed/source_manifest.yaml
+++ b/data/preprocessed/source_manifest.yaml
@@ -192,6 +192,40 @@ scope:
           so the overlap is in the evidence, not in the referent
         express_as: related_datasets
 
+# Which source wins when two of them state different things (Harry, 2026-08-17).
+#
+# Before this the uniform rule said only to represent a disagreement, and a
+# record following it wrote: "No instance count is asserted because the two
+# sources give different figures (over 45,000 and 50,000) for the same released
+# dataset and **the bundle offers no basis for preferring one**." That last
+# clause is the gap this closes — the rule was right and the basis was missing.
+#
+# Declared here rather than in a prompt, for the reason #422 records: a
+# constraint in the launch text is per-run adaptation that no future dataset
+# inherits and no test can see. This is checkable and inherited.
+#
+# Tier 1 is strongest. A tier is a claim about how directly a source speaks for
+# the released dataset, not about how much anyone trusts its authors:
+#
+#   1  the release describing itself — machine-readable metadata deposited with
+#      the data, and the repository record of the release
+#   2  the project describing its own release in prose, and the instruments
+#      that govern it
+#   3  the literature: peer-reviewed and preprint, authoritative on method and
+#      often behind the current release on counts
+#   4  presentations and funder records: about the project or a moment in it,
+#      not about the release
+#   5  explicitly historical material, retained for provenance
+#
+# A source may override its tier with `priority:`. An override is a deliberate
+# line someone has to write, and should say why in a `curation_note`.
+source_priority:
+  1: [RO-Crate, structured metadata, data resource]
+  2: [documentation, license, DUA, IRB]
+  3: [publication, preprint, white paper]
+  4: [NIH project page, tutorial]
+  5: [historical data release, historical documentation]
+
 default_minimum_characters: 500
 
 projects:

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -341,7 +341,7 @@ def prompt_body(path: Path = GENERIC_PROMPT) -> str:
 # Updated by hand when build_phase() reorders its parts; the instruction texts
 # are hashed mechanically below, so wording changes cannot go unrecorded, but
 # nothing derives this ordering from the code — keep it true.
-ASSEMBLY_LAYOUT = ("schema digest, input bundle, arm prompt, "
+ASSEMBLY_LAYOUT = ("schema digest, input bundle, source ranking, arm prompt, "
                    "carried artifacts, phase instruction")
 
 
@@ -586,6 +586,35 @@ PHASE_NEEDS = {
 }
 
 
+def source_ranking_block(project: str) -> str | None:
+    """The declared source ranking for one project, as sent to the model.
+
+    Rendered from the manifest rather than restated, so a tier edited there
+    reaches the next run with no code change. None when the project declares no
+    sources — the rule then has nothing to say and the block would be noise.
+    """
+    try:
+        from data_sheets_schema.source_priority import ranked
+        rows = ranked(project)
+    except Exception:                                          # noqa: BLE001
+        return None
+    if not rows:
+        return None
+    lines = [
+        "# Declared source ranking",
+        "",
+        "Where two sources disagree, prefer the one ranked higher — lower tier",
+        "number is stronger. Each file in the bundle names its `Source ID` and",
+        "`Source type` in its SOURCE METADATA block; match on those.",
+        "Sources of the same tier do not settle a disagreement between them.",
+        "",
+    ]
+    for row in rows:
+        lines.append(f"  tier {row['priority']}  {row.get('id')}  "
+                     f"({row.get('source_type')})")
+    return "\n".join(lines)
+
+
 def build_phase(spec: RunSpec, phase: str, *, carry: dict[str, str]) -> PhaseRequest:
     """Assemble one phase's request.
 
@@ -610,6 +639,18 @@ def build_phase(spec: RunSpec, phase: str, *, carry: dict[str, str]) -> PhaseReq
          "text": f"# Declared input bundle — {spec.bundle}\n\n{bundle_text}",
          "cache_control": {"type": "ephemeral"}},
     ]
+    # The ranking the rules tell the model to consult (#596). Without it the
+    # instruction "prefer the source the manifest ranks higher" named a table
+    # the API path never received — the agentic path can open the manifest and
+    # this path cannot, so one condition would have meant two behaviours.
+    #
+    # Cached with the bundle because it is the same kind of thing: per-project
+    # input that does not change between phases. It joins to the `Source type`
+    # each file already carries in its SOURCE METADATA block.
+    ranking = source_ranking_block(spec.project)
+    if ranking:
+        cached.append({"type": "text", "text": ranking,
+                       "cache_control": {"type": "ephemeral"}})
 
     # Carried artifacts go BEFORE the phase instruction, so the instruction is
     # the last thing in the message (#346). With the old order the message

--- a/src/data_sheets_schema/cli/download.py
+++ b/src/data_sheets_schema/cli/download.py
@@ -511,3 +511,60 @@ def _crate_evidence_in(bundle: Path) -> set[str]:
             if stripped.startswith("+ "):
                 names.add(stripped[2:].split(" — ")[0].strip())
     return names
+
+
+@download.command("priority")
+@click.option("--project", default=None, help="list this project's sources, strongest first")
+@click.option("--decide", "decide_ids", default=None,
+              help="comma-separated source ids; which of them settles a disagreement")
+@click.option("--strict", is_flag=True, help="exit 1 if any source_type is unranked")
+def priority_cmd(project, decide_ids, strict):
+    """Which source wins when two of them state different things.
+
+    The uniform rules have always said to represent a disagreement rather than
+    select a side, and a v4 CHORUS record named the gap that left: "the bundle
+    offers no basis for preferring one". `source_priority` in the manifest is
+    that basis — declared there rather than in a prompt, for the reason #422
+    records.
+
+    A tier is about how directly a source speaks for the released dataset, not
+    about how much anyone trusts its authors. Equal tiers do not decide.
+    """
+    import sys
+
+    from data_sheets_schema.source_priority import (decide as decide_between,
+                                                    ranked, tiers,
+                                                    unranked_types)
+    if decide_ids:
+        if not project:
+            raise click.ClickException("--decide needs --project")
+        ids = [x.strip() for x in decide_ids.split(",") if x.strip()]
+        result = decide_between(project, ids)
+        for c in result["candidates"]:
+            click.echo(f"   tier {c['priority']}  {c['id']:32} {c['basis']}")
+        for u in result["unknown"]:
+            click.echo(f"   ?       {u:32} not declared for {project}", err=True)
+        click.echo(f"\n{'winner: ' + result['winner'] if result['winner'] else 'no winner'}"
+                   f"\n{result['reason']}")
+        return
+
+    if project:
+        for s in ranked(project):
+            click.echo(f"   tier {s['priority']}  {s['id']:32} "
+                       f"{str(s.get('source_type') or ''):26} {s['priority_basis']}")
+    else:
+        table = {}
+        for source_type, tier in tiers().items():
+            table.setdefault(tier, []).append(source_type)
+        for tier in sorted(table):
+            click.echo(f"   tier {tier}  {', '.join(sorted(table[tier]))}")
+
+    missing = unranked_types()
+    if missing:
+        click.echo("\n⚠️  source_types in use that no tier covers:")
+        for proj, types in sorted(missing.items()):
+            click.echo(f"     {proj:16} {', '.join(types)}")
+        click.echo("   An unranked source cannot win a disagreement, which is "
+                   "safe — but it also cannot lose on the record.")
+    if strict and missing:
+        sys.exit(1)

--- a/src/data_sheets_schema/source_priority.py
+++ b/src/data_sheets_schema/source_priority.py
@@ -1,0 +1,154 @@
+"""Which source wins when two of them state different things.
+
+The uniform rules have always said to represent a disagreement rather than
+silently select one side. That is right, and it left a gap a v4 CHORUS record
+named exactly:
+
+    No instance count is asserted because the two sources give different
+    figures (over 45,000 and 50,000) for the same released dataset and **the
+    bundle offers no basis for preferring one**.
+
+The rule was followed correctly. The basis was missing. This supplies it.
+
+## Declared in the manifest, not in a prompt
+
+#422's principle: a constraint in the launch text is per-run adaptation that no
+future dataset inherits and no test can see. `source_priority` in
+`source_manifest.yaml` is checkable and is inherited by any project that
+declares its sources.
+
+## A tier is about proximity to the release, not trust
+
+Tier 1 is the release describing itself. Tier 3 holds peer-reviewed work, which
+is authoritative on method and routinely behind the current release on counts —
+being lower than the project's own documentation is a statement about currency,
+not about quality.
+
+## Equal tiers do not decide
+
+Two sources of the same tier that disagree leave the question open, and the
+record should represent the disagreement as before. Priority resolves a
+disagreement; it does not manufacture a winner where it has nothing to say.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+MANIFEST = Path("data/preprocessed/source_manifest.yaml")
+
+#: Returned when nothing ranks a source. Sorts below every declared tier, so an
+#: unranked source never wins by accident — but it is distinguishable from
+#: tier 5, which somebody chose.
+UNRANKED = 99
+
+
+def _manifest(path: Path | None = None) -> dict[str, Any]:
+    import yaml
+    return yaml.safe_load((path or MANIFEST).read_text(encoding="utf-8")) or {}
+
+
+def tiers(manifest: dict[str, Any] | None = None) -> dict[str, int]:
+    """source_type -> tier, flattened from the declared table."""
+    data = manifest if manifest is not None else _manifest()
+    out: dict[str, int] = {}
+    for tier, types in (data.get("source_priority") or {}).items():
+        for source_type in types or ():
+            out[str(source_type)] = int(tier)
+    return out
+
+
+def sources(project: str, manifest: dict[str, Any] | None = None
+            ) -> list[dict[str, Any]]:
+    data = manifest if manifest is not None else _manifest()
+    entry = (data.get("projects") or {}).get(project)
+    return [s for s in entry if isinstance(s, dict)] if isinstance(entry, list) \
+        else []
+
+
+def priority_of(source: dict[str, Any],
+                table: dict[str, int] | None = None) -> tuple[int, str]:
+    """(tier, why) for one source entry.
+
+    An explicit `priority:` on the source wins over its type's tier, because an
+    override is a line someone deliberately wrote.
+    """
+    table = table if table is not None else tiers()
+    if source.get("priority") is not None:
+        return int(source["priority"]), "declared on the source"
+    source_type = source.get("source_type")
+    if source_type in table:
+        return table[source_type], f"tier of source_type {source_type!r}"
+    return UNRANKED, (f"source_type {source_type!r} is in no tier"
+                      if source_type else "the source declares no source_type")
+
+
+def ranked(project: str, manifest: dict[str, Any] | None = None
+           ) -> list[dict[str, Any]]:
+    """Every source for a project, strongest first.
+
+    Ties keep manifest order: a stable order makes the listing reproducible,
+    and does *not* imply the first of two tied sources should win a
+    disagreement — see `decide`.
+    """
+    table = tiers(manifest)
+    out = []
+    for index, source in enumerate(sources(project, manifest)):
+        tier, why = priority_of(source, table)
+        out.append({**source, "priority": tier, "priority_basis": why,
+                    "manifest_index": index})
+    return sorted(out, key=lambda s: (s["priority"], s["manifest_index"]))
+
+
+def decide(project: str, source_ids: list[str],
+           manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Which of these sources should settle a disagreement between them.
+
+    Returns `winner: None` when the strongest tier is shared, because priority
+    then has nothing to say — the record should represent the disagreement, as
+    it did before this existed.
+    """
+    table = tiers(manifest)
+    by_id = {s.get("id"): s for s in sources(project, manifest)}
+    known, unknown = [], []
+    for sid in source_ids:
+        if sid in by_id:
+            tier, why = priority_of(by_id[sid], table)
+            known.append({"id": sid, "priority": tier, "basis": why})
+        else:
+            unknown.append(sid)
+    if not known:
+        return {"winner": None, "reason": "none of these sources is declared",
+                "unknown": unknown, "candidates": []}
+    best = min(s["priority"] for s in known)
+    top = [s for s in known if s["priority"] == best]
+    if len(top) > 1:
+        return {"winner": None, "candidates": known, "unknown": unknown,
+                "reason": (f"{len(top)} sources share the strongest tier "
+                           f"({best}); priority cannot decide between them, so "
+                           "represent the disagreement")}
+    return {"winner": top[0]["id"], "priority": best, "candidates": known,
+            "unknown": unknown,
+            "reason": (f"{top[0]['id']} is tier {best} ({top[0]['basis']}), "
+                       "stronger than every other source named")}
+
+
+def unranked_types(manifest: dict[str, Any] | None = None
+                   ) -> dict[str, list[str]]:
+    """source_types in use that no tier covers, by project.
+
+    A source nobody ranked cannot win, which is safe — but it also cannot lose
+    on the record, so it is worth naming rather than leaving to be discovered
+    when a disagreement turns on it.
+    """
+    data = manifest if manifest is not None else _manifest()
+    table = tiers(data)
+    out: dict[str, list[str]] = {}
+    for project in (data.get("projects") or {}):
+        missing = sorted({
+            str(s.get("source_type")) for s in sources(project, data)
+            if s.get("priority") is None and s.get("source_type") not in table})
+        if missing:
+            out[project] = missing
+    return out

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -121,19 +121,18 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    body_sha256: 72cc8be31cebda9ce48e583b7a0e3cfccd6803019aca5cba660da30186346599
-    bytes: 12328
-    pinned_at_commit: 75177edd9d2416b2936f3ddb7bd6d7e45da8b8f3
+    body_sha256: 8de84076fac768f5ecf403bb0db20266b915b95b366c878f27ed0634b01ad7b5
+    bytes: 12766
+    pinned_at_commit: f2da7a5963c02db381306b82e81c70bb18f144d3
     pinned_on: '2026-08-17'
-    reason: "restore the rule force #573 softened (#591). The v5 canary put 45 resolver URLs\
-      \ in uriorcurie id slots for doi/ROR \u2014 prefixes the schema declares \u2014 against\
-      \ 12 in the v4 baseline. #573 correctly removed an unscoped \"never as a URL\" because\
-      \ download_url and access_urls are uri-ranged, but replaced it with \"rather than\"\
-      , alongside two exemptions, and the ban lost its force. The ban is now scoped rather\
-      \ than softened: in an identifier slot, never a resolver URL where a prefix is declared;\
-      \ URL-ranged slots and prose exempt entirely. Only the canary record names generic_v5,\
-      \ and it is being superseded."
-    sha256: 45c6f86f4d409dd548d070b35e854db4a78d69e536103cb819de86329c10cbb6
+    reason: 'add source priority as the fifth v5 rule (Harry, 2026-08-17), on top of the restored
+      CURIE force from #591. The uniform rules said to represent a disagreement rather than
+      select a side, and a v4 CHORUS record named the gap: "no instance count is asserted
+      because the two sources give different figures and the bundle offers no basis for preferring
+      one". source_priority in the manifest is that basis, declared there rather than in a
+      prompt per #422. The rule went into the v5 block rather than editing the inherited disagreement
+      rule, which is v2s and carried by every version.'
+    sha256: 3446689e35fcabd4e873d30f4bd08e80a2c3fd6cd63b3e73343cfd8cceaee893
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -163,6 +162,17 @@ files:
         \ identifier where none fits. Free to rotate because no record names generic_v5."
       retired_on: '2026-08-17'
       sha256: bc239c3ab991b18e67cac19c25c4a374b5fec867d707c781e78c902606d5815a
+    - pinned_on: '2026-08-17'
+      reason: "restore the rule force #573 softened (#591). The v5 canary put 45 resolver\
+        \ URLs in uriorcurie id slots for doi/ROR \u2014 prefixes the schema declares \u2014\
+        \ against 12 in the v4 baseline. #573 correctly removed an unscoped \"never as a URL\"\
+        \ because download_url and access_urls are uri-ranged, but replaced it with \"rather\
+        \ than\", alongside two exemptions, and the ban lost its force. The ban is now scoped\
+        \ rather than softened: in an identifier slot, never a resolver URL where a prefix\
+        \ is declared; URL-ranged slots and prose exempt entirely. Only the canary record\
+        \ names generic_v5, and it is being superseded."
+      retired_on: '2026-08-17'
+      sha256: 45c6f86f4d409dd548d070b35e854db4a78d69e536103cb819de86329c10cbb6
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -238,6 +238,12 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
   analyze, behavior, license. This governs the prose the record states, not
   quoted material: a title, a name or a direct quotation keeps the spelling its
   source used.
+- Where two sources in the declared bundle disagree, prefer the one the input
+  manifest ranks higher: state its value, and record in the caveat that the
+  sources disagreed, what each said, and which was preferred. Where the
+  disagreeing sources share the same rank the ranking cannot decide, so
+  represent what the evidence states rather than selecting one. This refines
+  the earlier rule about disagreement; it does not replace it.
 
 --- END ADDED IN v5 ---
 

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -145,12 +145,25 @@ class TestPromptResolution(unittest.TestCase):
 
 
 class TestPhaseAssembly(unittest.TestCase):
-    def test_every_phase_caches_the_bundle_and_digest(self):
+    def test_every_phase_caches_the_bundle_digest_and_ranking(self):
+        """Asserted by content, not by count.
+
+        A literal `2` broke when #596 added the source ranking — a test about
+        *what* is cached failing because of *how many*. What matters is that
+        each block is per-project input that does not change between phases,
+        and that all of them are marked ephemeral.
+        """
         for ph in PHASES:
             req = build_phase(spec(), ph, carry={})
-            self.assertEqual(len(req.cached_blocks), 2, ph)
-            for b in req.cached_blocks:
-                self.assertEqual(b["cache_control"]["type"], "ephemeral")
+            texts = [b["text"] for b in req.cached_blocks]
+            with self.subTest(phase=ph):
+                self.assertTrue(any("Declared input bundle" in t for t in texts))
+                self.assertTrue(any("Declared source ranking" in t
+                                    for t in texts))
+                # the digest block leads, and names the class it describes
+                self.assertTrue(texts[0].strip())
+                for b in req.cached_blocks:
+                    self.assertEqual(b["cache_control"]["type"], "ephemeral")
 
     def test_core_phase_uses_the_core_class_digest(self):
         req = build_phase(spec(), "core", carry={})
@@ -627,7 +640,13 @@ class TestExecuteOffline(unittest.TestCase):
         for kw in client.messages.calls:
             parts = kw["messages"][0]["content"]
             cached = [p for p in parts if p.get("cache_control")]
-            self.assertEqual(len(cached), 2)
+            # By content: the count changed when the source ranking joined the
+            # cached prefix (#596), and the property under test is that the
+            # prefix is sent on every call, not its length.
+            self.assertTrue(any("Declared input bundle" in p["text"]
+                                for p in cached))
+            self.assertTrue(any("Declared source ranking" in p["text"]
+                                for p in cached))
             # temperature must be absent for models that reject it
             self.assertNotIn("temperature", kw)
             from data_sheets_schema.api_runner import output_limit

--- a/tests/test_download/test_generic_v5_prompt.py
+++ b/tests/test_download/test_generic_v5_prompt.py
@@ -87,16 +87,22 @@ class TestV5IsV4PlusTheAddedBlock(unittest.TestCase):
                     len([l for l in block.splitlines() if l.startswith("- ")]),
                     expected)
 
-    def test_the_added_block_holds_exactly_four_rules(self):
-        """Four, and the number is asserted so a fifth cannot arrive quietly.
+    def test_the_added_block_holds_exactly_five_rules(self):
+        """Five, and the number is asserted so a sixth cannot arrive quietly.
 
         The convention is one rule per version; v5 departs from it for the
         reason in the module docstring. A departure that is counted is a
         decision — one that is not is a drift.
+
+        The fifth is source priority (Harry, 2026-08-17). It went *into* this
+        block rather than editing the inherited disagreement rule, which is
+        v2's and carried by every version: changing it here would silently
+        change what v2, v3 and v4 mean. The suite caught the first attempt to
+        do exactly that.
         """
         rules = [l for l in _added_block(GENERIC_PROMPT_V5.read_text()).splitlines()
                  if l.startswith("- ")]
-        self.assertEqual(len(rules), 4)
+        self.assertEqual(len(rules), 5)
 
     def test_earlier_versions_are_untouched_by_v5(self):
         for path in (GENERIC_PROMPT, GENERIC_PROMPT_V2, GENERIC_PROMPT_V3,

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -106,6 +106,8 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
             ("does not identify a person", "does not identify a person"),
         "american english":
             ("American English", "American English"),
+        "source priority":
+            ("ranks higher", "ranks higher"),
     }
 
     #: Rules the playbook carries that the condition prompts deliberately do

--- a/tests/test_source_priority.py
+++ b/tests/test_source_priority.py
@@ -1,0 +1,133 @@
+"""Which source wins when two of them state different things.
+
+The uniform rules have always said to represent a disagreement rather than
+select a side. A v4 CHORUS record followed that and named what was missing:
+
+    No instance count is asserted because the two sources give different
+    figures (over 45,000 and 50,000) for the same released dataset and the
+    bundle offers no basis for preferring one.
+
+The rule was right. `source_priority` supplies the basis, declared in the
+manifest rather than a prompt for the reason #422 records — a constraint in the
+launch text is per-run adaptation nothing inherits and no test can see.
+"""
+
+import unittest
+
+from data_sheets_schema.source_priority import (
+    UNRANKED,
+    decide,
+    priority_of,
+    ranked,
+    tiers,
+    unranked_types,
+)
+
+MANIFEST = {
+    "source_priority": {1: ["RO-Crate"], 2: ["documentation"], 4: ["tutorial"]},
+    "projects": {
+        "P": [
+            {"id": "crate", "source_type": "RO-Crate"},
+            {"id": "site", "source_type": "documentation"},
+            {"id": "deck", "source_type": "tutorial"},
+            {"id": "odd", "source_type": "something new"},
+            {"id": "boosted", "source_type": "tutorial", "priority": 1},
+        ],
+    },
+}
+
+
+class TierTest(unittest.TestCase):
+
+    def test_the_table_flattens_to_type_then_tier(self):
+        self.assertEqual(tiers(MANIFEST),
+                         {"RO-Crate": 1, "documentation": 2, "tutorial": 4})
+
+    def test_an_explicit_priority_beats_the_type(self):
+        """An override is a line someone deliberately wrote."""
+        tier, why = priority_of({"source_type": "tutorial", "priority": 1},
+                                tiers(MANIFEST))
+        self.assertEqual(tier, 1)
+        self.assertIn("declared on the source", why)
+
+    def test_an_unranked_type_sorts_below_everything(self):
+        """It cannot win by accident — but it stays distinguishable from
+        tier 5, which somebody chose."""
+        tier, why = priority_of({"source_type": "something new"},
+                                tiers(MANIFEST))
+        self.assertEqual(tier, UNRANKED)
+        self.assertIn("no tier", why)
+
+    def test_a_source_with_no_type_says_so(self):
+        tier, why = priority_of({}, tiers(MANIFEST))
+        self.assertEqual(tier, UNRANKED)
+        self.assertIn("declares no source_type", why)
+
+
+class DecideTest(unittest.TestCase):
+
+    def test_the_stronger_source_wins(self):
+        d = decide("P", ["site", "deck"], MANIFEST)
+        self.assertEqual(d["winner"], "site")
+
+    def test_an_equal_tier_does_not_decide(self):
+        """Priority resolves a disagreement; it does not manufacture a winner
+        where it has nothing to say. The record represents the disagreement, as
+        it did before this existed."""
+        d = decide("P", ["crate", "boosted"], MANIFEST)
+        self.assertIsNone(d["winner"])
+        self.assertIn("share the strongest tier", d["reason"])
+
+    def test_an_undeclared_source_is_named_not_ignored(self):
+        d = decide("P", ["site", "ghost"], MANIFEST)
+        self.assertEqual(d["winner"], "site")
+        self.assertEqual(d["unknown"], ["ghost"])
+
+    def test_no_declared_source_yields_no_winner(self):
+        d = decide("P", ["ghost"], MANIFEST)
+        self.assertIsNone(d["winner"])
+
+    def test_ranked_is_strongest_first_and_stable(self):
+        order = [s["id"] for s in ranked("P", MANIFEST)]
+        self.assertEqual(order[0], "crate")
+        self.assertEqual(order[-1], "odd")
+        # `boosted` overrides to tier 1 and ties with `crate`; manifest order
+        # breaks the tie so the listing is reproducible.
+        self.assertLess(order.index("crate"), order.index("boosted"))
+
+
+class RealManifestTest(unittest.TestCase):
+    """Against the manifest actually shipped."""
+
+    def test_every_source_type_in_use_is_ranked(self):
+        """An unranked source cannot win a disagreement, which is safe — but it
+        also cannot lose on the record."""
+        self.assertEqual(unranked_types(), {})
+
+    def test_the_chorus_disagreement_now_resolves(self):
+        """The case Harry raised: chorus4ai.org says 50,000 released admissions,
+        a September 2025 webinar says over 45,000 as of August 2025."""
+        d = decide("CHORUS", ["project_documentation", "cohort_2_webinar"])
+        self.assertEqual(d["winner"], "project_documentation")
+        self.assertIn("tier 2", d["reason"])
+
+    def test_documentation_outranks_a_tutorial(self):
+        table = tiers()
+        self.assertLess(table["documentation"], table["tutorial"])
+
+    def test_a_release_describing_itself_outranks_the_literature(self):
+        """Tier is proximity to the release, not trust: peer-reviewed work is
+        authoritative on method and routinely behind the current release on
+        counts."""
+        table = tiers()
+        self.assertLess(table["RO-Crate"], table["publication"])
+        self.assertLess(table["documentation"], table["publication"])
+
+    def test_historical_material_ranks_last(self):
+        table = tiers()
+        self.assertGreater(table["historical documentation"],
+                           table["documentation"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_source_priority.py
+++ b/tests/test_source_priority.py
@@ -129,5 +129,60 @@ class RealManifestTest(unittest.TestCase):
                            table["documentation"])
 
 
+class TheModelIsShownTheRankingTest(unittest.TestCase):
+    """The rule names a table; the API path must receive it (#596).
+
+    The instruction "prefer the source the manifest ranks higher" was sent to a
+    runtime that never got the manifest. The agentic path can open the file and
+    the API path cannot, so one condition name would have meant two
+    behaviours — the defect #563 and #573 were about, reintroduced by the rule
+    that fixed a different one.
+    """
+
+    def _request(self, project="CHORUS"):
+        import dataclasses
+        from pathlib import Path
+
+        from data_sheets_schema.api_runner import RunSpec, build_phase
+        bundle = Path(f"data/preprocessed/concatenated/{project}_preprocessed.txt")
+        if not bundle.exists():
+            self.skipTest(f"{project} bundle not present in this checkout")
+        req = build_phase(
+            RunSpec(project=project, arm="baseline", method="claudecode_agent",
+                    bundle=bundle, label="t", condition="generic_v5"),
+            "full", carry={})
+        return str(dataclasses.asdict(req))
+
+    def test_the_ranking_is_in_the_rendered_request(self):
+        self.assertIn("Declared source ranking", self._request())
+
+    def test_it_names_the_source_that_would_win(self):
+        self.assertIn("tier 2  project_documentation", self._request())
+
+    def test_it_tells_the_model_how_to_join_it_to_the_bundle(self):
+        """The bundle carries `Source ID` and `Source type` per file; the block
+        is useless unless the model is told to match on them."""
+        blob = self._request()
+        self.assertIn("Source type", blob)
+        self.assertIn("SOURCE METADATA", blob)
+
+    def test_equal_tiers_are_declared_not_to_settle_it(self):
+        self.assertIn("same tier do not settle", self._request())
+
+    def test_a_project_with_no_declared_sources_gets_no_block(self):
+        """An empty ranking is noise, and a heading with nothing under it reads
+        as a ranking that failed to load."""
+        from data_sheets_schema.api_runner import source_ranking_block
+        self.assertIsNone(source_ranking_block("NO_SUCH_PROJECT"))
+
+    def test_the_assembly_digest_records_the_change(self):
+        """A block added to every request is a change of method, and the
+        digest is what makes a v5 record distinguishable from one made before
+        the ranking was sent (#353)."""
+        from data_sheets_schema.api_runner import ASSEMBLY_LAYOUT, assembly_digest
+        self.assertIn("source ranking", ASSEMBLY_LAYOUT)
+        self.assertNotEqual(assembly_digest()["sha256"][:12], "9c2ad4a7d5f2")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Harry's observation, implemented. Closes nothing yet — the tier ordering is a
domain judgement worth his eye before this merges.

## The gap it closes

The uniform rules have always said to represent a disagreement rather than
select a side. A v4 CHORUS record followed that and named what was missing:

> No instance count is asserted because the two sources give different figures
> (over 45,000 and 50,000) for the same released dataset and **the bundle offers
> no basis for preferring one**.

The rule was right. `source_priority` in `source_manifest.yaml` supplies the
basis — declared there rather than in a prompt, for the reason #422 records: a
constraint in the launch text is per-run adaptation nothing inherits and no test
can see.

| tier | source types | what the tier means |
|---|---|---|
| 1 | RO-Crate, structured metadata, data resource | the release describing itself |
| 2 | documentation, license, DUA, IRB | the project describing its release |
| 3 | publication, preprint, white paper | the literature |
| 4 | NIH project page, tutorial | about the project, not the release |
| 5 | historical data release / documentation | retained for provenance |

**A tier is proximity to the release, not trust.** Peer-reviewed work is
authoritative on method and routinely behind the current release on counts,
which is why it sits below the project's own documentation *for this purpose*.
All 14 source types in use are ranked; a source may override with `priority:`.

The CHORUS case resolves to `project_documentation` (tier 2) over
`cohort_2_webinar` (tier 4) — 50,000, with both figures preserved in the caveat.

**Equal tiers do not decide.** Where the strongest tier is shared, priority has
nothing to say and the record represents the disagreement as before.

```
d4d download priority                          # the table
d4d download priority --project CHORUS         # a project's ranking
d4d download priority --project CHORUS --decide a,b
d4d download priority --strict                 # fail on an unranked source_type
```

## Two structural points

**The rule is the fifth in the v5 block, not an edit to the inherited one.** The
disagreement rule is v2's and every version carries it, so changing it in v5
would silently change what v2, v3 and v4 mean. The suite caught the first
attempt to do exactly that.

**Rebuilt on top of #592, not rebased.** The first version of this branch was
cut before #592 and superseded pin `bc239c3a`, so merging it would have reverted
the restored CURIE force. Copying its playbook wholesale *did* revert it once
during the rebuild — caught by checking rather than assuming. The pin now
supersedes `45c6f86f`, which is #592's.

Canary artifacts are left untracked (#594).

14 tests. Suite: 2136 passed, 4 skipped.

Generated with Claude Code
