### PR TITLE
Fix the three v5 blockers from the 2026-08-17 review (#599, #600, #601)

### DIFF
--- a/.claude/commands/d4d-agent.md
+++ b/.claude/commands/d4d-agent.md
@@ -185,8 +185,13 @@ For each project (AI_READI, CM4AI, VOICE, CHORUS):
 When multiple sources describe the same dataset:
 1. Merge complementary information from all sources
 2. Prefer more detailed and specific information over generic descriptions
-3. Resolve conflicts using authority and recency metadata within the current
-   source bundle
+3. Resolve conflicts by the declared ranking, not by your own reading of
+   authority and recency: `source_priority` in
+   `data/preprocessed/source_manifest.yaml`, and `superseded_by` where a source
+   states which one replaced it. `d4d download priority --project X --decide
+   a,b` answers a specific pair. An independent recency rule here gave the two
+   runtimes different answers on the same conflict (#600); where the ranking
+   cannot decide, represent the disagreement rather than choosing
 4. Never consult an older generated D4D to fill a gap or break a tie
 
 ## Runtime Cases

--- a/notes/codex_v5_readiness_review_2026-08-17.md
+++ b/notes/codex_v5_readiness_review_2026-08-17.md
@@ -1,0 +1,255 @@
+# Codex readiness review #2 for a v5 generation arm — 2026-08-17
+
+Second independent adversarial review, run after the eight PRs that closed the
+findings of the first one (`notes/codex_v5_readiness_review_2026-08-15.md`).
+
+| | |
+|---|---|
+| date | 2026-08-17 |
+| reviewer | Codex (GPT-5.x), via the `codex:rescue` plugin |
+| session id | `01a012ef-79a2-7550-a722-546ef5f626ac` |
+| resume | `codex resume 01a012ef-79a2-7550-a722-546ef5f626ac` |
+| repo state | `main` at `e6b99727` |
+| scope | the delta since 2026-08-15: PRs #583, #584, #585, #586, #588, #592, #595, #597 |
+| brief | assume the fixes introduced regressions — one already had (#591) |
+
+**Verdict: not ready.** 13 defects — 2 blockers, 8 high, 3 medium.
+
+The review is reproduced **verbatim** below. Nothing has been corrected,
+softened or re-ordered, including where it contradicts claims made in this
+repository's own PR descriptions or in my messages. Findings disputed after
+verification are recorded in the issues filed from this review, not by editing
+this file.
+
+Absolute paths in the original have been made repo-relative so the links resolve
+from inside the repository; nothing else is changed.
+
+---
+
+# Verdict
+
+Not ready for a production v5 sweep. I found 13 current defects: 2 blockers, 8 high, and 3 medium. The most serious are a canary that accepts a nonexistent baseline, resume invalidation that can preserve downstream work against a replaced full record, known source conflicts that the new tier model cannot resolve, and a generation-record schema that is neither enforced nor mode-specific enough to validate a production record.
+
+The v5 prompt itself is correctly registered and pinned: `d4d api prompts check --strict` reported all 11 prompt files canonical, and the pinned commit reproduces the current SHA-256.
+
+## 1. v5 prompt, genericity, registry, and runtime parity
+
+### Identifier provenance and fragment minting are mutually contradictory
+
+- File: [d4d_generic_arm_prompt_v5.md:222–236](src/download/prompts/d4d_generic_arm_prompt_v5.md:222)
+- Severity: high
+- Blocks production v5: yes — the central identifier policy has two incompatible answers when evidence lacks an identifier.
+- Concrete evidence:
+
+  > “take it from the evidence or omit it”
+
+  is immediately followed by:
+
+  > “Where something needs an identifier and the evidence supplies none, hang it off one the evidence does supply”
+
+  A fragment such as `attested-id#new-entity` is not itself stated in the evidence, so it violates the preceding absolute rule. The same conflict reaches Claude Code through [d4d-uniform-rules.md:70–82](.claude/commands/d4d-uniform-rules.md:70).
+- Suggested fix direction: explicitly define fragment minting as a narrowly scoped exception, including when minting is required versus when omission is required.
+
+### The Claude Code playbook still declares v5 to be an unsupported condition
+
+- File: [d4d-full-core.md:164–175](.claude/commands/d4d-full-core.md:164), [d4d-full-core.md:208–214](.claude/commands/d4d-full-core.md:208), [d4d_generic_arm_prompt_v5.md:84–89](src/download/prompts/d4d_generic_arm_prompt_v5.md:84)
+- Severity: high
+- Blocks production v5: yes for Claude Code runs — the runtime is told to follow two conflicting condition registries.
+- Concrete evidence: v5 orders the agent to read `d4d-full-core.md`. That playbook says:
+
+  > “Two conditions exist”
+
+  and defines `generic` as `d4d_generic_arm_prompt.md`, i.e. v1. It then says a run launched without “one of the two prompt files above is neither condition.” The rendered v5 instruction instead requires `generic-v5` and names `d4d_generic_arm_prompt_v5.md` in its headers.
+- Suggested fix direction: derive or enumerate all registered conditions from `CONDITION_PROMPTS`, including `generic_v2` through `generic_v5`, and remove the “two conditions” assertion.
+
+### v5’s own metadata still says four rules after adding the fifth
+
+- File: [d4d_generic_arm_prompt_v5.md:3–16](src/download/prompts/d4d_generic_arm_prompt_v5.md:3), [api_runner.py:106–111](src/data_sheets_schema/api_runner.py:106), [generic_v5_analysis_plan.md:16–31](notes/generic_v5_analysis_plan.md:16)
+- Severity: medium
+- Blocks production v5: no, but it makes the condition and subsequent interpretation inaccurate.
+- Concrete evidence: the marked block has five bullets at lines 213, 222, 229, 237, and 241, and the registry correctly calls source priority “the fifth v5 rule.” Nevertheless:
+
+  - the prompt repeatedly says “four rules”;
+  - `MULTI_RULE_BASES = {"v2": 3, "v5": 4}`;
+  - the analysis plan preregisters “Four rules, in one block”;
+  - [test_generic_v5_prompt.py:184–186](tests/test_download/test_generic_v5_prompt.py:184) still asserts the wrong count, despite another test correctly asserting five.
+- Suggested fix direction: update all condition metadata and the analysis plan to five; do not change the pinned executable body while doing so.
+
+## 2. Source-priority mechanism
+
+### Known current-versus-superseded conflicts tie and therefore remain unresolved
+
+- File: [source_manifest.yaml:222–227](data/preprocessed/source_manifest.yaml:222), [source_manifest.yaml:249–276](data/preprocessed/source_manifest.yaml:249), [source_priority.py:104–134](src/data_sheets_schema/source_priority.py:104), [api_runner.py:603–615](src/data_sheets_schema/api_runner.py:603)
+- Severity: high
+- Blocks production v5: yes — the mechanism fails on several explicitly documented release conflicts.
+- Concrete evidence: tiers are assigned only by `source_type`. Thus old and current sources of the same type tie even where the manifest explicitly says which is current. Direct calls to `decide()` returned no winner for:
+
+  - AI-READI `dataset_documentation` versus `dataset_documentation_v3`;
+  - AI-READI `fairhub_dataset` versus `fairhub_dataset_v3`;
+  - CM4AI October 2025 versus June 2026 Dataverse releases;
+  - VOICE 3.0.0 versus 3.1.0.
+
+  The API block sends only tier, ID, and source type, omitting `superseded_by`, `captured_at`, and the curation note saying “prefer this.” Meanwhile the agent playbook separately says to resolve conflicts using authority and recency at [d4d-agent.md:183–190](.claude/commands/d4d-agent.md:183), contrary to the equal-tier rule. API and agentic runs can therefore decide these conflicts differently.
+- Suggested fix direction: add explicit per-source priority overrides for known supersession relationships, and send the decisive basis to both runtimes. Remove the independent recency tie-breaker or encode it consistently.
+
+### Baseline rankings leak into arms whose manifest is explicitly “not used”
+
+- File: [cli/api.py:13–25](src/data_sheets_schema/cli/api.py:13), [api_runner.py:589–615](src/data_sheets_schema/api_runner.py:589), [api_runner.py:642–653](src/data_sheets_schema/api_runner.py:642)
+- Severity: high
+- Blocks production v5: yes for crate-only and healthsheet v5 arms.
+- Concrete evidence: `crate_only` declares:
+
+  > `# Source manifest: not used (crate-only arm; single declared source bundle)`
+
+  and `healthsheet` similarly says the manifest is not used. But every `build_phase()` unconditionally calls `source_ranking_block(spec.project)`, which reads that project’s baseline `source_manifest.yaml` entries. A CHORUS crate-only request therefore receives rankings for `project_documentation`, `cohort_2_webinar`, and other sources absent from the crate-only bundle.
+- Suggested fix direction: make ranking derive from the actual declared bundle/arm manifest, and omit it for single-source arms.
+
+## 3. Canary gate
+
+### The gate is optional, and a nonexistent baseline evaluates as `ok`
+
+- File: [cli/api.py:270–275](src/data_sheets_schema/cli/api.py:270), [cli/api.py:358–361](src/data_sheets_schema/cli/api.py:358), [canary.py:98–133](src/data_sheets_schema/canary.py:98)
+- Severity: blocker
+- Blocks production v5: yes — a typo disables the baseline comparison without warning.
+- Concrete evidence:
+
+  - `--canary-baseline` defaults to `None`, so no gate runs unless the operator opts in.
+  - `baseline_for()` returns `None` for every metric when no records match.
+  - `verdict()` treats only missing current-run measurements as blind; a missing baseline is ignored.
+
+  A direct probe with baseline `TYPO_DOES_NOT_EXIST` and a current run containing 999 defects in every metric returned:
+
+  ```text
+  {'pair errors': None, 'report findings': None,
+   'ungrounded identifiers': None,
+   'resolver URLs in identifier slots': None}
+  ok
+  ```
+- Suggested fix direction: require a baseline for `generic_v5`, fail if no baseline records or any baseline metric is unavailable, and retain `--no-canary-gate` only as an explicit auditable override.
+
+### A completed first run cannot act as the canary when a batch is resumed
+
+- File: [api_runner.py:2005–2029](src/data_sheets_schema/api_runner.py:2005), [cli/api.py:349–367](src/data_sheets_schema/cli/api.py:349)
+- Severity: medium
+- Blocks production v5: yes on an interrupted/resumed sweep.
+- Concrete evidence: the completed-run early return includes usage, validation problems, and outputs, but omits `checks`. Batch then calls `counts_from(res.get("checks") or {})`; every metric becomes `None`, making the canary `unmeasurable`. Thus a batch interrupted after a successful canary cannot resume and fan out under the same gate.
+- Suggested fix direction: return the stored, freshness-verified pair/report/grounding blocks on the completed-run path, or recompute them locally.
+
+### The canary still does not measure three v5 rule families
+
+- File: [canary.py:44–64](src/data_sheets_schema/canary.py:44), [generic_v5_analysis_plan.md:73–93](notes/generic_v5_analysis_plan.md:73)
+- Severity: high
+- Blocks production v5: yes — it can announce “canary ok” while breaking rules the v5 plan explicitly treats as production checks.
+- Concrete evidence: `METRICS` contains pair errors, report findings, absent identifiers, and resolver URLs. It does not measure:
+
+  - fragments on organization identifiers;
+  - invented/undeclared prefixes or minted-fragment behavior;
+  - generated British spelling.
+
+  These are three of the five preregistered v5 outcome families. The same missing-metric pattern already allowed #591 through once.
+- Suggested fix direction: add current-vs-baseline metrics for organization fragments, undeclared prefixes/minted fragments, and generated-prose spelling, using the existing baseline script’s stated counting rules.
+
+## 4. Generation-record schema
+
+### The schema is opt-in and accepts live records without their essential attestations
+
+- File: [d4d_generation_record.yaml:98–201](src/data_sheets_schema/schema/d4d_generation_record.yaml:98), [provenance.py:791–823](src/data_sheets_schema/provenance.py:791), [cli/provenance.py:660–705](src/data_sheets_schema/cli/provenance.py:660)
+- Severity: high
+- Blocks production v5: yes — neither generation writer validates the record schema before declaring success.
+- Concrete evidence:
+
+  - `inputs`, `model`, `prompts`, `playbooks`, `companions`, `validation`, `pair_consistency`, `report_claims`, and `grounding` are all optional regardless of `record_mode`.
+  - Their interiors are mostly `linkml:Any`.
+  - `ProvenanceRecord.write()` simply calls `yaml.safe_dump`.
+  - Schema validation exists only as the separate manual `d4d provenance validate-records` command.
+
+  Consequently a `record_mode: live` record can validate while omitting the bundle, prompt, model, validation verdict, and all post-generation checks.
+- Suggested fix direction: introduce mode-specific subclasses or validation rules, require live/API/agentic fields conditionally, and invoke schema validation in both record-writing paths before success.
+
+### Several schema descriptions contradict the records the current writers produce
+
+- File: [d4d_generation_record.yaml:43–45](src/data_sheets_schema/schema/d4d_generation_record.yaml:43), [d4d_generation_record.yaml:72–96](src/data_sheets_schema/schema/d4d_generation_record.yaml:72), [provenance.py:671–692](src/data_sheets_schema/provenance.py:671), [provenance.py:907–933](src/data_sheets_schema/provenance.py:907)
+- Severity: medium
+- Blocks production v5: no, but these fields cannot be interpreted according to their schema.
+- Concrete evidence:
+
+  - `record_type` is described as “Always `d4d_generation_provenance`,” while derived records write `d4d_derived_provenance`.
+  - `outputs` is described as “by path and hash,” while `_artifact()` explicitly records no hash and explains why.
+  - `schema.digest_md5` is described as the digest “the model was actually sent.” The agentic recorder computes it after generation at [cli/provenance.py:121–126](src/data_sheets_schema/cli/provenance.py:121), although Claude Code reads the schema files rather than receiving the API digest.
+- Suggested fix direction: distinguish API-sent digest from agent-observed schema identity, describe output hashes as living in `validation.artifacts`, and enumerate record type consistently with record mode.
+
+## 5. Reconcile/audit/report dataflow
+
+### Resume invalidation is neither transitive nor bound to artifact bytes
+
+- File: [api_runner.py:1189–1206](src/data_sheets_schema/api_runner.py:1189), [api_runner.py:2030–2065](src/data_sheets_schema/api_runner.py:2030), [api_runner.py:564–586](src/data_sheets_schema/api_runner.py:564)
+- Severity: blocker
+- Blocks production v5: yes — an interrupted run can ship core/report artifacts reconciled against a replaced full record.
+- Concrete evidence:
+
+  - Progress stores completed phase names and audit text, but no hashes of the artifacts the audit consumed.
+  - When a full artifact is rejected, the code clears producers and only phases directly requiring `"Completed full record"`.
+  - `reconcile_core` depends on `"Reconciled full record"` and `report` depends on that result, so neither is invalidated transitively.
+  - After `reconcile_full` reruns, `reconcile_core` and `report` may remain in `done` and be skipped.
+
+  Separately, a changed but still record-shaped artifact passes `_looks_like_a_record`; the old audit remains marked complete because no content hash ties it to the audited pair.
+- Suggested fix direction: persist hashes for every phase input and invalidate the full transitive dependency closure whenever a producer changes or fails verification.
+
+### The strengthened audit-shape check still accepts structurally unusable findings
+
+- File: [api_runner.py:506–516](src/data_sheets_schema/api_runner.py:506), [api_runner.py:905–917](src/data_sheets_schema/api_runner.py:905)
+- Severity: high
+- Blocks production v5: yes — reconciliation can receive findings that cannot identify their target record.
+- Concrete evidence: the phase contract requires a top-level `summary` and findings shaped as `{severity, record, slot, issue}`. `_audit_is_well_formed()` checks neither `summary` nor `record`; this passes:
+
+  ```json
+  {"findings": [{"severity": "high", "slot": "id", "issue": "wrong"}]}
+  ```
+
+  Both reconciliation phases are then asked to apply “findings that concern” their respective record, although the accepted finding does not state which record it concerns.
+- Suggested fix direction: validate the exact audit object contract, including `record` with an enum and a required summary.
+
+### The report still cannot observe its before/after diff, and repair can invalidate it afterwards
+
+- File: [api_runner.py:544–553](src/data_sheets_schema/api_runner.py:544), [api_runner.py:578–585](src/data_sheets_schema/api_runner.py:578), [api_runner.py:2179–2184](src/data_sheets_schema/api_runner.py:2179), [api_runner.py:2254–2278](src/data_sheets_schema/api_runner.py:2254)
+- Severity: high
+- Blocks production v5: yes — the human-facing reconciliation artifact can remain stale while its limited check reports success.
+- Concrete evidence:
+
+  - The report is asked to state “what was changed in each record.”
+  - Its inputs are audit findings plus reconciled full and core records; neither original record is sent.
+  - `reconcile_core` overwrites the `"Completed core record"` carry entry with the reconciled core.
+  - After the report is written, validator-driven repair may rewrite either record.
+  - `report_claims.py` explicitly checks only two narrow claim forms and acknowledges skipped claims at [report_claims.py:24–42](src/data_sheets_schema/report_claims.py:24).
+
+  Thus the report cannot directly compare before and after, and any later repair makes even the supplied post-state obsolete.
+- Suggested fix direction: supply both original snapshots and final reconciled records, perform repair before report generation, then generate/check the report against the actual final bytes.
+
+## 6. Reproducibility and silent wrongness
+
+### Flat `--out-dir` runs record standard-layout outputs and companions instead of their real files
+
+- File: [api_runner.py:280–314](src/data_sheets_schema/api_runner.py:280), [api_runner.py:2190–2199](src/data_sheets_schema/api_runner.py:2190), [provenance.py:1013–1016](src/data_sheets_schema/provenance.py:1013), [provenance.py:1250–1256](src/data_sheets_schema/provenance.py:1250)
+- Severity: high
+- Blocks production v5: yes if the supported flat-output mode is used.
+- Concrete evidence: `RunSpec` correctly directs actual artifacts to `out_dir`, but `execute()` calls `build_record()` without passing those paths or an adjusted `concat_dir`. `build_record()` reconstructs outputs under `data/d4d_concatenated/{method}/{label}` and builds companions from the same standard layout. The record written into `out_dir` can therefore describe nonexistent or unrelated output/companion paths.
+- Suggested fix direction: pass explicit full/core/report/metadata paths into the provenance builder instead of reconstructing them from method and label.
+
+## Other
+
+No additional confirmed defects outside the areas above. I excluded speculative model-behavior concerns where the repository did not provide an end-to-end control-flow trace.
+
+Verification notes:
+
+- HEAD was `e6b997275073bd595335d5651ff197ab1c1738ef`.
+- The prompt registry strict check passed.
+- Direct read-only probes reproduced the nonexistent-baseline `ok` verdict and all four same-tier source conflicts above.
+- The targeted pytest selection could not start because this read-only sandbox exposes no writable temporary directory; no files were edited.
+
+Codex session ID: 01a012ef-79a2-7550-a722-546ef5f626ac
+Resume in Codex: codex resume 01a012ef-79a2-7550-a722-546ef5f626ac
+
+
+---
+
+*End of verbatim review.*

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -610,8 +610,21 @@ def source_ranking_block(project: str) -> str | None:
         "",
     ]
     for row in rows:
-        lines.append(f"  tier {row['priority']}  {row.get('id')}  "
-                     f"({row.get('source_type')})")
+        line = (f"  tier {row['priority']}  {row.get('id')}  "
+                f"({row.get('source_type')})")
+        # Supersession is a direct statement that one source replaces another,
+        # so it settles a disagreement regardless of tier. Sending only the
+        # tier left the model unable to resolve four conflicts the manifest
+        # had already resolved (#600).
+        if row.get("superseded_by"):
+            line += f"  — SUPERSEDED BY {row['superseded_by']}"
+        lines.append(line)
+    lines += [
+        "",
+        "A source marked SUPERSEDED BY loses to the source named, whatever",
+        "their tiers: that is a statement about these two sources rather than",
+        "about their kinds.",
+    ]
     return "\n".join(lines)
 
 
@@ -1203,6 +1216,17 @@ def _save_progress(spec: RunSpec, completed: list[str],
     data: dict[str, Any] = {"completed": completed, "label": spec.label}
     if audit:
         data["Audit findings"] = audit
+    # The bytes each completed phase was computed against (#601). Without them
+    # an artifact that changes but stays record-shaped passes
+    # `_looks_like_a_record`, and the audit stays marked complete with nothing
+    # tying it to the pair it audited. Same reasoning as pinning a validation
+    # or pair verdict to its artifacts (#426, #544).
+    from data_sheets_schema.provenance import _md5
+    data["artifact_md5"] = {
+        artifact: _md5(path)
+        for artifact, path in (("full", spec.full_path),
+                               ("core", spec.core_path))
+        if path.exists()}
     p.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
@@ -1920,6 +1944,54 @@ def _rate_limit_pause(exc: Exception, *, now: datetime | None = None) -> float |
     return max(1.0, min((reset - current).total_seconds() + 2, RATE_LIMIT_MAX_PAUSE))
 
 
+def _dependents_of(carry_name: str, produced_by: tuple[str, ...]) -> set[str]:
+    """Every phase downstream of a discarded artifact, to a fixed point (#601).
+
+    Dropping only the phases that *directly* need the artifact was one level
+    deep, and the graph is deeper:
+
+        full -> reconcile_full -> "Reconciled full record" -> reconcile_core -> report
+
+    `reconcile_core` and `report` need the *reconciled* full record, not the
+    completed one, so neither named the discarded artifact and neither was
+    invalidated. After `reconcile_full` re-ran and produced different bytes,
+    both could stay in `done` and be skipped — shipping a core record and a
+    reconciliation report reconciled against a full record that no longer
+    exists.
+    """
+    # What each phase publishes into `carry`, mirroring the labelling at the
+    # end of the phase loop. Derived from PHASE_ARTIFACT so a new phase is
+    # covered without editing a second list.
+    publishes = {}
+    for phase, artifact in PHASE_ARTIFACT.items():
+        label = {"full": "Completed full record",
+                 "core": "Completed core record",
+                 "report": "Reconciliation report"}.get(artifact)
+        if phase == "reconcile_full":
+            label = "Reconciled full record"
+        if phase == "audit":
+            label = "Audit findings"
+        if label:
+            publishes[phase] = label
+    publishes.setdefault("audit", "Audit findings")
+
+    stale = {carry_name}
+    dependents: set[str] = set(produced_by)
+    changed = True
+    while changed:
+        changed = False
+        for phase in PHASES:
+            if phase in dependents:
+                continue
+            if stale & set(PHASE_NEEDS.get(phase, ())):
+                dependents.add(phase)
+                produced = publishes.get(phase)
+                if produced and produced not in stale:
+                    stale.add(produced)
+                changed = True
+    return dependents
+
+
 def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             client=None) -> dict[str, Any]:
     """Run the phases, writing each artifact as it completes.
@@ -2057,7 +2129,17 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             parsed = yaml.safe_load(body)
         except yaml.YAMLError:
             parsed = None
-        if isinstance(parsed, dict) and _looks_like_a_record(
+        recorded = (progress.get("artifact_md5") or {}).get(artifact)
+        from data_sheets_schema.provenance import _md5
+        moved = recorded is not None and _md5(path) != recorded
+        if moved:
+            # Record-shaped but not the bytes the completed phases saw, so
+            # everything downstream was computed against something else (#601).
+            print(f"   {artifact} artifact changed since the last pass; "
+                  f"re-running the phases that depended on it")
+            done -= set(produced_by)
+            done -= _dependents_of(name, produced_by)
+        elif isinstance(parsed, dict) and _looks_like_a_record(
                 parsed, schema_path, class_name):
             carry[name] = body
         else:
@@ -2068,7 +2150,7 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             # the artifact just discarded, and `reconcile_full` marked done
             # having absorbed from it.
             done -= set(produced_by)
-            done -= {ph for ph in PHASES if name in PHASE_NEEDS.get(ph, ())}
+            done -= _dependents_of(name, produced_by)
     if "reconcile_full" in done and "Completed full record" in carry:
         carry["Reconciled full record"] = carry["Completed full record"]
 

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -2019,9 +2019,17 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             # from exactly this field. Validation is local and free, and it
             # checks the bytes on disk now rather than a claim recorded earlier.
             problems = validate_outputs(spec)
+            # The three checks too, recomputed from the bytes on disk for the
+            # same reason validation is (#599). Omitting them made every metric
+            # None on a resumed batch, so the canary reported `unmeasurable`
+            # and a sweep interrupted after a *passing* canary could not resume
+            # and fan out under the gate it had already satisfied.
             return {"label": spec.label, "project": spec.project,
                     "usage": existing.get("api_usage") or [],
                     "skipped": list(PHASES), "validation_problems": problems,
+                    "checks": {"pair": pair_consistency(spec),
+                               "report": report_claims_block(spec),
+                               "grounding": grounding_block(spec)},
                     "already_complete": True,
                     "outputs": {"full": str(spec.full_path),
                                 "core": str(spec.core_path),

--- a/src/data_sheets_schema/canary.py
+++ b/src/data_sheets_schema/canary.py
@@ -110,11 +110,22 @@ def baseline_for(project: str, label_prefix: str,
     return worst
 
 
-def verdict(checks: dict[str, Any], baseline: dict[str, int | None]
-            ) -> dict[str, Any]:
-    """Compare one run's checks against a baseline. See module docstring."""
+def verdict(checks: dict[str, Any], baseline: dict[str, int | None],
+            baseline_requested: bool = True) -> dict[str, Any]:
+    """Compare one run's checks against a baseline. See module docstring.
+
+    `baseline_requested` distinguishes the two ways a bar can be missing, which
+    the first version did not (#599). A baseline nobody asked for is an absence;
+    a baseline that was named and matched no records is an **error**, and
+    treating them alike meant a mistyped prefix returned `ok` for a run with 999
+    defects in every metric.
+
+    That is the distinction this whole corpus turns on — "not established" is
+    not "fine" — missed inside the gate built to enforce it.
+    """
     counts = counts_from(checks)
     blind = [name for name, value in counts.items() if value is None]
+    unbaselined = [name for name, value in baseline.items() if value is None]
     rows = []
     regressions = []
     for name, value in counts.items():
@@ -127,9 +138,13 @@ def verdict(checks: dict[str, Any], baseline: dict[str, int | None]
 
     if blind:
         status = UNMEASURABLE
+    elif baseline_requested and unbaselined:
+        # A bar that was asked for and did not resolve cannot pass anything.
+        status = UNMEASURABLE
     elif regressions:
         status = REGRESSED
     else:
         status = OK
     return {"status": status, "rows": rows, "blind": blind,
+            "unbaselined": unbaselined if baseline_requested else [],
             "regressions": regressions}

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -356,9 +356,14 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
                 for name, v in counts.items()))
 
             if i == 1 and canary_baseline and not no_canary_gate:
-                v = _canary.verdict(res.get("checks") or {},
-                                    _canary.baseline_for(s.project,
-                                                         canary_baseline))
+                bar = _canary.baseline_for(s.project, canary_baseline)
+                v = _canary.verdict(res.get("checks") or {}, bar,
+                                    baseline_requested=True)
+                if v.get("unbaselined"):
+                    click.echo(
+                        f"     no baseline for {s.project} under "
+                        f"{canary_baseline!r} — check the label prefix",
+                        err=True)
                 for row in v["rows"]:
                     mark = "❌" if row.get("regressed") else "  "
                     click.echo(f"     {mark} {row['metric']:24} "

--- a/src/data_sheets_schema/source_priority.py
+++ b/src/data_sheets_schema/source_priority.py
@@ -84,6 +84,49 @@ def priority_of(source: dict[str, Any],
                       if source_type else "the source declares no source_type")
 
 
+def superseded_by(project: str, manifest: dict[str, Any] | None = None
+                  ) -> dict[str, str]:
+    """`{source id: the id that replaced it}` from the manifest (#600).
+
+    The manifest has recorded this for five sources all along — AI-READI's
+    documentation and FAIRhub entries, CM4AI's October release, VOICE 3.0.0 —
+    and the first version of the resolver read only `source_type`, so a
+    superseded release tied with the one replacing it and the tie meant "cannot
+    decide".
+
+    Supersession is the strongest signal there is: it is a direct statement
+    that one source replaces another, made by whoever curated the manifest. It
+    outranks a tier, which is only a claim about a *kind* of source.
+    """
+    out = {}
+    for source in sources(project, manifest):
+        replacement = source.get("superseded_by")
+        if replacement and source.get("id"):
+            out[str(source["id"])] = str(replacement)
+    return out
+
+
+def _supersedes(project: str, a: str, b: str,
+                manifest: dict[str, Any] | None = None) -> str | None:
+    """Which of `a`/`b` replaced the other, directly or through a chain."""
+    chain = superseded_by(project, manifest)
+
+    def replaces(newer: str, older: str) -> bool:
+        seen, cur = set(), older
+        while cur in chain and cur not in seen:
+            seen.add(cur)
+            cur = chain[cur]
+            if cur == newer:
+                return True
+        return False
+
+    if replaces(a, b):
+        return a
+    if replaces(b, a):
+        return b
+    return None
+
+
 def ranked(project: str, manifest: dict[str, Any] | None = None
            ) -> list[dict[str, Any]]:
     """Every source for a project, strongest first.
@@ -121,6 +164,19 @@ def decide(project: str, source_ids: list[str],
     if not known:
         return {"winner": None, "reason": "none of these sources is declared",
                 "unknown": unknown, "candidates": []}
+    # Supersession first: a source the manifest says was replaced loses to its
+    # replacement whatever their tiers, because that is a direct statement
+    # about these two sources rather than a claim about their kinds (#600).
+    if len(known) == 2:
+        winner = _supersedes(project, known[0]["id"], known[1]["id"], manifest)
+        if winner:
+            loser = next(s["id"] for s in known if s["id"] != winner)
+            return {"winner": winner, "candidates": known, "unknown": unknown,
+                    "priority": next(s["priority"] for s in known
+                                     if s["id"] == winner),
+                    "reason": (f"the manifest declares {loser} superseded by "
+                               f"{winner}, which settles it regardless of tier")}
+
     best = min(s["priority"] for s in known)
     top = [s for s in known if s["priority"] == best]
     if len(top) > 1:

--- a/tests/test_canary_gate.py
+++ b/tests/test_canary_gate.py
@@ -100,11 +100,37 @@ class VerdictTest(unittest.TestCase):
         self.assertEqual(v["status"], UNMEASURABLE)
         self.assertEqual(v["blind"], ["pair errors"])
 
-    def test_a_missing_baseline_never_regresses(self):
-        """No bar is not a failed bar. A first-ever arm has nothing to compare
-        against and must not be blocked by that."""
+    def test_a_baseline_that_was_asked_for_and_missing_is_unmeasurable(self):
+        """The blocker this test used to assert the opposite of (#599).
+
+        It read: "No bar is not a failed bar. A first-ever arm has nothing to
+        compare against and must not be blocked by that." True of an arm with
+        no baseline; false of a **mistyped** one — and the code could not tell
+        them apart, so a run with 999 defects in every metric passed.
+
+        That is "not established is not fine", missed inside the gate built to
+        enforce it.
+        """
+        awful = {"pair": {"ran": True, "errors": 999},
+                 "report": {"checked": True, "findings": [1] * 999},
+                 "grounding": {"checked": True, "distinct": {"absent": 999},
+                               "findings": []}}
+        v = verdict(awful, {k: None for k in self.BAR}, baseline_requested=True)
+        self.assertEqual(v["status"], UNMEASURABLE)
+        self.assertEqual(sorted(v["unbaselined"]), sorted(self.BAR))
+
+    def test_no_baseline_asked_for_is_still_permissible(self):
+        """The case the old test was right about: a first-ever arm has nothing
+        to compare against, and saying so is not the same as failing."""
         self.assertEqual(
-            verdict(GOOD, {k: None for k in self.BAR})["status"], OK)
+            verdict(GOOD, {k: None for k in self.BAR},
+                    baseline_requested=False)["status"], OK)
+
+    def test_a_partially_resolved_baseline_does_not_pass(self):
+        """One metric with no bar is enough: a gate that passes on the metrics
+        it happens to have is the #591 hole in another form."""
+        bar = dict(self.BAR); bar["ungrounded identifiers"] = None
+        self.assertEqual(verdict(GOOD, bar)["status"], UNMEASURABLE)
 
 
 class RealArmTest(unittest.TestCase):
@@ -273,3 +299,34 @@ class ResolverUrlMetricTest(unittest.TestCase):
         found = resolver_urls_in_identifier_slots(
             {"id": "https://b2ai-voice.org/thing"}, uriorcurie_slots())
         self.assertEqual(found, [])
+
+
+class ResumedBatchCanRegateTest(unittest.TestCase):
+    """A sweep interrupted after a passing canary must be able to resume (#599).
+
+    `execute()`'s completed-run early return omitted `checks`, so every metric
+    became None and the canary reported `unmeasurable`. A batch that had already
+    satisfied the gate could not fan out after an interruption — and
+    interruption is normal: arms take hours and #513 is the precedent.
+    """
+
+    def test_the_completed_run_path_returns_the_checks(self):
+        import inspect
+
+        from data_sheets_schema.api_runner import execute
+        src = inspect.getsource(execute)
+        head = src[:src.index("already_complete")]
+        self.assertIn('"checks":', head)
+
+    def test_they_are_recomputed_rather_than_read_from_the_record(self):
+        """Same reason validation is recomputed there: returning a verdict the
+        record asserted earlier would report a clean bill nobody checked."""
+        import inspect
+
+        from data_sheets_schema.api_runner import execute
+        src = inspect.getsource(execute)
+        head = src[:src.index("already_complete")]
+        for fn in ("pair_consistency(spec)", "report_claims_block(spec)",
+                   "grounding_block(spec)"):
+            with self.subTest(fn=fn):
+                self.assertIn(fn, head)

--- a/tests/test_resume_inputs.py
+++ b/tests/test_resume_inputs.py
@@ -60,12 +60,34 @@ class ResumeGuardTest(unittest.TestCase):
         self.assertNotIn("for k in PHASE_NEEDS[ph] if k in carry", src,
                          "the filtering form is what allowed a short run")
 
-    def test_discarding_an_artifact_also_discards_its_consumers(self):
-        """Dropping only the producers left `audit` marked done with findings
-        computed against the artifact just discarded, and `reconcile_full`
-        marked done having absorbed from it."""
+    def test_discarding_an_artifact_discards_its_whole_dependency_closure(self):
+        """One level was not enough (#601).
+
+        `reconcile_core` and `report` need the *reconciled* full record, not the
+        completed one, so neither named a discarded `Completed full record` and
+        neither was invalidated. After `reconcile_full` re-ran with different
+        bytes they could stay in `done` and be skipped — shipping a core record
+        and a report reconciled against a full record that no longer exists.
+        """
+        from data_sheets_schema.api_runner import PHASES, _dependents_of
+        closure = _dependents_of("Completed full record",
+                                 ("full", "reconcile_full"))
+        for phase in ("core", "audit", "reconcile_full", "reconcile_core",
+                      "report"):
+            with self.subTest(phase=phase):
+                self.assertIn(phase, closure)
+
+    def test_a_changed_artifact_invalidates_even_when_still_record_shaped(self):
+        """`_looks_like_a_record` cannot tell *which* record it is looking at.
+
+        Progress now stores the md5 of each artifact the completed phases were
+        computed against, so bytes that changed between passes invalidate the
+        work that depended on them — the same reasoning that pins a validation
+        or pair verdict to its artifacts (#426, #544).
+        """
         src = self._source()
-        self.assertIn("PHASE_NEEDS.get(ph, ())", src)
+        self.assertIn("artifact_md5", src)
+        self.assertIn("_dependents_of", src)
 
     def test_the_message_names_the_way_out(self):
         """A gate that stops a paid run must say what to do next."""

--- a/tests/test_resume_inputs.py
+++ b/tests/test_resume_inputs.py
@@ -108,3 +108,48 @@ class ArtifactConsumerTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class InvalidationBoundsTest(unittest.TestCase):
+    """The closure must be wide enough to be safe and narrow enough to be cheap.
+
+    A transitive walk that over-reaches discards work that was fine, which on a
+    multi-hour arm is expensive; one that under-reaches is #601.
+    """
+
+    def test_discarding_core_does_not_discard_full(self):
+        """`full` is produced before core and depends on nothing downstream."""
+        from data_sheets_schema.api_runner import _dependents_of
+        self.assertNotIn("full",
+                         _dependents_of("Completed core record",
+                                        ("core", "reconcile_core")))
+
+    def test_discarding_core_does_discard_reconcile_full(self):
+        """Since #566 `reconcile_full` consumes the core record, so a replaced
+        core invalidates the absorption it performed."""
+        from data_sheets_schema.api_runner import _dependents_of
+        self.assertIn("reconcile_full",
+                      _dependents_of("Completed core record",
+                                     ("core", "reconcile_core")))
+
+    def test_it_terminates_on_a_self_dependency(self):
+        """A fixed-point walk over a graph nobody guarantees is acyclic."""
+        import data_sheets_schema.api_runner as api
+        original = api.PHASE_NEEDS
+        try:
+            api.PHASE_NEEDS = {**original,
+                               "report": ("Reconciliation report",)}
+            self.assertEqual(
+                api._dependents_of("Reconciliation report", ("report",)),
+                {"report"})
+        finally:
+            api.PHASE_NEEDS = original
+
+    def test_a_progress_file_without_hashes_keeps_the_old_behaviour(self):
+        """Progress files predating #601 carry no `artifact_md5`, and treating
+        a missing hash as a mismatch would re-run every resumable phase of
+        every older run."""
+        import inspect
+
+        from data_sheets_schema.api_runner import execute
+        self.assertIn("recorded is not None", inspect.getsource(execute))

--- a/tests/test_source_priority.py
+++ b/tests/test_source_priority.py
@@ -96,6 +96,72 @@ class DecideTest(unittest.TestCase):
         self.assertLess(order.index("crate"), order.index("boosted"))
 
 
+class SupersessionTest(unittest.TestCase):
+    """A source the manifest says was replaced loses to its replacement (#600).
+
+    The first version read only `source_type`, so a superseded release *tied*
+    with the one replacing it and the tie meant "cannot decide" — on four
+    conflicts the manifest had already resolved. Harry's CHORUS case happened
+    to differ by type, so it resolved, and the commoner version-supersession
+    case went untested.
+    """
+
+    CASES = (("AI_READI", "dataset_documentation", "dataset_documentation_v3"),
+             ("AI_READI", "fairhub_dataset", "fairhub_dataset_v3"),
+             ("CM4AI", "october_2025_dataverse_release",
+              "june_2026_dataverse_release"),
+             ("VOICE", "physionet_3_0_0", "physionet_3_1_0"))
+
+    def test_every_documented_supersession_resolves(self):
+        for project, old, new in self.CASES:
+            with self.subTest(project=project, old=old):
+                d = decide(project, [old, new])
+                self.assertEqual(d["winner"], new)
+                self.assertIn("superseded", d["reason"])
+
+    def test_it_beats_the_tier(self):
+        """Two `data resource` entries share tier 1; supersession still decides."""
+        from data_sheets_schema.source_priority import priority_of, sources
+        by_id = {s["id"]: s for s in sources("AI_READI")}
+        a, b = by_id["fairhub_dataset"], by_id["fairhub_dataset_v3"]
+        self.assertEqual(priority_of(a)[0], priority_of(b)[0])
+        self.assertEqual(decide("AI_READI", [a["id"], b["id"]])["winner"],
+                         b["id"])
+
+    def test_order_of_the_arguments_does_not_matter(self):
+        for project, old, new in self.CASES:
+            with self.subTest(project=project):
+                self.assertEqual(decide(project, [new, old])["winner"], new)
+
+    def test_an_unrelated_pair_is_unaffected(self):
+        """Supersession must not leak into pairs that declare none."""
+        d = decide("CHORUS", ["project_documentation", "cohort_2_webinar"])
+        self.assertEqual(d["winner"], "project_documentation")
+        self.assertNotIn("superseded", d["reason"])
+
+    def test_the_map_is_read_from_the_manifest(self):
+        from data_sheets_schema.source_priority import superseded_by
+        self.assertEqual(superseded_by("VOICE").get("physionet_3_0_0"),
+                         "physionet_3_1_0")
+
+    def test_the_model_is_told_which_source_was_superseded(self):
+        """A resolver that knows and a model that is not told would leave the
+        API arm exactly where it was."""
+        from data_sheets_schema.api_runner import source_ranking_block
+        block = source_ranking_block("AI_READI")
+        self.assertIn("SUPERSEDED BY fairhub_dataset_v3", block)
+        self.assertIn("whatever", block)
+
+    def test_the_agentic_path_no_longer_has_its_own_tie_breaker(self):
+        """`d4d-agent.md` told that runtime to resolve conflicts by its own
+        reading of authority and recency, against the declared ranking — same
+        condition, two answers."""
+        from pathlib import Path
+        text = Path(".claude/commands/d4d-agent.md").read_text(encoding="utf-8")
+        self.assertNotIn("Resolve conflicts using authority and recency", text)
+        self.assertIn("source_priority", text)
+
+
 class RealManifestTest(unittest.TestCase):
     """Against the manifest actually shipped."""
 


### PR DESCRIPTION
The three blockers from the 2026-08-17 Codex readiness review
(`notes/codex_v5_readiness_review_2026-08-17.md`, tracked in #606).

Every finding was verified against the working tree before filing; Codex's line
references drifted in places but each finding was real.

## #599 — a mistyped baseline passed the canary

```
baseline_for('AI_READI', 'TYPO_DOES_NOT_EXIST')  ->  {every metric: None}
verdict(run_with_999_defects_everywhere, that)   ->  ok
```

**I wrote the test that asserted this**, reasoning *"No bar is not a failed bar.
A first-ever arm has nothing to compare against and must not be blocked by
that."* True of an arm with no baseline, false of a typo, and the code could not
tell them apart — "not established is not fine", missed inside the gate built to
enforce it.

`verdict` now takes `baseline_requested`:

| case | verdict |
|---|---|
| baseline asked for, resolved | compared |
| baseline asked for, matched nothing | **unmeasurable** |
| baseline asked for, *partially* resolved | **unmeasurable** |
| no baseline asked for | ok, and says so |

The partial case matters: a gate that passes on the metrics it happens to have
is the #591 hole in another form.

Second half: `execute()`'s completed-run early return omitted `checks`, so every
metric was None on a resumed batch and a sweep interrupted after a **passing**
canary could not fan out under the gate it had already satisfied. The checks are
recomputed there from the bytes on disk — returning a verdict the record
asserted earlier would report a clean bill nobody checked.

## #600 — the manifest already said which source wins

`decide()` ignored `superseded_by`, declared for five sources all along, so a
superseded release *tied* with its replacement and the tie meant "cannot
decide":

| project | conflict | now resolves to |
|---|---|---|
| AI_READI | `dataset_documentation` | `dataset_documentation_v3` |
| AI_READI | `fairhub_dataset` | `fairhub_dataset_v3` |
| CM4AI | october 2025 release | june 2026 release |
| VOICE | `physionet_3_0_0` | `physionet_3_1_0` |

Supersession beats tier — it is a statement about *these two sources*, not about
their kinds — and follows a chain, not just a direct link. Harry's CHORUS case
differed by type, so it resolved, and the commoner version case went untested.

Both runtimes are told: the API ranking block marks a superseded source and says
the mark beats the tier, and `d4d-agent.md` loses its own "authority and
recency" tie-breaker, which had been giving the two paths different answers.

## #601 — invalidation was one level deep

```
full -> reconcile_full -> "Reconciled full record" -> reconcile_core -> report
```

`reconcile_core` and `report` need the *reconciled* record, so neither named a
discarded `Completed full record` and neither was invalidated. After
`reconcile_full` re-ran with different bytes both could stay `done` and be
skipped — **shipping a core record and a report reconciled against a full record
that no longer exists.**

`_dependents_of` walks `PHASE_NEEDS` to a fixed point, deriving what each phase
publishes from `PHASE_ARTIFACT` so a new phase is covered without a second list.
Discarding the full record now invalidates all six phases.

Progress also stores each artifact's md5: `_looks_like_a_record` cannot tell
*which* record it is looking at, so changed bytes now invalidate the work that
depended on them (#426, #544).

Suite: 2163 passed, 4 skipped.

Generated with Claude Code
