### PR TITLE
Name the range the CURIE rule governs: uriorcurie, not "an identifier" (#644)

### DIFF
--- a/.claude/commands/d4d-uniform-rules.md
+++ b/.claude/commands/d4d-uniform-rules.md
@@ -51,8 +51,8 @@ to every project:
   `ORCID:` CURIE, not the orcid.org URL; a `doi:` CURIE, not the doi.org
   resolver form. (Form only, deliberately: an example carrying a real registry
   identifier or a real DOI prefix leaks one project's identity into text every
-  project reads — a PhysioNet DOI prefix, i.e. VOICE's publisher, sat here for
-  a month.) Two records naming one thing in one form produce one identity;
+  project reads — one project's real publisher prefix sat here for a month,
+  #647.) Two records naming one thing in one form produce one identity;
   the same thing written as a prefix here and a resolver URL there produces
   two. A resolver URL in such a slot is a defect even though it resolves: the
   v5 canary wrote 45 of them and that is what #591 records.

--- a/.claude/commands/d4d-uniform-rules.md
+++ b/.claude/commands/d4d-uniform-rules.md
@@ -47,19 +47,26 @@ to every project:
   relationship to any other arm or project. Apply your own judgment about what
   the evidence supports.
 - **In an identifier slot, never write a resolver URL where the schema declares
-  a prefix — write the CURIE.** `ROR:01an7q238`, not
-  `https://ror.org/01an7q238`; `ORCID:0000-0002-…`, not the orcid.org URL;
-  `doi:10.13026/…`, not `https://doi.org/…`. Two records naming one thing in
-  one form produce one identity; the same thing written as a prefix here and a
-  resolver URL there produces two. A resolver URL in such a slot is a defect
-  even though it resolves: the v5 canary wrote 45 of them and that is what
-  #591 records.
+  a prefix — write the CURIE.** A `ROR:` CURIE, not the ror.org URL; an
+  `ORCID:` CURIE, not the orcid.org URL; a `doi:` CURIE, not the doi.org
+  resolver form. (Form only, deliberately: an example carrying a real registry
+  identifier or a real DOI prefix leaks one project's identity into text every
+  project reads — a PhysioNet DOI prefix, i.e. VOICE's publisher, sat here for
+  a month.) Two records naming one thing in one form produce one identity;
+  the same thing written as a prefix here and a resolver URL there produces
+  two. A resolver URL in such a slot is a defect even though it resolves: the
+  v5 canary wrote 45 of them and that is what #591 records.
 
   **This governs slots whose declared range is an identifier** —
-  `uriorcurie`. A slot whose declared range is a URL takes a URL: `download_url`
-  and `access_urls` are declared `uri` and a CURIE there is wrong. A URL inside
-  prose or a citation is text, not an identifier, and must be left exactly as
-  written.
+  `uriorcurie`. A slot whose declared range is `uri` — not `uriorcurie` —
+  takes a URL: `download_url` and `access_urls` are declared `uri` and a CURIE
+  there is wrong. ("Not `uriorcurie`" is load-bearing: the 2026-08-19 canary
+  read the older wording, "declared range is a URL", as covering `uriorcurie`
+  and expanded every id to a resolver URL — #644.) A slot whose declared range
+  is `string` follows its own description and pattern even when it holds an
+  identifier — the `doi` slot takes the bare DOI, neither prefixed nor
+  resolved. A URL inside prose or a citation is text, not an identifier, and
+  must be left exactly as written.
 
   **Where no declared prefix fits, never invent one.** A prefix the schema does
   not declare resolves to nothing, so do not mint `b2ai-voice:` or similar
@@ -82,7 +89,7 @@ to every project:
   does not reach it: no evidence can supply it. The test is whether the thing
   named has a referent outside this record. Where it does not, hang the label
   off one the bundle does supply — a fragment on the identifier of the thing
-  it is part of, `doi:10.60775/fairhub.3#split-train`, rather than a new
+  it is part of, `<the dataset's own DOI CURIE>#split-train`, rather than a new
   namespace (#531). A person is identified by an ORCID and an organisation by a
   ROR; **a fragment appended to an organisation's ROR does not identify a
   person**, it asserts something false about that organisation.

--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -217,6 +217,35 @@ today's source; it says nothing about whether today's source is the same one v4
 was generated against. It is not — v4 recorded `622e6d03` — and that remains a
 decision about the comparison rather than a defect to fix here.
 
+## Canary history (updated as canaries run)
+
+Two canaries so far, both AI-READI, neither authorising a fan-out:
+
+- **2026-08-16** — completed and was read as a pass, but its recorded
+  `grounding` block predates the resolver-URL finding, so its stored verdict is
+  an absence of measurement that reads like one. Recomputed from its artifacts:
+  REGRESSED, 22 resolver URLs against a v4 baseline of 0 (#640, #591).
+- **2026-08-19** — run from `main` at `0e9ff4a3` through `d4d api batch` with
+  the gate live. **REGRESSED, and the gate stopped the sweep**: resolver URLs
+  24 vs 0, pair errors 13 vs 10. Cost one run (~786k in / 250k out) instead of
+  twelve. Diagnosis (#644): rule 1's exemption said "a slot whose declared
+  range is a URL takes a URL", and the schema's identifier slots are ranged
+  `uriorcurie` — which satisfies that clause on a plain reading. The run's own
+  reconciliation report confirms the model read it exactly that way ("the
+  resolver URL for the `uriorcurie`-ranged `id`"). The result inverted the
+  rule's intent: v4, with no rule at all, wrote 62/68 ids as CURIEs; v5 wrote
+  0/29. The exemption now names the ranges literally (`uri`, not `uriorcurie`),
+  matching the agentic playbook, whose wording always did.
+
+  The same canary settled the 68→29 "entity drop" as **mostly intended**: the
+  16 dropped ORCID creators were clinical-trial investigators promoted by v4
+  from a lower-tier source, and the release's own citation names the AI-READI
+  Consortium as sole creator — source priority working. The train/val/test
+  split survives in prose rather than as `subsets[]` entities. The extra pair
+  errors are `notes` divergences from repair rewriting the full record only,
+  downstream of the identifier mess above; re-measure after the fix rather
+  than patching separately.
+
 ## The canary is AI-READI, and the context risk is smaller than first stated
 
 The v4 arm canaried CHORUS, whose largest request is 64k tokens against

--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -242,8 +242,9 @@ Two canaries so far, both AI-READI, neither authorising a fan-out:
   from a lower-tier source, and the release's own citation names the AI-READI
   Consortium as sole creator — source priority working. The train/val/test
   split survives in prose rather than as `subsets[]` entities. The extra pair
-  errors (13 vs v4's worst of 10) are the same class as v4's — shared-slot
-  content divergences, 7 of 13 in `notes` paths; the run's provenance shows
+  errors (13 vs v4's worst of 10) are 12 shared-slot-content divergences (7 of
+  them in `notes` paths) plus one shared-slot-presence on `$.download_url`;
+  the run's provenance shows
   repair touched *both* records, so the first version of this sentence, which
   blamed repair rewriting the full record only, was wrong (#645 review).
   Plausibly downstream of the identifier mess above; re-measure after the fix

--- a/notes/generic_v5_analysis_plan.md
+++ b/notes/generic_v5_analysis_plan.md
@@ -242,9 +242,12 @@ Two canaries so far, both AI-READI, neither authorising a fan-out:
   from a lower-tier source, and the release's own citation names the AI-READI
   Consortium as sole creator — source priority working. The train/val/test
   split survives in prose rather than as `subsets[]` entities. The extra pair
-  errors are `notes` divergences from repair rewriting the full record only,
-  downstream of the identifier mess above; re-measure after the fix rather
-  than patching separately.
+  errors (13 vs v4's worst of 10) are the same class as v4's — shared-slot
+  content divergences, 7 of 13 in `notes` paths; the run's provenance shows
+  repair touched *both* records, so the first version of this sentence, which
+  blamed repair rewriting the full record only, was wrong (#645 review).
+  Plausibly downstream of the identifier mess above; re-measure after the fix
+  rather than diagnosing further from one run.
 
 ## The canary is AI-READI, and the context risk is smaller than first stated
 

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -121,15 +121,13 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    body_sha256: 4fbfd3d69e8d3ca179b6a7ab8f35db7f48808c0ca771402171842c031e204903
-    bytes: 13723
-    pinned_at_commit: c4f17ab248352423e9a6c6eeab61a8216e3b749f
+    body_sha256: 65a52d098350ceeb5b2430f85e23f591cf2c1195f2f11d05dc39b7e9955558e8
+    bytes: 13719
+    pinned_at_commit: 31ad57ba4a1cdbc93ec46a46476199817e5aaee8
     pinned_on: '2026-08-19'
-    reason: "Rule 1 exemption said \"declared range is a URL\", which uriorcurie satisfies\
-      \ on a plain reading \u2014 the model expanded every id to a resolver URL (29/29) where\
-      \ v4 with no rule wrote 62/68 CURIEs (#644). The governed range is now named literally,\
-      \ matching the playbook wording that never had the hole."
-    sha256: 4d83f0dd032270d1f8f4a6c481a8edbb58dca3dcfe1e70febc28df0e5a0fa0a9
+    reason: 'The #644 fix examples leaked AI-READI DOI prefix 10.60775 into the generic prompt;
+      examples now show CURIE form without any project quantity.'
+    sha256: c7fcc2283d1d8d84c11a156b26205c93e507134ec90cccc3adb2199d29b3ada5
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -198,6 +196,13 @@ files:
         \ and the condition is not re-baselined."
       retired_on: '2026-08-19'
       sha256: 97ccf288e22b52c7baca4fb163c60218f821b365c846e9eaa9a81b292c4b0513
+    - pinned_on: '2026-08-19'
+      reason: "Rule 1 exemption said \"declared range is a URL\", which uriorcurie satisfies\
+        \ on a plain reading \u2014 the model expanded every id to a resolver URL (29/29)\
+        \ where v4 with no rule wrote 62/68 CURIEs (#644). The governed range is now named\
+        \ literally, matching the playbook wording that never had the hole."
+      retired_on: '2026-08-19'
+      sha256: 4d83f0dd032270d1f8f4a6c481a8edbb58dca3dcfe1e70febc28df0e5a0fa0a9
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -121,14 +121,15 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    body_sha256: eacd39e002e148c22c4e8012b171bcdbe59d25f2b0c94710a7eef1af446241b9
-    bytes: 13237
-    pinned_at_commit: 7c3400b7f422575c1ae81935e43562cafad88f19
+    body_sha256: 4fbfd3d69e8d3ca179b6a7ab8f35db7f48808c0ca771402171842c031e204903
+    bytes: 13723
+    pinned_at_commit: c4f17ab248352423e9a6c6eeab61a8216e3b749f
     pinned_on: '2026-08-19'
-    reason: "Rationale said \"Four rules\"; the block holds five (#638). Rationale only \u2014\
-      \ above `## Prompt body`, never sent to the model, so the body hash is unchanged and\
-      \ the condition is not re-baselined."
-    sha256: 97ccf288e22b52c7baca4fb163c60218f821b365c846e9eaa9a81b292c4b0513
+    reason: "Rule 1 exemption said \"declared range is a URL\", which uriorcurie satisfies\
+      \ on a plain reading \u2014 the model expanded every id to a resolver URL (29/29) where\
+      \ v4 with no rule wrote 62/68 CURIEs (#644). The governed range is now named literally,\
+      \ matching the playbook wording that never had the hole."
+    sha256: 4d83f0dd032270d1f8f4a6c481a8edbb58dca3dcfe1e70febc28df0e5a0fa0a9
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -191,6 +192,12 @@ files:
         \ the record. Also corrects the rationale from four rules to five."
       retired_on: '2026-08-19'
       sha256: 389f7bfe6a202f3e7207e28296b87dad44de19f956c503532e2d6530768613ec
+    - pinned_on: '2026-08-19'
+      reason: "Rationale said \"Four rules\"; the block holds five (#638). Rationale only\
+        \ \u2014 above `## Prompt body`, never sent to the model, so the body hash is unchanged\
+        \ and the condition is not re-baselined."
+      retired_on: '2026-08-19'
+      sha256: 97ccf288e22b52c7baca4fb163c60218f821b365c846e9eaa9a81b292c4b0513
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -121,13 +121,14 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    body_sha256: 65a52d098350ceeb5b2430f85e23f591cf2c1195f2f11d05dc39b7e9955558e8
-    bytes: 13719
-    pinned_at_commit: 31ad57ba4a1cdbc93ec46a46476199817e5aaee8
+    body_sha256: c1bdc4795e3ca6629ec6c287e7546ed31b35a1f75b41e90b691ad3724bbebd5a
+    bytes: 13895
+    pinned_at_commit: d0ac369189a32e4d742f5b868a225cff390102ec
     pinned_on: '2026-08-19'
-    reason: 'The #644 fix examples leaked AI-READI DOI prefix 10.60775 into the generic prompt;
-      examples now show CURIE form without any project quantity.'
-    sha256: c7fcc2283d1d8d84c11a156b26205c93e507134ec90cccc3adb2199d29b3ada5
+    reason: 'Round-2 review of #645: examples are form-only (a real UC Berkeley ROR id had
+      entered the text), and string-ranged identifier slots get one sentence of guidance (doi
+      takes the bare DOI). The uri-not-uriorcurie exemption is unchanged from the #644 fix.'
+    sha256: d22c9084436458e67600ea0e54cd936b8705105a554d50479655123b9708fbe5
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -203,6 +204,11 @@ files:
         \ literally, matching the playbook wording that never had the hole."
       retired_on: '2026-08-19'
       sha256: 4d83f0dd032270d1f8f4a6c481a8edbb58dca3dcfe1e70febc28df0e5a0fa0a9
+    - pinned_on: '2026-08-19'
+      reason: 'The #644 fix examples leaked AI-READI DOI prefix 10.60775 into the generic
+        prompt; examples now show CURIE form without any project quantity.'
+      retired_on: '2026-08-19'
+      sha256: c7fcc2283d1d8d84c11a156b26205c93e507134ec90cccc3adb2199d29b3ada5
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/canonical_hashes.yaml
+++ b/src/download/prompts/canonical_hashes.yaml
@@ -121,14 +121,13 @@ files:
       retired_on: '2026-08-13'
       sha256: a47e61b52c05a0aa81c2a8629be551942ab2e6e24a39d11dc75ba96ef5b3482a
   src/download/prompts/d4d_generic_arm_prompt_v5.md:
-    body_sha256: c1bdc4795e3ca6629ec6c287e7546ed31b35a1f75b41e90b691ad3724bbebd5a
-    bytes: 13895
-    pinned_at_commit: d0ac369189a32e4d742f5b868a225cff390102ec
-    pinned_on: '2026-08-19'
-    reason: 'Round-2 review of #645: examples are form-only (a real UC Berkeley ROR id had
-      entered the text), and string-ranged identifier slots get one sentence of guidance (doi
-      takes the bare DOI). The uri-not-uriorcurie exemption is unchanged from the #644 fix.'
-    sha256: d22c9084436458e67600ea0e54cd936b8705105a554d50479655123b9708fbe5
+    body_sha256: bdc18672ba485dbc15a4b1f1321e61dbda0e292fde502b8b2cc568053dafef98
+    bytes: 13909
+    pinned_at_commit: 1f54bd791495038e3a8d8c8fbca3cb925502b3c3
+    pinned_on: '2026-08-20'
+    reason: 'Round-3 fix: the exemption paragraph said "Two things" while listing three, a
+      stale literal count in the paragraph #644 proved is read literally.'
+    sha256: c4bbcc41eb4f0b83704228a0bf040294dedd6edf5afbf06035c2fd9d7587ebbb
     superseded:
     - pinned_on: '2026-08-14'
       reason: "initial pin for the generic-v5 condition (#547, #531, #545): v4 plus one marked\
@@ -209,6 +208,13 @@ files:
         prompt; examples now show CURIE form without any project quantity.'
       retired_on: '2026-08-19'
       sha256: c7fcc2283d1d8d84c11a156b26205c93e507134ec90cccc3adb2199d29b3ada5
+    - pinned_on: '2026-08-19'
+      reason: 'Round-2 review of #645: examples are form-only (a real UC Berkeley ROR id had
+        entered the text), and string-ranged identifier slots get one sentence of guidance
+        (doi takes the bare DOI). The uri-not-uriorcurie exemption is unchanged from the #644
+        fix.'
+      retired_on: '2026-08-20'
+      sha256: d22c9084436458e67600ea0e54cd936b8705105a554d50479655123b9708fbe5
   src/download/prompts/d4d_tuned_arm_prompt.md:
     bytes: 2877
     pinned_at_commit: 225f224544aa8f9ca8ac7f61f57aab9813536866

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -212,9 +212,9 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
 
 - In a slot whose declared range is `uriorcurie`, never write a resolver URL
   where the schema declares a prefix: write the CURIE — a prefix, a colon, and
-  the local part. `ROR:01an7q238`, not `https://ror.org/01an7q238`; an
-  `ORCID:` CURIE, not the orcid.org URL; a `doi:` CURIE, not the doi.org
-  resolver form. **`uriorcurie` is the range this rule exists for**: its
+  the local part. A `ROR:` CURIE, not the ror.org URL; an `ORCID:` CURIE, not
+  the orcid.org URL; a `doi:` CURIE, not the doi.org resolver form.
+  **`uriorcurie` is the range this rule exists for**: its
   "uri" half is the fallback for an identifier that no declared prefix covers,
   never permission to expand one that a prefix does cover. Two records naming
   one thing in one form produce one identity; the same thing written as a
@@ -225,7 +225,10 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
   Two things this does not govern, and they are exempt entirely: a slot whose
   declared range is `uri` — not `uriorcurie` — takes a URL (`download_url` and
   `access_urls` are declared `uri`, and a CURIE there is wrong), and a URL
-  inside prose or a citation is text. Leave both exactly as written.
+  inside prose or a citation is text. Leave both exactly as written. A slot
+  whose declared range is `string` follows its own description and pattern
+  even when it holds an identifier — the `doi` slot takes the bare DOI,
+  neither prefixed nor resolved.
 - An identifier that names something outside this dataset — an organisation, a
   person, a publication, another dataset — is a fact about the world, subject to
   the same rule as any other fact: take it from the evidence or omit it. Do not

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -222,13 +222,13 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
   declared prefixes and use one whenever it fits; a resolver URL in a
   `uriorcurie` slot whose prefix is declared is a defect even though it
   resolves.
-  Two things this does not govern, and they are exempt entirely: a slot whose
-  declared range is `uri` — not `uriorcurie` — takes a URL (`download_url` and
-  `access_urls` are declared `uri`, and a CURIE there is wrong), and a URL
-  inside prose or a citation is text. Leave both exactly as written. A slot
-  whose declared range is `string` follows its own description and pattern
-  even when it holds an identifier — the `doi` slot takes the bare DOI,
-  neither prefixed nor resolved.
+  Three things this does not govern, and they are exempt entirely: a slot
+  whose declared range is `uri` — not `uriorcurie` — takes a URL
+  (`download_url` and `access_urls` are declared `uri`, and a CURIE there is
+  wrong); a URL inside prose or a citation is text — leave both of these
+  exactly as written; and a slot whose declared range is `string` follows its
+  own description and pattern even when it holds an identifier — the `doi`
+  slot takes the bare DOI, neither prefixed nor resolved.
 - An identifier that names something outside this dataset — an organisation, a
   person, a publication, another dataset — is a fact about the world, subject to
   the same rule as any other fact: take it from the evidence or omit it. Do not

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -210,15 +210,22 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
 --- END ADDED IN v3 ---
 --- ADDED IN v5 ---
 
-- In a slot whose declared range is an identifier, never write a resolver URL
+- In a slot whose declared range is `uriorcurie`, never write a resolver URL
   where the schema declares a prefix: write the CURIE — a prefix, a colon, and
-  the local part. Two records naming one thing in one form produce one
-  identity; the same thing written as a prefix here and a resolver URL there
-  produces two. Check the schema's declared prefixes and use one whenever it
-  fits; a resolver URL in such a slot is a defect even though it resolves.
+  the local part. `ROR:01an7q238`, not `https://ror.org/01an7q238`;
+  `ORCID:0000-0002-…`, not the orcid.org URL; `doi:10.60775/…`, not
+  `https://doi.org/…`. **`uriorcurie` is the range this rule exists for**: its
+  "uri" half is the fallback for an identifier that no declared prefix covers,
+  never permission to expand one that a prefix does cover. Two records naming
+  one thing in one form produce one identity; the same thing written as a
+  prefix here and a resolver URL there produces two. Check the schema's
+  declared prefixes and use one whenever it fits; a resolver URL in a
+  `uriorcurie` slot whose prefix is declared is a defect even though it
+  resolves.
   Two things this does not govern, and they are exempt entirely: a slot whose
-  declared range is a URL takes a URL, and a URL inside prose or a citation is
-  text. Leave both exactly as written.
+  declared range is `uri` — not `uriorcurie` — takes a URL (`download_url` and
+  `access_urls` are declared `uri`, and a CURIE there is wrong), and a URL
+  inside prose or a citation is text. Leave both exactly as written.
 - An identifier that names something outside this dataset — an organisation, a
   person, a publication, another dataset — is a fact about the world, subject to
   the same rule as any other fact: take it from the evidence or omit it. Do not

--- a/src/download/prompts/d4d_generic_arm_prompt_v5.md
+++ b/src/download/prompts/d4d_generic_arm_prompt_v5.md
@@ -212,9 +212,9 @@ UNIFORM DECISION RULES — these apply identically to every project and every ar
 
 - In a slot whose declared range is `uriorcurie`, never write a resolver URL
   where the schema declares a prefix: write the CURIE — a prefix, a colon, and
-  the local part. `ROR:01an7q238`, not `https://ror.org/01an7q238`;
-  `ORCID:0000-0002-…`, not the orcid.org URL; `doi:10.60775/…`, not
-  `https://doi.org/…`. **`uriorcurie` is the range this rule exists for**: its
+  the local part. `ROR:01an7q238`, not `https://ror.org/01an7q238`; an
+  `ORCID:` CURIE, not the orcid.org URL; a `doi:` CURIE, not the doi.org
+  resolver form. **`uriorcurie` is the range this rule exists for**: its
   "uri" half is the fallback for an identifier that no declared prefix covers,
   never permission to expand one that a prefix does cover. Two records naming
   one thing in one form produce one identity; the same thing written as a

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -227,12 +227,22 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
         # phrase, which is a check enforcing the bug.
         # Phrases below are matched against `_texts()` output, which strips
         # backticks and asterisks — so they are written without them. The
-        # second alternative names the exemption's range with its boundary
+        # required phrase names the exemption's range with its boundary
         # spelled out ("uri — not uriorcurie"), because a bare "range is uri"
         # would substring-match "range is uriorcurie" and assert nothing.
+        #
+        # The ambiguous sentence is *forbidden*, in both texts. The first fix
+        # kept "declared range is a url" as an accepted alternative because
+        # the playbook still used it — which meant reintroducing the exact
+        # #644 sentence into the prompt passed every test, and the claim that
+        # this had been mutation-tested was true only of a full rule revert.
+        # The playbook is now disambiguated too, so nothing needs the old
+        # phrase and its reappearance anywhere is a failure.
         ("a URL-ranged slot still takes a URL",
-         ("declared range is a url",
-          "range is uri — not uriorcurie — takes a url"), ()),
+         ("range is uri — not uriorcurie — takes a url",),
+         ("declared range is a url takes a url",)),
+        ("string-ranged identifier slots follow their own description",
+         ("declared range is string",), ()),
         ("prose and citations are left alone",
          ("prose or a citation",), ()),
         ("an undeclared prefix is never invented",

--- a/tests/test_playbook_reach.py
+++ b/tests/test_playbook_reach.py
@@ -218,8 +218,21 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
     #: the model to write a URL where no prefix is declared and the other said
     #: never to write one.
     AGREEMENTS = (
+        # "declared range is `uri`" joined this list when #644 showed the
+        # older phrasing — "declared range is a URL" — was itself the defect:
+        # a range literally named `uriorcurie` satisfies "is a URL" on a plain
+        # reading, and the canary's own report said so in as many words ("the
+        # resolver URL for the uriorcurie-ranged id"). The exemption must name
+        # the range it means. This test used to *require* the ambiguous
+        # phrase, which is a check enforcing the bug.
+        # Phrases below are matched against `_texts()` output, which strips
+        # backticks and asterisks — so they are written without them. The
+        # second alternative names the exemption's range with its boundary
+        # spelled out ("uri — not uriorcurie"), because a bare "range is uri"
+        # would substring-match "range is uriorcurie" and assert nothing.
         ("a URL-ranged slot still takes a URL",
-         ("declared range is a URL",), ()),
+         ("declared range is a url",
+          "range is uri — not uriorcurie — takes a url"), ()),
         ("prose and citations are left alone",
          ("prose or a citation",), ()),
         ("an undeclared prefix is never invented",
@@ -231,7 +244,17 @@ class TestTheRuleSetsDoNotSilentlyDiverge(unittest.TestCase):
         ("no unqualified ban on URLs",
          (), ("never as a URL", "never a URL,")),
         ("the ban that remains is scoped to identifier slots",
-         ("identifier slot", "range is an identifier"), ()),
+         ("identifier slot", "range is an identifier",
+          "range is uriorcurie"), ()),
+        # The #644 lesson as a standing requirement: both texts must name
+        # `uriorcurie` explicitly, because "identifier slot" and "URL-ranged
+        # slot" are prose categories the model has to map onto the digest's
+        # literal range names — and the one range that contains both words is
+        # exactly where that mapping inverted. The v5 canary wrote 29/29 ids
+        # as resolver URLs under a rule written to forbid them, where v4 with
+        # no rule at all wrote 62/68 as CURIEs.
+        ("the governed range is named, not paraphrased",
+         ("uriorcurie",), ()),
     )
 
     def test_the_two_texts_do_not_contradict_each_other(self):


### PR DESCRIPTION
Fixes the defect behind the 2026-08-19 canary regression. #644 stays open until a canary passes under this prompt.

## What the canary found

The gate stopped the sweep after one run (~786k in / 250k out instead of twelve runs): resolver URLs **24 vs baseline 0**, pair errors 13 vs 10. Structural comparison showed the rule had **inverted** its own intent:

| arm | ids | resolver URLs | CURIEs |
|---|---:|---:|---:|
| v4 — no CURIE rule at all | 68 | 6 | **62** |
| v5 — with the rule | 29 | **29** | **0** |

## The mechanism, confirmed by the run itself

Rule 1's exemption read *"a slot whose declared range is a URL takes a URL"*. The schema's identifier slots are ranged **`uriorcurie`** — a name that satisfies that clause on a plain reading. The run's own reconciliation report says it read it exactly that way: *"the resolver URL for the `uriorcurie`-ranged `id`"*.

This is a **parity defect**: the agentic playbook's wording never had the hole (*"This governs slots whose declared range is an identifier — `uriorcurie`"*). The API prompt lost that disambiguation when the rule was ported, and #591's fix re-pinned without touching the exemption — so the defect survived a fix aimed at it. The prompt now matches the playbook: the governed range is named literally, and the exemption names `uri` — not `uriorcurie`.

## The test that enforced the bug

`test_playbook_reach`'s AGREEMENTS list **required** the phrase "declared range is a URL" verbatim — a check enforcing the ambiguity. It now accepts the disambiguated wording and adds a standing requirement that both texts name `uriorcurie` explicitly. Mutation-tested: reverting the prompt to the ambiguous exemption fails the guard.

## A second leak the suite caught

My first version of the examples carried `doi:10.60775/…` — **AI-READI's DOI prefix** — into the generic prompt, and `test_no_expected_quantities` failed it. That is the per-GC leakage this arm exists to measure the absence of, and the same class the generalizability review catalogued. Examples are now form-only. Two pin rotations in one branch is honest churn; the superseded chain records the intermediate bytes.

## What the canary settled without a fix

- The 68→29 entity drop is **mostly intended**: the 16 dropped ORCID creators were clinical-trial investigators v4 promoted from a lower-tier source; the release's own citation names the AI-READI Consortium as sole creator — source priority working. The train/val/test split survives in prose.
- The extra pair errors are `notes` divergences from repair rewriting full only — downstream of the identifier mess; re-measure after this fix.

Canary history is now recorded in the analysis plan.

## Verification

2221 passed, 4 skipped. Prompts at pin (`c7fcc228`); prior pins superseded so both canaries still verify. Mutation test on the parity guard.

**After merge: re-canary under a fresh label.** Fix and fan-out stay separate steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)