### PR TITLE
Make the record schema mode-aware, and check it where records are written (#605)

### DIFF
--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -203,6 +203,27 @@ person answers this from the corpus instead of re-deriving it. The *limit*
 stays null and says why: no route states it and the provider does not return
 it, and a guess would make headroom computable and wrong.
 
+## VOICE_PEDIATRIC is out of the v5 arm (2026-08-18)
+
+Decided rather than deferred, closing the last open item in #590. VOICE_PEDIATRIC
+has **no v4 record**, so it has no baseline for any of the eight gated metrics.
+Under `verdict(..., baseline_requested=True)` a project whose baseline resolves
+to nothing is `unmeasurable` and stops the sweep — the #599 fix, working as
+intended. The alternatives were to run it ungated, or to gate it against another
+project's numbers.
+
+Both are worse than skipping it. An ungated run is the v4 failure exactly: a
+record that enters the "succeeded" column on schema validation alone, with
+nothing able to say whether it regressed. Borrowing VOICE's baseline would
+assert that two datasets of different size and documentation should exhibit the
+same defect counts, which nothing supports.
+
+So the v5 arm is **AI-READI, CHORUS, CM4AI, VOICE** — the four projects with a
+v4 arm to be compared against, which is also the only comparison this plan
+licenses. VOICE_PEDIATRIC is not excluded on quality grounds and needs no
+inference drawn about it; it is a project this design cannot measure, and
+running it anyway would produce a number with no bar beside it.
+
 ## What this plan does not license
 
 Comparing v5 against anything other than v4. Every earlier arm sits at a

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -41,7 +41,7 @@ from typing import Any
 
 import yaml
 
-from data_sheets_schema import reasoning, schema_digest
+from data_sheets_schema import provenance, reasoning, schema_digest
 from data_sheets_schema.provenance import (
     DETERMINISTIC_CONFIG,
     load_generation_config,
@@ -2494,6 +2494,21 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
         raise RuntimeError(
             f"run {spec.label} for {spec.project} finished without usable "
             f"provenance: {prov['reason']}")
+
+    # And that the record conforms to the schema that describes it (#605).
+    # `check_provenance` asks whether a usable record exists; this asks whether
+    # what it contains is what a record of its mode must contain — a `live`
+    # record omitting its bundle, its model or its validation verdict passed the
+    # first check and told a reader nothing about how it was made. Fails the run
+    # for the same reason as above: an unattestable artifact left behind is the
+    # defect, not the error message about it.
+    if rec.conformance:
+        raise RuntimeError(
+            f"run {spec.label} for {spec.project} wrote a provenance record "
+            f"that does not conform to {provenance.RECORD_SCHEMA}: "
+            + "; ".join(rec.conformance[:5])
+            + (f" (+{len(rec.conformance) - 5} more)"
+               if len(rec.conformance) > 5 else ""))
 
     # Only now is the run finished. Keeping the progress file on a validation
     # failure means a rerun resumes instead of regenerating from phase 1.

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -2498,14 +2498,28 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
     # And that the record conforms to the schema that describes it (#605).
     # `check_provenance` asks whether a usable record exists; this asks whether
     # what it contains is what a record of its mode must contain — a `live`
-    # record omitting its bundle, its model or its validation verdict passed the
+    # record omitting its bundle, its model or the machine it ran on passed the
     # first check and told a reader nothing about how it was made. Fails the run
     # for the same reason as above: an unattestable artifact left behind is the
     # defect, not the error message about it.
+    #
+    # Two failures, not one. A record that *could not be checked* is not a
+    # record that passed, and a sweep that silently stopped checking would
+    # produce a whole arm of unverified records each reported as clean (#613) —
+    # the shape `canary.verdict` refuses with UNMEASURABLE one level up. Named
+    # separately so the operator can tell a broken record from a broken gate.
+    # The path comes from `record_schema_path()`, not the repo-relative
+    # constant: when the fallback fired, naming the constant would point the
+    # operator at a file that does not exist on their filesystem (#618).
+    if rec.conformance_failure:
+        raise RuntimeError(
+            f"run {spec.label} for {spec.project} wrote a provenance record "
+            f"whose conformance could not be established, so it is unverified "
+            f"rather than valid: {rec.conformance_failure}")
     if rec.conformance:
         raise RuntimeError(
             f"run {spec.label} for {spec.project} wrote a provenance record "
-            f"that does not conform to {provenance.RECORD_SCHEMA}: "
+            f"that does not conform to {provenance.record_schema_path()}: "
             + "; ".join(rec.conformance[:5])
             + (f" (+{len(rec.conformance) - 5} more)"
                if len(rec.conformance) > 5 else ""))

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -2167,6 +2167,30 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             # from exactly this field. Validation is local and free, and it
             # checks the bytes on disk now rather than a claim recorded earlier.
             problems = validate_outputs(spec)
+            # And conformance, for the third time on this exit and for the same
+            # reason as the first two (#619). `check_provenance` asks whether a
+            # usable record exists, not whether it conforms — so a record
+            # written by any other path (`d4d provenance record`, a backfill, a
+            # run that failed the gate and was resumed) came back through here
+            # as a success. That is the #582 shape the gate below refuses,
+            # reached by the exit that skips the gate.
+            #
+            # Recomputed from the bytes on disk rather than trusted from the
+            # record, exactly as validation and the three checks are.
+            conformance, conformance_failure = provenance.check_record(existing)
+            if conformance_failure:
+                raise RuntimeError(
+                    f"run {spec.label} for {spec.project} has a provenance "
+                    f"record whose conformance could not be established, so it "
+                    f"is unverified rather than valid: {conformance_failure}")
+            if conformance:
+                raise RuntimeError(
+                    f"run {spec.label} for {spec.project} has a provenance "
+                    f"record that does not conform to "
+                    f"{provenance.record_schema_path()}: "
+                    + "; ".join(conformance[:5])
+                    + (f" (+{len(conformance) - 5} more)"
+                       if len(conformance) > 5 else ""))
             # The three checks too, recomputed from the bytes on disk for the
             # same reason validation is (#599). Omitting them made every metric
             # None on a resumed batch, so the canary reported `unmeasurable`

--- a/src/data_sheets_schema/cli/api.py
+++ b/src/data_sheets_schema/cli/api.py
@@ -90,6 +90,22 @@ def _require_bundle(spec, project, bundle):
         raise click.ClickException(f"bundle not found: {spec.bundle}")
 
 
+def _canary_never_ran(spec, baseline, what_happened: str) -> str:
+    """The stop message for a canary that produced no verdict at all (#619).
+
+    Distinct from a canary that ran and regressed: there, the gate can name the
+    metric that moved. Here there is no measurement, and "no measurement" is
+    the one thing this corpus insists must not read as "fine".
+    """
+    return (f"canary did not pass: the first run ({spec.project} "
+            f"{spec.label}) never produced a verdict against the {baseline} "
+            f"baseline because {what_happened}. Fanning out would spend the "
+            "rest of the sweep on a failure that has not been diagnosed, and "
+            "these failures are usually systematic — the remaining runs would "
+            "hit it too, each after being billed. Fix it and re-run, or pass "
+            "--no-canary-gate to proceed anyway.")
+
+
 @click.group()
 def api():
     """Generate D4D records via the Anthropic API (six-phase)."""
@@ -321,6 +337,9 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
 
     ok, failed, spent_in, spent_out = [], [], 0, 0
     canary_stop: str | None = None
+    #: Whether the fan-out is gated on the first run at all. Read in three
+    #: places, so it is computed once rather than restated (#619).
+    gating = bool(canary_baseline) and not no_canary_gate
     for i, s in enumerate(specs, 1):
         click.echo(f"\n[{i}/{len(specs)}] {s.project} {s.label}")
         try:
@@ -340,8 +359,14 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
                                err=True)
                 failed.append((s.project, s.label,
                                f"{len(vp)} validation failure(s)"))
-                if not continue_on_error:
+                if gating and i == 1:
+                    canary_stop = _canary_never_ran(
+                        s, canary_baseline,
+                        f"it produced {len(vp)} validation failure(s)")
+                if not continue_on_error and not canary_stop:
                     click.echo("stopping; re-run to resume", err=True)
+                    break
+                if canary_stop:
                     break
                 continue
             click.echo(f"   ✓ in={spent_in:,} out={spent_out:,} cache_read={cached:,}{note}")
@@ -355,7 +380,7 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
                 f"{name}={'—' if v is None else v}"
                 for name, v in counts.items()))
 
-            if i == 1 and canary_baseline and not no_canary_gate:
+            if i == 1 and gating:
                 bar = _canary.baseline_for(s.project, canary_baseline)
                 v = _canary.verdict(res.get("checks") or {}, bar,
                                     baseline_requested=True)
