### PR TITLE
Three defects in the phase dataflow (#604)

### DIFF
--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -923,6 +923,13 @@ def _looks_like_a_record(parsed: dict, schema_path: str = FULL_SCHEMA_PATH,
 MIN_RECORD_SLOTS = 5
 
 
+#: What a finding's `record` may say. Enumerated because "the findings that
+#: concern the FULL record" is only answerable if the value is one the
+#: reconciliation phases can match on; a free-text record name would be a
+#: finding nobody can route (#604).
+AUDIT_RECORD_VALUES = frozenset({"full", "core", "both"})
+
+
 def _audit_is_well_formed(parsed: dict) -> bool:
     """Does this JSON actually carry an audit, or merely the word `findings`?
 
@@ -934,7 +941,18 @@ def _audit_is_well_formed(parsed: dict) -> bool:
     findings = parsed.get("findings")
     if not isinstance(findings, list):
         return False
-    return all(isinstance(f, dict) and {"severity", "slot", "issue"} <= set(f)
+    # `summary` and `record` are checked because the instruction asks for them
+    # and reconciliation depends on them (#604). Each reconciliation phase is
+    # told to apply "the findings that concern" its record — a finding that
+    # does not say which record it concerns cannot be applied by either, and
+    # since #574 conditions absorption on the audit's verdict, a finding that
+    # cannot be attributed is worse than one that is absent.
+    if not isinstance(parsed.get("summary"), str) or not parsed["summary"].strip():
+        return False
+    required = {"severity", "record", "slot", "issue"}
+    return all(isinstance(f, dict) and required <= set(f)
+               and str(f.get("record", "")).strip().lower()
+               in AUDIT_RECORD_VALUES
                for f in findings)
 
 
@@ -1957,6 +1975,51 @@ def _rate_limit_pause(exc: Exception, *, now: datetime | None = None) -> float |
     return max(1.0, min((reset - current).total_seconds() + 2, RATE_LIMIT_MAX_PAUSE))
 
 
+def _regenerate_report(spec: RunSpec, client, settings: dict[str, Any],
+                       usage: list[dict[str, Any]],
+                       carry: dict[str, str]) -> None:
+    """Rewrite the reconciliation report against the repaired records (#604).
+
+    Reads the records from disk rather than from `carry`: the point is that
+    repair changed them, so the carried copies are precisely the stale ones.
+    """
+    fresh = dict(carry)
+    if spec.full_path.exists():
+        fresh["Reconciled full record"] = spec.full_path.read_text(
+            encoding="utf-8")
+    if spec.core_path.exists():
+        fresh["Completed core record"] = spec.core_path.read_text(
+            encoding="utf-8")
+    needed = {k: fresh[k] for k in PHASE_NEEDS["report"] if k in fresh}
+    if len(needed) != len(PHASE_NEEDS["report"]):
+        return                      # cannot rebuild it honestly; leave it
+    req = build_phase(spec, "report", carry=needed)
+    try:
+        resp = _call_with_retry(
+            client, model=settings["name"],
+            max_tokens=PHASE_MAX_TOKENS.get("report", settings["max_tokens"]),
+            temperature=(settings["temperature"]
+                         if settings["temperature_applies"] else None),
+            system=req.system, messages=req.messages)
+    except Exception:                                          # noqa: BLE001
+        return                      # a stale report is better than none
+    text = "".join(getattr(b, "text", "") for b in getattr(resp, "content", [])
+                   if getattr(b, "type", None) == "text")
+    usage.append({"phase": "report_after_repair", "attempt": 1,
+                  "input_tokens": getattr(resp.usage, "input_tokens", None),
+                  "output_tokens": getattr(resp.usage, "output_tokens", None),
+                  "cache_read": getattr(resp.usage,
+                                        "cache_read_input_tokens", None),
+                  "cache_write": getattr(resp.usage,
+                                         "cache_creation_input_tokens", None),
+                  "stop_reason": getattr(resp, "stop_reason", None)})
+    try:
+        body = _extract(text, "md")
+    except RuntimeError:
+        return
+    spec.report_path.write_text(body, encoding="utf-8")
+
+
 def _dependents_of(carry_name: str, produced_by: tuple[str, ...]) -> set[str]:
     """Every phase downstream of a discarded artifact, to a fixed point (#601).
 
@@ -2300,6 +2363,12 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         # (#419). `prompt_request_hash` was written for this and had no caller.
         prompt_request=spec.instruction,
         prompt_request_spec=spec.render_spec(),
+        # The spec already knows where this run wrote; reconstructing the
+        # standard layout made an --out-dir record name files that are not
+        # there (#604).
+        outputs={"full": spec.full_path, "core": spec.core_path,
+                 "report": spec.report_path,
+                 "reasoning": _reasoning_path(spec)},
         schema_digest_md5=schema_digest.fingerprint(schema_digest.digest_text("Dataset")),
         extra_notes=[
             (f"Generated via {RUNTIME}; temperature {settings['temperature']} "
@@ -2368,10 +2437,32 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         # cheaper than discarding the run. Hashing happens in
         # validation_block() below, *after* repair — integrity pins the final
         # bytes, never an intermediate state.
+        from data_sheets_schema.provenance import _md5
+        before = {a: _md5(pth) for a, pth in (("full", spec.full_path),
+                                              ("core", spec.core_path))
+                  if pth.exists()}
         rec.data["repair"] = (prior_repair
                               + _repair_invalid(spec, client, settings,
                                                 usage)) or None
         problems = validate_outputs(spec)
+        # The report was written in phase 6 and repair runs after the whole
+        # loop, so a repair that rewrites a record leaves the report describing
+        # bytes that no longer exist — and `report_claims` then checks a stale
+        # report against the repaired records (#604). Regenerated only when
+        # repair actually changed something, so the extra call is paid exactly
+        # when it buys a report that matches its records.
+        after = {a: _md5(pth) for a, pth in (("full", spec.full_path),
+                                             ("core", spec.core_path))
+                 if pth.exists()}
+        if after != before:
+            rec.data["report_regenerated_after_repair"] = {
+                "changed": sorted(a for a in after
+                                  if before.get(a) != after.get(a)),
+                "why": ("repair rewrote a record after the report was written; "
+                        "a report describing bytes that no longer exist is the "
+                        "artifact a reviewer reads instead of the diff"),
+            }
+            _regenerate_report(spec, client, settings, usage, carry)
     else:
         rec.data["repair"] = prior_repair or None
     rec.data["validation"] = validation_block(spec, problems)

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -963,7 +963,8 @@ COMPANION_FILES = (
 
 
 def companion_facts(project: str, method: str, label: str,
-                    concat_dir: Path = CONCAT_DIR) -> dict[str, Any]:
+                    concat_dir: Path = CONCAT_DIR,
+                    reasoning: Path | None = None) -> dict[str, Any]:
     """Everything else a reader of this record may need, by reference.
 
     The record already names its bundle, prompts, playbooks, schemas, outputs
@@ -975,7 +976,7 @@ def companion_facts(project: str, method: str, label: str,
     """
     out: dict[str, Any] = {}
     label_dir = concat_dir / f"{method}_core" / label
-    reasoning = label_dir / f"{project}_reasoning.jsonl"
+    reasoning = reasoning or label_dir / f"{project}_reasoning.jsonl"
     out["reasoning_log"] = {
         "path": repo_relative(reasoning), "present": reasoning.exists(),
         "md5": _md5(reasoning) if reasoning.exists() else None,
@@ -1003,6 +1004,7 @@ def build_record(project: str, method: str, label: str, *, mode: str,
                  schema_digest_md5: str | None = None,
                  reasoning_effort: str | None = None,
                  phases: list[dict[str, Any]] | None = None,
+                 outputs: dict[str, Path] | None = None,
                  extra_notes: list[str] | None = None) -> ProvenanceRecord:
     """Assemble a provenance record for one project-run.
 
@@ -1010,10 +1012,19 @@ def build_record(project: str, method: str, label: str, *, mode: str,
     only when the input bundle on disk is known to be the same bytes the run
     consumed; otherwise the input hash is withheld as unrecoverable.
     """
+    # Taken from the caller when it knows, reconstructed only when it does not.
+    # A run with `--out-dir` writes flat into that directory, and rebuilding the
+    # standard layout here made the record name output and companion files that
+    # were elsewhere or absent — the GitHub assistant's layout, and the same
+    # class as the declared-bundle defect: a path assumed rather than derived
+    # from the spec that already knew it (#604).
     base = method[:-5] if method.endswith("_core") else method
-    full = concat_dir / base / label / f"{project}_d4d.yaml"
-    core = concat_dir / f"{base}_core" / label / f"{project}_d4d_core.yaml"
-    report = concat_dir / f"{base}_core" / label / f"{project}_reconciliation.md"
+    outputs = outputs or {}
+    full = outputs.get("full") or concat_dir / base / label / f"{project}_d4d.yaml"
+    core = outputs.get("core") or (
+        concat_dir / f"{base}_core" / label / f"{project}_d4d_core.yaml")
+    report = outputs.get("report") or (
+        concat_dir / f"{base}_core" / label / f"{project}_reconciliation.md")
 
     header = parse_header(full)
     unrecoverable: list[dict[str, str]] = []
@@ -1253,7 +1264,8 @@ def build_record(project: str, method: str, label: str, *, mode: str,
         "outputs": {"full": _artifact(full), "core": _artifact(core),
                     "report": _artifact(report)},
         # Everything else a reader may need, by reference rather than by copy.
-        "companions": companion_facts(project, method, label, concat_dir),
+        "companions": companion_facts(project, method, label, concat_dir,
+                                      reasoning=outputs.get("reasoning")),
         "unrecoverable": unrecoverable or None,
         "unverified": unverified or None,
         "notes": notes or None,

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -776,9 +776,15 @@ class TestValidatorDrivenRepair(unittest.TestCase):
         self.assertIn("repaired", s.full_path.read_text())
         d = _yaml.safe_load((self.out / "CHORUS_provenance.yaml").read_text())
         self.assertEqual([x["outcome"] for x in d["repair"]], ["applied"])
-        self.assertEqual([u["phase"] for u in d["api_usage"]][-1],
-                         "repair_full")
-        self.assertEqual(len(d["api_usage"]), 7)
+        # Repair rewrote the full record *after* the report was written in
+        # phase 6, so the report is regenerated against the repaired bytes and
+        # is the last call (#604). Before that, `report_claims` checked a stale
+        # report against records it no longer described.
+        phases = [u["phase"] for u in d["api_usage"]]
+        self.assertEqual(phases[-2:], ["repair_full", "report_after_repair"])
+        self.assertEqual(len(phases), 8)
+        self.assertEqual(
+            d["report_regenerated_after_repair"]["changed"], ["full"])
 
     def test_resume_of_a_completed_run_keeps_the_prior_accounting(self):
         """#362: re-running an invalid-but-complete run is how repair is
@@ -1564,8 +1570,11 @@ class TestExtractionRefusesProse(unittest.TestCase):
 
     def test_a_well_formed_audit_is_accepted(self):
         from data_sheets_schema.api_runner import _extract
-        good = ('{"findings": [{"severity": "high", "slot": "id", '
-                '"issue": "mismatch"}], "summary": "one finding"}')
+        # `record` is required since #604: each reconciliation phase applies
+        # "the findings that concern" its record, so a finding that does not
+        # say which record it concerns cannot be applied by either.
+        good = ('{"findings": [{"severity": "high", "record": "full", '
+                '"slot": "id", "issue": "mismatch"}], "summary": "one finding"}')
         self.assertEqual(_extract(f"```json\n{good}\n```", "json"), good)
 
     def test_an_audit_with_no_findings_is_still_an_audit(self):

--- a/tests/test_phase_dataflow.py
+++ b/tests/test_phase_dataflow.py
@@ -1,0 +1,151 @@
+"""Three defects in the phase dataflow (#604), from the 2026-08-17 review."""
+
+import inspect
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from data_sheets_schema.api_runner import (
+    AUDIT_RECORD_VALUES,
+    PHASE_NEEDS,
+    RunSpec,
+    _audit_is_well_formed,
+    execute,
+)
+
+
+class AuditContractTest(unittest.TestCase):
+    """A finding that names no record cannot be applied by either phase.
+
+    Each reconciliation phase is told to apply "the findings that concern" its
+    record. Since #574 conditions absorption on the audit's verdict, a finding
+    that cannot be attributed is worse than one that is absent.
+    """
+
+    GOOD = {"summary": "one issue", "findings": [
+        {"severity": "high", "record": "full", "slot": "id", "issue": "wrong"}]}
+
+    def test_the_shape_the_review_showed_passing_is_rejected(self):
+        self.assertFalse(_audit_is_well_formed(
+            {"findings": [{"severity": "high", "slot": "id",
+                           "issue": "wrong"}]}))
+
+    def test_a_missing_summary_is_rejected(self):
+        bad = {"findings": self.GOOD["findings"]}
+        self.assertFalse(_audit_is_well_formed(bad))
+
+    def test_an_empty_summary_is_rejected(self):
+        self.assertFalse(_audit_is_well_formed({**self.GOOD, "summary": "  "}))
+
+    def test_a_record_value_nothing_can_route_is_rejected(self):
+        """Free text would be a finding nobody can act on."""
+        bad = {"summary": "s", "findings": [
+            {"severity": "high", "record": "the yaml file", "slot": "id",
+             "issue": "x"}]}
+        self.assertFalse(_audit_is_well_formed(bad))
+
+    def test_the_routable_values_are_the_ones_the_phases_match_on(self):
+        self.assertEqual(AUDIT_RECORD_VALUES, {"full", "core", "both"})
+
+    def test_a_well_formed_audit_passes(self):
+        self.assertTrue(_audit_is_well_formed(self.GOOD))
+
+    def test_a_clean_audit_with_no_findings_passes(self):
+        """Finding nothing is a result, not a malformed response."""
+        self.assertTrue(_audit_is_well_formed(
+            {"summary": "nothing found", "findings": []}))
+
+
+class ReportAfterRepairTest(unittest.TestCase):
+    """Repair runs after the whole phase loop, including `report` (#604).
+
+    So a repair that rewrites a record leaves the report describing bytes that
+    no longer exist — and `report_claims` then checks a stale report against
+    the repaired records.
+    """
+
+    def test_the_report_is_regenerated_only_when_repair_changed_bytes(self):
+        src = inspect.getsource(execute)
+        self.assertIn("if after != before:", src)
+        self.assertIn("_regenerate_report(", src)
+
+    def test_it_records_that_it_did_and_which_records_moved(self):
+        src = inspect.getsource(execute)
+        self.assertIn("report_regenerated_after_repair", src)
+
+    def test_it_reads_the_repaired_records_from_disk(self):
+        """The carried copies are precisely the stale ones — that is the point."""
+        from data_sheets_schema.api_runner import _regenerate_report
+        src = inspect.getsource(_regenerate_report)
+        self.assertIn("read_text", src)
+        self.assertIn("Reconciled full record", src)
+
+    def test_it_refuses_rather_than_guesses_when_an_input_is_missing(self):
+        from data_sheets_schema.api_runner import _regenerate_report
+        self.assertIn("cannot rebuild it honestly",
+                      inspect.getsource(_regenerate_report))
+
+    def test_report_still_declares_the_inputs_it_needs(self):
+        self.assertIn("Reconciled full record", PHASE_NEEDS["report"])
+
+
+class FlatOutputLayoutTest(unittest.TestCase):
+    """An `--out-dir` run must record where it actually wrote (#604).
+
+    `RunSpec` sends artifacts to `out_dir`, and `build_record` rebuilt the
+    standard `data/d4d_concatenated/{method}/{label}` layout — so the record
+    written into `out_dir` named output and companion files that were elsewhere
+    or absent. Same class as the declared-bundle defect: a path assumed rather
+    than derived from the spec that already knew it.
+    """
+
+    SOURCE = Path("data/d4d_concatenated/claudecode_agent"
+                  "/2026-08-13_claude-opus-5-api-generic-v4_rep1/CHORUS_d4d.yaml")
+
+    def setUp(self):
+        if not self.SOURCE.exists():
+            self.skipTest("v4 arm not present in this checkout")
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.out = Path(tmp.name)
+        self.spec = RunSpec(
+            project="CHORUS", arm="baseline", method="claudecode_agent",
+            bundle=Path("data/preprocessed/concatenated/CHORUS_preprocessed.txt"),
+            label="flat_test", condition="generic_v5", out_dir=self.out)
+        shutil.copy2(self.SOURCE, self.spec.full_path)
+
+    def _record(self):
+        from data_sheets_schema.provenance import build_record
+        return build_record(
+            "CHORUS", "claudecode_agent", "flat_test", mode="live",
+            input_bundle=self.spec.bundle, input_verified=True,
+            outputs={"full": self.spec.full_path, "core": self.spec.core_path,
+                     "report": self.spec.report_path,
+                     "reasoning": self.out / "CHORUS_reasoning.jsonl"})
+
+    def test_the_record_names_the_file_the_run_wrote(self):
+        rec = self._record()
+        self.assertEqual(Path(rec.data["outputs"]["full"]["path"]).name,
+                         self.spec.full_path.name)
+        self.assertNotIn("d4d_concatenated", rec.data["outputs"]["full"]["path"])
+
+    def test_companions_follow_the_same_layout(self):
+        """The companion block was rebuilt from the standard layout too, so it
+        pointed at a reasoning log in a directory this run never used."""
+        rec = self._record()
+        self.assertNotIn("d4d_concatenated",
+                         rec.data["companions"]["reasoning_log"]["path"])
+
+    def test_the_standard_layout_is_still_the_default(self):
+        """Reconstruction is the fallback, not the removed behaviour: the
+        agentic recorder passes no paths and must keep working."""
+        from data_sheets_schema.provenance import build_record
+        rec = build_record("CHORUS", "claudecode_agent",
+                           "2026-08-13_claude-opus-5-api-generic-v4_rep1",
+                           mode="reconstructed")
+        self.assertIn("d4d_concatenated", rec.data["outputs"]["full"]["path"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #604. Last of the P1s from the 2026-08-17 review (#606).

## An audit finding could name no record

The instruction asks for a `summary` and findings shaped
`{severity, record, slot, issue}`. `_audit_is_well_formed` checked neither, so
this passed:

```json
{"findings": [{"severity": "high", "slot": "id", "issue": "wrong"}]}
```

Both reconciliation phases are then told to apply "the findings that concern"
their record — from a finding that does not say which record it concerns. Since
**#574 conditions absorption on the audit's verdict**, a finding that cannot be
attributed is worse than one that is absent.

`record` must now be `full`, `core` or `both`; free text would be a finding
nobody can route. A clean audit with no findings still passes — finding nothing
is a result, not a malformed response.

## The report described bytes repair had already replaced

`report` is phase 6; repair runs after the whole loop. So repair rewrites a
record and the report — **the artifact a reviewer reads instead of the diff**,
which is what made #546 matter — describes something that no longer exists,
while `report_claims` checks the stale report against the repaired records.

Regenerated when, and only when, repair actually changed bytes, so the extra
call is paid exactly where it buys a report matching its records. It reads them
from disk, because the carried copies are precisely the stale ones, and records
that it happened and which records moved. If an input is missing it declines
rather than guessing: a stale report beats an invented one.

## A flat `--out-dir` run recorded paths that were not there

`RunSpec` writes to `out_dir`; `build_record` rebuilt the standard
`data/d4d_concatenated/{method}/{label}` layout — so the record named output and
companion files that were elsewhere or absent. The GitHub assistant's layout,
and the same class as the declared-bundle defect: a path assumed rather than
derived from the spec that already knew it.

`build_record` now takes the paths when the caller knows them and reconstructs
only when it does not, so the agentic recorder is unchanged — asserted by a test.

## Both test failures were the new contracts working

An audit fixture without `record`, and a repair test asserting the last call was
`repair_full` when it is now the regenerated report. Neither was a regression.

Rebased onto main after #608 and #609 merged; suite re-run after the rebase.
Suite: 2193 passed, 4 skipped.

Generated with Claude Code
