### PR TITLE
Give the generation record a schema, and let it reference everything else

### DIFF
--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -655,3 +655,52 @@ def backfill_context(execute, label):
                f"; {skipped} skipped as having no api_usage (agentic runs)")
     if not execute:
         click.echo("Nothing was changed. Re-run with --execute to write.")
+
+
+@provenance.command("validate-records")
+@click.option('--strict', is_flag=True, help='exit 1 if any record fails')
+@click.option('--label', default=None, help='restrict to one run label')
+def validate_records(strict, label):
+    """Validate generation records against their own LinkML schema.
+
+    This repository schematises metadata about datasets, and its own generation
+    metadata was a hand-built dictionary that nothing could check — 25
+    top-level keys and no definition. The one artifact that did have a schema,
+    `d4d_run_telemetry.yaml`, is the derived report rather than the
+    authoritative record.
+
+    The schema is deliberately not imported by `data_sheets_schema.yaml`: it
+    describes the pipeline, not a dataset, so importing it would move the
+    `Dataset` digest a generation arm is frozen against.
+    """
+    import subprocess
+    import sys
+
+    from data_sheets_schema.provenance import CONCAT_DIR
+
+    schema = Path("src/data_sheets_schema/schema/d4d_generation_record.yaml")
+    paths = sorted(CONCAT_DIR.glob("*_core/*/*_provenance.yaml"))
+    if label:
+        paths = [p for p in paths if p.parts[-2] == label]
+    if not paths:
+        click.echo("no records matched")
+        return
+
+    failed = []
+    for p in paths:
+        r = subprocess.run(
+            ["poetry", "run", "linkml-validate", "-s", str(schema),
+             "-C", "GenerationRecord", str(p)],
+            capture_output=True, text=True)
+        if r.returncode != 0:
+            failed.append(p)
+            click.echo(f"   ❌ {p.parts[-2][:38]:38} {p.name}")
+            for line in (r.stdout + r.stderr).splitlines():
+                if "[ERROR]" in line:
+                    click.echo(f"      {line.split(']')[-1].strip()[:110]}")
+
+    click.echo(f"\n{len(paths)} record(s) checked, {len(failed)} failing")
+    if not failed:
+        click.echo("Every generation record conforms to its schema.")
+    if strict and failed:
+        sys.exit(1)

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -945,6 +945,54 @@ def build_derived_record(project: str, method: str, label: str, *,
     return ProvenanceRecord(data=data)
 
 
+#: Files a run is checked against or writes alongside its records, which the
+#: record pointed at only implicitly. A reader had the bundle, the prompts, the
+#: playbooks, the schemas and the outputs, and had to know by other means that a
+#: reasoning log sat beside the record or which pin registry the prompt hashes
+#: were judged against.
+#:
+#: Referenced with a hash rather than inlined: a registry is shared across runs
+#: and appended to over time, so copying it into every record would multiply it
+#: and still not say which version was in force. The hash does say.
+COMPANION_FILES = (
+    ("prompt_registry", Path("src/download/prompts/canonical_hashes.yaml"),
+     "the pins the recorded prompt hashes were judged against"),
+    ("digest_inventory", Path("src/data_sheets_schema/schema/digest_inventory.yaml"),
+     "digest to slot inventory, which decides whether a slot predates a pair"),
+)
+
+
+def companion_facts(project: str, method: str, label: str,
+                    concat_dir: Path = CONCAT_DIR) -> dict[str, Any]:
+    """Everything else a reader of this record may need, by reference.
+
+    The record already names its bundle, prompts, playbooks, schemas, outputs
+    and phase snapshots. This adds what it did not: the reasoning log beside it,
+    the registries it was checked against, and the telemetry report derived from
+    it. A path that does not exist is recorded with `present: false` rather than
+    omitted — an absent reasoning log is a fact about the runtime (#400), not a
+    gap in the record.
+    """
+    out: dict[str, Any] = {}
+    label_dir = concat_dir / f"{method}_core" / label
+    reasoning = label_dir / f"{project}_reasoning.jsonl"
+    out["reasoning_log"] = {
+        "path": repo_relative(reasoning), "present": reasoning.exists(),
+        "md5": _md5(reasoning) if reasoning.exists() else None,
+        "note": ("one JSON line per phase; absent for a runtime that cannot "
+                 "report its own token accounting (#400)")}
+    telemetry = Path("data/run_telemetry") / f"{label.rsplit('_rep', 1)[0]}.yaml"
+    out["telemetry_report"] = {
+        "path": repo_relative(telemetry), "present": telemetry.exists(),
+        "note": ("derived from records like this one, per label rather than "
+                 "per run; `d4d runs telemetry` writes it")}
+    for name, path, note in COMPANION_FILES:
+        out[name] = {"path": repo_relative(path), "present": path.exists(),
+                     "md5": _md5(path) if path.exists() else None,
+                     "note": note}
+    return out
+
+
 def build_record(project: str, method: str, label: str, *, mode: str,
                  input_bundle: Path | None = None,
                  input_verified: bool = False,
@@ -1204,6 +1252,8 @@ def build_record(project: str, method: str, label: str, *, mode: str,
         "inputs": inputs,
         "outputs": {"full": _artifact(full), "core": _artifact(core),
                     "report": _artifact(report)},
+        # Everything else a reader may need, by reference rather than by copy.
+        "companions": companion_facts(project, method, label, concat_dir),
         "unrecoverable": unrecoverable or None,
         "unverified": unverified or None,
         "notes": notes or None,

--- a/src/data_sheets_schema/schema/d4d_generation_record.yaml
+++ b/src/data_sheets_schema/schema/d4d_generation_record.yaml
@@ -1,0 +1,363 @@
+id: https://w3id.org/bridge2ai/d4d-generation-record
+name: d4d-generation-record
+title: D4D Generation Record
+description: >-
+  The record a generation run writes about itself: what it consumed, what it
+  produced, what was checked afterwards, and what it could not establish.
+
+  This repository schematises metadata about datasets. Until now its own
+  generation metadata was a hand-built Python dictionary written as YAML —
+  25 top-level keys, `record_version: 1`, and nothing that could be validated.
+  The one artifact that did have a LinkML schema, `d4d_run_telemetry.yaml`, is
+  the *derived* report rather than the authoritative record.
+
+  **This schema is deliberately not imported by `data_sheets_schema.yaml`.** It
+  describes the pipeline, not a dataset, and importing it would move the
+  `Dataset` digest that a generation arm is frozen against.
+
+  **It describes today's record rather than a tidier one.** Across 195 records
+  the shape genuinely varies: a `live` record carries `model`, `system` and
+  `api_usage`; a `derived` record carries `derivation` and `sources` and none of
+  those; older records predate blocks added later. Requiring a field that some
+  honest record cannot have would make the schema a fiction. Only what every
+  record has is required; the rest is optional and documented.
+license: MIT
+prefixes:
+  linkml: https://w3id.org/linkml/
+  d4dgen: https://w3id.org/bridge2ai/d4d-generation-record/
+default_prefix: d4dgen
+default_range: string
+imports:
+  - linkml:types
+
+classes:
+
+  GenerationRecord:
+    description: >-
+      One run, one project. Written by `d4d api run` or by
+      `d4d provenance record` from an agentic run, and read by every gate in
+      `d4d runs check`.
+    tree_root: true
+    attributes:
+
+      record_type:
+        description: Always `d4d_generation_provenance`; names the kind of file.
+        required: true
+      record_version:
+        description: >-
+          Bumped when the record's shape changes incompatibly. Still 1: every
+          block added since has been additive, which is why records written
+          months apart still validate together.
+        range: integer
+        required: true
+      record_mode:
+        description: >-
+          How much of this record is observed. `live` is written by the run
+          itself; `reconstructed` is assembled afterwards and names what it
+          cannot recover; `derived` describes a record computed from other
+          records rather than generated.
+        range: RecordMode
+        required: true
+      record_generated_at:
+        description: When the record was written, not when the run started.
+        range: datetime
+        required: true
+
+      run:
+        description: Which project, method, label and arm this run is.
+        range: RunIdentity
+        required: true
+        inlined: true
+
+      schema:
+        description: >-
+          The schema the run generated against, by hash and by digest. The
+          digest is what the model was actually sent.
+        required: true
+        inlined: true
+        range: SchemaFacts
+
+      repo:
+        description: The commit the run was made at.
+        required: true
+        inlined: true
+        range: AnyBlock
+
+      software:
+        description: Versions of the packages that produced the record.
+        required: true
+        inlined: true
+        range: AnyBlock
+
+      outputs:
+        description: The records this run wrote, by path and hash.
+        required: true
+        inlined: true
+        range: AnyBlock
+
+      inputs:
+        description: >-
+          The bundle the run consumed, its hash, and the manifest that selected
+          it. Absent on a `derived` record, which consumes records rather than
+          a bundle.
+        inlined: true
+        range: AnyBlock
+
+      model:
+        description: >-
+          Model, provider, route, per-phase ceilings, and what can honestly be
+          said about temperature, reasoning effort and context.
+        inlined: true
+        range: AnyBlock
+
+      system:
+        description: The machine the run was made on.
+        inlined: true
+        range: AnyBlock
+
+      prompts:
+        description: >-
+          Every prompt file the run consumed, hashed, plus the assembly digest
+          covering the phase instructions and their order.
+        inlined: true
+        range: AnyBlock
+
+      playbooks:
+        description: >-
+          The instruction files an agentic run opens for itself, hashed. Carries
+          `consumed`, which says whether this runtime reads them at all.
+        inlined: true
+        range: AnyBlock
+
+      companions:
+        description: >-
+          Everything else a reader may need, by reference rather than by copy:
+          the reasoning log beside this record, the registries the run was
+          checked against, and the telemetry report derived from records like
+          it. A registry is shared and appended to over time, so copying it into
+          every record would multiply it and still not say which version was in
+          force; a hash does say.
+        inlined: true
+        range: CompanionFiles
+
+      api_usage:
+        description: >-
+          One entry per API call: phase, attempt, timing, tokens and stop
+          reason. Absent for a runtime with no access to its own accounting.
+        multivalued: true
+        inlined_as_list: true
+        range: AnyBlock
+
+      phase_log:
+        description: >-
+          What an agentic run says about the phases it performed. The
+          counterpart to `api_usage` for a runtime that knows which phase it ran
+          but not what the call cost.
+        inlined: true
+        range: AnyBlock
+
+      phases_skipped:
+        description: Phases a resumed run did not repeat.
+        multivalued: true
+
+      repair:
+        description: Validator-driven repair rounds, in order.
+        multivalued: true
+        inlined_as_list: true
+        range: AnyBlock
+
+      intermediates:
+        description: Phase snapshots written as the run progressed.
+        multivalued: true
+        inlined_as_list: true
+        range: AnyBlock
+
+      validation:
+        description: >-
+          Whether the records validate, pinned to the bytes and the schema the
+          verdict was reached on, so a stale verdict is detectable.
+        inlined: true
+        range: AnyBlock
+
+      pair_consistency:
+        description: >-
+          Whether the full and core records agree. A property of two files
+          together, which no single-file gate can see.
+        inlined: true
+        range: AnyBlock
+
+      report_claims:
+        description: >-
+          Whether the reconciliation report's claims survive checking against
+          the record and the schema.
+        inlined: true
+        range: AnyBlock
+
+      grounding:
+        description: >-
+          Whether external identifiers appear in the bundle they were read
+          from, and whether identifier slots hold resolver URLs.
+        inlined: true
+        range: AnyBlock
+
+      unverified:
+        description: >-
+          Values recorded but not observed. Named rather than silently trusted.
+        multivalued: true
+        inlined_as_list: true
+        range: AnyBlock
+
+      unrecoverable:
+        description: >-
+          Fields a reconstructed record cannot establish, with the reason. The
+          difference between a gap that is named and one that is hidden.
+        multivalued: true
+        inlined_as_list: true
+        range: AnyBlock
+
+      notes:
+        description: Free-text observations about this run.
+        multivalued: true
+
+      derivation:
+        description: >-
+          For a `derived` record: how it was computed from other records.
+        inlined: true
+        range: AnyBlock
+
+      sources:
+        description: "For a `derived` record: the records it consumed, hashed."
+        multivalued: true
+        inlined_as_list: true
+        range: AnyBlock
+
+      not_applicable:
+        description: >-
+          Fields that do not apply to this kind of record, with the reason —
+          distinct from a field that is missing.
+        multivalued: true
+        inlined_as_list: true
+        range: AnyBlock
+
+      canonical:
+        description: "For a canonicalised record: what it was canonicalised from."
+        inlined: true
+        range: AnyBlock
+
+      canonical_superseded_by:
+        description: The record that replaced this one, if any.
+        inlined: true
+        range: AnyBlock
+
+  RunIdentity:
+    description: Which run this is.
+    attributes:
+      project:
+        required: true
+      method:
+        required: true
+      label:
+        description: "The run label; `_rep{N}` names the replicate."
+        required: true
+      arm:
+        description: Which arm of the study, where one applies.
+        required: true
+      replicate:
+        description: >-
+          Which replicate of the series, or absent for a record that is not one
+          of a series — five records carry it as null rather than omitting it.
+        range: integer
+
+  SchemaFacts:
+    description: The schema a run generated against.
+    attributes:
+      declared_version:
+        description: The schema version the run declared.
+        required: true
+      declared_in:
+        description: Where that version was read from.
+        required: true
+      merged_schema_carries_version:
+        description: >-
+          Whether the merged schema states the version itself, rather than it
+          being taken from the source schema alone.
+        range: boolean
+        required: true
+      full_path:
+        required: true
+      core_path:
+        required: true
+      digest_md5:
+        description: >-
+          Fingerprint of the rendered digest the model was sent. This is what a
+          straddle check compares, and what the digest inventory keys on. Absent
+          on records written before the digest was recorded.
+      full_md5:
+      core_md5:
+      full_sha256:
+        description: >-
+          Recorded alongside the md5 rather than instead of it: `_artifact`
+          hashes run outputs with md5 and the prompt registry uses sha256, so
+          both appear and neither is a mistake.
+      core_sha256:
+      note:
+
+  CompanionFiles:
+    description: >-
+      Related files, by reference. Each says whether it was present, because an
+      absent reasoning log is a fact about the runtime rather than a gap.
+    attributes:
+      reasoning_log:
+        inlined: true
+        range: FileReference
+      telemetry_report:
+        inlined: true
+        range: FileReference
+      prompt_registry:
+        inlined: true
+        range: FileReference
+      digest_inventory:
+        inlined: true
+        range: FileReference
+
+  FileReference:
+    description: A file this record points at rather than copies.
+    attributes:
+      path:
+        required: true
+      present:
+        range: boolean
+        required: true
+      md5:
+        description: Absent when the file is absent, or when it is not hashed.
+      note:
+        description: Why this file matters to a reader of the record.
+
+  AnyBlock:
+    description: >-
+      A block whose interior varies legitimately across record modes and
+      versions, described here as a reference rather than enumerated.
+
+      Enumerating every field of `model`, `validation` or `grounding` would
+      freeze blocks that are still being added to — `grounding` gained a
+      finding kind this week — and a schema that has to be edited before an
+      additive change can be recorded would be a brake rather than a contract.
+      What is asserted here is that the block exists and what it is for; the
+      code that writes each block is its own definition, and the checks that
+      read them fail loudly on a shape they do not expect.
+    class_uri: linkml:Any
+
+enums:
+  RecordMode:
+    description: How much of a record is observed rather than reconstructed.
+    permissible_values:
+      live:
+        description: Written by the run itself; every field observed at run time.
+      reconstructed:
+        description: >-
+          Assembled after the fact for a run that predates live recording. Names
+          what it cannot recover instead of filling it in.
+      derived:
+        description: >-
+          Computed from other records rather than generated. Consumes replicates
+          instead of a bundle, so it declares `bundle_md5` not-applicable.

--- a/tests/test_generation_record_schema.py
+++ b/tests/test_generation_record_schema.py
@@ -1,0 +1,133 @@
+"""The generation record has a schema of its own.
+
+This repository schematises metadata about datasets. Its own generation
+metadata was a hand-built Python dictionary written as YAML — 25 top-level
+keys, `record_version: 1`, and nothing that could validate it. The one artifact
+that *did* carry a LinkML schema, `d4d_run_telemetry.yaml`, is the derived
+report rather than the authoritative record.
+
+The schema describes today's record rather than a tidier one. Across 195
+records the shape genuinely varies by `record_mode`, and requiring a field an
+honest record cannot have would make the schema a fiction.
+"""
+
+import subprocess
+import unittest
+from pathlib import Path
+
+import yaml
+
+SCHEMA = Path("src/data_sheets_schema/schema/d4d_generation_record.yaml")
+CORPUS = Path("data/d4d_concatenated")
+
+
+class SchemaShapeTest(unittest.TestCase):
+
+    def setUp(self):
+        if not SCHEMA.exists():
+            self.skipTest("schema not present in this checkout")
+        self.schema = yaml.safe_load(SCHEMA.read_text(encoding="utf-8"))
+
+    def test_it_is_not_imported_by_the_dataset_schema(self):
+        """Importing it would move the `Dataset` digest an arm is frozen
+        against, and it describes the pipeline rather than a dataset."""
+        main = yaml.safe_load(
+            Path("src/data_sheets_schema/schema/data_sheets_schema.yaml")
+            .read_text(encoding="utf-8"))
+        self.assertNotIn("d4d_generation_record", main.get("imports") or [])
+
+    def test_only_universal_fields_are_required(self):
+        """A `derived` record has no `inputs`, `model` or `system`; requiring
+        them would make the schema describe a record that does not exist."""
+        attrs = self.schema["classes"]["GenerationRecord"]["attributes"]
+        required = {k for k, v in attrs.items() if v.get("required")}
+        for optional in ("inputs", "model", "system", "api_usage",
+                         "playbooks", "prompts", "derivation", "sources"):
+            with self.subTest(field=optional):
+                self.assertNotIn(optional, required)
+        for universal in ("record_type", "record_version", "record_mode",
+                          "run", "schema", "outputs"):
+            with self.subTest(field=universal):
+                self.assertIn(universal, required)
+
+    def test_the_three_record_modes_are_enumerated(self):
+        values = self.schema["enums"]["RecordMode"]["permissible_values"]
+        self.assertEqual(set(values), {"live", "reconstructed", "derived"})
+
+    def test_variable_blocks_are_declared_as_such(self):
+        """`AnyBlock` says a block exists and what it is for without freezing
+        an interior that is still being added to — `grounding` gained a finding
+        kind this week. A schema needing an edit before an additive change can
+        be recorded would be a brake rather than a contract."""
+        self.assertEqual(
+            self.schema["classes"]["AnyBlock"]["class_uri"], "linkml:Any")
+
+
+class CompanionReferenceTest(unittest.TestCase):
+    """Everything else a reader needs, by reference (#596 and this thread)."""
+
+    def test_the_record_points_at_its_companions(self):
+        from data_sheets_schema.provenance import companion_facts
+        c = companion_facts("CHORUS", "claudecode_agent",
+                            "2026-08-13_claude-opus-5-api-generic-v4_rep1")
+        self.assertEqual(set(c), {"reasoning_log", "telemetry_report",
+                                  "prompt_registry", "digest_inventory"})
+
+    def test_absence_is_recorded_rather_than_omitted(self):
+        """An absent reasoning log is a fact about the runtime (#400), not a
+        gap in the record — so the reference exists and says `present: false`.
+        """
+        from data_sheets_schema.provenance import companion_facts
+        c = companion_facts("NO_SUCH_PROJECT", "claudecode_agent", "nope")
+        self.assertFalse(c["reasoning_log"]["present"])
+        self.assertTrue(c["reasoning_log"]["path"])
+
+    def test_registries_are_referenced_by_hash_not_copied(self):
+        """A registry is shared and appended to over time: copying it into
+        every record would multiply it and still not say which version was in
+        force. A hash does say."""
+        from data_sheets_schema.provenance import companion_facts
+        c = companion_facts("CHORUS", "claudecode_agent",
+                            "2026-08-13_claude-opus-5-api-generic-v4_rep1")
+        if not c["prompt_registry"]["present"]:
+            self.skipTest("registry not present in this checkout")
+        self.assertTrue(c["prompt_registry"]["md5"])
+
+
+class CorpusValidatesTest(unittest.TestCase):
+
+    def test_a_real_record_validates(self):
+        """One record, run through the real validator. The corpus-wide pass is
+        `d4d provenance validate-records --strict`, too slow for a unit test at
+        one linkml-validate invocation per record."""
+        p = (CORPUS / "claudecode_agent_core"
+             / "2026-08-13_claude-opus-5-api-generic-v4_rep1"
+             / "CHORUS_provenance.yaml")
+        if not (p.exists() and SCHEMA.exists()):
+            self.skipTest("record or schema not present in this checkout")
+        r = subprocess.run(
+            ["poetry", "run", "linkml-validate", "-s", str(SCHEMA),
+             "-C", "GenerationRecord", str(p)],
+            capture_output=True, text=True, timeout=300)
+        self.assertEqual(r.returncode, 0, (r.stdout + r.stderr)[-500:])
+
+    def test_a_record_missing_a_required_field_is_rejected(self):
+        """Otherwise the schema is decorative."""
+        import tempfile
+        if not SCHEMA.exists():
+            self.skipTest("schema not present in this checkout")
+        with tempfile.TemporaryDirectory() as d:
+            bad = Path(d) / "bad.yaml"
+            bad.write_text(yaml.safe_dump(
+                {"record_type": "d4d_generation_provenance",
+                 "record_version": 1, "record_mode": "live"}),
+                encoding="utf-8")
+            r = subprocess.run(
+                ["poetry", "run", "linkml-validate", "-s", str(SCHEMA),
+                 "-C", "GenerationRecord", str(bad)],
+                capture_output=True, text=True, timeout=300)
+            self.assertNotEqual(r.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Answers "don't we already have metadata output about d4d generation?" — we have
three overlapping artifacts, and the authoritative one had no schema.

| artifact | scope | schematised? | authoritative? |
|---|---|---|---|
| `{PROJECT}_provenance.yaml` | per run, 25 top-level keys | **no** | **yes** |
| `{PROJECT}_reasoning.jsonl` | per attempt | no | yes |
| `data/run_telemetry/{label}.yaml` | per label, 12 LinkML classes | **yes** | **no** (derived) |

In a repository whose purpose is schematising metadata, the only piece with a
LinkML schema was the derived report — and `AttemptTelemetry`'s 13 attributes
are a re-derivation of `api_usage` plus the reasoning sidecar.

## One record, referencing the rest

The record already named 9 of the 13 relevant artifacts: bundle, manifest,
prompts, playbooks, schemas, outputs, phase snapshots. It did **not** name the
reasoning log beside it, the prompt registry its hashes were judged against, the
digest inventory, or the telemetry report derived from it. `companions` adds
those four.

**By reference, not by copy.** A registry is shared across runs and appended to
over time: inlining it would multiply it into every record and still not say
which version was in force. A hash does. And a missing file is recorded with
`present: false` rather than omitted — an absent reasoning log is a fact about
the runtime (#400), not a gap in the record.

## The schema describes today's record

Surveyed across all 195 records before writing a line of it. The shape genuinely
varies — a `live` record has `model`/`system`/`api_usage`, a `derived` record has
`derivation`/`sources` and none of those, older records predate later blocks. So
only what **every** record has is required. Requiring a field an honest record
cannot have would make the schema a fiction.

Blocks still being added to are `AnyBlock` (`class_uri: linkml:Any`): the block
exists and its purpose is stated, its interior is not frozen. `grounding` gained
a finding kind this week — a schema needing an edit before an additive change
could be recorded would be a brake rather than a contract.

**All 195 records validate.** `d4d provenance validate-records --strict` is the
gate, and a record missing a required field is rejected — asserted, or the
schema would be decorative.

## Deliberately not imported by the main schema

It describes the pipeline, not a dataset. Importing it would move the `Dataset`
digest a generation arm is frozen against. Verified unchanged at `44d29023`.

## What this does not do

It does not yet collapse the three artifacts into one file — `reasoning.jsonl`
still sits beside the record, telemetry is still written separately. That is a
format migration, and it belongs after the arm, on records that already
validate against a schema.

9 tests. Suite: 2151 passed, 4 skipped.

Generated with Claude Code