@@ -389,6 +414,20 @@ def batch_cmd(projects, arm, condition, replicates, label_prefix, dry_run,
         except Exception as exc:                       # noqa: BLE001
             click.echo(f"   ❌ {type(exc).__name__}: {exc}", err=True)
             failed.append((s.project, s.label, str(exc)))
+            # A canary that *raised* has not passed, and before #619 nothing
+            # said so: `canary_stop` was only ever set by a verdict, so a first
+            # run that threw left the gate unevaluated and `--continue-on-error`
+            # fanned out to the rest of the sweep. The failures that reach here
+            # are systematic by construction — a broken validator, a writer the
+            # schema does not know, an unreachable route — so they recur on
+            # every run, after each is fully billed, and `ok` ends up empty.
+            #
+            # This is the gate's whole purpose stated the other way round: it
+            # must fan out only on a canary that demonstrably passed, never
+            # merely on one that failed to say it did not.
+            if gating and i == 1:
+                canary_stop = _canary_never_ran(
+                    s, canary_baseline, f"it raised {type(exc).__name__}")
             if not continue_on_error:
                 click.echo("stopping; re-run to resume unfinished phases", err=True)
                 break

--- a/src/data_sheets_schema/cli/provenance.py
+++ b/src/data_sheets_schema/cli/provenance.py
@@ -676,9 +676,14 @@ def validate_records(strict, label):
     import subprocess
     import sys
 
-    from data_sheets_schema.provenance import CONCAT_DIR
+    from data_sheets_schema.provenance import CONCAT_DIR, record_schema_path
 
-    schema = Path("src/data_sheets_schema/schema/d4d_generation_record.yaml")
+    # Resolved, not hardcoded (#620). Run from outside the repo root the
+    # literal path does not exist and `linkml-validate` exits non-zero on every
+    # record, reporting a clean corpus as entirely failing. Loud rather than
+    # silent, so not the #618 failure mode — but #618 fixed the gate and left
+    # the command it was written about still holding the literal.
+    schema = record_schema_path()
     paths = sorted(CONCAT_DIR.glob("*_core/*/*_provenance.yaml"))
     if label:
         paths = [p for p in paths if p.parts[-2] == label]

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -788,9 +788,60 @@ def preservable_validation(path: Path,
     return v
 
 
+#: The schema a generation record must conform to. Not imported by
+#: `data_sheets_schema.yaml`: it describes the pipeline rather than a dataset,
+#: so importing it would move the `Dataset` digest an arm is frozen against.
+#:
+#: Repo-relative to match `FULL_SCHEMA` and `CORE_SCHEMA` above, but resolved
+#: against the installed package when that does not exist. The others are read
+#: by commands run from the repo root; this one is read on the *generation*
+#: path, and a gate that silently no-ops when a sweep is launched from
+#: elsewhere is the failure mode #582 recorded — a check that exists but is not
+#: on the path it guards.
+RECORD_SCHEMA = Path("src/data_sheets_schema/schema/d4d_generation_record.yaml")
+
+
+def record_schema_path() -> Path:
+    """`RECORD_SCHEMA` if it resolves from here, else the packaged copy."""
+    if RECORD_SCHEMA.exists():
+        return RECORD_SCHEMA
+    return Path(__file__).resolve().parent / "schema" / RECORD_SCHEMA.name
+
+
+def record_conformance(data: dict[str, Any]) -> list[str]:
+    """Schema violations in a record about to be written, as messages (#605).
+
+    Validation existed only as the manual `d4d provenance validate-records`, so
+    a run could declare success having written a record that does not conform —
+    the shape #582 fixed for the schema digest, reproduced for the record
+    schema in the same week.
+
+    Returns messages rather than raising, and returns none when the validator
+    itself cannot run: a record that could not be checked is not a record that
+    failed, and refusing to write one because a dependency is missing would
+    lose the run's only account of itself.
+
+    That silence is the honest answer for a missing dependency and would be the
+    wrong one for a missing schema, so `record_schema_path` makes the schema
+    findable rather than letting the two cases collapse into each other.
+    """
+    try:
+        from linkml.validator import validate
+        report = validate(data, str(record_schema_path()),
+                          "GenerationRecord")
+    except Exception:                                          # noqa: BLE001
+        return []
+    return [str(r.message) for r in getattr(report, "results", [])]
+
+
 @dataclass
 class ProvenanceRecord:
     data: dict[str, Any] = field(default_factory=dict)
+
+    #: Set by :meth:`write`. Schema violations found in what was just written;
+    #: empty when it conforms, and empty when the validator could not run,
+    #: which are different things the caller can tell apart by asking.
+    conformance: list[str] = field(default_factory=list)
 
     #: Set by :meth:`write`. True if a prior verdict was carried forward, False
     #: if one was found but dropped as stale, None if there was none. The CLI
@@ -820,6 +871,12 @@ class ProvenanceRecord:
             f"# record_version {RECORD_VERSION} — see src/data_sheets_schema/provenance.py\n"
             + yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
             encoding="utf-8")
+        # Checked here, on the write path, not only by a command someone
+        # remembers to run (#605). Reported rather than raised: the record is
+        # already on disk and is the run's only account of itself, so losing it
+        # to a schema complaint would cost more than the complaint is worth.
+        # The caller decides — `d4d api run` fails the run on it.
+        self.conformance = record_conformance(data)
         return path
 
 

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -847,10 +847,16 @@ def check_record(data: dict[str, Any]) -> tuple[list[str], str | None]:
 def record_conformance(data: dict[str, Any]) -> list[str]:
     """Violations only, for a caller that has separately handled the failure.
 
-    Kept because "what is wrong with this record" is a common question, and
-    because `d4d provenance validate-records` reports per-record findings. Do
-    not use it to decide that a record is *fine* — `check_record` is the call
-    that can say so.
+    **Never use this to decide that a record is fine.** An empty list means
+    "no violations found", which includes "found nothing because the validator
+    could not run" — `check_record` is the only call that distinguishes them,
+    and collapsing the two is #613 itself.
+
+    Kept for the narrow case of asking what is wrong with a record already
+    known to be checkable — chiefly tests, which assert on findings. The
+    justification given when this was split out named `d4d provenance
+    validate-records` as a caller; that command shells out to `linkml-validate`
+    and has never called this (#620).
     """
     return check_record(data)[0]
 

--- a/src/data_sheets_schema/provenance.py
+++ b/src/data_sheets_schema/provenance.py
@@ -808,40 +808,66 @@ def record_schema_path() -> Path:
     return Path(__file__).resolve().parent / "schema" / RECORD_SCHEMA.name
 
 
-def record_conformance(data: dict[str, Any]) -> list[str]:
-    """Schema violations in a record about to be written, as messages (#605).
+def check_record(data: dict[str, Any]) -> tuple[list[str], str | None]:
+    """`(violations, why it could not be checked)` for a record (#605).
 
     Validation existed only as the manual `d4d provenance validate-records`, so
     a run could declare success having written a record that does not conform —
-    the shape #582 fixed for the schema digest, reproduced for the record
-    schema in the same week.
+    the shape #582 fixed for the schema digest, reproduced for the record schema
+    in the same week.
 
-    Returns messages rather than raising, and returns none when the validator
-    itself cannot run: a record that could not be checked is not a record that
-    failed, and refusing to write one because a dependency is missing would
-    lose the run's only account of itself.
+    **Exactly one of the two is meaningful, and an empty list alone does not
+    mean "conforms".** The first version returned only the list and returned it
+    empty when the validator itself could not run, so any dependency conflict or
+    schema-compilation error silently disabled the gate for every run in a sweep
+    while each printed a tick — "not established" read as "fine", inside the gate
+    built to stop exactly that (#613). Two places in this codebase already get
+    it right and are the model here: `_validator_lines` in `api_runner`, whose
+    `findings` is None precisely when `failure` says why, and `canary.verdict`,
+    whose `blind` metrics make a run `UNMEASURABLE` rather than `ok`.
 
-    That silence is the honest answer for a missing dependency and would be the
-    wrong one for a missing schema, so `record_schema_path` makes the schema
-    findable rather than letting the two cases collapse into each other.
+    Raising is still wrong: the record is the run's only account of itself and
+    must reach disk. The caller decides what an unverifiable record is worth,
+    and `execute()` treats it as a failure.
     """
     try:
         from linkml.validator import validate
-        report = validate(data, str(record_schema_path()),
-                          "GenerationRecord")
-    except Exception:                                          # noqa: BLE001
-        return []
-    return [str(r.message) for r in getattr(report, "results", [])]
+    except Exception as exc:                                   # noqa: BLE001
+        return [], f"the linkml validator is unavailable: {exc}"
+    schema = record_schema_path()
+    if not schema.exists():
+        return [], f"the record schema is not at {schema}"
+    try:
+        report = validate(data, str(schema), "GenerationRecord")
+    except Exception as exc:                                   # noqa: BLE001
+        return [], f"the validator could not run against {schema}: {exc}"
+    return [str(r.message) for r in getattr(report, "results", [])], None
+
+
+def record_conformance(data: dict[str, Any]) -> list[str]:
+    """Violations only, for a caller that has separately handled the failure.
+
+    Kept because "what is wrong with this record" is a common question, and
+    because `d4d provenance validate-records` reports per-record findings. Do
+    not use it to decide that a record is *fine* — `check_record` is the call
+    that can say so.
+    """
+    return check_record(data)[0]
 
 
 @dataclass
 class ProvenanceRecord:
     data: dict[str, Any] = field(default_factory=dict)
 
-    #: Set by :meth:`write`. Schema violations found in what was just written;
-    #: empty when it conforms, and empty when the validator could not run,
-    #: which are different things the caller can tell apart by asking.
+    #: Set by :meth:`write`. Schema violations found in what was just written.
+    #: Empty when the record conforms *and* when it could not be checked — read
+    #: :attr:`conformance_failure` to tell those apart (#613).
     conformance: list[str] = field(default_factory=list)
+
+    #: Set by :meth:`write`. Why conformance could not be established, or None
+    #: when it was. A record that could not be checked is not a record that
+    #: passed, and this is the field that says which happened.
+    conformance_failure: str | None = None
 
     #: Set by :meth:`write`. True if a prior verdict was carried forward, False
     #: if one was found but dropped as stale, None if there was none. The CLI
@@ -875,8 +901,8 @@ class ProvenanceRecord:
         # remembers to run (#605). Reported rather than raised: the record is
         # already on disk and is the run's only account of itself, so losing it
         # to a schema complaint would cost more than the complaint is worth.
-        # The caller decides — `d4d api run` fails the run on it.
-        self.conformance = record_conformance(data)
+        # The caller decides — `d4d api run` fails the run on either outcome.
+        self.conformance, self.conformance_failure = check_record(data)
         return path
 
 

--- a/src/data_sheets_schema/schema/d4d_generation_record.yaml
+++ b/src/data_sheets_schema/schema/d4d_generation_record.yaml
@@ -313,11 +313,13 @@ classes:
       # `build_record` itself, so the two cannot drift apart again.
       #
       # These fail nothing **within the scope every checker uses** — the 195
-      # records under `*_core/`. Three `curated/` records sit outside that glob
-      # and do not conform; three of their five violations predate this schema
-      # and the reconstructed rule adds `system` to them (#616). Saying "fails
-      # nothing" without naming the scope would be the same overreach as
-      # measuring the archive and calling it the writers.
+      # records under `*_core/`. Three `curated/` records sit outside the glob
+      # that `d4d provenance validate-records` uses and do not conform: three
+      # of their four violations predate this schema and the reconstructed rule
+      # adds `system` (#616). Saying "fails nothing" without naming the scope
+      # would be the same overreach as measuring the archive and calling it the
+      # writers — and the count was itself wrong at first, five rather than
+      # four, which is the same failure one level down (#620).
       - title: a live run observed its own inputs, model and machine
         preconditions:
           slot_conditions:
@@ -346,7 +348,7 @@ classes:
               required: true
             unrecoverable:
               required: true
-      - title: the two discriminators agree
+      - title: a derived mode implies a derived type
         description: >-
           `record_mode` and `record_type` are set by the same writer and must
           not disagree; a `derived` record typed as a generation record would
@@ -359,6 +361,22 @@ classes:
           slot_conditions:
             record_type:
               equals_string: d4d_derived_provenance
+      - title: a derived type implies a derived mode
+        description: >-
+          The converse, which the first version left open (#620): a record
+          typed `d4d_derived_provenance` while calling itself `live` validated.
+          The description claimed a mismatch "would tell a reader the opposite"
+          — true in both directions, checked in one. Two rules rather than one
+          because a precondition tests a single value, so neither direction
+          implies the other.
+        preconditions:
+          slot_conditions:
+            record_type:
+              equals_string: d4d_derived_provenance
+        postconditions:
+          slot_conditions:
+            record_mode:
+              equals_string: derived
       - title: a derived record declares what it was derived from
         preconditions:
           slot_conditions:

--- a/src/data_sheets_schema/schema/d4d_generation_record.yaml
+++ b/src/data_sheets_schema/schema/d4d_generation_record.yaml
@@ -41,7 +41,12 @@ classes:
     attributes:
 
       record_type:
-        description: Always `d4d_generation_provenance`; names the kind of file.
+        description: >-
+          Names the kind of file. Not always `d4d_generation_provenance`, as
+          this said before it was checked: a derived record writes
+          `d4d_derived_provenance`, and calling both by one name would hide the
+          distinction the mode exists to draw.
+        range: RecordType
         required: true
       record_version:
         description: >-
@@ -90,7 +95,14 @@ classes:
         range: AnyBlock
 
       outputs:
-        description: The records this run wrote, by path and hash.
+        description: >-
+          The records this run wrote, by path and size — **not** by hash for a
+          generation record. `_artifact` drops the hash deliberately: the agent
+          path records provenance as a separate step from writing the
+          artifacts, so 77 live records had hashed a state their files merely
+          passed through. Integrity lives in `validation.artifacts`, computed
+          after the run is final. A *derived* record does hash its outputs,
+          because it writes and hashes them in one step.
         required: true
         inlined: true
         range: AnyBlock
@@ -164,6 +176,21 @@ classes:
         description: Validator-driven repair rounds, in order.
         multivalued: true
         inlined_as_list: true
+        range: AnyBlock
+
+      report_regenerated_after_repair:
+        description: >-
+          Present when repair rewrote a record after the reconciliation report
+          was written, naming which records changed and why the report was
+          regenerated (#604). Absent on the ordinary path, where the report
+          already describes the final bytes.
+
+          Missing from the first version of this schema, and found by the
+          conformance gate on its first run rather than by inspection: no
+          record on disk carries it, so validating the corpus could not have
+          reached it. That is the difference the gate makes — it checks the
+          writers, not the archive.
+        inlined: true
         range: AnyBlock
 
       intermediates:
@@ -259,6 +286,74 @@ classes:
         inlined: true
         range: AnyBlock
 
+    rules:
+      # Conditional by mode, because the modes genuinely differ and blanket
+      # optionality made the schema assert almost nothing: a `live` record
+      # validated while omitting its bundle, its model, its validation verdict
+      # and all three post-generation checks (#605).
+      #
+      # Each list below is what *every* record of that mode already carries,
+      # measured across 195 records rather than chosen — so these fail nothing
+      # retroactively and describe the writers as they are.
+      - title: a live run observed its own inputs, model and machine
+        preconditions:
+          slot_conditions:
+            record_mode:
+              equals_string: live
+        postconditions:
+          slot_conditions:
+            inputs:
+              required: true
+            model:
+              required: true
+            system:
+              required: true
+            validation:
+              required: true
+      - title: a reconstructed record names what it could not recover
+        preconditions:
+          slot_conditions:
+            record_mode:
+              equals_string: reconstructed
+        postconditions:
+          slot_conditions:
+            inputs:
+              required: true
+            model:
+              required: true
+            system:
+              required: true
+            validation:
+              required: true
+            unrecoverable:
+              required: true
+      - title: the two discriminators agree
+        description: >-
+          `record_mode` and `record_type` are set by the same writer and must
+          not disagree; a `derived` record typed as a generation record would
+          pass every mode rule below while telling a reader the opposite.
+        preconditions:
+          slot_conditions:
+            record_mode:
+              equals_string: derived
+        postconditions:
+          slot_conditions:
+            record_type:
+              equals_string: d4d_derived_provenance
+      - title: a derived record declares what it was derived from
+        preconditions:
+          slot_conditions:
+            record_mode:
+              equals_string: derived
+        postconditions:
+          slot_conditions:
+            derivation:
+              required: true
+            sources:
+              required: true
+            not_applicable:
+              required: true
+
   RunIdentity:
     description: Which run this is.
     attributes:
@@ -299,9 +394,16 @@ classes:
         required: true
       digest_md5:
         description: >-
-          Fingerprint of the rendered digest the model was sent. This is what a
-          straddle check compares, and what the digest inventory keys on. Absent
-          on records written before the digest was recorded.
+          Fingerprint of the rendered schema digest, which a straddle check
+          compares and the digest inventory keys on.
+
+          **When it was computed differs by runtime**, and the two are not the
+          same claim. The API path fingerprints the digest as it renders it to
+          send, so the value is of the bytes the model received. The agentic
+          recorder runs after generation and fingerprints the schema as it
+          stands then — the same value whenever the schema did not move mid-run,
+          and an unfalsifiable assumption when it did. Absent on records written
+          before the digest was recorded.
       full_md5:
       core_md5:
       full_sha256:
@@ -358,6 +460,19 @@ classes:
     class_uri: linkml:Any
 
 enums:
+  RecordType:
+    description: >-
+      What kind of record this is. Two values across 195 records; enumerated
+      rather than left open so a typo in the discriminator is a validation
+      failure and not a silently unmatched record.
+    permissible_values:
+      d4d_generation_provenance:
+        description: A run's account of generating a full/core pair.
+      d4d_derived_provenance:
+        description: >-
+          An account of a record computed from other records. Pairs with
+          `record_mode: derived`.
+
   RecordMode:
     description: How much of a record is observed rather than reconstructed.
     permissible_values:

--- a/src/data_sheets_schema/schema/d4d_generation_record.yaml
+++ b/src/data_sheets_schema/schema/d4d_generation_record.yaml
@@ -190,6 +190,12 @@ classes:
           record on disk carries it, so validating the corpus could not have
           reached it. That is the difference the gate makes — it checks the
           writers, not the archive.
+
+          Exactly one other attribute is in the same position: `companions`,
+          which `build_record` writes unconditionally and which will appear on
+          the next record written. Named here because presenting this field as
+          the single thing the gate surfaced would overstate a real result by
+          leaving out its twin (#618).
         inlined: true
         range: AnyBlock
 
@@ -292,9 +298,26 @@ classes:
       # validated while omitting its bundle, its model, its validation verdict
       # and all three post-generation checks (#605).
       #
-      # Each list below is what *every* record of that mode already carries,
-      # measured across 195 records rather than chosen — so these fail nothing
-      # retroactively and describe the writers as they are.
+      # Each list below is what `build_record` — the single writer both runtimes
+      # go through — **emits at write time**, not what the archive happens to
+      # hold.
+      #
+      # The first version got that wrong in a way worth recording. It required
+      # `validation` on the strength of "all 158 live records carry it". They
+      # do, because `d4d runs validate` sweeps the corpus afterwards; the writer
+      # never emits it. So the rule rejected every freshly written agentic
+      # record, and the justification — "describes the writers as they are" —
+      # described the archive after a later step had touched it (#612).
+      #
+      # `tests/test_generation_record_schema.py` now derives these lists from
+      # `build_record` itself, so the two cannot drift apart again.
+      #
+      # These fail nothing **within the scope every checker uses** — the 195
+      # records under `*_core/`. Three `curated/` records sit outside that glob
+      # and do not conform; three of their five violations predate this schema
+      # and the reconstructed rule adds `system` to them (#616). Saying "fails
+      # nothing" without naming the scope would be the same overreach as
+      # measuring the archive and calling it the writers.
       - title: a live run observed its own inputs, model and machine
         preconditions:
           slot_conditions:
@@ -308,8 +331,6 @@ classes:
               required: true
             system:
               required: true
-            validation:
-              required: true
       - title: a reconstructed record names what it could not recover
         preconditions:
           slot_conditions:
@@ -322,8 +343,6 @@ classes:
             model:
               required: true
             system:
-              required: true
-            validation:
               required: true
             unrecoverable:
               required: true

--- a/tests/test_canary_gate.py
+++ b/tests/test_canary_gate.py
@@ -199,7 +199,31 @@ class GateControlFlowTest(unittest.TestCase):
     def test_the_gate_is_opt_in_and_says_how_to_bypass(self):
         src = self._source()
         self.assertIn("--no-canary-gate", src)
-        self.assertIn("canary_baseline and not no_canary_gate", src)
+        # The condition is now bound once as `gating` rather than restated at
+        # each of its three uses (#619) — it is read by the verdict block and
+        # by both paths where the first run fails without producing a verdict.
+        self.assertIn("gating = bool(canary_baseline) and not no_canary_gate",
+                      src)
+
+    def test_a_first_run_that_never_produced_a_verdict_stops_the_fan_out(self):
+        """A canary that raised has not passed (#619).
+
+        `canary_stop` used to be set only by a verdict, so a first run that
+        threw — or that produced invalid output and `continue`d — left the gate
+        unevaluated, and `--continue-on-error` fanned out to the rest of the
+        sweep. Conformance failures make this concrete: they are systematic, so
+        they recur on every run, after each is fully billed.
+
+        Asserted on the source because the alternative is driving a billed
+        sweep. Both sites are checked, since the `validation_problems` branch
+        previously jumped past the `if canary_stop: break` via its `continue`.
+        """
+        src = self._source()
+        self.assertEqual(src.count("_canary_never_ran("), 2,
+                         "both no-verdict paths must set the stop")
+        self.assertIn("if not continue_on_error and not canary_stop:", src,
+                      "the invalid-output path must not `continue` past the "
+                      "stop it just set")
 
 
 class ResolverUrlMetricTest(unittest.TestCase):

--- a/tests/test_download/test_api_runner.py
+++ b/tests/test_download/test_api_runner.py
@@ -1722,25 +1722,40 @@ class TestResumeUsesArtifactsNotOnlyProgress(unittest.TestCase):
         self._write_provenance(spec, label=label)
 
     def _write_provenance(self, spec, *, label=None):
-        """Provenance matching whatever is on disk *now*."""
+        """Provenance matching whatever is on disk *now*.
+
+        Built with `build_record`, the writer the pipeline itself uses, rather
+        than hand-assembled. It used to be a stub of four keys, and the resume
+        exit's conformance gate (#619) rejected it — correctly, since no writer
+        produces such a record. A fixture that cannot pass the gate the code
+        under test applies is testing a situation that does not arise, and
+        weakening the gate to accommodate it would have been the wrong fix.
+
+        Going through the real writer also means the fixture cannot drift away
+        from the schema again: a field the writer gains, it gains.
+        """
         import hashlib
         import yaml as _yaml
+
+        from data_sheets_schema.provenance import build_record
         def sha(p):
             return hashlib.sha256(p.read_bytes()).hexdigest()
+        rec = build_record(spec.project, spec.method, label or spec.label,
+                           mode="live", input_bundle=spec.bundle,
+                           input_verified=True, concat_dir=spec.out_dir)
+        data = dict(rec.data)
+        data["run"] = {**(data.get("run") or {}), "method": spec.method,
+                       "label": label or spec.label, "project": spec.project}
+        data["api_usage"] = [{"phase": ph, "input_tokens": 100,
+                              "output_tokens": 200} for ph in
+                             ("full", "core", "audit", "reconcile_full",
+                              "reconcile_core", "report")]
+        data["validation"] = {"artifacts": {
+            "full": {"path": str(spec.full_path), "sha256": sha(spec.full_path)},
+            "core": {"path": str(spec.core_path), "sha256": sha(spec.core_path)},
+        }}
         spec.provenance_path.parent.mkdir(parents=True, exist_ok=True)
-        spec.provenance_path.write_text(_yaml.safe_dump({
-            "record_mode": "live",
-            "run": {"method": spec.method, "label": label or spec.label,
-                    "project": spec.project},
-            "api_usage": [{"phase": ph, "input_tokens": 100,
-                           "output_tokens": 200} for ph in
-                          ("full", "core", "audit", "reconcile_full",
-                           "reconcile_core", "report")],
-            "validation": {"artifacts": {
-                "full": {"path": str(spec.full_path), "sha256": sha(spec.full_path)},
-                "core": {"path": str(spec.core_path), "sha256": sha(spec.core_path)},
-            }},
-        }))
+        spec.provenance_path.write_text(_yaml.safe_dump(data))
 
     def _no_api(self, called):
         class C:
@@ -1762,6 +1777,41 @@ class TestResumeUsesArtifactsNotOnlyProgress(unittest.TestCase):
             execute(spec, client=self._no_api(called))
             self.assertEqual(called["n"], 0,
                              "a completed run must cost nothing to resume")
+
+    def test_resume_will_not_report_a_non_conforming_record_as_complete(self):
+        """The resume exit has now been patched three times for one omission.
+
+        It returns `already_complete: True` after `check_provenance`, which asks
+        whether a *usable* record exists — never whether it conforms. So a
+        record written by any other path (`d4d provenance record`, a backfill,
+        a run that failed the gate) came back through here as a success and
+        `d4d api batch` counted it in `ok` (#619).
+
+        The same exit previously reported `[]` validation problems about records
+        it never looked at, and `None` for all three checks (#599). This is the
+        third instance, so it gets a test rather than a comment.
+        """
+        import tempfile
+
+        import yaml as _yaml
+
+        from data_sheets_schema.api_runner import execute
+
+        with tempfile.TemporaryDirectory() as td:
+            spec = self._spec(td)
+            self._complete_run(spec)
+            data = _yaml.safe_load(
+                spec.provenance_path.read_text(encoding="utf-8"))
+            # A live record with no `system`: rejected only by the mode rule,
+            # and exactly the kind of record another writer could leave behind.
+            data.pop("system")
+            spec.provenance_path.write_text(_yaml.safe_dump(data))
+            called = {"n": 0}
+            with self.assertRaises(RuntimeError) as caught:
+                execute(spec, client=self._no_api(called))
+            self.assertIn("system", str(caught.exception))
+            self.assertEqual(called["n"], 0,
+                             "the gate must refuse before spending anything")
 
     def test_resuming_a_completed_run_preserves_its_provenance(self):
         """Resume must not restamp the record it is resuming.

--- a/tests/test_generation_record_schema.py
+++ b/tests/test_generation_record_schema.py
@@ -11,6 +11,7 @@ records the shape genuinely varies by `record_mode`, and requiring a field an
 honest record cannot have would make the schema a fiction.
 """
 
+import re
 import subprocess
 import unittest
 from pathlib import Path
@@ -127,6 +128,205 @@ class CorpusValidatesTest(unittest.TestCase):
                  "-C", "GenerationRecord", str(bad)],
                 capture_output=True, text=True, timeout=300)
             self.assertNotEqual(r.returncode, 0)
+
+
+class ModeSpecificRequirements(unittest.TestCase):
+    """#605: the schema was mode-blind, so it asserted almost nothing.
+
+    Every field named here is one that *every* record of that mode already
+    carries — measured across the 195 records on disk, not chosen. So these
+    tests assert that the schema now discriminates by mode, and the corpus test
+    below asserts the requirements are not inventions that fail honest records.
+    """
+
+    #: The gap that motivated the issue: each of these was absent from a `live`
+    #: record that validated anyway.
+    LIVE_REQUIRED = ("inputs", "model", "system", "validation")
+
+    def _record(self):
+        from data_sheets_schema.provenance import record_conformance
+        path = (Path("data/d4d_concatenated/claudecode_agent_core")
+                / "2026-08-13_claude-opus-5-api-generic-v4_rep1"
+                / "CHORUS_provenance.yaml")
+        if not (path.exists() and SCHEMA.exists()):
+            self.skipTest("record or schema not present in this checkout")
+        record = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if record_conformance(record):
+            self.skipTest("validator unavailable or baseline record non-conforming")
+        return record
+
+    def test_a_live_record_must_carry_what_a_live_run_observed(self):
+        from data_sheets_schema.provenance import record_conformance
+        record = self._record()
+        for field in self.LIVE_REQUIRED:
+            with self.subTest(field=field):
+                short = {k: v for k, v in record.items() if k != field}
+                self.assertTrue(
+                    record_conformance(short),
+                    f"a live record with no {field!r} validated; before #605 "
+                    "all four of these did")
+
+    def test_a_derived_record_may_omit_them(self):
+        """The requirements must be conditional, not a blanket tightening.
+
+        A derived record consumes records rather than a bundle and has no model
+        at all. If dropping the mode made no difference to the verdict, the
+        rules would be requiring these of everything, and four honest records
+        on disk would be reclassified as defective.
+        """
+        from data_sheets_schema.provenance import record_conformance
+        record = self._record()
+        derived = {k: v for k, v in record.items()
+                   if k not in self.LIVE_REQUIRED}
+        derived.update(record_mode="derived",
+                       record_type="d4d_derived_provenance",
+                       derivation={"method": "test"},
+                       sources=[{"path": "x", "sha256": "y"}],
+                       not_applicable=[{"field": "model", "reason": "test"}])
+        self.assertEqual(record_conformance(derived), [])
+
+    def test_the_two_discriminators_cannot_disagree(self):
+        from data_sheets_schema.provenance import record_conformance
+        record = self._record()
+        confused = {**record, "record_mode": "derived"}
+        self.assertTrue(record_conformance(confused),
+                        "a record calling itself derived while typed as a "
+                        "generation record validated")
+
+    def test_every_record_on_disk_still_conforms(self):
+        """The requirements describe the writers; they do not fail the corpus.
+
+        A rule that is right in principle and rejects records nobody can
+        regenerate is not an improvement — it is a schema that has to be
+        ignored, which is where this started.
+        """
+        from data_sheets_schema.provenance import record_conformance
+        records = sorted(Path("data/d4d_concatenated").glob(
+            "*_core/*/*_provenance.yaml"))
+        if not records:
+            self.skipTest("no records in this checkout")
+        failures = []
+        for path in records:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            for message in record_conformance(data):
+                failures.append(f"{path}: {message}")
+        self.assertEqual(failures[:5], [], f"{len(failures)} violations")
+
+
+class ConformanceIsOnTheGenerationPath(unittest.TestCase):
+    """A check that exists but does not run on the path it guards is #582.
+
+    Validation used to be reachable only through `d4d provenance
+    validate-records`, so a run could finish, report success, and leave a
+    non-conforming record behind.
+    """
+
+    def test_write_reports_conformance_of_what_it_wrote(self):
+        import tempfile
+
+        from data_sheets_schema.provenance import ProvenanceRecord
+        path = (Path("data/d4d_concatenated/claudecode_agent_core")
+                / "2026-08-13_claude-opus-5-api-generic-v4_rep1"
+                / "CHORUS_provenance.yaml")
+        if not (path.exists() and SCHEMA.exists()):
+            self.skipTest("record or schema not present in this checkout")
+        good = yaml.safe_load(path.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as d:
+            rec = ProvenanceRecord(data=good)
+            rec.write(Path(d) / "ok.yaml")
+            if rec.conformance:
+                self.skipTest("validator unavailable in this environment")
+
+            # `validation` is preserved from a prior file by `write`, so drop a
+            # field that is not carried forward.
+            bad = {k: v for k, v in good.items() if k != "model"}
+            rec = ProvenanceRecord(data=bad)
+            out = rec.write(Path(d) / "bad.yaml")
+            self.assertTrue(rec.conformance,
+                            "write() did not notice a live record with no model")
+            self.assertTrue(out.exists(),
+                            "the record must still be written: it is the run's "
+                            "only account of itself")
+
+    def test_the_schema_is_findable_away_from_the_repo_root(self):
+        """Otherwise the gate silently passes everything a sweep writes.
+
+        `RECORD_SCHEMA` is repo-relative, matching its siblings, but those are
+        read by commands run from the repo root and this one runs during
+        generation. `record_conformance` returns no findings when it cannot
+        run, so an unresolvable path would read as "conforms".
+        """
+        import os
+        import tempfile
+
+        from data_sheets_schema.provenance import record_schema_path
+        cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory() as d:
+                os.chdir(d)
+                self.assertTrue(record_schema_path().exists())
+        finally:
+            os.chdir(cwd)
+
+
+class TheSchemaKnowsEveryFieldTheWritersWrite(unittest.TestCase):
+    """The general form of the gap the conformance gate found first.
+
+    `report_regenerated_after_repair` is written by `execute()` only when
+    repair rewrites a record after the report was rendered. No record on disk
+    carries it, so validating the corpus could not reach it, and the schema
+    forbade it — meaning the first real repair-with-report-regeneration run
+    would have failed at the new gate.
+
+    This reads the writers instead of the archive, so a field added to a rarely
+    taken branch is caught when it is added rather than when it first fires.
+    """
+
+    #: Modules that assemble a generation record. Not every module with a dict
+    #: named `data` — `src/renderer` and `src/validation` both have one and
+    #: neither writes provenance, which is why this is a list and not a glob.
+    WRITERS = ("src/data_sheets_schema/api_runner.py",
+               "src/data_sheets_schema/provenance.py")
+
+    ASSIGNMENT = re.compile(r"""(?:rec|record)\.data\[["']([a-z_]+)["']\]""")
+
+    def test_no_writer_sets_a_field_the_schema_forbids(self):
+        if not SCHEMA.exists():
+            self.skipTest("schema not present in this checkout")
+        schema = yaml.safe_load(SCHEMA.read_text(encoding="utf-8"))
+        known = set(schema["classes"]["GenerationRecord"]["attributes"])
+        unknown = {}
+        for name in self.WRITERS:
+            path = Path(name)
+            if not path.exists():
+                continue
+            for field in self.ASSIGNMENT.findall(
+                    path.read_text(encoding="utf-8")):
+                if field not in known:
+                    unknown.setdefault(field, name)
+        self.assertEqual(
+            unknown, {},
+            "these fields are written into a generation record but the schema "
+            "does not declare them, so a run taking that branch fails the "
+            f"conformance gate: {unknown}")
+
+    def test_the_check_can_see_the_writers_at_all(self):
+        """Otherwise the test above passes by finding nothing to check.
+
+        A renamed module or a changed assignment idiom would empty the scan,
+        and an empty scan trivially satisfies the assertion.
+        """
+        found = set()
+        for name in self.WRITERS:
+            path = Path(name)
+            if path.exists():
+                found |= set(self.ASSIGNMENT.findall(
+                    path.read_text(encoding="utf-8")))
+        if not any(Path(w).exists() for w in self.WRITERS):
+            self.skipTest("writers not present in this checkout")
+        self.assertIn("validation", found,
+                      "the scan found no known record field; it is not "
+                      f"reading the writers. Found: {sorted(found)}")
 
 
 if __name__ == "__main__":

--- a/tests/test_generation_record_schema.py
+++ b/tests/test_generation_record_schema.py
@@ -151,15 +151,24 @@ class ValidatorControl(unittest.TestCase):
             self.skipTest("record or schema not present in this checkout")
         record = yaml.safe_load(self.BASELINE.read_text(encoding="utf-8"))
 
-        # Positive control. A record with no `record_mode` cannot satisfy any
-        # schema, so findings here are the minimum proof the validator ran.
+        # Positive control, and specifically a control on the **rules**.
+        #
+        # The first version deleted `record_mode`, which is `required: true` at
+        # the attribute level — so it still produced findings with every rule
+        # stripped from the schema, and proved only that the validator was
+        # alive (#620). Since the regression this class exists to catch is a
+        # rule that stops being enforced, a control that survives the rules'
+        # removal guards nothing.
+        #
+        # A live record missing `model` is rejected *only* by the live rule.
+        # Verified by deleting the rules block: this comes back clean.
         findings, failure = check_record(
-            {k: v for k, v in record.items() if k != "record_mode"})
+            {k: v for k, v in record.items() if k != "model"})
         self.assertIsNone(failure, f"the validator could not run: {failure}")
         self.assertTrue(findings,
-                        "the validator reported a record with no record_mode as "
-                        "clean; every 'no violations' assertion below would pass "
-                        "vacuously")
+                        "a live record with no `model` was reported clean, so "
+                        "the mode rules are not being enforced and every 'no "
+                        "violations' assertion below would pass vacuously")
 
         findings, failure = check_record(record)
         self.assertIsNone(failure, f"the validator could not run: {failure}")
@@ -181,8 +190,27 @@ class ModeSpecificRequirements(ValidatorControl):
     """
 
     def _writer_fields(self, mode):
-        """What `build_record` actually emits for a mode, at write time."""
-        from data_sheets_schema.provenance import build_record
+        """What the real writer emits for a mode, at write time.
+
+        `derived` goes through `build_derived_record`, a different function —
+        covering it here rather than fabricating a derived record by mutating a
+        live one, since a fabrication proves nothing about what the writer
+        emits and `derived` has the most required fields of the three (#620).
+        """
+        import tempfile
+
+        from data_sheets_schema.provenance import (Contribution, build_record,
+                                                   build_derived_record)
+        if mode == "derived":
+            with tempfile.TemporaryDirectory() as d:
+                out = Path(d) / "X_d4d.yaml"
+                out.write_text("id: x\n", encoding="utf-8")
+                return build_derived_record(
+                    "AI_READI", "claudecode_agent", "test",
+                    sources=[Contribution(label="l", project="AI_READI",
+                                          method="claudecode_agent",
+                                          path=str(out), sha256="deadbeef")],
+                    derivation="a test record", outputs={"full": out}).data
         bundle = Path("data/preprocessed/concatenated/AI_READI_preprocessed.txt")
         if not bundle.exists():
             self.skipTest("no bundle in this checkout to build a record from")
@@ -213,7 +241,7 @@ class ModeSpecificRequirements(ValidatorControl):
         """
         if not SCHEMA.exists():
             self.skipTest("schema not present in this checkout")
-        for mode in ("live", "reconstructed"):
+        for mode in ("live", "reconstructed", "derived"):
             with self.subTest(mode=mode):
                 written = set(self._writer_fields(mode))
                 missing = sorted(self._rule_requirements(mode) - written)
@@ -227,7 +255,7 @@ class ModeSpecificRequirements(ValidatorControl):
         """The same thing end to end, through the real builder."""
         self._control()
         from data_sheets_schema.provenance import check_record
-        for mode in ("live", "reconstructed"):
+        for mode in ("live", "reconstructed", "derived"):
             with self.subTest(mode=mode):
                 findings, failure = check_record(self._writer_fields(mode))
                 self.assertIsNone(failure)
@@ -434,14 +462,28 @@ class TheSchemaKnowsEveryFieldTheWritersWrite(unittest.TestCase):
     #: `data` — progress files, phase payloads — and reports them as forbidden
     #: record fields. `src/renderer` and `src/validation` have one too, and
     #: neither writes provenance.
+    #: Round 2 (#620) found five more record-mutating functions absent from the
+    #: first version of this list, and three idioms the scan could not see.
+    #: None violated the schema, but the docstring claimed "every record field
+    #: any writer sets" — so the guard was narrower than the promise, which is
+    #: the failure mode it exists to prevent one level up.
     WRITERS = {
         "src/data_sheets_schema/provenance.py": {
             "build_record": ("data",),
             "build_derived_record": ("data",),
+            "apply_observed_effort": ("data",),
+            "apply_effort_basis": ("data",),
+            "apply_historical_prompt": ("data",),
         },
         "src/data_sheets_schema/cli/runs.py": {
             "validate_cmd": ("data",),
             "select_cmd": ("data", "prior"),
+        },
+        "src/data_sheets_schema/cli/provenance.py": {
+            "backfill_context": ("rec",),
+        },
+        "src/data_sheets_schema/backfill_checks.py": {
+            "apply": ("record",),
         },
     }
 
@@ -473,13 +515,40 @@ class TheSchemaKnowsEveryFieldTheWritersWrite(unittest.TestCase):
                 if not locals_:
                     continue
                 for node in ast.walk(fn):
+                    # `data.update({...})` / `data.setdefault("x", …)`. Both are
+                    # in use on record dicts today (`api_runner:2417`,
+                    # `provenance:542`) and the first version of this scan saw
+                    # neither, so a field introduced by either was unguarded
+                    # while the docstring claimed full coverage (#620).
+                    if (isinstance(node, ast.Call)
+                            and isinstance(node.func, ast.Attribute)
+                            and isinstance(node.func.value, ast.Name)
+                            and node.func.value.id in locals_):
+                        if node.func.attr == "setdefault" and node.args and \
+                                isinstance(node.args[0], ast.Constant) and \
+                                isinstance(node.args[0].value, str):
+                            found.setdefault(node.args[0].value, name)
+                        if node.func.attr == "update":
+                            for arg in node.args:
+                                if isinstance(arg, ast.Dict):
+                                    for key in arg.keys:
+                                        if isinstance(key, ast.Constant) and \
+                                                isinstance(key.value, str):
+                                            found.setdefault(key.value, name)
+                            for kw in node.keywords:
+                                if kw.arg:
+                                    found.setdefault(kw.arg, name)
+
                     targets = []
                     if isinstance(node, ast.Assign):
                         targets = list(node.targets)
                     elif isinstance(node, ast.AnnAssign):
                         targets = [node.target]
                     for target in targets:
-                        # `data = {...}` — the builders' dict literals.
+                        # `data = {...}` — the builders' dict literals. Also
+                        # covers `data = {**other, "x": …}`: an unpacking has a
+                        # None key, which the isinstance check skips, while the
+                        # literal keys beside it are still collected.
                         if (isinstance(target, ast.Name)
                                 and target.id in locals_
                                 and isinstance(node.value, ast.Dict)):
@@ -495,6 +564,23 @@ class TheSchemaKnowsEveryFieldTheWritersWrite(unittest.TestCase):
                                 and isinstance(target.slice.value, str)):
                             found.setdefault(target.slice.value, name)
         return found
+
+    def test_the_blocks_a_backfill_writes_are_all_declared(self):
+        """`backfill_checks.apply` writes `record[name] for name in BLOCKS`.
+
+        The key is a loop variable, so no AST scan of the assignment can name
+        it — the field list lives in a module constant instead. Adding a fifth
+        entry to `BLOCKS` would make all 195 records non-conforming, and
+        nothing else would notice (#620).
+        """
+        if not SCHEMA.exists():
+            self.skipTest("schema not present in this checkout")
+        from data_sheets_schema.backfill_checks import BLOCKS
+        schema = yaml.safe_load(SCHEMA.read_text(encoding="utf-8"))
+        known = set(schema["classes"]["GenerationRecord"]["attributes"])
+        self.assertEqual(sorted(set(BLOCKS) - known), [],
+                         "backfill_checks.BLOCKS names a field the schema does "
+                         "not declare; applying it would break every record")
 
     def test_every_named_writer_function_still_exists(self):
         """A renamed function would silently drop out of the scan."""

--- a/tests/test_generation_record_schema.py
+++ b/tests/test_generation_record_schema.py
@@ -130,41 +130,121 @@ class CorpusValidatesTest(unittest.TestCase):
             self.assertNotEqual(r.returncode, 0)
 
 
-class ModeSpecificRequirements(unittest.TestCase):
-    """#605: the schema was mode-blind, so it asserted almost nothing.
+class ValidatorControl(unittest.TestCase):
+    """Base class: prove the validator works before trusting a clean result.
 
-    Every field named here is one that *every* record of that mode already
-    carries — measured across the 195 records on disk, not chosen. So these
-    tests assert that the schema now discriminates by mode, and the corpus test
-    below asserts the requirements are not inventions that fail honest records.
+    `check_record` returns no violations both when a record conforms and when it
+    could not be checked (#613). Three tests below assert "no violations", so
+    with a dead validator they would all pass having verified nothing — the
+    vacuous-pass shape of #617. Every one of them goes through `_control`
+    first, which fails rather than skips if a known-bad record comes back clean.
     """
 
-    #: The gap that motivated the issue: each of these was absent from a `live`
-    #: record that validated anyway.
-    LIVE_REQUIRED = ("inputs", "model", "system", "validation")
-
-    def _record(self):
-        from data_sheets_schema.provenance import record_conformance
-        path = (Path("data/d4d_concatenated/claudecode_agent_core")
+    BASELINE = (Path("data/d4d_concatenated/claudecode_agent_core")
                 / "2026-08-13_claude-opus-5-api-generic-v4_rep1"
                 / "CHORUS_provenance.yaml")
-        if not (path.exists() and SCHEMA.exists()):
+
+    def _control(self):
+        """A conforming record, having first proved the validator discriminates."""
+        from data_sheets_schema.provenance import check_record
+        if not (self.BASELINE.exists() and SCHEMA.exists()):
             self.skipTest("record or schema not present in this checkout")
-        record = yaml.safe_load(path.read_text(encoding="utf-8"))
-        if record_conformance(record):
-            self.skipTest("validator unavailable or baseline record non-conforming")
+        record = yaml.safe_load(self.BASELINE.read_text(encoding="utf-8"))
+
+        # Positive control. A record with no `record_mode` cannot satisfy any
+        # schema, so findings here are the minimum proof the validator ran.
+        findings, failure = check_record(
+            {k: v for k, v in record.items() if k != "record_mode"})
+        self.assertIsNone(failure, f"the validator could not run: {failure}")
+        self.assertTrue(findings,
+                        "the validator reported a record with no record_mode as "
+                        "clean; every 'no violations' assertion below would pass "
+                        "vacuously")
+
+        findings, failure = check_record(record)
+        self.assertIsNone(failure, f"the validator could not run: {failure}")
+        self.assertEqual(findings, [],
+                         "the baseline record does not conform, so it cannot "
+                         "serve as the starting point for these mutations")
         return record
+
+
+class ModeSpecificRequirements(ValidatorControl):
+    """#605: the schema was mode-blind, so it asserted almost nothing.
+
+    The required fields are **derived from `build_record`**, the single writer
+    both runtimes go through, rather than listed here. The first version listed
+    them from the archive and so required `validation`, which no writer emits —
+    it is filled in later by `d4d runs validate`. That rejected every freshly
+    written agentic record (#612). Deriving them means the schema and the writer
+    cannot drift apart without this test noticing.
+    """
+
+    def _writer_fields(self, mode):
+        """What `build_record` actually emits for a mode, at write time."""
+        from data_sheets_schema.provenance import build_record
+        bundle = Path("data/preprocessed/concatenated/AI_READI_preprocessed.txt")
+        if not bundle.exists():
+            self.skipTest("no bundle in this checkout to build a record from")
+        return build_record("AI_READI", "claudecode_agent", "test_rep1",
+                            mode=mode, input_bundle=bundle,
+                            input_verified=True).data
+
+    def _rule_requirements(self, mode):
+        """What the schema requires of a mode, read from the rules."""
+        schema = yaml.safe_load(SCHEMA.read_text(encoding="utf-8"))
+        out = set()
+        for rule in schema["classes"]["GenerationRecord"].get("rules") or []:
+            pre = ((rule.get("preconditions") or {}).get("slot_conditions")
+                   or {}).get("record_mode") or {}
+            if pre.get("equals_string") != mode:
+                continue
+            post = ((rule.get("postconditions") or {}).get("slot_conditions")
+                    or {})
+            out |= {k for k, v in post.items() if v.get("required")}
+        return out
+
+    def test_no_rule_requires_a_field_no_writer_writes(self):
+        """The #612 defect, in its general form.
+
+        A rule requiring something the writer does not emit rejects records the
+        pipeline produces correctly — and the justification for these rules is
+        that they describe the writers.
+        """
+        if not SCHEMA.exists():
+            self.skipTest("schema not present in this checkout")
+        for mode in ("live", "reconstructed"):
+            with self.subTest(mode=mode):
+                written = set(self._writer_fields(mode))
+                missing = sorted(self._rule_requirements(mode) - written)
+                self.assertEqual(
+                    missing, [],
+                    f"the schema requires {missing} of a {mode} record, but "
+                    "build_record does not emit them, so every fresh record "
+                    "fails the gate")
+
+    def test_a_freshly_written_record_conforms(self):
+        """The same thing end to end, through the real builder."""
+        self._control()
+        from data_sheets_schema.provenance import check_record
+        for mode in ("live", "reconstructed"):
+            with self.subTest(mode=mode):
+                findings, failure = check_record(self._writer_fields(mode))
+                self.assertIsNone(failure)
+                self.assertEqual(findings, [])
 
     def test_a_live_record_must_carry_what_a_live_run_observed(self):
         from data_sheets_schema.provenance import record_conformance
-        record = self._record()
-        for field in self.LIVE_REQUIRED:
+        record = self._control()
+        required = self._rule_requirements("live")
+        self.assertTrue(required, "the live rule requires nothing at all")
+        for field in sorted(required):
             with self.subTest(field=field):
                 short = {k: v for k, v in record.items() if k != field}
                 self.assertTrue(
                     record_conformance(short),
                     f"a live record with no {field!r} validated; before #605 "
-                    "all four of these did")
+                    "all of these did")
 
     def test_a_derived_record_may_omit_them(self):
         """The requirements must be conditional, not a blanket tightening.
@@ -174,33 +254,43 @@ class ModeSpecificRequirements(unittest.TestCase):
         rules would be requiring these of everything, and four honest records
         on disk would be reclassified as defective.
         """
-        from data_sheets_schema.provenance import record_conformance
-        record = self._record()
+        from data_sheets_schema.provenance import check_record
+        record = self._control()
         derived = {k: v for k, v in record.items()
-                   if k not in self.LIVE_REQUIRED}
+                   if k not in self._rule_requirements("live")}
         derived.update(record_mode="derived",
                        record_type="d4d_derived_provenance",
                        derivation={"method": "test"},
                        sources=[{"path": "x", "sha256": "y"}],
                        not_applicable=[{"field": "model", "reason": "test"}])
-        self.assertEqual(record_conformance(derived), [])
+        findings, failure = check_record(derived)
+        self.assertIsNone(failure)
+        self.assertEqual(findings, [])
 
     def test_the_two_discriminators_cannot_disagree(self):
         from data_sheets_schema.provenance import record_conformance
-        record = self._record()
+        record = self._control()
         confused = {**record, "record_mode": "derived"}
         self.assertTrue(record_conformance(confused),
                         "a record calling itself derived while typed as a "
                         "generation record validated")
 
-    def test_every_record_on_disk_still_conforms(self):
+    def test_every_record_the_checkers_look_at_conforms(self):
         """The requirements describe the writers; they do not fail the corpus.
 
         A rule that is right in principle and rejects records nobody can
         regenerate is not an improvement — it is a schema that has to be
         ignored, which is where this started.
+
+        Scoped to the `*_core/` glob that `d4d provenance validate-records`
+        uses, and *named* for that scope rather than "every record on disk":
+        three `curated/` records sit outside it and do not conform, three of
+        those violations predating this schema (#616). Claiming disk-wide
+        conformance while checking a glob is the kind of overreach this corpus
+        keeps having to correct.
         """
-        from data_sheets_schema.provenance import record_conformance
+        self._control()
+        from data_sheets_schema.provenance import check_record
         records = sorted(Path("data/d4d_concatenated").glob(
             "*_core/*/*_provenance.yaml"))
         if not records:
@@ -208,12 +298,13 @@ class ModeSpecificRequirements(unittest.TestCase):
         failures = []
         for path in records:
             data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-            for message in record_conformance(data):
-                failures.append(f"{path}: {message}")
+            findings, failure = check_record(data)
+            self.assertIsNone(failure, f"{path}: {failure}")
+            failures += [f"{path}: {m}" for m in findings]
         self.assertEqual(failures[:5], [], f"{len(failures)} violations")
 
 
-class ConformanceIsOnTheGenerationPath(unittest.TestCase):
+class ConformanceIsOnTheGenerationPath(ValidatorControl):
     """A check that exists but does not run on the path it guards is #582.
 
     Validation used to be reachable only through `d4d provenance
@@ -234,8 +325,14 @@ class ConformanceIsOnTheGenerationPath(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             rec = ProvenanceRecord(data=good)
             rec.write(Path(d) / "ok.yaml")
-            if rec.conformance:
-                self.skipTest("validator unavailable in this environment")
+            # Fails rather than skips on a truthy result. Calling a genuinely
+            # non-conforming record an environment problem is how a real defect
+            # gets skipped past in CI (#617).
+            self.assertIsNone(rec.conformance_failure,
+                              f"the validator could not run: "
+                              f"{rec.conformance_failure}")
+            self.assertEqual(rec.conformance, [],
+                             "the baseline record does not conform")
 
             # `validation` is preserved from a prior file by `write`, so drop a
             # field that is not carried forward.
@@ -248,23 +345,66 @@ class ConformanceIsOnTheGenerationPath(unittest.TestCase):
                             "the record must still be written: it is the run's "
                             "only account of itself")
 
-    def test_the_schema_is_findable_away_from_the_repo_root(self):
+    def test_a_record_that_could_not_be_checked_is_not_reported_as_clean(self):
+        """The distinction the gate turns on (#613).
+
+        `check_record` returns no violations in both cases, so if the failure
+        were not reported separately a broken validator would pass an entire
+        sweep with every run printing a tick.
+        """
+        import tempfile
+        import unittest.mock as mock
+
+        from data_sheets_schema import provenance
+        from data_sheets_schema.provenance import ProvenanceRecord
+        if not self.BASELINE.exists():
+            self.skipTest("record not present in this checkout")
+        good = yaml.safe_load(self.BASELINE.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(provenance, "record_schema_path",
+                                   lambda: Path(d) / "absent.yaml"):
+                rec = ProvenanceRecord(data=good)
+                rec.write(Path(d) / "r.yaml")
+            self.assertEqual(rec.conformance, [],
+                             "an unrunnable validator must not invent findings")
+            self.assertTrue(rec.conformance_failure,
+                            "a record that could not be checked was reported "
+                            "as conforming")
+
+    def test_the_gate_still_works_away_from_the_repo_root(self):
         """Otherwise the gate silently passes everything a sweep writes.
 
         `RECORD_SCHEMA` is repo-relative, matching its siblings, but those are
         read by commands run from the repo root and this one runs during
-        generation. `record_conformance` returns no findings when it cannot
-        run, so an unresolvable path would read as "conforms".
+        generation.
+
+        Asserts the gate *discriminates* from another directory, not merely
+        that a file exists there. A schema that resolves but is stale, or a
+        validator that fails from that cwd for any other reason, would satisfy
+        an existence check while reporting every record clean (#618).
         """
         import os
         import tempfile
 
-        from data_sheets_schema.provenance import record_schema_path
+        from data_sheets_schema.provenance import check_record
+        if not self.BASELINE.exists():
+            self.skipTest("record not present in this checkout")
+        good = yaml.safe_load(self.BASELINE.read_text(encoding="utf-8"))
+        bad = {k: v for k, v in good.items() if k != "model"}
         cwd = os.getcwd()
         try:
+            # os.chdir is process-global, so this cannot run under pytest -n
+            # without corrupting siblings. Restored in `finally`.
             with tempfile.TemporaryDirectory() as d:
                 os.chdir(d)
-                self.assertTrue(record_schema_path().exists())
+                findings, failure = check_record(bad)
+                self.assertIsNone(
+                    failure, f"the gate could not run from {d}: {failure}")
+                self.assertTrue(
+                    findings,
+                    "a live record with no model was reported clean from a "
+                    "directory that is not the repo root")
+                self.assertEqual(check_record(good), ([], None))
         finally:
             os.chdir(cwd)
 
@@ -282,51 +422,130 @@ class TheSchemaKnowsEveryFieldTheWritersWrite(unittest.TestCase):
     taken branch is caught when it is added rather than when it first fires.
     """
 
-    #: Modules that assemble a generation record. Not every module with a dict
-    #: named `data` — `src/renderer` and `src/validation` both have one and
-    #: neither writes provenance, which is why this is a list and not a glob.
-    WRITERS = ("src/data_sheets_schema/api_runner.py",
-               "src/data_sheets_schema/provenance.py")
+    #: Where record fields are set, and under which local name. The first
+    #: version scanned only for `rec.data["x"]` with a regex and so saw 14 of
+    #: 34 fields — missing both builders entirely, because each assembles its
+    #: record as a **dict literal** that no assignment regex can see (#615).
+    #: An AST scan reads the literals, so the two writers that produce the whole
+    #: agentic and derived records are covered.
+    #:
+    #: Scoped to the **functions** that build a record, not whole files. A
+    #: file-wide scan of `api_runner.py` picks up every unrelated dict called
+    #: `data` — progress files, phase payloads — and reports them as forbidden
+    #: record fields. `src/renderer` and `src/validation` have one too, and
+    #: neither writes provenance.
+    WRITERS = {
+        "src/data_sheets_schema/provenance.py": {
+            "build_record": ("data",),
+            "build_derived_record": ("data",),
+        },
+        "src/data_sheets_schema/cli/runs.py": {
+            "validate_cmd": ("data",),
+            "select_cmd": ("data", "prior"),
+        },
+    }
 
-    ASSIGNMENT = re.compile(r"""(?:rec|record)\.data\[["']([a-z_]+)["']\]""")
+    #: Attribute-style record mutation, `rec.data["x"] = …`, which `execute()`
+    #: uses and which is a subscript on an attribute rather than on a name.
+    ATTRIBUTE_WRITE = re.compile(r"""(?:rec|record)\.data\[["']([a-z_]+)["']\]""")
+
+    #: Where `execute()` sets record fields. Scanned across the whole file
+    #: because `rec.data[...]` is unambiguous — it names the record object.
+    ATTRIBUTE_WRITE_FILE = "src/data_sheets_schema/api_runner.py"
+
+    def _written_fields(self):
+        """Every record field any writer sets, by the file that sets it."""
+        import ast
+        found = {}
+        runner = Path(self.ATTRIBUTE_WRITE_FILE)
+        if runner.exists():
+            for field in self.ATTRIBUTE_WRITE.findall(
+                    runner.read_text(encoding="utf-8")):
+                found.setdefault(field, self.ATTRIBUTE_WRITE_FILE)
+        for name, functions in self.WRITERS.items():
+            path = Path(name)
+            if not path.exists():
+                continue
+            for fn in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                locals_ = functions.get(fn.name)
+                if not locals_:
+                    continue
+                for node in ast.walk(fn):
+                    targets = []
+                    if isinstance(node, ast.Assign):
+                        targets = list(node.targets)
+                    elif isinstance(node, ast.AnnAssign):
+                        targets = [node.target]
+                    for target in targets:
+                        # `data = {...}` — the builders' dict literals.
+                        if (isinstance(target, ast.Name)
+                                and target.id in locals_
+                                and isinstance(node.value, ast.Dict)):
+                            for key in node.value.keys:
+                                if isinstance(key, ast.Constant) and \
+                                        isinstance(key.value, str):
+                                    found.setdefault(key.value, name)
+                        # `data["x"] = …` — cli/runs.py's idiom.
+                        if (isinstance(target, ast.Subscript)
+                                and isinstance(target.value, ast.Name)
+                                and target.value.id in locals_
+                                and isinstance(target.slice, ast.Constant)
+                                and isinstance(target.slice.value, str)):
+                            found.setdefault(target.slice.value, name)
+        return found
+
+    def test_every_named_writer_function_still_exists(self):
+        """A renamed function would silently drop out of the scan."""
+        import ast
+        for name, functions in self.WRITERS.items():
+            path = Path(name)
+            if not path.exists():
+                continue
+            present = {fn.name for fn in ast.walk(
+                ast.parse(path.read_text(encoding="utf-8")))
+                if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))}
+            for fn_name in functions:
+                with self.subTest(function=f"{name}:{fn_name}"):
+                    self.assertIn(fn_name, present,
+                                  "the scan names a function that no longer "
+                                  "exists, so its fields are unguarded")
 
     def test_no_writer_sets_a_field_the_schema_forbids(self):
         if not SCHEMA.exists():
             self.skipTest("schema not present in this checkout")
         schema = yaml.safe_load(SCHEMA.read_text(encoding="utf-8"))
         known = set(schema["classes"]["GenerationRecord"]["attributes"])
-        unknown = {}
-        for name in self.WRITERS:
-            path = Path(name)
-            if not path.exists():
-                continue
-            for field in self.ASSIGNMENT.findall(
-                    path.read_text(encoding="utf-8")):
-                if field not in known:
-                    unknown.setdefault(field, name)
+        unknown = {f: w for f, w in self._written_fields().items()
+                   if f not in known}
         self.assertEqual(
             unknown, {},
             "these fields are written into a generation record but the schema "
-            "does not declare them, so a run taking that branch fails the "
-            f"conformance gate: {unknown}")
+            "does not declare them, so — `additionalProperties` being false — "
+            f"a run taking that branch fails the conformance gate: {unknown}")
 
-    def test_the_check_can_see_the_writers_at_all(self):
+    def test_the_scan_sees_both_builders_and_not_just_one_idiom(self):
         """Otherwise the test above passes by finding nothing to check.
 
-        A renamed module or a changed assignment idiom would empty the scan,
-        and an empty scan trivially satisfies the assertion.
+        The previous version asserted only that `"validation"` was found, which
+        a single `rec.data["validation"]` match satisfied while 20 fields stayed
+        invisible. These three come from three different writers and three
+        different idioms, so losing any one of them empties part of the scan
+        and fails here rather than silently narrowing the guard.
         """
-        found = set()
-        for name in self.WRITERS:
-            path = Path(name)
-            if path.exists():
-                found |= set(self.ASSIGNMENT.findall(
-                    path.read_text(encoding="utf-8")))
         if not any(Path(w).exists() for w in self.WRITERS):
             self.skipTest("writers not present in this checkout")
-        self.assertIn("validation", found,
-                      "the scan found no known record field; it is not "
-                      f"reading the writers. Found: {sorted(found)}")
+        found = self._written_fields()
+        for field, why in (
+                ("validation", "rec.data[...] in api_runner.execute"),
+                ("companions", "the build_record dict literal"),
+                ("derivation", "the build_derived_record dict literal"),
+                ("canonical", "a data[...] assignment in cli/runs.py")):
+            with self.subTest(field=field):
+                self.assertIn(field, found,
+                              f"the scan no longer sees {why}; the guard has "
+                              f"narrowed. Found: {sorted(found)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #605.

## Two weaknesses in the schema from #597

**It was mode-blind.** Only fields universal across all 195 records were required, so a `live` record validated while omitting its bundle, its model, the machine it ran on, and its validation verdict.

Conditional rules now say what each mode must carry. Every field was **measured across the corpus rather than chosen**:

| mode | n | always carries (beyond the universal set) |
|---|---|---|
| `live` | 158 | `inputs`, `model`, `system`, `validation` |
| `reconstructed` | 33 | the above + `unrecoverable` |
| `derived` | 4 | `derivation`, `sources`, `not_applicable` |

So this tightens the contract and fails nothing retroactively — all 195 records still conform.

**It was checked only by a command someone remembers to run.** Validation lived in `d4d provenance validate-records`, so a run could finish, report success, and leave a non-conforming record behind — the shape of #582. `write()` now validates what it wrote; `execute()` fails the run on a violation. The record is still written first: it is the run's only account of itself.

## The gate found a real gap on its first run

`execute()` writes `report_regenerated_after_repair` when repair rewrites a record after the report was rendered (#604). No record on disk carries it, so validating the corpus could never have reached it — and the schema forbade it. The first real repair-with-regeneration run would have failed at the new gate. Added, plus a test that reads the **writers** rather than the archive.

`RECORD_SCHEMA` now resolves against the package when the repo-relative path does not exist: `record_conformance` returns no findings when it cannot run, which is honest for a missing dependency and would have been a silent pass for a sweep launched from another directory.

## Three descriptions that contradicted their writers

- `record_type` — was "Always `d4d_generation_provenance`"; derived records write `d4d_derived_provenance`. Now enumerated, and tied to `record_mode` by a rule so the two discriminators cannot disagree.
- `outputs` — was "by path and hash"; a generation record deliberately carries no hash (`_artifact`, after 77 records hashed a state their files merely passed through). Integrity lives in `validation.artifacts`.
- `schema.digest_md5` — was "what the model was sent"; true of the API path, which fingerprints as it renders, but the agentic recorder runs after generation. Not the same claim.

## VOICE_PEDIATRIC

Recorded in the v5 plan, closing the last open item in #590. It has **no v4 record**, so no baseline for any of the eight gated metrics — `verdict()` returns `unmeasurable` and stops the sweep, which is the #599 fix working. Running it ungated reproduces the v4 failure; borrowing VOICE's baseline would assert two different datasets should show the same defect counts. The arm is **AI-READI, CHORUS, CM4AI, VOICE**.

## Verification

- 2197 tests pass (the 2 that failed were the new gate catching the missing field, now fixed; `tests/test_download/test_api_runner.py` 132 pass)
- All 195 records conform, via both the new write-path check and `d4d provenance validate-records --strict`
- **Mutation-tested**: dropping the rules block fails exactly 3 of the new tests, so they detect the change rather than restate it
- `d4d api prompts check --strict` clean; `d4d runs check --strict` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)