### PR TITLE
Give the report phase both sides of the diff, and make the plan describe the arm (#638, #639)

### DIFF
--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -15,7 +15,7 @@ meant to test instructs the model to produce it.
 
 ## What v5 changes
 
-Four rules, in one block. This breaks the one-rule-per-version convention that
+Five rules, in one block. This breaks the one-rule-per-version convention that
 v2, v3 and v4 kept, and the cost is stated rather than hidden: **a v4-against-v5
 comparison measures the whole block and cannot attribute any effect to a rule
 within it.**
@@ -39,14 +39,29 @@ differs. Against the 2026-08-13 v4 arm the differences are already known:
 | field | v4 | v5 |
 |---|---|---|
 | schema digest | `622e6d03` | `44d29023` |
-| assembly digest | `77331f08` | `2c1442fc` |
+| assembly digest | `77331f08` | `7d0ce8f3` |
 | condition | `generic_v4` | `generic_v5` |
 
-So a v4-v5 difference measures **the four v5 rules, plus a schema change, plus
-`reconcile_full` gaining the core record and the audit gaining a clause**.
-`comparable_conditions('generic_v4', 'generic_v5')` now returns False, and
-`MULTI_RULE_BASES` records why: a step that adds five rules cannot have a
-difference attributed to one of them.
+> The v5 assembly digest has moved three times since this table was first
+> written: `2c1442fc`, then `d59f8532` when the source-ranking block entered the
+> layout, then `7d0ce8f3` when the report phase gained the pre-reconciliation
+> records (#639). It is stated as of 2026-08-19 and **must be re-checked against
+> `assembly_digest()` immediately before the canary** — a plan naming a digest
+> the arm did not run against describes a different arm, which is what #638 was
+> filed for.
+
+So a v4-v5 difference measures **the five v5 rules, plus a schema change, plus
+`reconcile_full` gaining the core record, the audit gaining a clause, and — as
+of 2026-08-19 — the report phase receiving both records' pre-reconciliation
+states (#639)**.
+
+`comparable_conditions('generic_v4', 'generic_v5')` returns **True**, not False
+as this said before it was checked (#638). That is not a contradiction of the
+paragraph above: the function deliberately assesses *prompt adjacency only* —
+whether one condition is the other plus one marked block — and the procedural
+differences are carried by `runs.arm_confounds`, which is where a reader should
+look before attributing anything. `MULTI_RULE_BASES` records the rest: a step
+that adds five rules cannot have a difference attributed to one of them.
 
 ### What is still worth comparing
 
@@ -88,9 +103,34 @@ Stated so they can be wrong.
 4. **The invented-prefix population stops growing.** ~12,000 values across the
    corpus today (#531), five spellings for the VOICE namespace alone. v5 records
    should add none; existing records are not rewritten (#520).
-5. **British spellings fall on the API arm and are unchanged on the agentic
-   arm.** This is the parity fix's own test. If the agentic arm moves, something
-   other than the rule moved with it.
+5. **British spellings fall on the API arm.** Narrowed to the API arm on
+   2026-08-19, before generation, because the planned arm contains no agentic
+   runs and the original wording — "and are unchanged on the agentic arm" —
+   could not be measured by it (#638). Deciding that after seeing the results
+   is what pre-registration exists to prevent, so it is decided here.
+
+   **What the narrowing costs, stated rather than absorbed.** The agentic clause
+   was the control: the agentic playbook has carried the American-English rule
+   all along (`.claude/commands/d4d-uniform-rules.md:90`), so v5 changes nothing
+   for that arm, and an agentic arm that moved would have shown that something
+   other than rule 5 moved with it. Without it, **a fall on the API arm is
+   consistent with rule 5 and equally consistent with any other corpus-wide
+   change between the two dates.** The result is evidence, not attribution.
+
+   **Calibration, measured rather than assumed.** The agentic arm already has
+   this rule and is not at zero:
+
+   | arm | n | total | mean/record | max |
+   |---|---|---|---|---|
+   | agentic 2026-08-11 | 15 | 461 | 30.7 | 99 |
+   | API v4 2026-08-13 | 12 | 613 | 51.1 | 146 |
+
+   So the rule's observed effect where it already applies is a lower rate, not
+   elimination. A v5 API arm landing near ~31 per record would be the outcome
+   this rule can produce; predicting zero would be predicting something no arm
+   has achieved, including the one that has had the rule the whole time. The two
+   arms differ in runtime and in which records they wrote, so this is a
+   reference point and not a matched comparison.
 
 ## Measured v4 baselines
 

--- a/src/data_sheets_schema/api_runner.py
+++ b/src/data_sheets_schema/api_runner.py
@@ -131,7 +131,7 @@ def comparable_conditions(a: str, b: str) -> bool:
     (`622e6d03` to `44d29023`) and `reconcile_full` had gained an input.
 
     A True here also does not mean one *rule* changed: see `MULTI_RULE_BASES`,
-    where v2's step is three rules and v5's is four.
+    where v2's step is three rules and v5's is five.
 
     `generic` vs `generic_v2` differs only in base — that is the v2 experiment.
     `generic` vs `tuned` differs only in tuning — that is the study's main
@@ -544,8 +544,11 @@ PHASE_INSTRUCTIONS = {
     "report": (
         "Phase 4c. Write the reconciliation report as Markdown: what the audit "
         "found, what was changed in each record and why, and what was left "
-        "as-is and why. The reconciled records are supplied above — check each "
-        "statement against them before you write it. Do not report a slot as "
+        "as-is and why. Both the original records and the reconciled records "
+        "are supplied above: compare them and report the differences you can "
+        "see. Do not describe a change you cannot locate in that comparison — "
+        "if the two are identical for a finding, say the finding was left "
+        "as-is. Check each statement against them before you write it. Do not report a slot as "
         "removed if it is still present, and do not state that a slot is not "
         "declared in the schema without the schema digest supporting you: both "
         "are checked against the records afterwards, and a report that fails "
@@ -581,8 +584,20 @@ PHASE_NEEDS = {
     # emitted a `distributions` block reporting a removal that did not happen;
     # a phase asked to narrate a diff it cannot see is a plausible cause, and
     # #546 fixed the checking rather than the cause.
-    "report": ("Audit findings", "Reconciled full record",
-               "Completed core record"),
+    #
+    # #580 supplied the after-states and stopped there, so the diff was still
+    # unobservable — half of it was missing. Both prior readiness reviews
+    # raised it again; a marker test confirmed the original full record was
+    # never sent. The before-states are now supplied too (#639), so the phase
+    # can read a change rather than infer one, and `report_claims` checks a
+    # narrative the model was actually in a position to write.
+    #
+    # Costed before adopting: the two originals add ~41k tokens on AI-READI,
+    # the largest project, taking its report request from ~67k to ~108k. The
+    # corpus has sent 363,261 successfully, so this is inside demonstrated
+    # headroom rather than inside an assumption about the limit.
+    "report": ("Audit findings", "Original full record", "Original core record",
+               "Reconciled full record", "Completed core record"),
 }
 
 
@@ -2252,6 +2267,35 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             # having absorbed from it.
             done -= set(produced_by)
             done -= _dependents_of(name, produced_by)
+    # The pre-reconciliation states, recovered from the snapshots the `full`
+    # and `core` phases wrote (#639). They are not artifacts — reconciliation
+    # overwrites those in place — so a resumed run cannot rebuild them from
+    # `spec.full_path`/`spec.core_path`, and without them the `report` phase
+    # would find its inputs absent and refuse to resume at all.
+    #
+    # Read only; a snapshot that is missing or unparseable simply leaves the
+    # key absent, and the resume check below then re-runs the phase that
+    # produces it rather than reporting a diff against a record it never saw.
+    for phase, name in (("full", "Original full record"),
+                        ("core", "Original core record")):
+        snapshot = _intermediate_dir(spec) / f"{spec.project}_{phase}.yaml"
+        if not snapshot.exists():
+            continue
+        body = snapshot.read_text(encoding="utf-8")
+        schema_path, class_name = PHASE_SCHEMA[phase]
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError:
+            parsed = None
+        if isinstance(parsed, dict) and _looks_like_a_record(
+                parsed, schema_path, class_name):
+            carry[name] = body
+        else:
+            # The snapshot is not a record, so the phase that wrote it must
+            # run again — the same reasoning as the artifact branch above.
+            done.discard(phase)
+            done -= _dependents_of(name, (phase,))
+
     if "reconcile_full" in done and "Completed full record" in carry:
         carry["Reconciled full record"] = carry["Completed full record"]
 
@@ -2373,6 +2417,17 @@ def execute(spec: RunSpec, *, dry_run: bool = False, resume: bool = True,
             if ph == "reconcile_full":
                 label = "Reconciled full record"
             carry[label] = body
+            # The pre-reconciliation state, kept under a key nothing later
+            # overwrites (#639). `Completed full record` and `Completed core
+            # record` are both rewritten in place by reconciliation and repair,
+            # so by the report phase they hold the *final* records despite
+            # their names — which is why the report was asked what changed and
+            # shown only after-states. These two are written once, by the
+            # phases that produce them, and never again.
+            if ph == "full":
+                carry["Original full record"] = body
+            elif ph == "core":
+                carry["Original core record"] = body
 
         done.add(ph)
         _save_progress(spec, [x for x in PHASES if x in done],

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -123,18 +123,12 @@ files:
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
     body_sha256: eacd39e002e148c22c4e8012b171bcdbe59d25f2b0c94710a7eef1af446241b9
     bytes: 13237
-    pinned_at_commit: 38f0e76d26a20d923d6083e628a980d8292f6afb
-    pinned_on: '2026-08-18'
-    reason: "resolve the identifier contradiction and correct the rule count (#603). The provenance\
-      \ rule said \"take it from the evidence or omit it\" and the minting rule said to hang\
-      \ a new identifier off an attested one \u2014 a minted fragment is not in the evidence,\
-      \ so the first forbade what the second required, on the case a model meets for every\
-      \ identifier it writes. The line is now external referent versus internal label: an\
-      \ identifier naming something outside this dataset is a claim about the world and comes\
-      \ from the evidence; one naming a part of this record is a label no evidence can supply,\
-      \ and the test is whether the thing named has a referent outside the record. Also corrects\
-      \ the rationale from four rules to five."
-    sha256: 389f7bfe6a202f3e7207e28296b87dad44de19f956c503532e2d6530768613ec
+    pinned_at_commit: 7c3400b7f422575c1ae81935e43562cafad88f19
+    pinned_on: '2026-08-19'
+    reason: "Rationale said \"Four rules\"; the block holds five (#638). Rationale only \u2014\
+      \ above `## Prompt body`, never sent to the model, so the body hash is unchanged and\
+      \ the condition is not re-baselined."
+    sha256: 97ccf288e22b52c7baca4fb163c60218f821b365c846e9eaa9a81b292c4b0513
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -185,6 +179,18 @@ files:
         editing the inherited disagreement rule, which is v2s and carried by every version.'
       retired_on: '2026-08-18'
       sha256: 3446689e35fcabd4e873d30f4bd08e80a2c3fd6cd63b3e73343cfd8cceaee893
+    - pinned_on: '2026-08-18'
+      reason: "resolve the identifier contradiction and correct the rule count (#603). The\
+        \ provenance rule said \"take it from the evidence or omit it\" and the minting rule\
+        \ said to hang a new identifier off an attested one \u2014 a minted fragment is not\
+        \ in the evidence, so the first forbade what the second required, on the case a model\
+        \ meets for every identifier it writes. The line is now external referent versus internal\
+        \ label: an identifier naming something outside this dataset is a claim about the\
+        \ world and comes from the evidence; one naming a part of this record is a label no\
+        \ evidence can supply, and the test is whether the thing named has a referent outside\
+        \ the record. Also corrects the rationale from four rules to five."
+      retired_on: '2026-08-19'
+      sha256: 389f7bfe6a202f3e7207e28296b87dad44de19f956c503532e2d6530768613ec
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -10,7 +10,7 @@ a test asserts that the only difference is the block marked `ADDED IN v5`.
 
 ## Why v5 exists
 
-Four rules, not one. Two of them are not new instructions at all — they already
+Five rules, not one. Two of them are not new instructions at all — they already
 reach the agentic arm through the playbook and reach the API arm through
 nothing, which is the divergence #545 measured. Bringing them here is a parity
 fix; a condition whose two runtimes read different rules is not one condition.

--- a/tests/test_resume_inputs.py
+++ b/tests/test_resume_inputs.py
@@ -25,6 +25,14 @@ class DeclaredInputsTest(unittest.TestCase):
         """Otherwise a required input could never be satisfiable on resume."""
         produced = {"Completed full record": "full",
                     "Completed core record": "core",
+                    # The pre-reconciliation states (#639). Produced by the
+                    # same phases as the "Completed" keys, but never
+                    # overwritten — which is the whole point of their existing
+                    # separately, since reconciliation rewrites the others in
+                    # place and the report was being asked to describe a diff
+                    # against records it had only the after-state of.
+                    "Original full record": "full",
+                    "Original core record": "core",
                     "Audit findings": "audit",
                     "Reconciled full record": "reconcile_full"}
         for i, ph in enumerate(PHASES):
@@ -34,6 +42,41 @@ class DeclaredInputsTest(unittest.TestCase):
                     self.assertIsNotNone(src, f"nothing produces {need!r}")
                     self.assertLess(PHASES.index(src), i,
                                     f"{ph} needs {need}, produced later")
+
+    def test_the_report_can_see_both_sides_of_the_diff(self):
+        """It is asked what changed; it must receive a before and an after.
+
+        Before #639 it received the audit findings, the reconciled full record
+        and a key named `Completed core record` that reconciliation had
+        overwritten with the *final* core — so it held the after-state of both
+        records and the before-state of neither, while being asked to narrate
+        the difference. Both prior readiness reviews raised it.
+        """
+        needs = PHASE_NEEDS["report"]
+        for before, after in (("Original full record", "Reconciled full record"),
+                              ("Original core record", "Completed core record")):
+            with self.subTest(record=before):
+                self.assertIn(before, needs)
+                self.assertIn(after, needs)
+
+    def test_the_originals_are_not_the_keys_reconciliation_overwrites(self):
+        """A before-state that a later phase rewrites is not a before-state."""
+        for phase in ("reconcile_full", "reconcile_core", "report"):
+            for need in PHASE_NEEDS[phase]:
+                self.assertNotEqual(
+                    need, "Original full record" if phase == "reconcile_full"
+                    else None,
+                    "reconciliation must not consume the originals as its "
+                    "working copy")
+        # The producers write them once, under names nothing else assigns.
+        import inspect
+
+        from data_sheets_schema import api_runner
+        source = inspect.getsource(api_runner.execute)
+        for key in ("Original full record", "Original core record"):
+            self.assertEqual(
+                source.count(f'carry["{key}"] = '), 1,
+                f"{key} is assigned more than once, so it is not an original")
 
     def test_reconcile_full_declares_the_core_record(self):
         """The dependency #566 added, and the one #575 can strand."""

--- a/tests/test_smaller_defects.py
+++ b/tests/test_smaller_defects.py
@@ -95,9 +95,29 @@ class ReportPhaseTest(unittest.TestCase):
 
     def test_it_is_told_to_check_before_asserting(self):
         from data_sheets_schema.api_runner import PHASE_INSTRUCTIONS
-        text = PHASE_INSTRUCTIONS["report"]
+        # Case-insensitive: the phrase became sentence-initial when #639
+        # rewrote the instruction, and an assertion on the capitalisation of
+        # prose fails for a reason that has nothing to do with the behaviour
+        # it is guarding.
+        text = PHASE_INSTRUCTIONS["report"].lower()
         self.assertIn("check each statement against them", text)
         self.assertIn("still present", text)
+
+    def test_it_is_given_both_sides_of_the_diff_and_told_to_use_them(self):
+        """#639. The instruction and the inputs have to agree.
+
+        Asking for a change account while supplying only after-states is what
+        both readiness reviews found; supplying the before-states without
+        telling the phase they are there would be the same defect with the
+        halves swapped.
+        """
+        from data_sheets_schema.api_runner import (PHASE_INSTRUCTIONS,
+                                                   PHASE_NEEDS)
+        for key in ("Original full record", "Original core record"):
+            self.assertIn(key, PHASE_NEEDS["report"])
+        text = PHASE_INSTRUCTIONS["report"].lower()
+        self.assertIn("original records", text)
+        self.assertIn("compare them", text)
 
     def test_the_verdict_pins_the_records_and_the_schema(self):
         """A claim is checked *against* a record and a slot inventory, so a


### PR DESCRIPTION
The two blockers from the 2026-08-19 readiness review (#640 remains — the re-canary).

## #639 — the report was asked what changed and shown only after-states

Raised by **both** prior readiness reviews and fixed halfway each time. The asymmetry was worse than "missing the originals": `report` received the *reconciled* full record and a key named `Completed core record` that reconciliation overwrites in place with the final core. So it held the after-state of both records and the before-state of neither, while being asked to narrate the difference.

Marker test, before and after:

| | before | after |
|---|---|---|
| `AUDIT_MARKER` | ✅ | ✅ |
| `ORIGINAL_FULL_MARKER` | ❌ | ✅ |
| `ORIGINAL_CORE_MARKER` | ❌ | ✅ |
| `FINAL_FULL_MARKER` | ✅ | ✅ |
| `FINAL_CORE_MARKER` | ✅ | ✅ |

`full` and `core` now also write `Original full record` / `Original core record` — keys nothing later assigns — and the instruction tells the phase to compare them and **not to describe a change it cannot locate in that comparison**.

**Costed before adopting.** The originals add ~41k tokens on AI-READI, taking its report request from ~67k to ~108k. The corpus has sent 363,261 successfully, so this is inside demonstrated headroom rather than inside an assumption about the limit.

**Resume needed handling.** The originals are not artifacts — reconciliation overwrites those — so a resumed run could not rebuild them and `report` would have refused to resume. They are recovered from the snapshots `full` and `core` already write; a missing or unparseable snapshot re-runs its phase rather than reporting a diff against a record it never saw.

## #638 — the plan described a different arm

**Prediction 5 narrowed to the API arm, now, before generation.** It required British spelling unchanged "on the agentic arm" and the planned arm is API-only.

What the narrowing costs is stated rather than absorbed: the agentic playbook has carried the American-English rule all along (`d4d-uniform-rules.md:90`), so that arm was the control — and without it, a fall on the API arm is consistent with rule 5 **and** with any other corpus-wide change. Evidence, not attribution.

The plan now also records the calibration, measured rather than assumed:

| arm | n | total | mean/record | max |
|---|---|---|---|---|
| agentic 2026-08-11 | 15 | 461 | 30.7 | 99 |
| API v4 2026-08-13 | 12 | 613 | 51.1 | 146 |

The agentic arm **has** this rule and is not at zero, so the rule's effect where it already applies is a lower rate, not elimination. Predicting zero would predict something no arm has achieved.

Three factual corrections, each verified first:

- the added block holds **five** rules, not four — three places said four, including `api_runner`'s own comment, while `MULTI_RULE_BASES` had it right
- assembly digest is `7d0ce8f3`, with a note that it has moved three times and **must be re-checked immediately before the canary**
- `comparable_conditions('generic_v4','generic_v5')` returns **True**, not False — it assesses prompt adjacency only, with `runs.arm_confounds` carrying the procedural differences

## The prompt edit does not re-baseline the condition

The correction is to the rationale, above `## Prompt body`, which `prompt_body` never sends to the model — the case #560 built this distinction for. Verified: body hash `eacd39e0` unchanged on disk and in the rotated pin. The pin rotates to record the annotation, and the previous pin is kept as superseded, so the twelve v4 runs and the 2026-08-16 canary still verify against the bytes they read.

## Verification

2221 passed, 4 skipped. `prompts check --strict`, `provenance validate-records --strict`, `runs check --strict` all clean.

⚠️ **The assembly digest moved to `7d0ce8f3`** — required by #639 and the reason it had to land before the canary. #640 (re-canary) is now the only remaining v5 blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)